### PR TITLE
fix(domain): block issue when manager request preparation fails

### DIFF
--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -10,6 +10,7 @@ from vibe3.domain.events.flow_lifecycle import ManagerDispatchIntent
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.roles.manager import build_manager_request
+from vibe3.services.issue_failure_service import block_manager_noop_issue
 
 
 def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
@@ -111,11 +112,18 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
             )
 
             if request is None:
+                reason = "Failed to prepare role execution request"
                 logger.bind(
                     domain="issue_state_dispatch_handler",
                     role="manager",
                     issue_number=event.issue_number,
-                ).error("Failed to prepare role execution request")
+                ).error(reason)
+                block_manager_noop_issue(
+                    issue_number=event.issue_number,
+                    repo=None,
+                    reason=reason,
+                    actor="agent:manager",
+                )
                 return
 
             result = await loop.run_in_executor(

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -39,6 +39,19 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
     ).info("Manager dispatch intent received, scheduling async dispatch")
 
     async def _do_dispatch() -> None:
+        def _block_for_noop(reason: str) -> None:
+            logger.bind(
+                domain="issue_state_dispatch_handler",
+                role="manager",
+                issue_number=event.issue_number,
+            ).error(reason)
+            block_manager_noop_issue(
+                issue_number=event.issue_number,
+                repo=None,
+                reason=reason,
+                actor="agent:manager",
+            )
+
         loop = asyncio.get_event_loop()
         config = OrchestraConfig.from_settings()
 
@@ -63,32 +76,22 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
             )
 
             if issue_data is None or isinstance(issue_data, str):
-                logger.bind(
-                    domain="issue_state_dispatch_handler",
-                    role="manager",
-                    issue_number=event.issue_number,
-                    error="issue_not_found",
-                ).error("Failed to fetch issue details from GitHub")
+                _block_for_noop(
+                    "Failed to fetch issue details from GitHub for manager dispatch"
+                )
                 return
 
             issue_info = IssueInfo.from_github_payload(issue_data)
             if issue_info is None:
-                logger.bind(
-                    domain="issue_state_dispatch_handler",
-                    role="manager",
-                    issue_number=event.issue_number,
-                    error="invalid_issue_data",
-                ).error("Failed to parse issue data from GitHub response")
+                _block_for_noop(
+                    "Failed to parse issue data from GitHub response for manager dispatch"
+                )
                 return
 
             issue_info.state = target_state
 
         if issue_info is None:
-            logger.bind(
-                domain="issue_state_dispatch_handler",
-                role="manager",
-                issue_number=event.issue_number,
-            ).error("Issue info is None, cannot dispatch role")
+            _block_for_noop("Issue info is None, cannot dispatch manager role")
             return
 
         from vibe3.agents.backends.codeagent import CodeagentBackend
@@ -112,18 +115,7 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
             )
 
             if request is None:
-                reason = "Failed to prepare role execution request"
-                logger.bind(
-                    domain="issue_state_dispatch_handler",
-                    role="manager",
-                    issue_number=event.issue_number,
-                ).error(reason)
-                block_manager_noop_issue(
-                    issue_number=event.issue_number,
-                    repo=None,
-                    reason=reason,
-                    actor="agent:manager",
-                )
+                _block_for_noop("Failed to prepare role execution request")
                 return
 
             result = await loop.run_in_executor(

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -84,7 +84,8 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
             issue_info = IssueInfo.from_github_payload(issue_data)
             if issue_info is None:
                 _block_for_noop(
-                    "Failed to parse issue data from GitHub response for manager dispatch"
+                    "Failed to parse issue data from GitHub"
+                    " response for manager dispatch"
                 )
                 return
 

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -127,16 +127,18 @@ class TestIssueStateDispatchHandler:
             )
         )
 
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
-    def test_request_none_logs_error(
+    def test_request_none_blocks_issue(
         self,
         mock_build_request: MagicMock,
         mock_config_cls: MagicMock,
         mock_coordinator_cls: MagicMock,
         mock_registry_cls: MagicMock,
+        mock_block_issue: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
@@ -159,3 +161,9 @@ class TestIssueStateDispatchHandler:
         )
 
         mock_coordinator.dispatch_execution.assert_not_called()
+        mock_block_issue.assert_called_once_with(
+            issue_number=42,
+            repo=None,
+            reason="Failed to prepare role execution request",
+            actor="agent:manager",
+        )

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -128,6 +128,90 @@ class TestIssueStateDispatchHandler:
         )
 
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
+    @patch("vibe3.clients.github_client.GitHubClient")
+    @patch("vibe3.environment.session_registry.SessionRegistryService")
+    @patch("vibe3.execution.coordinator.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    def test_issue_fetch_failure_blocks_issue(
+        self,
+        mock_build_request: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_registry_cls: MagicMock,
+        mock_github_client_cls: MagicMock,
+        mock_block_issue: MagicMock,
+    ) -> None:
+        from vibe3.domain.handlers.issue_state_dispatch import (
+            handle_manager_dispatch_intent,
+        )
+
+        mock_config = MagicMock()
+        mock_config_cls.from_settings.return_value = mock_config
+        mock_github_client = MagicMock()
+        mock_github_client.view_issue.return_value = None
+        mock_github_client_cls.return_value = mock_github_client
+
+        handle_manager_dispatch_intent(
+            ManagerDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="ready",
+            )
+        )
+
+        mock_build_request.assert_not_called()
+        mock_coordinator_cls.return_value.dispatch_execution.assert_not_called()
+        mock_block_issue.assert_called_once_with(
+            issue_number=42,
+            repo=None,
+            reason="Failed to fetch issue details from GitHub for manager dispatch",
+            actor="agent:manager",
+        )
+
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
+    @patch("vibe3.clients.github_client.GitHubClient")
+    @patch("vibe3.environment.session_registry.SessionRegistryService")
+    @patch("vibe3.execution.coordinator.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    def test_issue_parse_failure_blocks_issue(
+        self,
+        mock_build_request: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_registry_cls: MagicMock,
+        mock_github_client_cls: MagicMock,
+        mock_block_issue: MagicMock,
+    ) -> None:
+        from vibe3.domain.handlers.issue_state_dispatch import (
+            handle_manager_dispatch_intent,
+        )
+
+        mock_config = MagicMock()
+        mock_config_cls.from_settings.return_value = mock_config
+        mock_github_client = MagicMock()
+        mock_github_client.view_issue.return_value = {"id": "invalid_payload"}
+        mock_github_client_cls.return_value = mock_github_client
+
+        handle_manager_dispatch_intent(
+            ManagerDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="ready",
+            )
+        )
+
+        mock_build_request.assert_not_called()
+        mock_coordinator_cls.return_value.dispatch_execution.assert_not_called()
+        mock_block_issue.assert_called_once_with(
+            issue_number=42,
+            repo=None,
+            reason="Failed to parse issue data from GitHub response for manager dispatch",
+            actor="agent:manager",
+        )
+
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -152,11 +152,13 @@ class TestIssueStateDispatchHandler:
         mock_coordinator = MagicMock()
         mock_coordinator_cls.return_value = mock_coordinator
 
+        # Provide issue_title to skip GitHub API call
         handle_manager_dispatch_intent(
             ManagerDispatchIntent(
                 issue_number=42,
                 branch="task/issue-42",
                 trigger_state="ready",
+                issue_title="Test Issue",
             )
         )
 

--- a/tests/vibe3/domain/handlers/test_manager.py
+++ b/tests/vibe3/domain/handlers/test_manager.py
@@ -84,12 +84,14 @@ class TestManagerHandlerIssueFetching:
     """
 
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
     def test_records_failed_on_github_none(
         self,
         mock_config_cls: MagicMock,
         mock_github_cls: MagicMock,
+        mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
     ) -> None:
         """Handler should skip dispatch when GitHub returns None (slow path)."""
@@ -105,14 +107,17 @@ class TestManagerHandlerIssueFetching:
 
         # Should NOT dispatch
         mock_build_request.assert_not_called()
+        mock_block_noop.assert_called_once()
 
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
     def test_records_failed_on_network_error(
         self,
         mock_config_cls: MagicMock,
         mock_github_cls: MagicMock,
+        mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
     ) -> None:
         """Handler should skip dispatch when GitHub returns network error."""
@@ -126,14 +131,17 @@ class TestManagerHandlerIssueFetching:
         handle_manager_dispatch_intent(event)
 
         mock_build_request.assert_not_called()
+        mock_block_noop.assert_called_once()
 
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.OrchestraConfig")
     def test_records_failed_on_invalid_issue_data(
         self,
         mock_config_cls: MagicMock,
         mock_github_cls: MagicMock,
+        mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
     ) -> None:
         """Handler should skip dispatch when from_github_payload returns None."""
@@ -152,6 +160,7 @@ class TestManagerHandlerIssueFetching:
             handle_manager_dispatch_intent(event)
 
         mock_build_request.assert_not_called()
+        mock_block_noop.assert_called_once()
 
 
 class TestManagerHandlerDispatch:


### PR DESCRIPTION
## Summary
- When `build_manager_request()` returns `None`, the issue previously froze silently (only logged, no state transition)
- Now calls `block_manager_noop_issue()` to transition the issue to blocked state, making it visible and resumable
- Uses **block** (not fail) semantics: request preparation failure may be transient, block allows resume retry

## Changes
- `src/vibe3/domain/handlers/issue_state_dispatch.py`: import `block_manager_noop_issue`, call it when request is None
- `tests/vibe3/domain/handlers/test_issue_state_dispatch.py`: update test to verify block is called with correct args

## Why block, not fail?
PR #488 proposed using `fail_manager_issue` which force-transitions to FAILED state. This is too aggressive — `build_manager_request()` returning None can happen for transient reasons (flow creation race, config missing). Block semantics allow `resume` retry without manual state reset.

## Why repo=None?
`repo` is `str | None = None` through the entire call chain (`block_manager_noop_issue` → `_transition_issue_state` → GitHubClient methods). Passing `None` uses the current working directory's repo, which is correct for single-repo operation. No need to add repo to `ManagerDispatchIntent`.

Refs #481 (does not close — long-running debug tracking issue)

🤖 Generated with [Qoder][https://qoder.com]