### PR TITLE
fix(wt): patch PR38 regressions for vup path and exit codes

### DIFF
--- a/alias/tmux.sh
+++ b/alias/tmux.sh
@@ -126,6 +126,7 @@ vt() {
         [[ -n "$TMUX" ]] && tmux switch-client -t "${matches[$choice]}" || tmux attach -t "${matches[$choice]}"
       else
         echo "❌ Invalid choice"
+        return 1
       fi
       ;;
   esac

--- a/alias/worktree.sh
+++ b/alias/worktree.sh
@@ -267,8 +267,11 @@ vup() {
   # Resolve target to directory path using _wt_find
   local dir_path
   if [[ -z "$target" ]]; then
-    # No argument: use current directory
-    dir_path="$(pwd)"
+    # No argument: use current git worktree root
+    dir_path="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+      vibe_die "Not in a git worktree"
+      return 1
+    }
     target="${dir_path##*/}"
   else
     # Use _wt_find to locate worktree (supports exact/suffix/substring match)
@@ -296,10 +299,14 @@ vup() {
       fi
     else
       vibe_die "Worktree not found: $target (checked wtls)"
+      return 1
     fi
   fi
 
-  [[ -d "$dir_path" ]] || vibe_die "Not found: $dir_path"
+  [[ -d "$dir_path" ]] || {
+    vibe_die "Not found: $dir_path"
+    return 1
+  }
 
   # Session name = worktree name (e.g., main, wt-claude-fix)
   local session_name="$target"


### PR DESCRIPTION
## Summary
- fix `vup` no-arg path resolution to use current git worktree root instead of current subdirectory
- stop `vup` immediately when worktree lookup fails or resolved directory is invalid
- return non-zero from `vt` when multiple-match selection input is invalid

## Files
- alias/worktree.sh
- alias/tmux.sh

## Verification
- `zsh -n alias/worktree.sh && zsh -n alias/tmux.sh` -> `zsh -n OK`
- mocked `vup definitely-not-exist` -> `RC=1` and no tmux session creation
- mocked `vup` from `main/lib` -> session targets `main` root path
- mocked `printf "x\\n" | vt foo` -> `RC=1` with `Invalid choice`
