### PR TITLE
fix(flow): avoid hard failure when gh CLI is unavailable during spec derivation

### DIFF
--- a/src/vibe3/services/spec_ref_service.py
+++ b/src/vibe3/services/spec_ref_service.py
@@ -93,11 +93,26 @@ class SpecRefService:
         )
 
     def _fetch_issue_data(self, issue_number: int) -> dict | None:
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue_number), "--json", "number,title,body"],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--json",
+                    "number,title,body",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            logger.bind(
+                external="github",
+                operation="fetch_issue_data",
+                issue_number=issue_number,
+            ).warning("GitHub CLI not found, fallback to issue number only")
+            return None
 
         if result.returncode != 0:
             logger.bind(


### PR DESCRIPTION
### Motivation
- 修复在没有安装 GitHub CLI (`gh`) 的环境下，`flow add --task <id>` 在尝试从 issue 派生 `spec_ref` 时抛出 `FileNotFoundError` 导致命令/测试失败的问题。 

### Description
- 在 `SpecRefService._fetch_issue_data` 中为对 `gh` 的 `subprocess.run` 调用增加 `FileNotFoundError` 捕获，改为记录 warning 并返回 `None`，从而回退到仅使用 issue 编号的轻量派生逻辑，并保留原有对非零返回码的警告处理。 (`src/vibe3/services/spec_ref_service.py`) 

### Testing
- 运行了定向回归测试 `uv run pytest tests/vibe3/commands/test_flow_actor_defaults.py tests/vibe3/services/test_flow_usecase.py tests/vibe3/commands/test_pr_create_ai.py tests/vibe3/commands/test_task_hints.py -q`，结果全部通过；并单独运行 `uv run pytest tests/vibe3/services/test_spec_ref_service.py -q`，结果全部通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68180bf4c832b913f4a1da30d79cb)