### PR TITLE
feat(run): add run command for executing plans

### DIFF
--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -12,7 +12,18 @@ import typer.rich_utils as _ru
 from loguru import logger
 from rich import box as _box
 
-from vibe3.commands import check, flow, handoff, hooks, inspect, plan, pr, review, task
+from vibe3.commands import (
+    check,
+    flow,
+    handoff,
+    hooks,
+    inspect,
+    plan,
+    pr,
+    review,
+    run,
+    task,
+)
 from vibe3.exceptions import SystemError, UserError
 from vibe3.observability import setup_logging
 
@@ -41,6 +52,7 @@ app = typer.Typer(
 app.add_typer(flow.app, name="flow")
 app.add_typer(task.app, name="task")
 app.add_typer(plan.app, name="plan")
+app.add_typer(run.app, name="run")
 app.add_typer(pr.app, name="pr")
 app.add_typer(inspect.app, name="inspect")
 app.add_typer(review.app, name="review")

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -1,0 +1,152 @@
+"""Run command - Execute implementation plans using codeagent-wrapper."""
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+from loguru import logger
+
+from vibe3.clients.git_client import GitClient
+from vibe3.config.settings import VibeConfig
+from vibe3.services.flow_service import FlowService
+from vibe3.services.review_runner import ReviewAgentOptions, run_review_agent
+from vibe3.services.run_context_builder import build_run_context
+from vibe3.utils.trace import enable_trace
+
+app = typer.Typer(
+    name="run",
+    help="Execute implementation plans using codeagent-wrapper",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+_TRACE_OPT = Annotated[
+    bool, typer.Option("--trace", help="Enable call tracing + DEBUG logs")
+]
+_DRY_RUN_OPT = Annotated[
+    bool,
+    typer.Option("--dry-run", help="Print command and prompt without executing"),
+]
+_MESSAGE_OPT = Annotated[
+    Optional[str],
+    typer.Option("--message", "-m", help="Additional task guidance"),
+]
+_AGENT_OPT = Annotated[
+    Optional[str],
+    typer.Option(
+        "--agent", help="Override agent preset (e.g., executor, executor-pro)"
+    ),
+]
+_BACKEND_OPT = Annotated[
+    Optional[str],
+    typer.Option("--backend", help="Override backend (claude, codex)"),
+]
+_MODEL_OPT = Annotated[
+    Optional[str],
+    typer.Option("--model", help="Override model (e.g., claude-3-opus)"),
+]
+
+
+def _get_agent_options(
+    config: VibeConfig,
+    agent: str | None,
+    backend: str | None,
+    model: str | None,
+) -> ReviewAgentOptions:
+    run_config = getattr(config, "run", None)
+    config_agent = None
+    config_backend = None
+    config_model = None
+
+    if run_config and hasattr(run_config, "agent_config"):
+        ac = run_config.agent_config
+        config_agent = ac.agent if hasattr(ac, "agent") else None
+        config_backend = ac.backend if hasattr(ac, "backend") else None
+        config_model = ac.model if hasattr(ac, "model") else None
+
+    return ReviewAgentOptions(
+        agent=agent or config_agent or "executor",
+        backend=backend or config_backend,
+        model=model or config_model,
+    )
+
+
+def _run_execution(
+    plan_file: str,
+    config: VibeConfig,
+    dry_run: bool,
+    message: str | None,
+    agent: str | None,
+    backend: str | None,
+    model: str | None,
+) -> None:
+    log = logger.bind(domain="run", plan_file=plan_file)
+
+    log.info("Building run context")
+    prompt_file_content = build_run_context(plan_file, config)
+
+    task = message
+    if message:
+        log.info("Using custom task message")
+        typer.echo(f"-> Guidance: {message[:60]}{'...' if len(message) > 60 else ''}")
+
+    run_config = getattr(config, "run", None)
+    if not task and run_config and hasattr(run_config, "run_prompt"):
+        task = run_config.run_prompt
+
+    options = _get_agent_options(config, agent, backend, model)
+
+    log.info(
+        "Running execution agent",
+        agent=options.agent,
+        backend=options.backend,
+        model=options.model,
+    )
+    typer.echo(f"-> Executing plan with {options.agent or options.backend}...")
+    result = run_review_agent(prompt_file_content, options, task=task, dry_run=dry_run)
+
+    if dry_run:
+        return
+
+    typer.echo("\n" + result.stdout)
+
+
+@app.command()
+def execute(
+    file: Annotated[
+        Optional[Path],
+        typer.Option("--file", "-f", help="Path to plan file"),
+    ] = None,
+    trace: _TRACE_OPT = False,
+    dry_run: _DRY_RUN_OPT = False,
+    message: _MESSAGE_OPT = None,
+    agent: _AGENT_OPT = None,
+    backend: _BACKEND_OPT = None,
+    model: _MODEL_OPT = None,
+) -> None:
+    if trace:
+        enable_trace()
+
+    config = VibeConfig.get_defaults()
+
+    if file is None:
+        git = GitClient()
+        branch = git.get_current_branch()
+        flow = FlowService().get_flow_status(branch)
+        if not flow or not flow.plan_ref:
+            typer.echo(
+                "Error: No file provided and current flow has no plan "
+                "reference.\nUse 'vibe3 run execute --file plan.md' "
+                "or set a plan on the current flow.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        file = Path(flow.plan_ref)
+        typer.echo(f"-> Using flow plan: {file}")
+
+    plan_file = str(file)
+    log = logger.bind(domain="run", action="execute", plan_file=plan_file)
+    log.info("Starting plan execution")
+    typer.echo(f"-> Execute: {plan_file}")
+
+    _run_execution(plan_file, config, dry_run, message, agent, backend, model)

--- a/src/vibe3/services/run_context_builder.py
+++ b/src/vibe3/services/run_context_builder.py
@@ -1,0 +1,83 @@
+"""Run context builder - Build context for execution agent.
+
+Reuses plan_context_builder logic but changes:
+- Task section: execute the plan
+- Output contract: code changes + report
+"""
+
+from pathlib import Path
+
+from loguru import logger
+
+from vibe3.config.settings import VibeConfig
+
+
+def build_run_context(
+    plan_file: str,
+    config: VibeConfig | None = None,
+) -> str:
+    """Build run context from a plan file.
+
+    Args:
+        plan_file: Path to plan file (markdown)
+        config: VibeConfig instance
+
+    Returns:
+        Complete run context string
+    """
+    if config is None:
+        config = VibeConfig.get_defaults()
+
+    log = logger.bind(domain="run_context_builder", action="build_run_context")
+    log.info("Building run context from plan file")
+
+    if not Path(plan_file).exists():
+        raise FileNotFoundError(f"Plan file not found: {plan_file}")
+
+    plan_content = Path(plan_file).read_text(encoding="utf-8")
+
+    sections: list[str] = []
+
+    run_config = getattr(config, "run", None)
+    if run_config and hasattr(run_config, "policy_file"):
+        policy_path = run_config.policy_file
+        if policy_path and Path(policy_path).exists():
+            sections.append(Path(policy_path).read_text(encoding="utf-8"))
+
+    from vibe3.services.context_builder import build_tools_guide_section
+
+    tools_guide = build_tools_guide_section(
+        getattr(config.review, "tools_guide_file", None)
+    )
+    if tools_guide:
+        sections.append(tools_guide)
+
+    sections.append(f"## Implementation Plan\n\n{plan_content}")
+
+    sections.append("""## Execution Task
+
+- Execute the implementation plan
+- Make the necessary code changes
+- Ensure changes compile and pass tests
+- Output a report of changes made
+""")
+
+    sections.append("""## Output format requirements
+
+Output a structured report in this format:
+
+## Changes Made
+[List of files changed with brief description of modifications]
+
+## Summary
+[1-2 sentence summary of what was accomplished]
+
+## Verification
+- [ ] Code compiles
+- [ ] Tests pass
+- [ ] No regressions
+""")
+
+    context = "\n\n---\n\n".join(sections)
+    log.bind(context_len=len(context)).success("Run context built")
+    return context

--- a/tests/vibe3/commands/test_run.py
+++ b/tests/vibe3/commands/test_run.py
@@ -1,0 +1,85 @@
+"""Tests for run command."""
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from vibe3.cli import app as cli_app
+from vibe3.commands.run import app as run_app
+
+runner = CliRunner(env={"NO_COLOR": "1"})
+
+
+def strip_ansi(text: str) -> str:
+    ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
+    return ansi_escape.sub("", text)
+
+
+def test_run_help_shows_execute_command() -> None:
+    result = runner.invoke(run_app, ["--help"])
+    stdout = strip_ansi(result.stdout)
+
+    assert result.exit_code == 0
+    assert "execute" in stdout
+
+
+def test_run_execute_help_shows_file_option() -> None:
+    result = runner.invoke(run_app, ["execute", "--help"])
+    stdout = strip_ansi(result.stdout)
+
+    assert result.exit_code == 0
+    assert "--file" in stdout or "-f" in stdout
+
+
+def test_run_execute_requires_file_or_flow_plan() -> None:
+    result = runner.invoke(run_app, ["execute"])
+
+    assert result.exit_code != 0
+
+
+def test_run_execute_file_not_found() -> None:
+    result = runner.invoke(run_app, ["execute", "--file", "nonexistent.md"])
+
+    assert result.exit_code != 0
+
+
+def test_run_execute_dry_run_shows_command() -> None:
+    mock_context = "# Test Plan\n\n## Task\nTest execution"
+    mock_result = MagicMock()
+    mock_result.stdout = "Mocked execution output"
+
+    with patch("vibe3.commands.run.build_run_context", return_value=mock_context):
+        with patch("vibe3.commands.run.run_review_agent", return_value=mock_result):
+            result = runner.invoke(
+                cli_app, ["run", "execute", "--file", "plan.md", "--dry-run"]
+            )
+
+    assert result.exit_code == 0
+    assert "-> Execute: plan.md" in result.stdout
+    assert "-> Executing plan with executor" in result.stdout
+
+
+def test_run_execute_with_agent_override() -> None:
+    mock_context = "# Test Plan\n\n## Task\nTest execution"
+    mock_result = MagicMock()
+    mock_result.stdout = "Mocked execution output"
+
+    with patch("vibe3.commands.run.build_run_context", return_value=mock_context):
+        with patch("vibe3.commands.run.run_review_agent", return_value=mock_result):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "run",
+                    "execute",
+                    "--file",
+                    "plan.md",
+                    "--agent",
+                    "executor-pro",
+                    "--dry-run",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert "-> Execute: plan.md" in result.stdout
+    assert "-> Executing plan with executor-pro" in result.stdout


### PR DESCRIPTION
## Summary

实现 `vibe3 run` 命令：从 plan 文件执行代码变更，产出 report。

### Usage
\`\`\`bash
# 执行当前 flow 的 plan (flow.plan_ref)
vibe3 run execute

# 从指定文件执行
vibe3 run execute --file plan.md

# 附加指导
vibe3 run execute -m "优先处理安全问题"

# Agent 覆盖
vibe3 run execute --agent executor-pro
\`\`\`

### Files Changed
- \`src/vibe3/commands/run.py\` - Run CLI 命令
- \`src/vibe3/services/run_context_builder.py\` - Run 上下文构建器
- \`src/vibe3/cli.py\` - 注册 run 命令
- \`tests/vibe3/commands/test_run.py\` - 测试

### Design
- 复用 \`review_runner\` 和 \`ReviewAgentOptions\`
- 默认 agent: "executor"
- 从 \`flow.plan_ref\` 读取默认 plan 文件

## Test Plan
- [x] 6 tests pass
- [x] Pre-commit checks pass
- [x] Dry-run shows correct command