### PR TITLE
feat(orchestra): add orchestra skill periodic execution (Issue #362)

### DIFF
--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -222,6 +222,14 @@ class OrchestraPRReviewDispatchSettings(BaseModel):
     use_worktree: bool = False
 
 
+class OrchestraSkillSettings(BaseModel):
+    """Orchestra skill periodic execution settings."""
+
+    enabled: bool = True
+    skill_name: str = "vibe-orchestra"
+    timeout_seconds: int = 300
+
+
 class OrchestraSettings(BaseModel):
     """Orchestra daemon settings."""
 
@@ -243,6 +251,9 @@ class OrchestraSettings(BaseModel):
         default_factory=OrchestraPRReviewDispatchSettings
     )
     master_agent: MasterAgentSettings = Field(default_factory=MasterAgentSettings)
+    orchestra_skill: OrchestraSkillSettings = Field(
+        default_factory=OrchestraSkillSettings
+    )
 
 
 class VibeConfig(BaseModel):

--- a/src/vibe3/orchestra/config.py
+++ b/src/vibe3/orchestra/config.py
@@ -60,6 +60,18 @@ class PRReviewDispatchConfig(BaseModel):
     use_worktree: bool = False
 
 
+class OrchestraSkillConfig(BaseModel):
+    """Orchestra skill periodic execution settings."""
+
+    enabled: bool = True
+    skill_name: str = "vibe-orchestra"
+    timeout_seconds: int = Field(
+        default=300,
+        ge=30,
+        description="Timeout for skill execution",
+    )
+
+
 class MasterAgentConfig(BaseModel):
     """Master agent configuration."""
 
@@ -102,6 +114,7 @@ class OrchestraConfig(BaseModel):
     pr_review_dispatch: PRReviewDispatchConfig = Field(
         default_factory=PRReviewDispatchConfig
     )
+    orchestra_skill: OrchestraSkillConfig = Field(default_factory=OrchestraSkillConfig)
 
     @classmethod
     def from_settings(cls) -> "OrchestraConfig":
@@ -142,5 +155,10 @@ class OrchestraConfig(BaseModel):
                 enabled=src.pr_review_dispatch.enabled,
                 async_mode=src.pr_review_dispatch.async_mode,
                 use_worktree=src.pr_review_dispatch.use_worktree,
+            ),
+            orchestra_skill=OrchestraSkillConfig(
+                enabled=src.orchestra_skill.enabled,
+                skill_name=src.orchestra_skill.skill_name,
+                timeout_seconds=src.orchestra_skill.timeout_seconds,
             ),
         )

--- a/src/vibe3/orchestra/dispatcher.py
+++ b/src/vibe3/orchestra/dispatcher.py
@@ -83,7 +83,7 @@ class Dispatcher(WorktreeResolverMixin):
         flow_branch = str(flow.get("branch") or "").strip()
         if not flow_branch:
             log.error(
-                "Cannot dispatch manager: flow branch missing " f"for #{issue.number}"
+                f"Cannot dispatch manager: flow branch missing for #{issue.number}"
             )
             return False
 
@@ -123,6 +123,33 @@ class Dispatcher(WorktreeResolverMixin):
             return True
 
         return self._run_command(cmd, review_cwd, "Review execution")
+
+    def dispatch_skill(self, skill_name: str) -> bool:
+        """Dispatch orchestra skill execution for periodic triage."""
+        log = logger.bind(
+            domain="orchestra",
+            action="skill_dispatch",
+            skill=skill_name,
+        )
+
+        cmd = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "vibe3",
+            "run",
+            "--skill",
+            skill_name,
+            "--async",
+        ]
+        log.info(f"Dispatching skill: {skill_name}")
+
+        if self.dry_run:
+            log.info(f"Dry run: {' '.join(cmd)}")
+            return True
+
+        return self._run_command(cmd, self.repo_path, f"Skill execution ({skill_name})")
 
     def build_manager_command(self, issue: IssueInfo) -> list[str]:
         """Build executable manager command for an issue."""

--- a/src/vibe3/orchestra/serve.py
+++ b/src/vibe3/orchestra/serve.py
@@ -23,6 +23,7 @@ from vibe3.orchestra.serve_utils import (
 )
 from vibe3.orchestra.services.assignee_dispatch import AssigneeDispatchService
 from vibe3.orchestra.services.comment_reply import CommentReplyService
+from vibe3.orchestra.services.orchestra_skill_service import OrchestraSkillService
 from vibe3.orchestra.services.pr_review_dispatch import PRReviewDispatchService
 from vibe3.orchestra.webhook_handler import make_webhook_router
 
@@ -68,6 +69,13 @@ def _build_server(config: OrchestraConfig) -> tuple[HeartbeatServer, FastAPI]:
                 config,
                 dispatcher=shared_dispatcher,
                 executor=shared_executor,
+            )
+        )
+    if config.orchestra_skill.enabled:
+        heartbeat.register(
+            OrchestraSkillService(
+                config,
+                dispatcher=shared_dispatcher,
             )
         )
 

--- a/src/vibe3/orchestra/services/orchestra_skill_service.py
+++ b/src/vibe3/orchestra/services/orchestra_skill_service.py
@@ -1,0 +1,59 @@
+"""OrchestraSkillService: periodically trigger vibe-orchestra skill."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from loguru import logger
+
+from vibe3.orchestra.config import OrchestraConfig
+from vibe3.orchestra.dispatcher import Dispatcher
+from vibe3.orchestra.event_bus import GitHubEvent, ServiceBase
+
+
+class OrchestraSkillService(ServiceBase):
+    """Periodically trigger vibe-orchestra skill for issue triage."""
+
+    event_types: list[str] = []
+
+    def __init__(
+        self,
+        config: OrchestraConfig,
+        dispatcher: Dispatcher | None = None,
+    ) -> None:
+        self.config = config
+        self._dispatcher = dispatcher or Dispatcher(config, dry_run=config.dry_run)
+        self._last_trigger: float = 0.0
+        self._running: bool = False
+
+    async def handle_event(self, event: GitHubEvent) -> None:
+        pass
+
+    async def on_tick(self) -> None:
+        if self._running:
+            return
+
+        elapsed = time.time() - self._last_trigger
+        if elapsed < self.config.polling_interval:
+            return
+
+        self._running = True
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._dispatch_skill)
+        finally:
+            self._running = False
+            self._last_trigger = time.time()
+
+    def _dispatch_skill(self) -> None:
+        skill_name = self.config.orchestra_skill.skill_name
+        log = logger.bind(domain="orchestra", action="skill_trigger", skill=skill_name)
+
+        log.info(f"Triggering orchestra skill: {skill_name}")
+
+        if self.config.dry_run:
+            log.info("Dry run mode enabled")
+            return
+
+        self._dispatcher.dispatch_skill(skill_name)

--- a/tests/vibe3/orchestra/test_dispatcher.py
+++ b/tests/vibe3/orchestra/test_dispatcher.py
@@ -159,3 +159,44 @@ class TestDispatcherReviewWorktreeResolution:
         mock_resolve.assert_not_called()
         assert "--worktree" in cmd
         assert cwd == Path("/tmp/repo")
+
+
+class TestDispatcherSkillDispatch:
+    def test_dispatch_skill_builds_correct_command(self):
+        config = OrchestraConfig()
+        dispatcher = Dispatcher(config, repo_path=Path("/tmp/repo"))
+
+        with patch.object(dispatcher, "_run_command", return_value=True) as mock_run:
+            result = dispatcher.dispatch_skill("vibe-orchestra")
+
+        assert result is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "vibe3",
+            "run",
+            "--skill",
+            "vibe-orchestra",
+            "--async",
+        ]
+
+    def test_dispatch_skill_dry_run_skips_execution(self):
+        config = OrchestraConfig()
+        dispatcher = Dispatcher(config, dry_run=True, repo_path=Path("/tmp/repo"))
+
+        result = dispatcher.dispatch_skill("vibe-orchestra")
+
+        assert result is True
+
+    def test_dispatch_skill_returns_false_on_failure(self):
+        config = OrchestraConfig()
+        dispatcher = Dispatcher(config, repo_path=Path("/tmp/repo"))
+
+        with patch.object(dispatcher, "_run_command", return_value=False):
+            result = dispatcher.dispatch_skill("vibe-orchestra")
+
+        assert result is False

--- a/tests/vibe3/orchestra/test_orchestra_skill_service.py
+++ b/tests/vibe3/orchestra/test_orchestra_skill_service.py
@@ -1,0 +1,76 @@
+"""Tests for OrchestraSkillService."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vibe3.orchestra.config import OrchestraConfig
+from vibe3.orchestra.services.orchestra_skill_service import OrchestraSkillService
+
+
+class _ImmediateLoop:
+    async def run_in_executor(self, _executor, func, *args):  # type: ignore[no-untyped-def]
+        return func(*args)
+
+
+def _svc(dry_run: bool = True) -> OrchestraSkillService:
+    config = OrchestraConfig(
+        polling_interval=900,
+        dry_run=dry_run,
+    )
+    return OrchestraSkillService(config)
+
+
+@pytest.mark.asyncio
+async def test_on_tick_triggers_skill_after_interval() -> None:
+    svc = _svc(dry_run=True)
+    svc._last_trigger = 0.0
+
+    with patch("time.time", return_value=1000.0):
+        with patch("asyncio.get_running_loop", return_value=_ImmediateLoop()):
+            await svc.on_tick()
+
+    assert svc._last_trigger > 0
+
+
+@pytest.mark.asyncio
+async def test_on_tick_skips_when_interval_not_passed() -> None:
+    svc = _svc()
+    svc._last_trigger = 900.0
+
+    with patch("time.time", return_value=950.0):
+        with patch("asyncio.get_running_loop", return_value=_ImmediateLoop()):
+            await svc.on_tick()
+
+    assert svc._last_trigger == 900.0
+
+
+@pytest.mark.asyncio
+async def test_on_tick_skips_when_already_running() -> None:
+    svc = _svc()
+    svc._last_trigger = 0.0
+    svc._running = True
+
+    with patch("time.time", return_value=1000.0):
+        with patch("asyncio.get_running_loop", return_value=_ImmediateLoop()):
+            await svc.on_tick()
+
+    assert svc._last_trigger == 0.0
+
+
+def test_dispatch_skill_dry_run() -> None:
+    svc = _svc(dry_run=True)
+    svc._dispatcher.dispatch_skill = MagicMock()
+
+    svc._dispatch_skill()
+
+    svc._dispatcher.dispatch_skill.assert_not_called()
+
+
+def test_dispatch_skill_calls_dispatcher() -> None:
+    svc = _svc(dry_run=False)
+    svc._dispatcher.dispatch_skill = MagicMock(return_value=True)
+
+    svc._dispatch_skill()
+
+    svc._dispatcher.dispatch_skill.assert_called_once_with("vibe-orchestra")

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -10,6 +10,7 @@ from vibe3.orchestra.config import (
     AssigneeDispatchConfig,
     CommentReplyConfig,
     OrchestraConfig,
+    OrchestraSkillConfig,
     PRReviewDispatchConfig,
 )
 from vibe3.orchestra.serve import (
@@ -28,6 +29,7 @@ def test_build_server_registers_only_enabled_services() -> None:
         assignee_dispatch=AssigneeDispatchConfig(enabled=False),
         comment_reply=CommentReplyConfig(enabled=False),
         pr_review_dispatch=PRReviewDispatchConfig(enabled=True),
+        orchestra_skill=OrchestraSkillConfig(enabled=False),
     )
     heartbeat, _ = _build_server(cfg)
     assert heartbeat.service_names == ["PRReviewDispatchService"]
@@ -133,9 +135,7 @@ def test_start_help_mentions_config_port_and_current_repo_defaults() -> None:
     assert "current repository" in result.stdout.lower()
 
 
-def test_validate_pid_file_handles_read_errors(
-    tmp_path, monkeypatch
-) -> None:  # type: ignore[no-untyped-def]
+def test_validate_pid_file_handles_read_errors(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     pid_file = tmp_path / "orchestra.pid"
     pid_file.write_text("123")
 


### PR DESCRIPTION
## Summary

添加 OrchestraSkillService 用于定期触发 vibe-orchestra skill 进行 issue triage 和治理。

## Changes

### 新增文件
- `src/vibe3/orchestra/services/orchestra_skill_service.py` - Skill 触发服务
- `tests/vibe3/orchestra/test_orchestra_skill_service.py` - 5 个单元测试

### 修改文件
- `src/vibe3/config/settings.py` - 添加 OrchestraSkillSettings
- `src/vibe3/orchestra/config.py` - 添加 OrchestraSkillConfig
- `src/vibe3/orchestra/dispatcher.py` - 添加 dispatch_skill() 方法
- `src/vibe3/orchestra/serve.py` - 注册 OrchestraSkillService
- `tests/vibe3/orchestra/test_dispatcher.py` - 3 个 skill dispatch 测试
- `tests/vibe3/orchestra/test_serve.py` - 更新服务注册测试

## Architecture

```
Heartbeat.on_tick() (每 900s)
    ↓
OrchestraSkillService.on_tick()
    ↓
OrchestraSkillService._dispatch_skill()
    ↓
Dispatcher.dispatch_skill(skill_name)
    ↓
Dispatcher._run_command() (复用现有)
```

### 设计原则
- **复用现有基础设施**: 使用 `polling_interval`、`Dispatcher._run_command()`、`logger.bind()`
- **遵循现有模式**: 与 `AssigneeDispatchService`、`PRReviewDispatchService` 一致
- **结构化日志**: `logger.bind(domain="orchestra", action="skill_dispatch", skill=xxx)`
- **容错机制**: 通过 `Dispatcher._run_command` 统一处理错误和超时

## Testing

- ✅ 106 tests passed (新增 8 个)
- ✅ ruff check passed
- ✅ 与现有架构模式一致

## Related

- Issue #362
- Part of Orchestra Phase A (决策增强)
