### PR TITLE
fix(v2): improve error messages and help text for task/flow commands

### DIFF
--- a/lib/task_actions.sh
+++ b/lib/task_actions.sh
@@ -51,9 +51,12 @@ _vibe_task_update() {
     _vibe_task_require_file "$registry_file" "registry.json" || return 1
     jq -e --arg task_id "$task_id" '.tasks[]? | select(.task_id == $task_id)' "$registry_file" >/dev/null 2>&1 || { vibe_die "Task not found in registry: $task_id"; return 1; }
     [[ -z "$task_status" ]] || task_status="$(_vibe_task_normalize_and_validate_status "$task_status")" || { vibe_die "Invalid task status: $task_status"; return 1; }
-    [[ "$spec_mode" != "set" ]] || spec_standard="$(_vibe_task_normalize_and_validate_spec_standard "${spec_standard:-none}")" || { vibe_die "Invalid spec standard: ${spec_standard:-}"; return 1; }
+    [[ "$spec_mode" != "set" ]] || spec_standard="$(_vibe_task_normalize_and_validate_spec_standard "${spec_standard:-none}")" || {
+        vibe_die "Invalid spec standard: ${spec_standard:-}\n  支持的值: openspec, kiro, superpowers, supervisor"
+        return 1
+    }
     if [[ -n "$agent" ]]; then
-        case "$agent" in codex|antigravity|trae|claude|opencode|kiro) ;; *) [[ "$force" -eq 1 ]] || { vibe_die "Unsupported agent: $agent"; return 1; } ;; esac
+        # Accept any agent string (v2 bug fix: relaxed validation)
         email_slug="$agent"; [[ "$force" -eq 1 ]] && email_slug="$(_vibe_task_slugify "$agent")"
     fi
     if [[ "$unassign" == "true" ]]; then
@@ -111,6 +114,11 @@ _vibe_task_add() {
     local -a issue_refs roadmap_item_ids
     if [[ "$1" == "-h" || "$1" == "--help" ]]; then
         echo "Usage: vibe task add <title> [--id <task-id>] [--issue <ref>]... [--roadmap-item <id>]... [--pr <ref>] [--spec-standard <standard>] [--spec-ref <ref>]"
+        echo ""
+        echo "Options:"
+        echo "  --spec-standard <standard>  Execution spec 规范体系（必填）"
+        echo "                              支持的值: openspec, kiro, superpowers, supervisor"
+        echo "  --spec-ref <ref>            Execution spec 入口或文档引用（必填）"
         return 0
     fi
     if [[ $# -gt 0 && ! "$1" =~ ^-- ]]; then title="$1"; shift; fi
@@ -131,7 +139,11 @@ _vibe_task_add() {
         esac
     done
     [[ -n "$title" ]] || { vibe_die "Missing title for task add"; return 1; }
-    spec_standard="$(_vibe_task_normalize_and_validate_spec_standard "$spec_standard")" || { vibe_die "Invalid spec standard: $spec_standard"; return 1; }
+    local original_spec_standard="$spec_standard"
+    spec_standard="$(_vibe_task_normalize_and_validate_spec_standard "$spec_standard")" || {
+        vibe_die "Invalid spec standard: $original_spec_standard\n  支持的值: openspec, kiro, superpowers, supervisor"
+        return 1
+    }
     if [[ -z "$task_id" ]]; then local slug; slug="$(_vibe_task_slugify "$title")"; task_id="$(_vibe_task_today)-$slug"; fi
     [[ "$spec_standard" == "kiro" && -z "$spec_ref" ]] && spec_ref=".kiro/specs/$task_id"
     _vibe_task_require_plan_binding_for_add "$spec_standard" "$spec_ref" || return 1

--- a/lib/task_roadmap_links.sh
+++ b/lib/task_roadmap_links.sh
@@ -44,7 +44,7 @@ _vibe_task_sync_roadmap_links() {
 _vibe_task_require_plan_binding_for_add() {
     local spec_standard="$1" spec_ref="$2"
     if [[ "$spec_standard" == "none" || -z "$spec_ref" ]]; then
-        vibe_die "Task creation requires a plan binding. Create or select a roadmap item via 'vibe roadmap add (shell)', then use the writing-plans skill to produce a plan, and re-run vibe task add with --spec-standard/--spec-ref."
+        vibe_die $'Task creation requires a plan binding.\n\n  选项 1: 从已有 plan 创建（推荐）\n    vibe task add <title> --issue <issue> \\\n      --spec-standard openspec \\\n      --spec-ref docs/plans/example.md\n\n  选项 2: 从 roadmap item 创建\n    vibe roadmap add <title> --issue <issue>\n    vibe task add <title> --spec-standard openspec --spec-ref <plan-path>'
         return 1
     fi
 }

--- a/skills/vibe-start/SKILL.md
+++ b/skills/vibe-start/SKILL.md
@@ -25,7 +25,43 @@ description: Use when the user wants to execute the current flow's bound tasks f
 - 不允许：创建新的 roadmap item 或 plan；绕过 plan 自由编码；跨 worktree 调度
 - 若发现当前 flow 已有 PR，本 skill 只能处理该 flow 合法范围内的 follow-up 或当前已绑定 task，不得把新目标堆进当前 flow
 
+## Prerequisites
+
+在运行 `vibe-start` 之前，确保以下对象已存在：
+
+1. ✅ **Repo Issue** 已创建（`gh issue view <number>`）
+2. ✅ **Roadmap Item** 已创建（`vibe roadmap list` 检查）
+3. ✅ **Plan Document** 已存在（例如 `docs/plans/example.md`）
+4. ✅ **Task 已创建** 并具备 `spec_standard` 和 `spec_ref`（`vibe task show <task-id>` 检查）
+5. ✅ **Task 已绑定到当前 flow**（`vibe flow show` 检查）
+
+若缺少任何前置对象：
+- 先运行 `/vibe-new` 创建 flow 并绑定主 issue
+- 或手动补齐缺失对象后重新进入
+
 ## Workflow
+
+### Step 0: Check Prerequisites
+
+在执行前，验证所有前置对象已就位：
+
+```bash
+# 检查当前 flow 状态
+vibe flow show --json
+
+# 检查 task 是否已创建并绑定
+vibe task list --json
+
+# 检查 plan 文件是否存在
+ls docs/plans/<plan-name>.md
+```
+
+若发现缺失：
+- 缺少 issue → 运行 `/vibe-issue`
+- 缺少 roadmap item → 运行 `/vibe-roadmap`
+- 缺少 plan → 委托 `writing-plans` 或手动创建
+- 缺少 task → 使用 `vibe task add --spec-standard <standard> --spec-ref <plan-path>`
+- task 未绑定 flow → 使用 `vibe task update --bind-current`
 
 ### Step 1: 读取当前 flow、issue 与 task
 


### PR DESCRIPTION
## Summary
- Improve `vibe task add --spec-standard` error message to show supported values (openspec, kiro, superpowers, supervisor)
- Relax `vibe flow bind --agent` validation to accept any string
- Clarify `vibe task add` error message with two clear options when plan binding is missing
- Update `vibe-start` skill documentation with prerequisites section and Step 0 check

Fixes #181

## Test plan
- [x] `vibe task add --help` shows supported spec-standard values
- [x] `vibe task add --spec-standard invalid` shows helpful error with user's input
- [x] `vibe task update ... --agent "Claude Sonnet 4.6"` accepts custom agent
- [x] `vibe task add "Test"` shows clear options with proper formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)