### PR TITLE
fix(pr): include latest actor in contributors

### DIFF
--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -26,6 +26,7 @@ class PRMetadata(BaseModel):
     planner: Optional[str] = Field(None, description="Planner agent")
     executor: Optional[str] = Field(None, description="Executor agent")
     reviewer: Optional[str] = Field(None, description="Reviewer agent")
+    latest: Optional[str] = Field(None, description="Latest actor")
 
     @property
     def contributors(self) -> list[str]:
@@ -37,7 +38,7 @@ class PRMetadata(BaseModel):
         default_values = {"unknown", "system", "server", ""}
         seen: set[str] = set()
         result: list[str] = []
-        for actor in (self.planner, self.executor, self.reviewer):
+        for actor in (self.planner, self.executor, self.reviewer, self.latest):
             if actor and actor.lower() not in default_values and actor not in seen:
                 seen.add(actor)
                 result.append(actor)

--- a/src/vibe3/services/pr_utils.py
+++ b/src/vibe3/services/pr_utils.py
@@ -32,6 +32,7 @@ def get_metadata_from_flow(store: SQLiteClient, branch: str) -> PRMetadata | Non
         planner=flow_data.get("planner_actor"),
         executor=flow_data.get("executor_actor"),
         reviewer=flow_data.get("reviewer_actor"),
+        latest=flow_data.get("latest_actor"),
     )
 
     logger.bind(

--- a/tests/vibe3/services/test_pr_utils.py
+++ b/tests/vibe3/services/test_pr_utils.py
@@ -138,6 +138,17 @@ class TestContributors:
         metadata = PRMetadata(planner="", executor="claude-opus")
         assert metadata.contributors == ["claude-opus"]
 
+    def test_latest_actor_included(self) -> None:
+        metadata = PRMetadata(latest="codex/gpt-5.4")
+        assert metadata.contributors == ["codex/gpt-5.4"]
+
+    def test_latest_actor_deduplicated(self) -> None:
+        metadata = PRMetadata(
+            planner="claude-opus",
+            latest="claude-opus",
+        )
+        assert metadata.contributors == ["claude-opus"]
+
 
 class TestBuildPrBodyContributors:
     """Tests for contributors section in build_pr_body."""


### PR DESCRIPTION
Follow-up for #315.

## Summary
- Include `latest_actor` in PR metadata extraction (`latest` field)
- Include `latest` in contributors aggregation (filtered + deduplicated)
- Add tests for latest-actor inclusion and dedup behavior

## Why
Issue #311 defines contributor sources as:
- `planner_actor`
- `executor_actor`
- `reviewer_actor`
- `latest_actor`

PR #315 currently misses `latest_actor`, so contributor signatures can be incomplete.

## Testing
- `uv run pytest -q tests/vibe3/services/test_pr_utils.py`
- `uv run pytest -q tests/vibe3/services/test_pr_service.py tests/vibe3/services/test_pr_utils.py`
