### PR TITLE
fix: guard plan/task gh calls when GitHub CLI is unavailable

### DIFF
--- a/src/vibe3/services/plan_usecase.py
+++ b/src/vibe3/services/plan_usecase.py
@@ -110,7 +110,10 @@ class PlanUsecase:
         self.flow_service.bind_spec(branch, spec_path, "user")
 
     def _build_issue_context(self, issue_number: int, heading: str) -> str | None:
-        issue = self.github_client.view_issue(issue_number)
+        try:
+            issue = self.github_client.view_issue(issue_number)
+        except (FileNotFoundError, RuntimeError):
+            return None
         if not isinstance(issue, dict):
             return None
         parts = [f"## {heading}", f"Issue: #{issue_number}"]

--- a/src/vibe3/services/task_label_service.py
+++ b/src/vibe3/services/task_label_service.py
@@ -32,11 +32,19 @@ class TaskLabelService:
         return self._add_vibe_task_label(issue_number)
 
     def _has_vibe_task_label(self, issue_number: int) -> bool:
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue_number), "--json", "labels"],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", str(issue_number), "--json", "labels"],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            logger.bind(
+                external="github",
+                operation="check_vibe_task_label",
+                issue_number=issue_number,
+            ).warning("gh command not found, skipping label check")
+            return False
 
         if result.returncode != 0:
             logger.bind(
@@ -57,18 +65,26 @@ class TaskLabelService:
         return False
 
     def _add_vibe_task_label(self, issue_number: int) -> bool:
-        result = subprocess.run(
-            [
-                "gh",
-                "issue",
-                "edit",
-                str(issue_number),
-                "--add-label",
-                VIBE_TASK_LABEL,
-            ],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--add-label",
+                    VIBE_TASK_LABEL,
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            logger.bind(
+                external="github",
+                operation="add_vibe_task_label",
+                issue_number=issue_number,
+            ).warning("gh command not found, skipping label add")
+            return False
 
         if result.returncode != 0:
             logger.bind(


### PR DESCRIPTION
### Motivation
- 修复在不含 `gh` (GitHub CLI) 的运行/测试环境中，`plan task --dry-run` 与 task 自动标记流程因未捕获的 `FileNotFoundError` 崩溃的问题。
- 保持有 `gh` 时的原有行为不变，仅在无 `gh` 环境下降级为 fail-soft，以便本地/CI 环境稳定运行测试。 

### Description
- 在 `src/vibe3/services/plan_usecase.py` 中，`_build_issue_context()` 捕获 `FileNotFoundError` 与 `RuntimeError`，在无法获取 issue 上下文时返回 `None`，从而使 `plan task --dry-run` 等路径继续执行而不抛出异常。
- 在 `src/vibe3/services/task_label_service.py` 中，对两个使用 `subprocess.run` 调用 `gh` 的方法（读标签与加标签）增加 `FileNotFoundError` 捕获，记录 warning 并以安全方式跳过相关操作，避免在无 `gh` 时抛出异常。
- 仅添加降级/兜底逻辑，保留原有 returncode 判断与日志，确保有 `gh` 时行为一致。 

### Testing
- 运行定向回归：`uv run pytest tests/vibe3/commands/test_plan.py::test_plan_task_dry_run_shows_command tests/vibe3/commands/test_plan.py::test_plan_task_with_agent_override tests/vibe3/commands/test_plan.py::test_plan_task_with_instructions tests/vibe3/services/test_flow_binding.py::TestFlowBinding::test_bind_flow_already_bound -q`，结果为 `4 passed`。
- 运行全量测试：`uv run pytest -q`，结果为 `740 passed, 9 skipped, 1 xpassed`，所有测试通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c693359e84832b88b0fb0d86eb352e)