### PR TITLE
fix: address installer direnv hook bug for bash shells

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,6 +52,13 @@ _get_shell_rc() {
     esac
 }
 
+_get_direnv_hook() {
+    case "$SHELL" in
+        */bash) echo 'eval "$(direnv hook bash)"' ;;
+        *) echo 'eval "$(direnv hook zsh)"' ;;
+    esac
+}
+
 _setup_gh_noninteractive() {
     log_step "Setting up GitHub CLI defaults..."
 
@@ -169,7 +176,8 @@ _setup_direnv() {
     fi
 
     # Add direnv hook to RC file
-    local direnv_hook='eval "$(direnv hook zsh)"'
+    local direnv_hook
+    direnv_hook="$(_get_direnv_hook)"
     if ! grep -qF 'direnv hook zsh' "$RC_FILE" 2>/dev/null; then
         _append_to_rc "$RC_FILE" "$direnv_hook" "direnv"
         log_info "Added direnv hook to $RC_FILE"

--- a/tests/vibe2/integration/test_install_gh_noninteractive.bats
+++ b/tests/vibe2/integration/test_install_gh_noninteractive.bats
@@ -151,3 +151,51 @@ EOF
   [ "$(grep -c 'Vibe Local Bin' "$rc_file")" -eq 1 ]
   [ "$(grep -c '^export UV_PROJECT_ENVIRONMENT=' "$rc_file")" -eq 1 ]
 }
+
+@test "install writes bash direnv hook when current shell is bash" {
+  local fixture home_dir bin_dir source_root install_script rc_file
+
+  fixture="$(mktemp -d)"
+  home_dir="$fixture/home"
+  bin_dir="$fixture/bin"
+  source_root="$fixture/source"
+  install_script="$source_root/scripts/install.sh"
+  rc_file="$home_dir/.bashrc"
+
+  mkdir -p "$home_dir" "$bin_dir" "$source_root"
+  cp -R "$VIBE_ROOT/bin" "$source_root/bin"
+  cp -R "$VIBE_ROOT/lib" "$source_root/lib"
+  cp -R "$VIBE_ROOT/config" "$source_root/config"
+  cp -R "$VIBE_ROOT/scripts" "$source_root/scripts"
+
+  cat > "$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$bin_dir/direnv" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  hook|allow) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+
+  cat > "$bin_dir/uv" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "venv" ]]; then
+  mkdir -p "$2/bin"
+  touch "$2/bin/activate"
+  exit 0
+fi
+exit 0
+EOF
+
+  chmod +x "$bin_dir/gh" "$bin_dir/direnv" "$bin_dir/uv"
+
+  run env HOME="$home_dir" SHELL="/bin/bash" PATH="$bin_dir:$PATH" zsh "$install_script"
+
+  [ "$status" -eq 0 ]
+  grep -q 'direnv hook bash' "$rc_file"
+  ! grep -q 'direnv hook zsh' "$rc_file"
+}


### PR DESCRIPTION
### Motivation

- 修复安装器在检测 `direnv` 钩子时总是写入 zsh hook 的不正确行为，从而导致使用 `bash` 的用户收到错误的 shell 初始化配置。

### Description

- 在 `scripts/install.sh` 中新增函数 `_get_direnv_hook()`，根据当前 `$SHELL` 返回 `direnv` 钩子字符串（`bash` 返回 `eval "$(direnv hook bash)"`，其他默认返回 `eval "$(direnv hook zsh)"`）。
- 将 `_setup_direnv()` 中注入的钩子改为通过 `_get_direnv_hook()` 动态生成并写入到 RC 文件。 
- 增加回归测试 `tests/vibe2/integration/test_install_gh_noninteractive.bats` 的一个用例，以验证在 `SHELL=/bin/bash` 时会写入 bash 钩子且不会写 zsh 钩子。

### Testing

- 运行 `uv run pytest -q tests/vibe3/services/test_flow_lifecycle.py tests/vibe3/services/test_flow_lifecycle_close_switch.py tests/vibe3/services/test_flow_close_target.py`，结果 `16 passed`（通过）。
- 单独运行 `uv run pytest -q tests/vibe3/services/test_flow_lifecycle_close_switch.py`，结果 `6 passed`（通过）。
- 无法在此环境运行 `bats` 测试套件和 `zsh -n scripts/install.sh`，因为运行环境缺少 `bats` 与 `zsh`（`bats: command not found`，`zsh: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8afad19c8832b992b3745cc0ca924)