### PR TITLE
fix(git): tolerate no-op merge abort during upstream conflict check

### DIFF
--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -232,10 +232,17 @@ class GitClient:
                     target_ref,
                 ]
             )
-            # No conflicts -- abort the dry-run merge
-            self._run(["merge", "--abort"])
+            # No conflicts. In "Already up to date" case no merge state exists,
+            # so abort may fail and should be ignored.
+            try:
+                self._run(["merge", "--abort"])
+            except GitError:
+                pass
             return False
         except GitError:
-            # Conflict or error -- abort and report
-            self._run(["merge", "--abort"])
+            # Conflict or error -- best-effort abort and report conflict.
+            try:
+                self._run(["merge", "--abort"])
+            except GitError:
+                pass
             return True

--- a/tests/vibe3/clients/test_git_client.py
+++ b/tests/vibe3/clients/test_git_client.py
@@ -148,3 +148,33 @@ class TestGetDiff:
         """测试 PR diff 但未注入 GitHubClient 时抛出错误."""
         with pytest.raises(GitError, match="requires GitHubClient"):
             client.get_diff(PRSource(pr_number=99))
+
+
+class TestCheckMergeConflicts:
+    """check_merge_conflicts 测试."""
+
+    def test_returns_false_when_abort_not_needed(self) -> None:
+        """merge 成功但无 merge state 时，abort 失败也应视为无冲突."""
+        client = GitClient()
+        with patch.object(
+            client,
+            "_run",
+            side_effect=[
+                "",
+                GitError("merge --abort", "There is no merge to abort"),
+            ],
+        ):
+            assert client.check_merge_conflicts("origin/main") is False
+
+    def test_returns_true_when_conflict_and_abort_fails(self) -> None:
+        """merge 冲突且 abort 失败时，不应抛异常，应返回有冲突."""
+        client = GitClient()
+        with patch.object(
+            client,
+            "_run",
+            side_effect=[
+                GitError("merge", "CONFLICT"),
+                GitError("merge --abort", "There is no merge to abort"),
+            ],
+        ):
+            assert client.check_merge_conflicts("origin/main") is True


### PR DESCRIPTION
### Motivation

- 修复 `GitClient.check_merge_conflicts()` 在 dry-run merge 成功但没有可回滚的 merge state（例如 Git 报告"Already up to date"）时，执行 `git merge --abort` 会抛出异常或误报冲突的健壮性问题。
- 该逻辑是对之前新增的 upstream 冲突检测（在 PR 创建/标记 ready 前检查 `origin/main`）的补强，以避免因为真实 Git 状态差异阻断正常流程。

### Description

- 将 `GitClient.check_merge_conflicts()` 中对 `merge --abort` 的调用改为 best-effort 包裹在 `try/except GitError` 中，分别在成功路径和失败路径都忽略 `merge --abort` 抛出的错误以防止二次异常影响返回结果（见 `src/vibe3/clients/git_client.py`）。
- 保持原有冲突判定逻辑不变：dry-run 成功返回 `False`，dry-run 出错返回 `True`。
- 新增两个单元测试覆盖边界情况：成功但 `merge --abort` 失败应返回 `False`，以及冲突并且 `merge --abort` 失败应返回 `True`（见 `tests/vibe3/clients/test_git_client.py`）。

### Testing

- 运行 `uv run pytest tests/vibe3/clients/test_git_client.py tests/vibe3/services/test_pr_conflict_check.py -q`，测试通过（所有用例通过）。
- 运行 `uv run pytest tests/vibe3/services/test_pr_conflict_check.py tests/vibe3/services/test_pr_service.py tests/vibe3/clients/test_git_client.py -q`，测试通过（所有用例通过）。
- 本次变更已提交并包含新增测试，所有本地自动化测试均通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71c7fb6e4832baa4ee65ca776dcf2)