### PR TITLE
feat(vibe3): unify PR state evaluation and fix CLOSED PR handling

### DIFF
--- a/src/vibe3/execution/flow_dispatch.py
+++ b/src/vibe3/execution/flow_dispatch.py
@@ -12,7 +12,7 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.models.pr import PRState
+from vibe3.services.flow_pr_state import evaluate_flow_pr_state
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_failure_service import block_manager_noop_issue
 from vibe3.services.issue_flow_service import IssueFlowService
@@ -107,7 +107,8 @@ class FlowManager:
         pr_number = self.get_pr_for_issue(issue.number)
         if pr_number:
             pr = self.github.get_pr(pr_number=pr_number)
-            if pr and (pr.state == PRState.MERGED or pr.merged_at):
+            pr_eval = evaluate_flow_pr_state(pr)
+            if pr and pr_eval.is_merged:
                 # Block issue instead of throwing exception
                 # This is a tolerable issue that requires human intervention
                 logger.bind(

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -18,6 +18,8 @@ from vibe3.services.check_remote import (
     requires_handoff,
     resolve_task_issue_number,
 )
+from vibe3.services.flow_block_mixin import sync_flow_done_task_label
+from vibe3.services.flow_pr_state import evaluate_flow_pr_state
 from vibe3.utils.git_helpers import get_branch_handoff_dir
 
 
@@ -132,14 +134,19 @@ class CheckService(CheckRemote):
 
             if prs:
                 pr = prs[0]
-                # Check if PR is closed or merged - auto-complete flow
-                if pr.state in (PRState.CLOSED, PRState.MERGED) or pr.merged_at:
+                pr_eval = evaluate_flow_pr_state(pr)
+                if pr_eval.can_mark_flow_done:
                     self._mark_flow_done(
                         branch,
-                        f"PR #{pr.number} is {pr.state.value} (detected from GitHub)",
+                        f"PR #{pr_eval.pr_number} is MERGED (detected from GitHub)",
                         cleanup_local_scene=not branch_missing,
                     )
                     return CheckResult(is_valid=True, branch=branch, issues=[])
+                elif pr_eval.is_closed_not_merged:
+                    issues.append(
+                        f"PR #{pr_eval.pr_number} is CLOSED but not merged — "
+                        f"flow cannot auto-complete; consider abandon or manual resolution"
+                    )
         except Exception as e:
             logger.bind(domain="check", branch=branch).warning(
                 f"Failed to verify PR status from GitHub: {e}"
@@ -286,6 +293,7 @@ class CheckService(CheckRemote):
             branch=branch,
         ).info(f"Auto-completing flow: {reason}")
         self.store.update_flow_state(branch, flow_status="done")
+        sync_flow_done_task_label(self.store, branch)
         self.store.add_event(
             branch,
             "flow_auto_completed",

--- a/src/vibe3/services/flow_block_mixin.py
+++ b/src/vibe3/services/flow_block_mixin.py
@@ -30,6 +30,25 @@ def sync_flow_blocked_task_label(store: SQLiteClient, branch: str) -> None:
         )
 
 
+def sync_flow_done_task_label(store: SQLiteClient, branch: str) -> None:
+    """Sync task-role issues in a flow to state/done when flow is done."""
+    issue_links_raw = store.get_issue_links(branch)
+    issue_links = issue_links_raw if isinstance(issue_links_raw, list) else []
+    label_service = LabelService()
+    for link in issue_links:
+        if link.get("issue_role") != "task":
+            continue
+        issue_number = link.get("issue_number")
+        if issue_number is None:
+            continue
+        label_service.confirm_issue_state(
+            int(issue_number),
+            IssueState.DONE,
+            actor="flow:done",
+            force=True,
+        )
+
+
 class FlowLifecycleMixin:
     """Mixin providing flow lifecycle operations."""
 

--- a/src/vibe3/services/flow_pr_state.py
+++ b/src/vibe3/services/flow_pr_state.py
@@ -1,0 +1,49 @@
+"""Unified PR state evaluation for flow completion decisions."""
+
+from dataclasses import dataclass
+
+from vibe3.models.pr import PRResponse, PRState
+
+
+@dataclass(frozen=True)
+class FlowPRStateResult:
+    """Structured PR state evaluation result."""
+
+    pr_found: bool
+    pr_number: int | None
+    is_merged: bool
+    is_closed_not_merged: bool
+    can_mark_flow_done: bool
+
+
+def evaluate_flow_pr_state(pr: PRResponse | None) -> FlowPRStateResult:
+    """Evaluate PR state to determine if flow can be marked done.
+
+    This is the single source of truth for PR state evaluation in vibe3.
+    Used by check_service._check_branch() and
+    flow_dispatch._rebuild_stale_canonical_flow().
+    """
+    if pr is None:
+        return FlowPRStateResult(
+            pr_found=False,
+            pr_number=None,
+            is_merged=False,
+            is_closed_not_merged=False,
+            can_mark_flow_done=False,
+        )
+
+    pr_number = pr.number
+
+    is_merged = pr.state == PRState.MERGED or pr.merged_at is not None
+
+    is_closed_not_merged = pr.state == PRState.CLOSED and pr.merged_at is None
+
+    can_mark_flow_done = is_merged
+
+    return FlowPRStateResult(
+        pr_found=True,
+        pr_number=pr_number,
+        is_merged=is_merged,
+        is_closed_not_merged=is_closed_not_merged,
+        can_mark_flow_done=can_mark_flow_done,
+    )

--- a/tests/vibe3/services/test_check_pr_status.py
+++ b/tests/vibe3/services/test_check_pr_status.py
@@ -1,5 +1,6 @@
 """Tests for PR status detection and flow auto-completion."""
 
+from datetime import datetime
 from unittest.mock import MagicMock
 
 from vibe3.clients import SQLiteClient
@@ -13,7 +14,6 @@ class TestPRStatusDetection:
 
     def test_check_marks_flow_done_when_merged(self, tmp_path):
         """Should mark flow as done when PR is merged."""
-        # ARRANGE: Flow with merged PR
         store = SQLiteClient(db_path=tmp_path / "test.db")
         store.update_flow_state(
             "task/my-feature",
@@ -21,49 +21,47 @@ class TestPRStatusDetection:
             flow_status="active",
         )
 
-        # Mock git client
         from vibe3.clients.git_client import GitClient
 
         git_client = MagicMock(spec=GitClient)
         git_client.get_current_branch.return_value = "task/my-feature"
         git_client.get_git_common_dir.return_value = tmp_path
 
-        # Mock GitHub client to return merged PR
         github_client = MagicMock(spec=GitHubClient)
         merged_pr = PRResponse(
             number=42,
             title="Test PR",
+            body="",
             state=PRState.MERGED,
             head_branch="task/my-feature",
             base_branch="main",
             url="https://github.com/test/pr/42",
-            merged_at="2026-03-25T00:00:00Z",
             draft=False,
             is_ready=True,
             ci_passed=True,
+            merged_at=datetime(2026, 3, 25),
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 25),
         )
         github_client.list_prs_for_branch.return_value = [merged_pr]
 
-        # Create handoff file to avoid missing file warning
         from vibe3.utils.git_helpers import get_branch_handoff_dir
 
         handoff_dir = get_branch_handoff_dir(tmp_path, "task/my-feature")
         handoff_dir.mkdir(parents=True, exist_ok=True)
         (handoff_dir / "current.md").touch()
 
-        # ACT: Run check
         service = CheckService(
             store=store, git_client=git_client, github_client=github_client
         )
-        service.verify_current_flow()
+        result = service.verify_current_flow()
 
-        # ASSERT: Flow should be marked as done
         flow = store.get_flow_state("task/my-feature")
         assert flow["flow_status"] == "done"
+        assert result.is_valid
 
-    def test_check_detects_closed_pr(self, tmp_path):
-        """Should mark flow as done when PR is closed."""
-        # ARRANGE: Flow with closed PR
+    def test_check_detects_closed_not_merged_pr_returns_warning(self, tmp_path):
+        """Should NOT mark flow as done when PR is closed but not merged."""
         store = SQLiteClient(db_path=tmp_path / "test.db")
         store.update_flow_state(
             "task/my-feature",
@@ -71,18 +69,17 @@ class TestPRStatusDetection:
             flow_status="active",
         )
 
-        # Mock git client
         from vibe3.clients.git_client import GitClient
 
         git_client = MagicMock(spec=GitClient)
         git_client.get_current_branch.return_value = "task/my-feature"
         git_client.get_git_common_dir.return_value = tmp_path
 
-        # Mock GitHub client to return closed PR
         github_client = MagicMock(spec=GitHubClient)
         closed_pr = PRResponse(
             number=42,
             title="Test PR",
+            body="",
             state=PRState.CLOSED,
             head_branch="task/my-feature",
             base_branch="main",
@@ -90,29 +87,29 @@ class TestPRStatusDetection:
             draft=False,
             is_ready=True,
             ci_passed=True,
+            merged_at=None,
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 24),
         )
         github_client.list_prs_for_branch.return_value = [closed_pr]
 
-        # Create handoff file
         from vibe3.utils.git_helpers import get_branch_handoff_dir
 
         handoff_dir = get_branch_handoff_dir(tmp_path, "task/my-feature")
         handoff_dir.mkdir(parents=True, exist_ok=True)
         (handoff_dir / "current.md").touch()
 
-        # ACT: Run check
         service = CheckService(
             store=store, git_client=git_client, github_client=github_client
         )
-        service.verify_current_flow()
+        result = service.verify_current_flow()
 
-        # ASSERT: Flow should be marked as done
         flow = store.get_flow_state("task/my-feature")
-        assert flow["flow_status"] == "done"
+        assert flow["flow_status"] == "active"
+        assert any("CLOSED but not merged" in issue for issue in result.issues)
 
     def test_check_keeps_active_flow_for_open_pr(self, tmp_path):
         """Should NOT mark flow as done when PR is still open."""
-        # ARRANGE: Flow with open PR
         store = SQLiteClient(db_path=tmp_path / "test.db")
         store.update_flow_state(
             "task/my-feature",
@@ -120,18 +117,17 @@ class TestPRStatusDetection:
             flow_status="active",
         )
 
-        # Mock git client
         from vibe3.clients.git_client import GitClient
 
         git_client = MagicMock(spec=GitClient)
         git_client.get_current_branch.return_value = "task/my-feature"
         git_client.get_git_common_dir.return_value = tmp_path
 
-        # Mock GitHub client to return open PR
         github_client = MagicMock(spec=GitHubClient)
         open_pr = PRResponse(
             number=42,
             title="Test PR",
+            body="",
             state=PRState.OPEN,
             head_branch="task/my-feature",
             base_branch="main",
@@ -139,59 +135,53 @@ class TestPRStatusDetection:
             draft=False,
             is_ready=True,
             ci_passed=True,
+            merged_at=None,
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 24),
         )
         github_client.list_prs_for_branch.return_value = [open_pr]
 
-        # Create handoff file
         from vibe3.utils.git_helpers import get_branch_handoff_dir
 
         handoff_dir = get_branch_handoff_dir(tmp_path, "task/my-feature")
         handoff_dir.mkdir(parents=True, exist_ok=True)
         (handoff_dir / "current.md").touch()
 
-        # ACT: Run check
         service = CheckService(
             store=store, git_client=git_client, github_client=github_client
         )
         service.verify_current_flow()
 
-        # ASSERT: Flow should remain active
         flow = store.get_flow_state("task/my-feature")
         assert flow["flow_status"] == "active"
 
     def test_check_handles_no_pr_gracefully(self, tmp_path):
         """Should not fail when flow has no PR."""
-        # ARRANGE: Flow without PR
         store = SQLiteClient(db_path=tmp_path / "test.db")
         store.update_flow_state(
             "task/my-feature",
             flow_slug="my_feature",
         )
 
-        # Mock git client
         from vibe3.clients.git_client import GitClient
 
         git_client = MagicMock(spec=GitClient)
         git_client.get_current_branch.return_value = "task/my-feature"
         git_client.get_git_common_dir.return_value = tmp_path
 
-        # Mock GitHub client to return empty PR list
         github_client = MagicMock(spec=GitHubClient)
         github_client.list_prs_for_branch.return_value = []
 
-        # Create handoff file
         from vibe3.utils.git_helpers import get_branch_handoff_dir
 
         handoff_dir = get_branch_handoff_dir(tmp_path, "task/my-feature")
         handoff_dir.mkdir(parents=True, exist_ok=True)
         (handoff_dir / "current.md").touch()
 
-        # ACT: Run check
         service = CheckService(
             store=store, git_client=git_client, github_client=github_client
         )
         service.verify_current_flow()
 
-        # ASSERT: Flow should remain active and no exception should be raised
         flow = store.get_flow_state("task/my-feature")
         assert flow["flow_status"] == "active"

--- a/tests/vibe3/services/test_flow_pr_state.py
+++ b/tests/vibe3/services/test_flow_pr_state.py
@@ -1,0 +1,121 @@
+"""Tests for flow_pr_state module."""
+
+from datetime import datetime
+
+from vibe3.models.pr import PRResponse, PRState
+from vibe3.services.flow_pr_state import evaluate_flow_pr_state
+
+
+class TestEvaluateFlowPRState:
+    """Tests for evaluate_flow_pr_state function."""
+
+    def test_merged_state(self):
+        """PRState.MERGED should mark is_merged=True and can_mark_flow_done=True."""
+        pr = PRResponse(
+            number=42,
+            title="Test PR",
+            body="",
+            state=PRState.MERGED,
+            head_branch="task/test",
+            base_branch="main",
+            url="https://github.com/test/pr/42",
+            draft=False,
+            is_ready=True,
+            ci_passed=True,
+            merged_at=datetime(2026, 3, 25),
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 25),
+        )
+        result = evaluate_flow_pr_state(pr)
+
+        assert result.pr_found is True
+        assert result.pr_number == 42
+        assert result.is_merged is True
+        assert result.is_closed_not_merged is False
+        assert result.can_mark_flow_done is True
+
+    def test_closed_not_merged(self):
+        """PRState.CLOSED + merged_at=None should mark is_closed_not_merged=True."""
+        pr = PRResponse(
+            number=42,
+            title="Test PR",
+            body="",
+            state=PRState.CLOSED,
+            head_branch="task/test",
+            base_branch="main",
+            url="https://github.com/test/pr/42",
+            draft=False,
+            is_ready=True,
+            ci_passed=True,
+            merged_at=None,
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 24),
+        )
+        result = evaluate_flow_pr_state(pr)
+
+        assert result.pr_found is True
+        assert result.pr_number == 42
+        assert result.is_merged is False
+        assert result.is_closed_not_merged is True
+        assert result.can_mark_flow_done is False
+
+    def test_closed_with_merged_at(self):
+        """PRState.CLOSED + merged_at set should mark is_merged=True."""
+        # GitHub behavior: merged PRs have merged_at set even when closed
+        pr = PRResponse(
+            number=42,
+            title="Test PR",
+            body="",
+            state=PRState.CLOSED,
+            head_branch="task/test",
+            base_branch="main",
+            url="https://github.com/test/pr/42",
+            draft=False,
+            is_ready=True,
+            ci_passed=True,
+            merged_at=datetime(2026, 3, 25),
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 25),
+        )
+        result = evaluate_flow_pr_state(pr)
+
+        assert result.pr_found is True
+        assert result.pr_number == 42
+        assert result.is_merged is True
+        assert result.is_closed_not_merged is False
+        assert result.can_mark_flow_done is True
+
+    def test_open_pr(self):
+        """PRState.OPEN should mark can_mark_flow_done=False."""
+        pr = PRResponse(
+            number=42,
+            title="Test PR",
+            body="",
+            state=PRState.OPEN,
+            head_branch="task/test",
+            base_branch="main",
+            url="https://github.com/test/pr/42",
+            draft=False,
+            is_ready=True,
+            ci_passed=True,
+            merged_at=None,
+            created_at=datetime(2026, 3, 20),
+            updated_at=datetime(2026, 3, 24),
+        )
+        result = evaluate_flow_pr_state(pr)
+
+        assert result.pr_found is True
+        assert result.pr_number == 42
+        assert result.is_merged is False
+        assert result.is_closed_not_merged is False
+        assert result.can_mark_flow_done is False
+
+    def test_no_pr(self):
+        """pr=None should mark pr_found=False."""
+        result = evaluate_flow_pr_state(None)
+
+        assert result.pr_found is False
+        assert result.pr_number is None
+        assert result.is_merged is False
+        assert result.is_closed_not_merged is False
+        assert result.can_mark_flow_done is False


### PR DESCRIPTION
Closes #316

## Summary

Implements issue #316: unify vibe3 check 与 flow done 的 PR 状态判定

### Changes

- **New module**: `src/vibe3/services/flow_pr_state.py`
  - Introduces `evaluate_flow_pr_state()` as the single source of truth for PR state evaluation
  - Returns structured `FlowPRStateResult` with explicit flags for merged/closed-not-merged states
  - Distinguishes between MERGED (can mark done) vs CLOSED-not-merged (cannot mark done)

- **Enhanced `check_service.py`**:
  - `_check_branch()`: Now uses `evaluate_flow_pr_state()` instead of inline PR state checks
  - `_mark_flow_done()`: Adds `sync_flow_done_task_label()` to synchronize task issue labels
  - CLOSED-but-not-merged PRs now return warnings instead of incorrectly marking flow as done

- **New function in `flow_block_mixin.py`**:
  - `sync_flow_done_task_label()`: Syncs task-role issues to `state/done` when flow completes
  - Follows the same pattern as `sync_flow_blocked_task_label()` with `force=True`

- **Updated `flow_dispatch.py`**:
  - `_rebuild_stale_canonical_flow()`: Reuses `evaluate_flow_pr_state()` for consistency

### Test Coverage

- **New tests**: `tests/vibe3/services/test_flow_pr_state.py`
  - `test_merged_state`: VERIFIES MERGED → can_mark_flow_done=True
  - `test_closed_not_merged`: VERIFIES CLOSED+no merged_at → is_closed_not_merged=True
  - `test_closed_with_merged_at`: VERIFIES CLOSED+merged_at set → is_merged=True (GitHub behavior)
  - `test_open_pr`: VERIFIES OPEN → can_mark_flow_done=False
  - `test_no_pr`: VERIFIES None → pr_found=False

- **Updated tests**: `tests/vibe3/services/test_check_pr_status.py`
  - `test_check_detects_closed_not_merged_pr_returns_warning`: VERIFIES CLOSED PR does NOT mark flow done
  - All tests updated to use datetime objects for timestamp fields
  - Tests now verify that CLOSED-but-not-merged returns warning issues

### Verification

All PR state evaluation tests pass:
```bash
uv run pytest tests/vibe3/services/test_flow_pr_state.py tests/vibe3/services/test_check_pr_status.py -v
# 9 passed in 2.04s
```

### Impact

**Fixed Behavior**:
- CLOSED-but-not-merged PRs no longer incorrectly mark flows as done
- Flow completion now only triggers on merged PRs (or closed with merged_at set)

**New Behavior**:
- Task issue labels are automatically synced to `state/done` when flow completes
- All PR state evaluation uses a single, test-covered function

### Note

This PR resolves the core bug from issue #316 where `check_service.py` treated `PRState.CLOSED` and `PRState.MERGED` identically, leading to incorrect flow completion behavior.

---

## Contributors

claude/claude-sonnet-4-6, gemini/gemini-3-flash-preview, opencode/my-provider/gpt-4o
