### PR TITLE
fix(domain): enhance manager dispatch error handling for Issue #481

### DIFF
--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -10,6 +10,7 @@ from vibe3.domain.events.flow_lifecycle import ManagerDispatched
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.roles.manager import build_manager_request
+from vibe3.services.issue_failure_service import fail_manager_issue
 
 
 def handle_manager_dispatched(event: ManagerDispatched) -> None:
@@ -111,11 +112,16 @@ def handle_manager_dispatched(event: ManagerDispatched) -> None:
             )
 
             if request is None:
+                reason = "Failed to prepare role execution request"
                 logger.bind(
                     domain="issue_state_dispatch_handler",
                     role="manager",
                     issue_number=event.issue_number,
-                ).error("Failed to prepare role execution request")
+                ).error(reason)
+                fail_manager_issue(
+                    issue_number=event.issue_number,
+                    reason=reason,
+                )
                 return
 
             result = await loop.run_in_executor(

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -123,16 +123,18 @@ class TestIssueStateDispatchHandler:
             )
         )
 
+    @patch("vibe3.domain.handlers.issue_state_dispatch.fail_manager_issue")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
-    def test_request_none_logs_error(
+    def test_request_none_calls_fail_manager_issue(
         self,
         mock_build_request: MagicMock,
         mock_config_cls: MagicMock,
         mock_coordinator_cls: MagicMock,
         mock_registry_cls: MagicMock,
+        mock_fail_manager_issue: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import handle_manager_dispatched
 
@@ -149,7 +151,12 @@ class TestIssueStateDispatchHandler:
                 issue_number=42,
                 branch="task/issue-42",
                 trigger_state="ready",
+                issue_title="Test Issue",
             )
         )
 
         mock_coordinator.dispatch_execution.assert_not_called()
+        mock_fail_manager_issue.assert_called_once_with(
+            issue_number=42,
+            reason="Failed to prepare role execution request",
+        )


### PR DESCRIPTION
## Summary
Fixes Issue #481 by adding explicit failure handling when `build_manager_request()` returns None.

## Changes (by opencode)
- Import `fail_manager_issue` in `issue_state_dispatch.py`
- Call `fail_manager_issue()` when request is None to prevent silent issue freeze
- Update test `test_request_none_calls_fail_manager_issue` to verify the fix

## Testing
- All 5 tests in test_issue_state_dispatch.py pass ✅

## Related
- Closes #481
