### PR TITLE
docs: add root agent entry and align .agent rule references

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -19,6 +19,8 @@
 - **`lib/`**: **技能引擎 (Skill Engine)**。包含被 Workflow 调用的核心脚本库 (`.sh`)，实现了具体的业务逻辑。
   - `gh-ops.sh`: GitHub issue 和 PR 管理。
   - `audit.sh`: 代码与文档审计。
+  - `git-scope.sh`: 变更范围分析。
+  - `bump_version.sh`: 版本发布辅助脚本。
 - **`rules/`**: 具体的编码标准和项目规则。
 - **`templates/`**: Commit, PR 等模板。
 

--- a/.agent/context/agent.md
+++ b/.agent/context/agent.md
@@ -1,5 +1,7 @@
 # Agent Persona
 
+欢迎进入 Vibe Center。你当前是本仓库的执行代理（兼容 Claude/Codex/OpenCode 等）。
+
 - Name: Vibe Center Maintainer
 - Role: Tooling / Workflow Engineer
 - Output language: 中文
@@ -9,3 +11,9 @@
 - 维护 `bin/` + `lib/` 的稳定性与边界
 - 维护 `.agent/` 的规则与上下文一致性
 - 保证变更可通过测试并可审阅
+
+## Canonical references
+- Principles: `SOUL.md`
+- Project constraints: `CLAUDE.md`
+- Active task: `.agent/context/task.md`
+- Long-term memory: `.agent/context/memory.md`

--- a/.agent/templates/workflow.md
+++ b/.agent/templates/workflow.md
@@ -11,7 +11,7 @@ description: [Short Description of Workflow]
 ## 2. Standards Check (规范检查)
 **CRITICAL**: 执行前请复核以下规则：
 // turbo
-cat .agent/rules/coding-standards.md .agent/rules/git-rules.md
+cat .agent/rules/coding-standards.md .agent/rules/patterns.md
 
 ## 3. Execution (执行)
 [具体的步骤，保留原有的脚本调用逻辑]

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -6,12 +6,12 @@ description: Automated Release Workflow
 
 ## 1. Prerequisites (前置准备)
 - [ ] Context gathered: Check git status, ensure clean working directory.
-- [ ] Rules loaded: `git-rules.md`.
+- [ ] Rules loaded: `coding-standards.md`, `patterns.md`.
 
 ## 2. Standards Check (规范检查)
 **CRITICAL**: 执行前请复核以下规则：
 // turbo
-cat .agent/rules/coding-standards.md .agent/rules/git-rules.md
+cat .agent/rules/coding-standards.md .agent/rules/patterns.md
 
 ## 3. Execution (执行)
 Perform release steps.
@@ -79,4 +79,3 @@ git push origin "v$VERSION"
 git tag --list | head -n 5
 ```
 - [ ] Verify GitHub Release workflow triggered (optional).
-

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,18 @@
+# Agent Entry (Thin)
+
+此文件是兼容入口，供默认读取仓库根目录的 Agent 使用。
+
+## Canonical Context
+- Persona: `.agent/context/agent.md`
+- Current task: `.agent/context/task.md`
+- Historical memory: `.agent/context/memory.md`
+- Rules: `.agent/rules/`
+
+## Reading Order
+1. `SOUL.md`
+2. `CLAUDE.md`
+3. `.agent/context/task.md`
+4. `.agent/context/memory.md`
+5. `.agent/rules/*`
+
+如有冲突，以 `SOUL.md` 和 `CLAUDE.md` 为准。


### PR DESCRIPTION
## Summary
- 新增根目录 `agent.md` 作为薄入口（仅指路，不承载详细规则）。
- 将欢迎词和执行指引集中到 `.agent/context/agent.md`。
- 修复 `.agent` 内仍引用已删除规则文件的两处失效路径：
  - `.agent/workflows/release.md`
  - `.agent/templates/workflow.md`
- 同步 `.agent/README.md` 的 `lib/` 目录说明（补充 `git-scope.sh`、`bump_version.sh`）。

## Verification
- `rg -n "git-rules\.md|architecture\.md" .agent/workflows .agent/templates -S`（无命中）
- 结构检查：根目录 `agent.md` 与 `.agent/context/agent.md` 职责分离（入口 vs 详细上下文）
