### PR TITLE
refactor(flow): prune legacy task surfaces for 281/282

### DIFF
--- a/docs/standards/issue-standard.md
+++ b/docs/standards/issue-standard.md
@@ -102,7 +102,6 @@ vibe3 flow bind 218 --role dependency
 
 说明：
 - Issue 与 Flow 的角色关系统一由 `flow bind` 表达
-- `task link` 属于历史兼容入口，不作为标准流程推荐
 
 **约束**：
 1. 一个 flow 只有一个 task 指针，重复 `flow bind <issue>` 会覆盖 `flow_state.task_issue_number`
@@ -146,8 +145,8 @@ WHERE issue_role = 'repo';
 ## 查询语义
 
 ```bash
-# 查看某个 issue 的所有关联 flow
-vibe3 task list --issue 219
+# 查看所有本地 task（flow 维度）
+vibe3 task list
 
 # 查看 flow 完整信息
 vibe3 task show task/my-feature

--- a/docs/standards/v3/command-standard.md
+++ b/docs/standards/v3/command-standard.md
@@ -423,23 +423,7 @@ provider 只允许：
 - task 完成后必须清空 runtime 绑定
 - task 归档后必须清空 runtime 绑定
 
-### 5.8 `task link` 语义
-
-`vibe3 task link` 为当前 flow 记录 `related` / `dependency` issue 关系：
-
-```bash
-# 为当前 flow 增加 related issue
-vibe3 task link 219 --role related
-
-# 为当前 flow 增加 dependency issue
-vibe3 task link 218 --role dependency
-```
-
-**关键区别**:
-- `flow bind`: Issue → Flow 关系（支持 `task/related/dependency`，更新 `task_issue_number`）
-- `task link`: 当前 flow 的补充关系入口（只支持 `related/dependency`）
-
-### 5.9 Prohibited Semantics
+### 5.8 Prohibited Semantics
 
 禁止：
 

--- a/docs/standards/v3/handoff-store-standard.md
+++ b/docs/standards/v3/handoff-store-standard.md
@@ -340,10 +340,6 @@ CREATE TABLE flow_events (
 - `handoff audit` - 记录 audit handoff
 - `handoff append` - 追加轻量更新到 current.md
 
-**Task 操作**：
-- `task link` - 关联 issue 到 flow
-- `task status` - 更新 GitHub Project task 状态
-
 **PR 操作**：
 - `pr draft` - 创建 draft PR
 - `pr merge` - 合并 PR

--- a/docs/standards/vibe3-command-standard.md
+++ b/docs/standards/vibe3-command-standard.md
@@ -85,7 +85,7 @@ SQLite (本地缓存)                 GitHub (真源)
 
 **兼容说明**：
 - `flow new` 为历史别名，标准入口为 `flow add`
-- `task link` / `task status` / `task bridge` 不再作为标准流程推荐（收敛到 flow 驱动）
+- `task status` 不再作为标准流程推荐（收敛到 flow 驱动）
 
 ### 2.2 flow show vs task show
 
@@ -449,29 +449,21 @@ vibe3 task list [--issue <issue>]
 ```
 
 **参数**:
-- `--issue`: Issue number，当前按 task issue 反查 flow（可选）
-  - 类型: `int | None`
-  - 帮助: "Issue number to find linked flows"
+- 无（仅 `--trace` / `--json` 等通用输出参数）
 
 **行为**:
 - 列出所有 task（有 task_issue_number 的 flow）
-- 如果提供 `--issue`，当前查询该 task issue 关联的 flow
 - 搜索和状态过滤属于后续扩展
 
 **示例**:
 ```bash
 # 列出所有 task
 vibe3 task list
-
-# 反查关联 task
-vibe3 task list --issue 221
 ```
 
 ### 5.3 迁移与弃用
 
 标准流程收敛后，以下命令不再推荐：
-- `task link` → 统一迁移到 `flow bind --role related|dependency`
-- `task bridge` → 由 `flow bind --role task|dependency` 自动完成
 - `task status` → 目标由 flow 生命周期自动联动远端 Project 状态
 
 在兼容期内如果命令仍存在，视为历史兼容入口，不作为标准流程的一部分。

--- a/docs/standards/vibe3-user-guide.md
+++ b/docs/standards/vibe3-user-guide.md
@@ -460,35 +460,21 @@ vibe3 task list
 
 输出：
 ```
-  #220  task-bridge-github-project  active  [bound]  branch=task/task-bridge-github-project
-  #221  reports-unified-storage     active  [bound]  branch=task/reports-unified-storage
-  #222  pr-show-complete            active  [bound]  branch=task/pr-show-complete
-  #223  reports-cleanup             active  [bound]  branch=task/reports-cleanup
+  #220  task-bridge-github-project  active  branch=task/task-bridge-github-project
+  #221  reports-unified-storage     active  branch=task/reports-unified-storage
+  #222  pr-show-complete            active  branch=task/pr-show-complete
+  #223  reports-cleanup             active  branch=task/reports-cleanup
 ```
 
 ### 搜索 issue
 
-当前 `vibe3 task list` 只支持 `--issue` 反查 flow，不支持 `--search` / `--status`。
+`vibe3 task list` 只负责列出现有 flow/task 现场，不提供 issue 检索参数。
 
 如需搜索 GitHub issue，请使用：
 
 ```bash
 gh search issues "report"
 ```
-
-### 从 related issue 反查 flow
-
-```bash
-vibe3 task list --issue 221
-```
-
-输出：
-```
-Tasks linked to related issue #221:
-  #221  reports-unified-storage  active  [bound]  branch=task/reports-unified-storage
-```
-
-> **注意**：`--issue` 参数按 `related` 角色查询，不是按 `task` 角色。
 
 ### 查看单个 task 详情（含远端字段）
 

--- a/src/vibe3/clients/sqlite_client.py
+++ b/src/vibe3/clients/sqlite_client.py
@@ -220,27 +220,17 @@ class SQLiteClient:
             ).debug("Retrieved all flows")
             return flows
 
-    def get_flows_by_issue(
-        self, issue_number: int, role: str | None = None
-    ) -> list[dict[str, Any]]:
+    def get_flows_by_issue(self, issue_number: int, role: str) -> list[dict[str, Any]]:
         """Get all flows linked to a given issue number."""
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
-            if role:
-                cursor.execute(
-                    "SELECT f.* FROM flow_state f "
-                    "JOIN flow_issue_links l ON f.branch = l.branch "
-                    "WHERE l.issue_number = ? AND l.issue_role = ?",
-                    (issue_number, role),
-                )
-            else:
-                cursor.execute(
-                    "SELECT f.* FROM flow_state f "
-                    "JOIN flow_issue_links l ON f.branch = l.branch "
-                    "WHERE l.issue_number = ?",
-                    (issue_number,),
-                )
+            cursor.execute(
+                "SELECT f.* FROM flow_state f "
+                "JOIN flow_issue_links l ON f.branch = l.branch "
+                "WHERE l.issue_number = ? AND l.issue_role = ?",
+                (issue_number, role),
+            )
             flows = [dict(row) for row in cursor.fetchall()]
             logger.bind(
                 external="sqlite",

--- a/src/vibe3/commands/flow.py
+++ b/src/vibe3/commands/flow.py
@@ -19,7 +19,6 @@ from vibe3.ui.console import console
 from vibe3.ui.flow_ui import (
     render_flow_created,
     render_flow_status,
-    render_flow_status_table,
     render_flow_timeline,
     render_flows_table,
 )
@@ -148,11 +147,8 @@ def add(
         except FlowUsecaseError as error:
             _print_flow_error(error)
             raise typer.Exit(1) from error
-        except ValueError:
-            logger.bind(command="flow add", task=task_refs).warning(
-                "Invalid task ID format, skipping binding"
-            )
-            flow = usecase.add_flow(name=name, spec=spec, actor=actor)
+        except ValueError as error:
+            raise typer.BadParameter(str(error)) from error
 
         if json_output:
             typer.echo(json.dumps(flow.model_dump(), indent=2, default=str))
@@ -223,11 +219,8 @@ def create(
         except FlowUsecaseError as error:
             _print_flow_error(error)
             raise typer.Exit(1) from error
-        except ValueError:
-            logger.bind(command="flow create", task=task_refs).warning(
-                "Invalid task ID format, skipping binding"
-            )
-            flow = usecase.create_flow(name=name, base=base, spec=spec, actor=actor)
+        except ValueError as error:
+            raise typer.BadParameter(str(error)) from error
 
         if json_output:
             typer.echo(json.dumps(flow.model_dump(), indent=2, default=str))
@@ -351,7 +344,7 @@ def status(
             if not flow_status:
                 logger.info("No active flow on current branch")
                 raise typer.Exit(0)
-            render_flow_status_table(flow_status)
+            render_flow_status(flow_status)
 
 
 @app.command()

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -33,13 +33,6 @@ def _build_task_usecase() -> TaskUsecase:
 
 @app.command()
 def list(
-    issue: Annotated[
-        str | None,
-        typer.Option(
-            "--issue",
-            help="Issue number (or URL) — 查找该 issue 作为 related 角色关联的 flow",
-        ),
-    ] = None,
     trace: Annotated[bool, typer.Option("--trace")] = False,
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
@@ -48,24 +41,6 @@ def list(
         setup_logging(verbose=2)
 
     usecase = _build_task_usecase()
-
-    if issue is not None:
-        issue_number, flows_data = usecase.list_related_issue_tasks(issue)
-        if not flows_data:
-            typer.echo(f"No tasks linked to related issue #{issue_number}")
-            return
-        if json_output:
-            typer.echo(json.dumps(flows_data, indent=2, default=str))
-            return
-        typer.echo(f"Tasks linked to related issue #{issue_number}:")
-        for f in flows_data:
-            task_num = f.get("task_issue_number")
-            bound = "[bound]" if f.get("project_item_id") else "[unbound]"
-            typer.echo(
-                f"  #{task_num or '?'}  {f['flow_slug']}  "
-                f"{f['flow_status']}  {bound}  branch={f['branch']}"
-            )
-        return
 
     task_rows = usecase.list_task_rows()
     if not task_rows:
@@ -77,10 +52,9 @@ def list(
         )
         return
     for task_flow in task_rows:
-        bound = "[bound]" if task_flow.bound else "[unbound]"
         typer.echo(
             f"  #{task_flow.task_issue_number}  {task_flow.flow_slug}  "
-            f"{task_flow.flow_status}  {bound}  branch={task_flow.branch}"
+            f"{task_flow.flow_status}  branch={task_flow.branch}"
         )
 
 

--- a/src/vibe3/services/flow_usecase.py
+++ b/src/vibe3/services/flow_usecase.py
@@ -1,5 +1,6 @@
 """Usecase layer for flow command orchestration."""
 
+import re
 from collections.abc import Sequence
 from typing import Literal
 
@@ -10,7 +11,6 @@ from vibe3.services.handoff_service import HandoffService
 from vibe3.services.signature_service import SignatureService
 from vibe3.services.spec_ref_service import SpecRefService
 from vibe3.services.task_service import TaskService
-from vibe3.services.task_usecase import TaskUsecase
 
 
 class FlowUsecaseError(RuntimeError):
@@ -148,10 +148,13 @@ class FlowUsecase:
 
     @staticmethod
     def _parse_issue_number(issue: str) -> int:
-        try:
-            return TaskUsecase.parse_issue_ref(issue)
-        except ValueError as exc:
-            raise ValueError(f"Invalid issue format: {issue}") from exc
+        digits = issue.removeprefix("#")
+        if digits.isdigit():
+            return int(digits)
+        match = re.search(r"github\.com/[^/]+/[^/]+/issues/(\d+)", issue)
+        if match:
+            return int(match.group(1))
+        raise ValueError(f"Invalid issue format: {issue}")
 
     def _apply_initial_bindings(
         self,

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -84,60 +84,10 @@ class TaskService(TaskBridgeMixin):
             issue_role=role,
         )
 
-    def update_flow_status(
-        self,
-        branch: str,
-        status: Literal["active", "blocked", "done", "stale"],
-    ) -> FlowState:
-        """Update local flow scene status.
-
-        NOTE: flow_status 是本地执行现场状态，不等于 GitHub Project task 状态真源。
-        """
-        logger.bind(
-            domain="task",
-            action="update_flow_status",
-            branch=branch,
-            status=status,
-        ).info("Updating local flow scene status")
-
-        flow_data = self.store.get_flow_state(branch)
-        if not flow_data:
-            raise RuntimeError(f"Flow not found for branch {branch}")
-
-        self.store.update_flow_state(branch, flow_status=status)
-        self.store.add_event(
-            branch, "status_updated", "system", f"Status changed to {status}"
-        )
-        return FlowState(**flow_data)
-        return FlowState(**flow_data)
-
     def get_task(self, branch: str) -> FlowState | None:
         """Get task (flow) details."""
         logger.bind(domain="task", action="get", branch=branch).debug("Getting task")
         flow_data = self.store.get_flow_state(branch)
         if not flow_data:
             return None
-        return FlowState(**flow_data)
-
-    def set_next_step(
-        self,
-        branch: str,
-        next_step: str,
-    ) -> FlowState:
-        """Set next step for a task."""
-        logger.bind(
-            domain="task",
-            action="set_next_step",
-            branch=branch,
-            next_step=next_step,
-        ).info("Setting next step")
-
-        self.store.update_flow_state(branch, next_step=next_step)
-        self.store.add_event(
-            branch, "next_step_set", "system", f"Next step: {next_step}"
-        )
-
-        flow_data = self.store.get_flow_state(branch)
-        if not flow_data:
-            raise RuntimeError(f"Flow not found for branch {branch}")
         return FlowState(**flow_data)

--- a/src/vibe3/services/task_usecase.py
+++ b/src/vibe3/services/task_usecase.py
@@ -1,6 +1,5 @@
 """Usecase layer for task command orchestration."""
 
-import re
 from dataclasses import dataclass
 
 from vibe3.exceptions import GitError
@@ -18,7 +17,6 @@ class TaskListRow:
     flow_slug: str
     flow_status: str
     task_issue_number: int | None
-    bound: bool
 
 
 @dataclass
@@ -44,23 +42,6 @@ class TaskUsecase:
         self.flow_service = flow_service or FlowService()
         self.task_service = task_service or TaskService()
 
-    @staticmethod
-    def parse_issue_ref(issue_ref: str) -> int:
-        """Parse issue number from plain number or GitHub URL."""
-        digits = issue_ref.removeprefix("#")
-        if digits.isdigit():
-            return int(digits)
-        match = re.search(r"github\.com/[^/]+/[^/]+/issues/(\d+)", issue_ref)
-        if match:
-            return int(match.group(1))
-        raise ValueError(f"Invalid issue reference: {issue_ref}")
-
-    def list_related_issue_tasks(self, issue_ref: str) -> tuple[int, list[dict]]:
-        """List flows related to the given issue reference."""
-        issue_number = self.parse_issue_ref(issue_ref)
-        flows = self.flow_service.store.get_flows_by_issue(issue_number, role="related")
-        return issue_number, flows
-
     def list_task_rows(self) -> list[TaskListRow]:
         """List local tasks as UI-oriented rows."""
         task_flows = [
@@ -68,14 +49,12 @@ class TaskUsecase:
         ]
         rows: list[TaskListRow] = []
         for task_flow in task_flows:
-            links = self.flow_service.store.get_issue_links(task_flow.branch)
             rows.append(
                 TaskListRow(
                     branch=task_flow.branch,
                     flow_slug=task_flow.flow_slug,
                     flow_status=task_flow.flow_status,
                     task_issue_number=task_flow.task_issue_number,
-                    bound=any(link.get("project_item_id") for link in links),
                 )
             )
         return rows

--- a/src/vibe3/ui/flow_ui.py
+++ b/src/vibe3/ui/flow_ui.py
@@ -136,11 +136,6 @@ def render_flow_status(
     console.print()
 
 
-def render_flow_status_table(status: FlowStatusResponse) -> None:
-    """Alias kept for compatibility."""
-    render_flow_status(status)
-
-
 def render_flows_table(flows: list[FlowState]) -> None:
     """flow list — YAML style, one block per flow (branch-centric)."""
     for flow in flows:

--- a/tests/vibe3/commands/test_task_management_commands.py
+++ b/tests/vibe3/commands/test_task_management_commands.py
@@ -122,13 +122,12 @@ def test_task_link_command_removed() -> None:
     assert "No such command" in (result.stdout + result.stderr)
 
 
-def test_task_list_help_uses_issue_option() -> None:
+def test_task_list_help_no_issue_filter_option() -> None:
     result = runner.invoke(task_app, ["list", "--help"])
     stdout = strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "--issue" in stdout
-    assert "--repo-issue" not in stdout
+    assert "--issue" not in stdout
 
 
 def test_flow_bind_supports_related_role() -> None:

--- a/tests/vibe3/services/test_task_management.py
+++ b/tests/vibe3/services/test_task_management.py
@@ -1,60 +1,7 @@
 """Tests for Task management functionality."""
 
-import pytest
-
 from vibe3.models.flow import FlowState
 from vibe3.services.task_service import TaskService
-
-
-class TestFlowSceneStatus:
-    """Tests for local flow scene status management."""
-
-    def test_update_flow_status_success(self, mock_store) -> None:
-        """Test updating local flow scene status."""
-        # Configure mock to return updated state
-        updated_state = {
-            "branch": "test-branch",
-            "flow_slug": "test-flow",
-            "flow_status": "blocked",  # This is the updated status
-            "task_issue_number": None,
-            "next_step": None,
-            "updated_at": "2026-03-16T00:00:00",
-        }
-        mock_store.get_flow_state.return_value = updated_state
-
-        service = TaskService(store=mock_store)
-        result = service.update_flow_status(
-            branch="test-branch",
-            status="blocked",
-        )
-
-        assert isinstance(result, FlowState)
-        assert result.flow_status == "blocked"
-
-        # Verify store calls
-        mock_store.update_flow_state.assert_called_once_with(
-            "test-branch",
-            flow_status="blocked",
-        )
-        mock_store.add_event.assert_called_once_with(
-            "test-branch",
-            "status_updated",
-            "system",
-            "Status changed to blocked",
-        )
-
-    def test_update_flow_status_flow_not_found(self, mock_store) -> None:
-        """Test updating local flow scene status when flow not found."""
-        mock_store.get_flow_state.return_value = None
-
-        service = TaskService(store=mock_store)
-        with pytest.raises(RuntimeError, match="Flow not found"):
-            service.update_flow_status(
-                branch="nonexistent-branch",
-                status="blocked",
-            )
-        mock_store.update_flow_state.assert_not_called()
-        mock_store.add_event.assert_not_called()
 
 
 class TestTaskRetrieval:
@@ -88,47 +35,3 @@ class TestTaskRetrieval:
         result = service.get_task("nonexistent-branch")
 
         assert result is None
-
-
-class TestNextStep:
-    """Tests for managing next steps."""
-
-    def test_set_next_step_success(self, mock_store) -> None:
-        """Test setting next step for a task."""
-        # Configure mock to return state with next_step
-        updated_state = {
-            "branch": "test-branch",
-            "flow_slug": "test-flow",
-            "flow_status": "active",
-            "task_issue_number": None,
-            "next_step": "Write tests",  # This is the updated next_step
-            "updated_at": "2026-03-16T00:00:00",
-        }
-        mock_store.get_flow_state.return_value = updated_state
-
-        service = TaskService(store=mock_store)
-        result = service.set_next_step(
-            branch="test-branch",
-            next_step="Write tests",
-        )
-
-        assert isinstance(result, FlowState)
-        assert result.next_step == "Write tests"
-
-        # Verify store calls
-        mock_store.update_flow_state.assert_called_once_with(
-            "test-branch",
-            next_step="Write tests",
-        )
-        mock_store.add_event.assert_called_once()
-
-    def test_set_next_step_flow_not_found(self, mock_store) -> None:
-        """Test setting next step when flow not found."""
-        mock_store.get_flow_state.return_value = None
-
-        service = TaskService(store=mock_store)
-        with pytest.raises(RuntimeError, match="Flow not found"):
-            service.set_next_step(
-                branch="nonexistent-branch",
-                next_step="Write tests",
-            )

--- a/tests/vibe3/services/test_task_usecase.py
+++ b/tests/vibe3/services/test_task_usecase.py
@@ -2,15 +2,8 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from vibe3.models.task_bridge import HydrateError
 from vibe3.services.task_usecase import TaskUsecase
-
-
-def test_parse_issue_ref_accepts_github_url() -> None:
-    """Issue parsing should support GitHub issue URLs."""
-    assert TaskUsecase.parse_issue_ref("https://github.com/acme/repo/issues/248") == 248
 
 
 def test_show_task_returns_local_fallback_on_hydrate_error() -> None:
@@ -28,9 +21,3 @@ def test_show_task_returns_local_fallback_on_hydrate_error() -> None:
 
     assert result.hydrate_error is not None
     assert result.local_task is task_service.get_task.return_value
-
-
-def test_parse_issue_ref_rejects_invalid_reference() -> None:
-    """Invalid issue references should still fail fast."""
-    with pytest.raises(ValueError):
-        TaskUsecase.parse_issue_ref("not-an-issue")


### PR DESCRIPTION
## Summary
- Remove stale task-side write paths and obsolete compatibility surfaces
- Converge issue/task relationship entrypoints to flow-driven commands
- Clean outdated docs and tests to match current behavior

## Scope
- issue #281
- issue #282

## Validation
- pre-push checks passed locally (full pytest, lint, typecheck)
