### PR TITLE
fix: address PR 111 copilot follow-ups

### DIFF
--- a/.agent/workflows/vibe:commit.md
+++ b/.agent/workflows/vibe:commit.md
@@ -18,13 +18,13 @@ tags: [workflow, vibe, git, commit, orchestration]
    - 若存在 `current_task`，继续读取 `vibe task show <task-id> --json`
    - 若 `current_task` 缺失、无法解析，或 `runtime_branch` 与当前 flow branch 不一致，则 hard block
    - 若缺少 `issue_refs`、`roadmap_item_ids`、`spec_standard/spec_ref`，则至少报告 warning
-3. 由 `vibe-commit` skill 负责：
+4. 由 `vibe-commit` skill 负责：
    - 改动分类
    - commit 分组
    - 串行多 PR 判断
    - 何时使用 `vibe flow new <name> --branch <ref>`
    - 何时调用 `vibe flow pr --base <ref>`
-4. 当前 workflow 只负责把结果交回用户，或在 skill 完成后提示下一步去 `/vibe-integrate` / `/vibe-done`。
+5. 当前 workflow 只负责把结果交回用户，或在 skill 完成后提示下一步去 `/vibe-integrate` / `/vibe-done`。
 
 ## Boundary
 

--- a/docs/plans/2026-03-11-commit-preflight-metadata-plan.md
+++ b/docs/plans/2026-03-11-commit-preflight-metadata-plan.md
@@ -8,7 +8,7 @@ created: 2026-03-11
 last_updated: 2026-03-11
 related_docs:
   - skills/vibe-commit/SKILL.md
-  - .agent/workflows/vibe-commit.md
+  - .agent/workflows/vibe:commit.md
   - docs/standards/command-standard.md
   - docs/standards/git-workflow-standard.md
   - docs/standards/handoff-governance-standard.md
@@ -52,14 +52,14 @@ related_docs:
 
 ## Files To Modify
 
-- Modify: `.agent/workflows/vibe-commit.md`
+- Modify: `.agent/workflows/vibe:commit.md`
 - Modify: `skills/vibe-commit/SKILL.md`
 - Modify: `tests/skills/test_skills.bats`
 
 ## Task 1: 收敛 preflight 规则到 workflow
 
 **Files:**
-- Modify: `.agent/workflows/vibe-commit.md`
+- Modify: `.agent/workflows/vibe:commit.md`
 
 **Step tasks:**
 
@@ -118,7 +118,7 @@ related_docs:
 
 ```bash
 rg -n "preflight|current_task|runtime branch|issue_refs|roadmap_item_ids|spec_standard|spec_ref|hard block|warning" \
-  .agent/workflows/vibe-commit.md \
+  .agent/workflows/vibe:commit.md \
   skills/vibe-commit/SKILL.md
 
 bats tests/skills/test_skills.bats

--- a/lib/flow.sh
+++ b/lib/flow.sh
@@ -118,7 +118,7 @@ _flow_bind() {
   log_success "Bound: $tid ($title)"
 }
 _flow_new() {
-  local feat="" agent="" ref="origin/main" save_unstash=0 arg branch_name feature_slug current_branch dirty="" stash_ref="" branch_created=0
+  local feat="" agent="" ref="origin/main" save_unstash=0 arg branch_name feature_slug current_branch current_head="" dirty="" stash_ref="" branch_created=0
   for arg in "$@"; do [[ "$arg" == "-h" || "$arg" == "--help" ]] && { _flow_new_usage; return 0; }; done
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -133,6 +133,7 @@ _flow_new() {
   done
   [[ -n "$feat" ]] || { _flow_new_usage; return 1; }
   current_branch="$(git branch --show-current 2>/dev/null)"
+  current_head="$(git rev-parse --verify HEAD 2>/dev/null || true)"
   if [[ -n "$current_branch" ]]; then
     case "$current_branch" in
       main|master)
@@ -174,7 +175,7 @@ _flow_new() {
   branch_created=1
 
   _flow_update_current_worktree_branch "$branch_name" || {
-    _flow_restore_source_state "$current_branch" "$stash_ref" "flow new to $branch_name"
+    _flow_restore_source_state "$current_branch" "$stash_ref" "flow new to $branch_name" "$current_head"
     if [[ $branch_created -eq 1 ]]; then
       git branch -D "$branch_name" >/dev/null 2>&1 || log_warn "Failed to clean up incomplete branch: $branch_name"
     fi

--- a/lib/flow_runtime.sh
+++ b/lib/flow_runtime.sh
@@ -96,11 +96,17 @@ _flow_restore_captured_state() {
 }
 
 _flow_restore_source_state() {
-  local restore_branch="$1" stash_ref="$2" context="$3"
+  local restore_branch="$1" stash_ref="$2" context="$3" restore_ref="${4:-}"
 
   if [[ -n "$restore_branch" ]]; then
     git checkout "$restore_branch" || {
       log_error "Failed to restore original branch: $restore_branch"
+      [[ -n "$stash_ref" ]] && log_error "Saved changes remain in $stash_ref"
+      return 1
+    }
+  elif [[ -n "$restore_ref" ]]; then
+    git checkout --detach "$restore_ref" || {
+      log_error "Failed to restore original detached HEAD: $restore_ref"
       [[ -n "$stash_ref" ]] && log_error "Saved changes remain in $stash_ref"
       return 1
     }

--- a/tests/flow/test_flow_lifecycle.bats
+++ b/tests/flow/test_flow_lifecycle.bats
@@ -199,6 +199,42 @@ source "$BATS_TEST_DIRNAME/../helpers/flow_common.bash"
   [[ "$output" =~ "Failed to update worktree runtime state" ]]
 }
 
+@test "2.5.1a _flow_new restores detached HEAD before deleting the failed branch" {
+  local branch_cleanup_marker
+  branch_cleanup_marker="$(mktemp)"
+  rm -f "$branch_cleanup_marker"
+
+  run zsh -c '
+    source "'"$VIBE_ROOT"'/lib/config.sh"
+    source "'"$VIBE_ROOT"'/lib/utils.sh"
+    source "'"$VIBE_ROOT"'/lib/flow.sh"
+    _flow_history_has_closed_feature() { return 1; }
+    _flow_branch_exists() { return 1; }
+    _flow_update_current_worktree_branch() { return 1; }
+
+    git() {
+      case "$*" in
+        "branch --show-current") echo ""; return 0 ;;
+        "rev-parse --verify HEAD") echo "abc1234"; return 0 ;;
+        "status --porcelain") echo ""; return 0 ;;
+        "check-ref-format --branch task/next-flow") return 0 ;;
+        "checkout -b task/next-flow main") echo "CHECKOUT_NEW"; return 0 ;;
+        "checkout --detach abc1234") echo "RESTORE_DETACHED"; return 0 ;;
+        "branch -D task/next-flow") : > "'"$branch_cleanup_marker"'"; return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+
+    _flow_new next-flow --branch main
+  '
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "CHECKOUT_NEW" ]]
+  [[ "$output" =~ "RESTORE_DETACHED" ]]
+  [ -f "$branch_cleanup_marker" ]
+  [[ "$output" =~ "Failed to update worktree runtime state" ]]
+}
+
 @test "2.6 _flow_switch re-enters an existing open flow without PR history" {
   run zsh -c '
     source "'"$VIBE_ROOT"'/lib/config.sh"

--- a/tests/skills/test_skills.bats
+++ b/tests/skills/test_skills.bats
@@ -61,7 +61,7 @@ SHELL
 }
 
 @test "workflow and skill docs preserve github project orchestration terminology" {
-  run rg -n \
+  run rg -nH \
     "roadmap item.*GitHub Project item mirror|Roadmap Item: mirrored GitHub Project item|task.*execution record|Task: execution record" \
     "$REPO_ROOT/.agent/workflows" \
     "$REPO_ROOT/skills/vibe-roadmap/SKILL.md" \
@@ -74,7 +74,7 @@ SHELL
 }
 
 @test "task save and check docs treat spec_standard and spec_ref as extension fields" {
-  run rg -n \
+  run rg -nH \
     "spec_standard|spec_ref|扩展桥接字段|extension field|execution spec" \
     "$REPO_ROOT/.agent/workflows/vibe:save.md" \
     "$REPO_ROOT/.agent/workflows/vibe:check.md" \
@@ -88,7 +88,7 @@ SHELL
 }
 
 @test "orchestration docs require reading shell output before semantic decisions" {
-  run rg -n \
+  run rg -nH \
     "先读 shell 输出|先运行 `vibe|必须先运行 `vibe|read shell output" \
     "$REPO_ROOT/.agent/workflows/vibe:task.md" \
     "$REPO_ROOT/.agent/workflows/vibe:save.md" \
@@ -103,7 +103,7 @@ SHELL
 }
 
 @test "handoff governance is defined in a standard and referenced by CLAUDE and skills" {
-  run rg -n \
+  run rg -nH \
     "handoff-governance-standard|task\\.md.*不是.*真源|发现.*不一致.*必须修正" \
     "$REPO_ROOT/docs/standards/handoff-governance-standard.md" \
     "$REPO_ROOT/CLAUDE.md" \
@@ -129,12 +129,23 @@ SHELL
 }
 
 @test "vibe-commit docs require task metadata preflight before commit grouping" {
-  run rg -n \
+  run rg -nH \
     "metadata preflight|current_task|runtime_branch|issue_refs|roadmap_item_ids|spec_standard|spec_ref|hard block|warning" \
-    "$REPO_ROOT/.agent/workflows/vibe:commit.md" \
+    "$REPO_ROOT/.agent/workflows/vibe:commit.md"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "vibe:commit.md" ]]
+  [[ "$output" =~ "current_task" ]]
+  [[ "$output" =~ "runtime_branch" ]]
+  [[ "$output" =~ "issue_refs" ]]
+  [[ "$output" =~ "roadmap_item_ids" ]]
+
+  run rg -nH \
+    "metadata preflight|current_task|runtime_branch|issue_refs|roadmap_item_ids|spec_standard|spec_ref|hard block|warning" \
     "$REPO_ROOT/skills/vibe-commit/SKILL.md"
 
   [ "$status" -eq 0 ]
+  [[ "$output" =~ "vibe-commit/SKILL.md" ]]
   [[ "$output" =~ "current_task" ]]
   [[ "$output" =~ "runtime_branch" ]]
   [[ "$output" =~ "issue_refs" ]]


### PR DESCRIPTION
## Summary
- fix the `vibe:commit` workflow references and step numbering noted after PR #111 merged
- harden `vibe flow new` rollback so detached-HEAD worktrees restore the original commit before deleting the failed branch
- tighten the skill contract test so workflow and skill docs are each asserted independently

## Validation
- `bats -f '2.5.1 _flow_new restores the original branch when runtime update fails' tests/flow/test_flow_lifecycle.bats`
- `bats -f '2.5.1a _flow_new restores detached HEAD before deleting the failed branch' tests/flow/test_flow_lifecycle.bats`
- `bats tests/skills/test_skills.bats`
- `rg -n "vibe:commit\\.md|^4\\.|^5\\.|checkout --detach|flow new to \\$branch_name" .agent/workflows/vibe:commit.md docs/plans/2026-03-11-commit-preflight-metadata-plan.md lib/flow.sh lib/flow_runtime.sh`

Follow-up patch for merged PR #111.