### PR TITLE
fix: guard task milestone fetch in unbound/offline show flow

### DIFF
--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -28,12 +28,15 @@ def _fetch_milestone_data(issue_number: int) -> "dict[str, object] | None":
     """Fetch milestone orchestration context for a task issue from GitHub."""
     from vibe3.clients.github_client import GitHubClient
 
-    gh = GitHubClient()
-    issue = gh.view_issue(issue_number)
-    if not isinstance(issue, dict) or not issue.get("milestone"):
+    try:
+        gh = GitHubClient()
+        issue = gh.view_issue(issue_number)
+        if not isinstance(issue, dict) or not issue.get("milestone"):
+            return None
+        ms = issue["milestone"]
+        ms_issues = gh.get_milestone_issues(ms["number"])
+    except (FileNotFoundError, RuntimeError):
         return None
-    ms = issue["milestone"]
-    ms_issues = gh.get_milestone_issues(ms["number"])
     open_count = sum(1 for i in ms_issues if str(i.get("state", "")).upper() == "OPEN")
     closed_count = sum(
         1 for i in ms_issues if str(i.get("state", "")).upper() == "CLOSED"


### PR DESCRIPTION
### Motivation

- 修复在上一次对 `commands` 层重构后出现的回退路径回溯错误：`task show` 在无 GitHub 上下文或不可用环境下仍会尝试查询 milestone 并触发异常导致命令中止。 

### Description

- 在 `src/vibe3/commands/task.py` 中将 GitHub milestone 读取逻辑封装在 `try/except` 中以捕获 `FileNotFoundError` 和 `RuntimeError`，并在不可用时返回 `None`。 
- 该变更确保在本地/离线或未配置 GitHub 环境时，`task show` 的回退渲染路径不会因非关键的远端查询失败而中断。 

### Testing

- 运行 `uv run pytest tests/vibe3/commands/test_task_show.py -q`，结果为 `3 passed`。 
- 运行 `uv run pytest tests/vibe3/commands -q`，结果为 `205 passed`。 
- 运行 `uv run ruff check src/vibe3/commands/task.py`，所有检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c87fb499ac832b9e77fe177f39a32a)