### PR TITLE
fix(flow): clarify PR base and branch semantics

### DIFF
--- a/.agent/workflows/vibe-commit.md
+++ b/.agent/workflows/vibe-commit.md
@@ -26,4 +26,14 @@ tags: [workflow, vibe, git, commit]
    Output grouped commit drafts and **ask for the user's explicit confirmation** before any commit execution.
 
 5. **Post-Commit PR Proposal**
-   Once the user's working tree is completely clean and all changes are committed, automatically ask if they would like to create a Pull Request directly. If yes, generate the PR Title and Body, ask for confirmation again, and then execute `gh pr create` with the generated contents.
+   Once the user's working tree is completely clean and all changes are committed, you may propose creating a Pull Request. Keep the wording precise: this is only a proposal to start PR publication, not a claim that the branch is ready to merge into `main`.
+
+6. **Base Validation Before PR Draft**
+   Before drafting any PR command, read `vibe flow pr --help` and treat `vibe flow pr (shell)` as the source of truth for base selection.
+   If the current branch is not closest to `main`, do not imply the PR should target `main`; surface the inferred base or require an explicit `--base <ref>`.
+
+7. **Boundary Alignment**
+   Keep responsibilities explicit:
+   - `/vibe-commit`: skill-layer orchestration and commit/PR draft preparation
+   - `vibe flow pr`: shell-layer publication entry and PR base validation
+   - `gh pr create`: underlying external tool invoked by shell, not the workflow's direct source of truth

--- a/docs/plans/2026-03-08-fix-pr-base-selection.md
+++ b/docs/plans/2026-03-08-fix-pr-base-selection.md
@@ -1,0 +1,195 @@
+# Fix PR Base Selection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 修复 `vibe flow pr` 与 `/vibe-commit` 的 PR 基线选择逻辑，避免从非 `main` 近切分支直接错误地对 `main` 发 PR。
+
+**Architecture:** 先在 shell 层为 `vibe flow pr` 建立明确的 base branch 判定与参数接口，再让 `/vibe-commit` 在提议发 PR 前读取这套能力，而不是自行假定 `main`。测试优先覆盖“从 `claude/refactor` 派生时不得默认比较 `main`”这一事故路径。
+
+**Tech Stack:** Zsh CLI (`lib/flow.sh`, `lib/flow_help.sh`)、Markdown workflow/skill files、Bats (`tests/test_flow.bats`)。
+
+---
+
+## Goal
+
+- 让 `vibe flow pr` 不再硬编码 `main..HEAD`
+- 让 `/vibe-commit` 在建议发 PR 前显式检查正确 base
+- 为错误基线事故补回归测试
+
+## Non-goals
+
+- 不重做 `flow/worktree/branch` 全局语义模型
+- 不修改已关闭/已替代的历史 PR
+- 不重构无关的 release bump / CHANGELOG 流程
+
+## Task 1: 为 PR base 选择补失败测试
+
+**Files:**
+- Modify: `tests/test_flow.bats`
+- Inspect: `lib/flow.sh`
+
+**Step 1: 添加针对 `_flow_pr` 的失败测试**
+
+覆盖至少两种场景：
+- 当前分支从 `main` 近切时，默认基线可仍为 `main`
+- 当前分支不是从 `main` 近切、且存在更近祖先分支时，默认逻辑不能继续静默使用 `main`
+
+**Step 2: 运行单测确认当前实现失败**
+
+Run: `bats tests/test_flow.bats`
+
+Expected:
+- 新增用例失败
+- 失败原因明确指向 `_flow_pr` 仍把 `main` 当默认基线
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_flow.bats
+git commit -m "test(flow): cover PR base selection"
+```
+
+## Task 2: 在 shell 层实现明确的 base branch 选择
+
+**Files:**
+- Modify: `lib/flow.sh`
+- Modify: `lib/flow_help.sh`
+
+**Step 1: 为 `vibe flow pr` 增加显式 base 入口**
+
+新增或收紧参数契约，例如：
+- `--base <ref>` 或等价命名
+- 若未传，先通过 Git ancestry 计算候选 base，而不是直接写死 `main`
+
+**Step 2: 明确默认判定策略**
+
+要求实现满足：
+- 若当前分支确实从 `main` 近切，允许默认使用 `main`
+- 若当前分支并非从 `main` 近切，必须报错或要求显式确认/显式 `--base`
+- `commit_logs`、Open PR 检查、PR 创建所用 base 必须统一，不允许一处推断、一处仍写死 `main`
+
+**Step 3: 更新帮助文案**
+
+`lib/flow_help.sh` 必须说明：
+- `--base <ref>` 的用途
+- 默认行为何时会拒绝继续
+- 为什么不能从任意历史分支直接假定对 `main` 发 PR
+
+**Step 4: 运行测试确认通过**
+
+Run: `bats tests/test_flow.bats`
+
+Expected:
+- 新增测试通过
+- 旧有 `_flow_pr` 相关测试不回归
+
+**Step 5: Commit**
+
+```bash
+git add lib/flow.sh lib/flow_help.sh tests/test_flow.bats
+git commit -m "fix(flow): guard PR base selection"
+```
+
+## Task 3: 收紧 `/vibe-commit` 的 PR 提议文案与前置检查
+
+**Files:**
+- Modify: `skills/vibe-commit/SKILL.md`
+- Modify: `.agent/workflows/vibe-commit.md`
+
+**Step 1: 更新 workflow 文案**
+
+明确：
+- `/vibe-commit` 只是在提交完成后“提议”发 PR
+- 真正的 base 判定以 `vibe flow pr (shell)` 为准
+- 在 shell 未确认 base 之前，不得默认向用户暗示“准备好合并到主干”
+
+**Step 2: 更新 skill 文案**
+
+要求 skill 在生成 PR 草案前至少做两件事：
+- 先读取 `vibe flow pr --help` 或等价 shell 能力说明
+- 检查当前分支相对哪个 base 才是最小差异；若不是 `main`，不得默认建议发往 `main`
+
+**Step 3: 文案对齐 slash / shell 边界**
+
+把 `/vibe-commit`、`vibe flow pr`、`gh pr create` 三者职责写清楚：
+- `/vibe-commit`：skill 层编排
+- `vibe flow pr`：shell 层发布
+- `gh pr create`：底层外部工具
+
+**Step 4: Commit**
+
+```bash
+git add skills/vibe-commit/SKILL.md .agent/workflows/vibe-commit.md
+git commit -m "docs(commit): require PR base validation"
+```
+
+## Task 4: 端到端验证
+
+**Files to inspect during execution:**
+- `lib/flow.sh`
+- `lib/flow_help.sh`
+- `skills/vibe-commit/SKILL.md`
+- `.agent/workflows/vibe-commit.md`
+- `tests/test_flow.bats`
+
+**Step 1: 运行 flow 相关测试**
+
+Run: `bats tests/test_flow.bats`
+
+Expected:
+- `_flow_pr` 基线选择相关用例全部通过
+
+**Step 2: 运行 PR 发布相关全量回归**
+
+Run: `bin/vibe check`
+
+Expected:
+- `flow` / `link` / `task` / `docs` 组不因本次改动新增失败
+
+**Step 3: 运行命令帮助校验**
+
+Run:
+
+```bash
+bin/vibe flow pr --help
+```
+
+Expected:
+- 输出中出现新的 base 说明
+- 不再暗示所有 PR 都默认对 `main`
+
+**Step 4: Commit**
+
+```bash
+git add lib/flow.sh lib/flow_help.sh skills/vibe-commit/SKILL.md .agent/workflows/vibe-commit.md tests/test_flow.bats
+git commit -m "test(flow): verify PR base selection workflow"
+```
+
+## Files To Modify
+
+- `lib/flow.sh`
+- `lib/flow_help.sh`
+- `skills/vibe-commit/SKILL.md`
+- `.agent/workflows/vibe-commit.md`
+- `tests/test_flow.bats`
+
+## Test Command
+
+```bash
+bats tests/test_flow.bats
+bin/vibe check
+bin/vibe flow pr --help
+```
+
+## Expected Result
+
+- `vibe flow pr` 不再把 `main` 作为无条件默认基线
+- `/vibe-commit` 不再在未校验 ancestry 时默认建议“发往 main”
+- 从非 `main` 近切分支发布时，系统会要求显式 base 或直接拒绝继续
+
+## Change Summary
+
+- Files affected: 5
+- Expected added lines: 80-160
+- Expected removed lines: 20-60
+- Expected modified lines: 40-100

--- a/lib/flow.sh
+++ b/lib/flow.sh
@@ -74,7 +74,16 @@ _flow_bind() {
 _flow_new() {
   local feat="" agent="" ref="main" arg
   for arg in "$@"; do [[ "$arg" == "-h" || "$arg" == "--help" ]] && { _flow_new_usage; return 0; }; done
-  while [[ $# -gt 0 ]]; do case "$1" in --task) log_error "Use: vibe flow bind $2"; return 1 ;; --agent) agent="$2"; shift 2 ;; --branch|--base) ref="$2"; shift 2 ;; *) [[ -z "$feat" ]] && feat="$1"; shift ;; esac; done
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --task) log_error "Use: vibe flow bind $2"; return 1 ;;
+      --agent) agent="$2"; shift 2 ;;
+      --branch) ref="$2"; shift 2 ;;
+      --base) log_error "Unknown option: --base. Use --branch <ref> for the source branch when creating a flow."; return 1 ;;
+      -*) log_error "Unknown option for flow new: $1"; _flow_new_usage; return 1 ;;
+      *) [[ -z "$feat" ]] && feat="$1"; shift ;;
+    esac
+  done
   [[ -n "$feat" ]] || { _flow_new_usage; return 1; }
   _flow_new_worktree "$feat" "${agent:-$(_flow_default_agent)}" "$ref"
 }

--- a/lib/flow.sh
+++ b/lib/flow.sh
@@ -13,6 +13,27 @@ _flow_require_base_ref() { git fetch origin "$1" --quiet 2>/dev/null || true; gi
 _flow_branch_exists() { git show-ref --verify --quiet "refs/heads/$1" || git show-ref --verify --quiet "refs/remotes/origin/$1" || git ls-remote --exit-code --heads origin "$1" >/dev/null 2>&1; }
 _flow_is_main_worktree() { local d; d=$(basename "$PWD"); [[ "$d" =~ ^wt-[^-]+-.+$ ]] && return 1 || return 0; }
 _flow_shared_dir() { local d; d="$(git rev-parse --git-common-dir)/vibe/shared"; mkdir -p "$d"; echo "$d"; }
+_flow_branch_ref() { git show-ref --verify --quiet "refs/heads/$1" && { echo "$1"; return 0; }; git show-ref --verify --quiet "refs/remotes/origin/$1" && { echo "origin/$1"; return 0; }; return 1; }
+_flow_pr_candidate_bases() { local branch="$1"; git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin 2>/dev/null | sed 's#^origin/##' | awk -v b="$branch" 'NF && $0 != "HEAD" && $0 != b { seen[$0]=1 } END { for (name in seen) print name }'; }
+_flow_pick_pr_base() {
+  local branch="$1" candidate ref best="" best_count=""
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue; ref="$(_flow_branch_ref "$candidate")" || continue
+    git merge-base --is-ancestor "$ref" HEAD >/dev/null 2>&1 || continue
+    local ahead_count; ahead_count=$(git rev-list --count "$ref..HEAD" 2>/dev/null) || continue
+    [[ -z "$best" || "$ahead_count" -lt "$best_count" ]] && { best="$candidate"; best_count="$ahead_count"; }
+  done < <(_flow_pr_candidate_bases "$branch")
+  [[ -n "$best" ]] && echo "$best"
+}
+_flow_resolve_pr_base() {
+  local requested="$1" branch="$2" inferred=""
+  if [[ -n "$requested" ]]; then _flow_branch_exists "$requested" || { log_error "PR base not found: $requested"; return 1; }; echo "$requested"; return 0; fi
+  inferred="$(_flow_pick_pr_base "$branch")"
+  [[ -n "$inferred" ]] || { log_error "Unable to infer PR base. Re-run with --base <ref>."; return 1; }
+  [[ "$inferred" == "main" ]] && { echo "$inferred"; return 0; }
+  log_error "Refusing to default PR base to main. Current branch appears to be based on '$inferred'. Re-run with --base $inferred."
+  return 1
+}
 _flow_rollback_worktree() { git worktree remove "$1" --force >/dev/null 2>&1 || true; }
 _flow_new_worktree() {
   local feature="$1" agent="$2" ref="$3" repo_root wt_dir wt_path feature_slug branch_name suggested_task_id
@@ -85,17 +106,19 @@ _flow_sync() {
 }
 
 _flow_pr() {
-  local bump_type="" pr_title="" pr_body="" version_msg="" branch commit_logs first_msg open_prs
-  while [[ $# -gt 0 ]]; do case "$1" in -h|--help) _flow_pr_usage; return 0 ;; --bump) bump_type="$2"; shift 2 ;; --title) pr_title="$2"; shift 2 ;; --body) pr_body="$2"; shift 2 ;; --msg) version_msg="$2"; shift 2 ;; *) shift ;; esac; done
+  local bump_type="" pr_title="" pr_body="" version_msg="" branch base_ref="" commit_logs first_msg open_prs
+  while [[ $# -gt 0 ]]; do case "$1" in -h|--help) _flow_pr_usage; return 0 ;; --base) base_ref="$2"; shift 2 ;; --bump) bump_type="$2"; shift 2 ;; --title) pr_title="$2"; shift 2 ;; --body) pr_body="$2"; shift 2 ;; --msg) version_msg="$2"; shift 2 ;; *) shift ;; esac; done
   vibe_require git || return 1; branch=$(git branch --show-current); [[ "$branch" == "main" ]] && { log_error "Cannot create PR from main branch"; return 1; }
-  commit_logs=$(git log main..HEAD --oneline); [[ -z "$commit_logs" ]] && { log_warn "No new commits since main. Nothing to PR."; return 1; }
+  base_ref="$(_flow_resolve_pr_base "$base_ref" "$branch")" || return 1
+  log_info "Using PR base: $base_ref"
+  commit_logs=$(git log "$base_ref..HEAD" --oneline); [[ -z "$commit_logs" ]] && { log_warn "No new commits since $base_ref. Nothing to PR."; return 1; }
   [[ -z "$bump_type" ]] && bump_type="patch"; [[ -z "$pr_title" ]] && pr_title=$(echo "$commit_logs" | head -n 1 | sed 's/^[a-f0-9]* //'); [[ -z "$pr_body" ]] && pr_body=$(echo "$commit_logs" | sed 's/^[a-f0-9]* / - /')
   if [[ -z "$version_msg" ]]; then first_msg=$(echo "$commit_logs" | tail -n 1 | sed 's/^[a-f0-9]* //'); version_msg="${first_msg} ..."; fi
   
   local has_pr=0
   if vibe_has gh; then
-    log_step "Checking for open PRs to main..."; open_prs=$(gh pr list --state open --base main --json number,headRefName,title | jq -r --arg b "$branch" '.[] | select(.headRefName != $b) | "#\(.number) \(.title) (\(.headRefName))"')
-    [[ -n "$open_prs" ]] && { log_warn "Blocking: Sequential merge required. Other open PRs to 'main' detected."; echo "$open_prs" | sed 's/^/  - /'; return 1; }
+    log_step "Checking for open PRs to $base_ref..."; open_prs=$(gh pr list --state open --base "$base_ref" --json number,headRefName,title | jq -r --arg b "$branch" '.[] | select(.headRefName != $b) | "#\(.number) \(.title) (\(.headRefName))"')
+    [[ -n "$open_prs" ]] && { log_warn "Blocking: Sequential merge required. Other open PRs to '$base_ref' detected."; echo "$open_prs" | sed 's/^/  - /'; return 1; }
     
     # Check if a PR already exists from this branch
     gh pr view "$branch" >/dev/null 2>&1 && has_pr=1
@@ -117,10 +140,10 @@ _flow_pr() {
   log_info "GitHub CLI detected. Managing PR..."
   if [[ $has_pr -eq 1 ]]; then
     log_success "Updating existing PR..."
-    gh pr edit "$branch" --title "$pr_title" --body "$pr_body" || true
+    gh pr edit "$branch" --base "$base_ref" --title "$pr_title" --body "$pr_body" || true
   else
     log_step "Creating new PR: $pr_title"
-    gh pr create --title "$pr_title" --body "$pr_body" --web || log_warn "Failed to create PR with gh, please check manually."
+    gh pr create --title "$pr_title" --body "$pr_body" --base "$base_ref" --web || log_warn "Failed to create PR with gh, please check manually."
   fi
 }
 

--- a/lib/flow_help.sh
+++ b/lib/flow_help.sh
@@ -33,13 +33,19 @@ _flow_pr_usage() {
   echo "Usage: ${CYAN}vibe flow pr${NC} [options]"
   echo ""
   echo "提交当前工作区的修改并创建/更新 Pull Request。"
-  echo "核心职责：执行串行检查 -> 自动处理版本与 CHANGELOG -> 物理 Push -> 云端 PR 关联"
+  echo "核心职责：判定/校验 PR base -> 执行串行检查 -> 自动处理版本与 CHANGELOG -> 物理 Push -> 云端 PR 关联"
   echo ""
   echo "选项："
+  echo "  --base <ref>     显式指定 PR 基线分支；从非 main 近切分支发 PR 时必须传入"
   echo "  --bump <type>    自动版本升级 (patch|minor|major, 默认: patch)"
   echo "  --title <text>   PR 的标题 (默认: 首条 commit 标题)"
   echo "  --body <text>    PR 的正文描述 (默认: 所有 commit 列表)"
   echo "  --msg <text>     写入 CHANGELOG 的版本说明 (默认: 首条 commit...)"
+  echo ""
+  echo "默认行为："
+  echo "  - 仅当当前分支可判定为直接从 main 近切时，才会默认使用 main"
+  echo "  - 如果检测到当前分支更接近其他祖先分支，命令会拒绝继续并要求显式 --base"
+  echo "  - 这样可以避免把从中间分支派生的变更误向 main 发 PR"
 }
 
 _flow_review_usage() {

--- a/lib/flow_help.sh
+++ b/lib/flow_help.sh
@@ -9,20 +9,22 @@ _flow_usage() {
   echo "Subcommands:"
   echo "  ${GREEN}new${NC} <name> [--agent <name>] [--branch <ref>]        创建/切换现场（worktree + branch）"
   echo "  ${GREEN}bind${NC} <task-id> [--agent <name>]                    在当前 worktree 内复用环境领取已注册任务"
-  echo "  ${GREEN}done${NC}                                                 当前现场收尾（保留 worktree/branch）"
-  echo "  ${GREEN}status${NC} [<name>]                                      查看当前分支状态 (默认: 当前分支)"
-  echo "  ${GREEN}list${NC}                                                   查看全部分支状态"
-  echo "  ${GREEN}pr${NC}                                                   提交代码并打开 Pull Request"
-  echo "  ${GREEN}review${NC}                                               查看 PR 或进行本地最终检查"
+  echo "  ${GREEN}done${NC} [--branch <ref>]                               当前/指定现场收尾（保留 worktree/branch）"
+  echo "  ${GREEN}status${NC} [--branch <ref>]                             查看当前/指定分支状态"
+  echo "  ${GREEN}list${NC}                                                   查看当前未关闭 flow 列表"
+  echo "  ${GREEN}pr${NC} [--base <ref>]                                    提交代码并打开 Pull Request（目标基线分支）"
+  echo "  ${GREEN}review${NC} [--branch <ref>] [--local]                   查看 PR 或进行本地最终检查"
   echo ""
   echo "Options for 'new <name>':"
   echo "  --agent <name>     指定 AI 身份 (默认: claude)"
-  echo "  --branch <ref>     指定基础分支 (默认: main)"
+  echo "  --branch <ref>     指定创建现场时的起点分支 (默认: main)"
   echo "  # 标准路径：先 vibe task add/update，再 vibe flow new，再 vibe flow bind"
+  echo "  # 概念边界：flow new 用 --branch；flow pr 用 --base；两者不是同义参数"
 }
 
 _flow_new_usage() { 
     echo "Usage: vibe flow new <name> [--agent=claude] [--branch=main]"
+    echo "  --branch <ref>  创建 flow 时选择起点分支；不接受 --base"
 }
 
 _flow_bind_usage() { 
@@ -36,7 +38,7 @@ _flow_pr_usage() {
   echo "核心职责：判定/校验 PR base -> 执行串行检查 -> 自动处理版本与 CHANGELOG -> 物理 Push -> 云端 PR 关联"
   echo ""
   echo "选项："
-  echo "  --base <ref>     显式指定 PR 基线分支；从非 main 近切分支发 PR 时必须传入"
+  echo "  --base <ref>     显式指定 PR 目标基线分支；从非 main 近切分支发 PR 时必须传入"
   echo "  --bump <type>    自动版本升级 (patch|minor|major, 默认: patch)"
   echo "  --title <text>   PR 的标题 (默认: 首条 commit 标题)"
   echo "  --body <text>    PR 的正文描述 (默认: 所有 commit 列表)"
@@ -46,6 +48,7 @@ _flow_pr_usage() {
   echo "  - 仅当当前分支可判定为直接从 main 近切时，才会默认使用 main"
   echo "  - 如果检测到当前分支更接近其他祖先分支，命令会拒绝继续并要求显式 --base"
   echo "  - 这样可以避免把从中间分支派生的变更误向 main 发 PR"
+  echo "  - 概念边界：这里的 --base 是 PR 要合入的目标分支，不是创建 flow 时的起点分支"
 }
 
 _flow_review_usage() {

--- a/openspec/specs/cli-commands.yaml
+++ b/openspec/specs/cli-commands.yaml
@@ -12,7 +12,7 @@ commands:
     description: "开发工作流"
     subcommands:
       - name: start
-        description: "创建 worktree"
+        description: "从指定起点分支创建 worktree"
         parameters:
           - name: feature
             type: string
@@ -21,12 +21,12 @@ commands:
             type: string
             required: false
             default: "claude"
-          - name: "--base"
+          - name: "--branch"
             type: string
             required: false
             default: "main"
         returns: "0 on success"
-        example: "vibe flow start my-feature --agent=claude"
+        example: "vibe flow start my-feature --branch develop --agent=claude"
       - name: review
         description: "Pre-PR 检查清单 + lazygit"
         parameters:
@@ -36,13 +36,16 @@ commands:
         returns: "0 on success"
         example: "vibe flow review my-feature"
       - name: pr
-        description: "生成 PR 并通过 gh 创建"
+        description: "基于当前分支创建/更新 PR，并指定目标基线分支"
         parameters:
-          - name: feature
+          - name: "--base"
+            type: string
+            required: false
+          - name: "--bump"
             type: string
             required: false
         returns: "0 on success"
-        example: "vibe flow pr my-feature"
+        example: "vibe flow pr --base main"
       - name: done
         description: "清理 worktree"
         parameters:

--- a/skills/vibe-commit/SKILL.md
+++ b/skills/vibe-commit/SKILL.md
@@ -24,14 +24,17 @@ trigger: auto
    - **必做项**：在提交信息的末尾（在正文后空一行），必须强制拼接该组所有联合贡献者的 `Co-authored-by:` 后缀。例如：`Co-authored-by: Agent-Claude <claude@vibe.coding>`
 5. **Interactive Confirmation**: 将分类结果及带有 `Co-authored-by` 的完整草稿提交列出来，**明确提请用户检查并确认**。
 6. **Execution Recommendations**: 用户确认后，提取并正式执行 `git add ...` 及 `git commit -m "..."`。
-7. **自动化 PR 流 (Post-Commit PR Proposal)**: 当工作区的所有变更都已被成功提交（即 `git status` 干净后），你必须主动询问用户："所有变更已提交。是否需要帮您发起 Pull Request 发布流程？"
+7. **自动化 PR 流 (Post-Commit PR Proposal)**: 当工作区的所有变更都已被成功提交（即 `git status` 干净后），你可以主动询问用户："所有变更已提交。是否需要帮您发起 Pull Request 发布流程？" 但只能把它表述为“提议发 PR”，不能在未校验 base 前暗示“已经准备好合并到主干”。
    - **数据准备 (Agent 认知层)**：
+     - **Base Rule First**: 在生成任何 PR 草案前，必须先读取 `vibe flow pr --help`（或等价 shell 帮助输出），确认 `vibe flow pr (shell)` 当前支持的 base 规则。
+     - **Base Validation**: 先判断当前分支相对哪个 base 才是最小差异；若不是 `main`，不得默认建议发往 `main`，而应明确提示需要 `--base <ref>`。
      - **Bump Type**: 询问并确认本次升级级别（`patch` / `minor` / `major`）。
      - **PR Description**: 根据所有未提交的 Commit 记录，总结一份高质量的 PR Body（支持多行）。
      - **Version Note**: 提炼一份要写入 `CHANGELOG.md` 的版本变更说明。
    - **操作执行 (Physical Tier 1)**：
+     - `/vibe-commit` 负责认知层编排与草案生成；真正的 base 判定与发布入口以 `vibe flow pr (shell)` 为准；`gh pr create` 只是底层外部工具，不应由 skill 直接替代 shell 规则。
      - 向用户展示上述三部分内容，确认后调用指令（必须正确转义换行符）：
-       `vibe flow pr --bump <type> --title "<title>" --body "<body>" --msg "<version_msg>"`
+       `vibe flow pr --base <ref> --bump <type> --title "<title>" --body "<body>" --msg "<version_msg>"`
    - 创建成功后，立刻提示用户"不要忘记在 AI 助手中收口该任务！（执行 `/vibe-done`）"。
 
 ## Expected Output Format
@@ -61,8 +64,8 @@ trigger: auto
 ```markdown
 ✅ **所有变更已成功 commit！** 
 
-当前的特性代码目前都在本地，准备好合并到主干了吗？
-我可以为您读取最近这几次提交的内容，**一键生成并提交 Pull Request (PR)** 到仓库，免去您手动跑 `vibe flow pr` 的麻烦。
+当前的特性代码目前都在本地。我可以先帮您校验本分支应该相对哪个 base 发 PR，再生成发布草案。
+我会先读取 `vibe flow pr (shell)` 的 base 规则；如果当前分支不是直接从 `main` 近切，就不会默认建议发往 `main`。
 
 需要我帮您直接跑 PR 发版流程吗？
 ```

--- a/tests/test_flow.bats
+++ b/tests/test_flow.bats
@@ -284,12 +284,13 @@ JSON
     source "'"$VIBE_ROOT"'/lib/config.sh"
     source "'"$VIBE_ROOT"'/lib/utils.sh"
     source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_resolve_pr_base() { echo "main"; return 0; }
     vibe_has() { return 0; } # Mock all tools as present
     gh() {
       case "$*" in
         "pr list --state open --base main --json number,headRefName,title") echo "[]"; return 0 ;;
         "pr view current-branch") return 0 ;; # PR exists
-        "pr edit current-branch --title test --body test") return 0 ;;
+        "pr edit current-branch --base main --title test --body test") return 0 ;;
         *) return 0 ;;
       esac
     }
@@ -316,12 +317,13 @@ JSON
     source "'"$VIBE_ROOT"'/lib/config.sh"
     source "'"$VIBE_ROOT"'/lib/utils.sh"
     source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_resolve_pr_base() { echo "main"; return 0; }
     vibe_has() { return 0; } # Mock all tools as present
     gh() {
       case "$*" in
         "pr list --state open --base main --json number,headRefName,title") echo "[]"; return 0 ;;
         "pr view current-branch") return 1 ;; # PR does not exist
-        "pr create --title test --body test --web") return 0 ;;
+        "pr create --title test --body test --base main --web") return 0 ;;
         *) return 0 ;;
       esac
     }
@@ -354,12 +356,13 @@ EOF
     source "'"$VIBE_ROOT"'/lib/config.sh"
     source "'"$VIBE_ROOT"'/lib/utils.sh"
     source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_resolve_pr_base() { echo "main"; return 0; }
     vibe_has() { return 0; }
     gh() {
       case "$*" in
         "pr list --state open --base main --json number,headRefName,title") echo "[]"; return 0 ;;
         "pr view current-branch") return 1 ;;
-        "pr create --title test --body test --web") return 0 ;;
+        "pr create --title test --body test --base main --web") return 0 ;;
         *) return 0 ;;
       esac
     }
@@ -391,7 +394,7 @@ EOF
       case "$*" in
         "pr list --state open --base main --json number,headRefName,title") echo "[]"; return 0 ;;
         "pr view current-branch") return 0 ;;
-        "pr edit current-branch --title test --body test") return 0 ;;
+        "pr edit current-branch --base main --title test --body test") return 0 ;;
         *) return 0 ;;
       esac
     }
@@ -414,13 +417,12 @@ EOF
     source "'"$VIBE_ROOT"'/lib/config.sh"
     source "'"$VIBE_ROOT"'/lib/utils.sh"
     source "'"$VIBE_ROOT"'/lib/flow.sh"
-    _flow_resolve_pr_base() { echo "claude/refactor"; return 0; }
+    _flow_pick_pr_base() { echo "claude/refactor"; return 0; }
     vibe_has() { return 0; }
     gh() {
       case "$*" in
         "pr list --state open --base claude/refactor --json number,headRefName,title") echo "[]"; return 0 ;;
-        "pr view current-branch") return 1 ;;
-        "pr create --title test --body test --base claude/refactor --web") return 0 ;;
+        "pr view current-branch") return 0 ;;
         *) return 0 ;;
       esac
     }

--- a/tests/test_flow.bats
+++ b/tests/test_flow.bats
@@ -52,6 +52,21 @@ JSON
   [[ "$output" =~ "Usage: vibe flow new" ]]
 }
 
+@test "2.1 _flow_new rejects legacy --base alias to keep branch semantics explicit" {
+  run zsh -c '
+    source "'"$VIBE_ROOT"'/lib/config.sh"
+    source "'"$VIBE_ROOT"'/lib/utils.sh"
+    source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_new_worktree() { echo "UNEXPECTED_WORKTREE_CALL"; return 0; }
+    _flow_new demo --base develop
+  '
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Unknown option: --base" ]]
+  [[ "$output" =~ "--branch" ]]
+  [[ ! "$output" =~ "UNEXPECTED_WORKTREE_CALL" ]]
+}
+
 @test "3. vibe flow status in non-worktree returns error" {
   # Run in a directory that is definitely not a worktree
   cd /tmp

--- a/tests/test_flow.bats
+++ b/tests/test_flow.bats
@@ -380,6 +380,66 @@ EOF
   [ -f "$fixture/bump_called" ]
 }
 
+@test "14.1 _flow_pr allows inferred main as default base" {
+  run zsh -c '
+    source "'"$VIBE_ROOT"'/lib/config.sh"
+    source "'"$VIBE_ROOT"'/lib/utils.sh"
+    source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_resolve_pr_base() { echo "main"; return 0; }
+    vibe_has() { return 0; }
+    gh() {
+      case "$*" in
+        "pr list --state open --base main --json number,headRefName,title") echo "[]"; return 0 ;;
+        "pr view current-branch") return 0 ;;
+        "pr edit current-branch --title test --body test") return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    git() {
+      case "$*" in
+        "branch --show-current") echo "current-branch"; return 0 ;;
+        "log main..HEAD --oneline") echo "abcdef test commit"; return 0 ;;
+        "push origin HEAD") return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    _flow_pr --title "test" --body "test"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Skipping version bump" ]]
+}
+
+@test "14.2 _flow_pr refuses non-main inferred base without explicit override" {
+  run zsh -c '
+    source "'"$VIBE_ROOT"'/lib/config.sh"
+    source "'"$VIBE_ROOT"'/lib/utils.sh"
+    source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_resolve_pr_base() { echo "claude/refactor"; return 0; }
+    vibe_has() { return 0; }
+    gh() {
+      case "$*" in
+        "pr list --state open --base claude/refactor --json number,headRefName,title") echo "[]"; return 0 ;;
+        "pr view current-branch") return 1 ;;
+        "pr create --title test --body test --base claude/refactor --web") return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    git() {
+      case "$*" in
+        "branch --show-current") echo "current-branch"; return 0 ;;
+        "log main..HEAD --oneline") echo "abcdef test commit"; return 0 ;;
+        "log claude/refactor..HEAD --oneline") echo "abcdef test commit"; return 0 ;;
+        "push origin HEAD") return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    _flow_pr --title "test" --body "test"
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "claude/refactor" ]]
+  [[ "$output" =~ "--base" ]]
+}
+
 
 
 @test "14. vibe flow start with path feature does not auto-create or bind task" {


### PR DESCRIPTION
## Summary
- reject legacy `--base` on `vibe flow new` and require `--branch` for flow creation
- keep `vibe flow pr --base` as the PR target-branch input and document that it differs from flow creation semantics
- align help text, workflow guidance, OpenSpec docs, and regression coverage around the branch/base boundary

## Test Plan
- `bats tests/test_flow.bats`
- `bin/vibe flow help`
- `bin/vibe flow pr --help`
