### PR TITLE
fix: handle worktree-occupation race during flow close branch deletion

### DIFF
--- a/src/vibe3/services/flow_lifecycle.py
+++ b/src/vibe3/services/flow_lifecycle.py
@@ -171,7 +171,21 @@ class FlowLifecycleMixin:
                 "Skipping local branch deletion."
             )
         elif git.branch_exists(branch):
-            git.delete_branch(branch, force=True)
+            try:
+                git.delete_branch(branch, force=True)
+            except Exception as e:
+                error_message = str(e)
+                if "used by worktree" in error_message:
+                    logger.bind(
+                        domain="flow",
+                        action="close",
+                        branch=branch,
+                    ).warning(
+                        f"Branch '{branch}' became occupied by another worktree "
+                        "during close. Skipping local branch deletion."
+                    )
+                else:
+                    raise
 
         try:
             git.delete_remote_branch(branch)

--- a/tests/vibe3/services/test_flow_lifecycle_close_switch.py
+++ b/tests/vibe3/services/test_flow_lifecycle_close_switch.py
@@ -210,6 +210,49 @@ class TestFlowCloseBranchSwitching:
         assert "delete_remote:task/current-flow" in actions
 
     @patch("vibe3.services.flow_lifecycle.GitClient")
+    def test_close_flow_handles_worktree_occupied_race_during_delete(
+        self,
+        mock_git_class: MagicMock,
+        mock_store: Mock,
+    ) -> None:
+        """Delete race should be tolerated when branch becomes worktree-occupied."""
+        self._build_flow_store(mock_store)
+
+        actions: list[str] = []
+        mock_git = MagicMock()
+        mock_git.get_current_branch.return_value = "task/current-flow"
+        mock_git.get_worktree_root.return_value = "/repo/main"
+        mock_git.branch_exists.side_effect = (
+            lambda branch: branch in {"task/current-flow", "main"}
+        )
+        mock_git.is_branch_occupied_by_worktree.return_value = False
+        mock_git.switch_branch.side_effect = lambda branch: actions.append(
+            f"switch:{branch}"
+        )
+        mock_git.delete_branch.side_effect = RuntimeError(
+            "error: cannot delete branch 'task/current-flow' "
+            "used by worktree at '/repo/wt-other'"
+        )
+        mock_git.delete_remote_branch.side_effect = lambda branch: actions.append(
+            f"delete_remote:{branch}"
+        )
+        mock_git._run.side_effect = lambda args: actions.append(f"run:{' '.join(args)}")
+        mock_git_class.return_value = mock_git
+
+        mock_store.get_flow_dependents.return_value = []
+
+        service = FlowService(store=mock_store)
+
+        service.close_flow("task/current-flow", check_pr=False)
+
+        assert "delete_remote:task/current-flow" in actions
+        mock_store.update_flow_state.assert_called_once_with(
+            "task/current-flow",
+            flow_status="done",
+            latest_actor="workflow",
+        )
+
+    @patch("vibe3.services.flow_lifecycle.GitClient")
     def test_close_flow_returns_to_develop_branch_in_develop_worktree(
         self,
         mock_git_class: MagicMock,


### PR DESCRIPTION
### Motivation

- 增强 `flow done`（`close_flow`）在含 worktree 环境下的健壮性，避免在本地分支删除阶段遇到“cannot delete branch used by worktree”竞态时使整个关闭流程失败。

### Description

- 在 `close_flow` 中对 `git.delete_branch(branch, force=True)` 增加 `try/except`，如果异常消息包含 `used by worktree` 则记录 warning 并跳过本地删除，否则继续抛出异常。
- 新增回归测试 `test_close_flow_handles_worktree_occupied_race_during_delete` 来模拟删除时出现的 worktree 占用错误并验证流程继续（更新文件 `tests/vibe3/services/test_flow_lifecycle_close_switch.py`）。
- 修改文件：`src/vibe3/services/flow_lifecycle.py`（增加容错逻辑）和 `tests/vibe3/services/test_flow_lifecycle_close_switch.py`（新增测试用例）。

### Testing

- 运行 `uv run pytest tests/vibe3/services/test_flow_lifecycle_close_switch.py`，测试文件中所有用例均通过（7/7）。
- 新增的回归测试验证了在删除分支时出现 `used by worktree` 错误后仍能成功完成 flow 关闭并更新 flow 状态。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c92f3e3d58832bb203998acbe6bf30)