### PR TITLE
feat(pr): inject Closes keyword on pr create for issue-PR linkage

### DIFF
--- a/src/vibe3/services/pr_utils.py
+++ b/src/vibe3/services/pr_utils.py
@@ -3,6 +3,7 @@
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
+from vibe3.clients.github_issues_ops import parse_linked_issues
 from vibe3.models.pr import PRMetadata
 
 
@@ -39,19 +40,57 @@ def get_metadata_from_flow(store: SQLiteClient, branch: str) -> PRMetadata | Non
     return metadata
 
 
+def _has_issue_linked(body: str, issue_number: int) -> bool:
+    """Check if body already contains a GitHub auto-close keyword for the issue.
+
+    Args:
+        body: PR body text
+        issue_number: Issue number to check
+
+    Returns:
+        True if a linking keyword (Closes/Fixes/Resolves #<n>) already exists
+    """
+    return issue_number in parse_linked_issues(body)
+
+
+def _build_linked_section(metadata: PRMetadata, body: str) -> str:
+    """Build the GitHub auto-link section for the bound task issue.
+
+    Injects ``Closes #<n>`` at the top of the body unless the body already
+    references the same issue with a linking keyword.
+
+    Args:
+        metadata: PR metadata (may contain task_issue)
+        body: Original PR body
+
+    Returns:
+        Linking line with trailing blank line, or empty string
+    """
+    if not metadata.task_issue:
+        return ""
+    if _has_issue_linked(body, metadata.task_issue):
+        return ""
+    return f"Closes #{metadata.task_issue}\n\n"
+
+
 def build_pr_body(body: str, metadata: PRMetadata | None = None) -> str:
     """Build PR body with metadata.
+
+    If a task issue is bound, prepends ``Closes #<n>`` to trigger GitHub's
+    native issue-PR linkage (unless the body already contains a linking
+    keyword for that issue).
 
     Args:
         body: Original PR body
         metadata: PR metadata
 
     Returns:
-        Enhanced PR body with metadata section
+        Enhanced PR body with linking section and metadata
     """
     if not metadata:
         return body
 
+    linked_section = _build_linked_section(metadata, body)
     metadata_section = "\n\n---\n\n## Vibe3 Metadata\n\n"
 
     if metadata.branch:
@@ -67,4 +106,4 @@ def build_pr_body(body: str, metadata: PRMetadata | None = None) -> str:
     if metadata.executor:
         metadata_section += f"**Executor:** {metadata.executor}\n"
 
-    return body + metadata_section
+    return linked_section + body + metadata_section

--- a/tests/vibe3/services/test_pr_utils.py
+++ b/tests/vibe3/services/test_pr_utils.py
@@ -1,0 +1,103 @@
+"""Tests for PR utility functions."""
+
+from vibe3.models.pr import PRMetadata
+from vibe3.services.pr_utils import (
+    _build_linked_section,
+    _has_issue_linked,
+    build_pr_body,
+)
+
+
+class TestHasIssueLinked:
+    """Tests for _has_issue_linked."""
+
+    def test_detects_closes_keyword(self) -> None:
+        assert _has_issue_linked("Closes #42", 42) is True
+
+    def test_detects_fixes_keyword(self) -> None:
+        assert _has_issue_linked("Fixes #42", 42) is True
+
+    def test_detects_resolves_keyword(self) -> None:
+        assert _has_issue_linked("Resolves #42", 42) is True
+
+    def test_case_insensitive(self) -> None:
+        assert _has_issue_linked("CLOSES #42", 42) is True
+        assert _has_issue_linked("fixes #42", 42) is True
+
+    def test_closed_variant(self) -> None:
+        assert _has_issue_linked("Closed #42", 42) is True
+
+    def test_fixed_variant(self) -> None:
+        assert _has_issue_linked("Fixed #42", 42) is True
+
+    def test_no_match_different_issue(self) -> None:
+        assert _has_issue_linked("Closes #99", 42) is False
+
+    def test_no_match_no_keyword(self) -> None:
+        assert _has_issue_linked("Task Issue: #42", 42) is False
+
+    def test_empty_body(self) -> None:
+        assert _has_issue_linked("", 42) is False
+
+    def test_none_body(self) -> None:
+        assert _has_issue_linked(None, 42) is False  # type: ignore[arg-type]
+
+    def test_keyword_mid_body(self) -> None:
+        assert _has_issue_linked("some text\nCloses #42\nmore text", 42) is True
+
+
+class TestBuildLinkedSection:
+    """Tests for _build_linked_section."""
+
+    def test_no_task_issue(self) -> None:
+        metadata = PRMetadata(branch="main", task_issue=None)
+        assert _build_linked_section(metadata, "body") == ""
+
+    def test_injects_closes_when_new(self) -> None:
+        metadata = PRMetadata(branch="main", task_issue=42)
+        result = _build_linked_section(metadata, "body")
+        assert result == "Closes #42\n\n"
+
+    def test_skips_when_already_linked(self) -> None:
+        metadata = PRMetadata(branch="main", task_issue=42)
+        body = "Closes #42 already here"
+        assert _build_linked_section(metadata, body) == ""
+
+    def test_skips_when_linked_with_fixes(self) -> None:
+        metadata = PRMetadata(branch="main", task_issue=42)
+        body = "Fixes #42"
+        assert _build_linked_section(metadata, body) == ""
+
+
+class TestBuildPrBody:
+    """Tests for build_pr_body."""
+
+    def test_no_metadata_passthrough(self) -> None:
+        assert build_pr_body("plain body") == "plain body"
+
+    def test_metadata_appended(self) -> None:
+        metadata = PRMetadata(branch="feature-1", task_issue=None)
+        result = build_pr_body("body", metadata)
+        assert result.startswith("body")
+        assert "**Branch:** feature-1" in result
+
+    def test_task_issue_injected_at_top(self) -> None:
+        metadata = PRMetadata(branch="feature-1", task_issue=42)
+        result = build_pr_body("body", metadata)
+        assert result.startswith("Closes #42\n\nbody")
+        assert "**Task Issue:** #42" in result
+
+    def test_no_duplicate_linking_keyword(self) -> None:
+        metadata = PRMetadata(branch="feature-1", task_issue=42)
+        body = "Fixes #42\n\nOriginal body"
+        result = build_pr_body(body, metadata)
+        # Should not prepend another Closes/Fixes
+        assert result.startswith("Fixes #42\n\nOriginal body")
+        # Count occurrences of linking keywords for #42
+        count = result.count("#42")
+        assert count == 2  # one in body, one in metadata section
+
+    def test_task_issue_only_in_metadata_when_zero(self) -> None:
+        metadata = PRMetadata(branch="feature-1", task_issue=0)
+        result = build_pr_body("body", metadata)
+        assert not result.startswith("Closes")


### PR DESCRIPTION
## Summary

- `build_pr_body()` 在有绑定 task issue 时，于 PR body 开头注入 `Closes #<n>`，触发 GitHub 原生双向 issue-PR 关联
- 复用已有 `parse_linked_issues()` 做去重检测，避免重复注入
- PR 合并时自动关闭对应 issue；若用户已手动写入关联关键词则跳过

Closes #300

## Test plan

- [x] 20 个新增单测覆盖：关键词检测（大小写/变体）、注入逻辑、去重防重复、无绑定 pass-through
- [x] 既有的 `test_pr_service.py` 6 个测试全部通过（无回归）
- [x] pre-push 全量检查通过（lint + type check + LOC + risk assessment）