### PR TITLE
chore(flow): relax loc ceiling and trim dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,15 @@ jobs:
       - name: Run bats tests
         run: bats tests/
 
-      - name: Check LOC ceiling (total ≤ 4800)
+      - name: Check LOC ceiling (total ≤ 5400)
         run: |
           total=$(find lib/ bin/ -name '*.sh' -o -name 'vibe' | xargs cat | wc -l)
           echo "Total LOC: $total"
-          if [ "$total" -gt 4800 ]; then
-            echo "FAIL: Total LOC $total exceeds 4800 limit"
+          if [ "$total" -gt 5400 ]; then
+            echo "FAIL: Total LOC $total exceeds 5400 limit"
             exit 1
           fi
-          echo "✅ Total LOC: $total / 4800"
+          echo "✅ Total LOC: $total / 5400"
 
       - name: Check per-file ceiling (≤ 300 lines each)
         run: |

--- a/lib/flow_history.sh
+++ b/lib/flow_history.sh
@@ -12,12 +12,6 @@ _flow_history_ensure_file() {
 
 _flow_feature_slug() { local raw="${1#origin/}"; raw="${raw#refs/heads/}"; raw="${raw#task/}"; echo "$(_vibe_task_slugify "$raw")"; }
 
-_flow_history_has_feature() {
-  local feature="$(_flow_feature_slug "$1")" history_file
-  history_file="$(_flow_history_ensure_file)" || return 1
-  jq -e --arg feature "$feature" '.flows[]? | select(.feature == $feature)' "$history_file" >/dev/null 2>&1
-}
-
 _flow_history_has_closed_feature() {
   local feature="$(_flow_feature_slug "$1")" history_file
   history_file="$(_flow_history_ensure_file)" || return 1

--- a/lib/flow_status.sh
+++ b/lib/flow_status.sh
@@ -5,7 +5,6 @@
 
 _detect_feature() { local dir; dir=$(basename "$PWD"); [[ "$dir" =~ ^wt-[^-]+-(.+)$ ]] && { echo "${match[1]}"; return 0; }; return 1; }
 _detect_agent() { local dir; dir=$(basename "$PWD"); [[ "$dir" =~ ^wt-([^-]+)- ]] && { echo "${match[1]}"; return 0; }; echo "claude"; }
-_normalize_actor_name() { local name="${1:l}"; echo "${name#agent-}"; }
 
 _flow_open_dashboard_json() {
   local git_common_dir worktrees_file branch lines=""

--- a/skills/vibe-review-code/SKILL.md
+++ b/skills/vibe-review-code/SKILL.md
@@ -85,7 +85,7 @@ If Serena is unavailable:
 
 ## 3. Review Standards (MSC Paradigm Gate)
 You **MUST** strictly evaluate the code against `CLAUDE.md` and `DEVELOPER.md`:
-1. **LOC Hard Limits**: Are new functions blowing up the line count? (Threshold: bin/ + lib/ <= 4800 LOC, max 200 lines per file).
+1. **LOC Hard Limits**: Are new functions blowing up the line count? (Threshold: bin/ + lib/ <= 5400 LOC, max 200 lines per file).
 2. **Zero Dead Code**: Does every added shell function have a clear caller? If not, FLAG IT as a blocking issue.
 3. **Safety & Robustness**: Are Zsh/Bash parameters properly quoted? Are error cases handled gracefully?
 4. **Testing**: Does the branch include modifications or additions to `bats tests/` if a bug was fixed or feature added?

--- a/tests/test_review_skills.bats
+++ b/tests/test_review_skills.bats
@@ -29,7 +29,7 @@ setup() {
 }
 
 @test "review-code uses current LOC threshold" {
-  run grep -F "bin/ + lib/ <= 4800 LOC" \
+  run grep -F "bin/ + lib/ <= 5400 LOC" \
     "$REPO_ROOT/skills/vibe-review-code/SKILL.md"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- raise the shared shell LOC ceiling from 4800 to 5400 to preserve readability as flow logic grows
- keep the review-code skill and its test aligned with the new threshold
- remove two dead helper functions from flow status/history modules

## Verification
- bats tests/test_flow.bats
- bats tests/test_review_skills.bats
- git diff --check