### PR TITLE
fix(ci): add checkout and Python setup to issue-state-sync workflow

### DIFF
--- a/.github/workflows/issue-state-sync.yml
+++ b/.github/workflows/issue-state-sync.yml
@@ -12,6 +12,20 @@ jobs:
       issues: write
       pull-requests: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install Python dependencies
+        run: uv sync --dev
+
       - name: Set linked issues to done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +40,7 @@ jobs:
           fi
 
           export ISSUE_NUMBERS
-          python - <<'PY'
+          uv run python - <<'PY'
           import os
           import sys
 


### PR DESCRIPTION
## Summary

修复 `Issue State Sync` workflow 失败问题。

## Problem

workflow 缺少：
- Checkout step 获取代码
- Python 和 uv 环境设置
- 使用 `uv run python` 而不是裸 `python`

导致 workflow 在尝试导入 `vibe3.models.orchestration` 时失败，因为 `src` 目录不存在。

## Changes

- 添加 `actions/checkout@v4` step
- 添加 `astral-sh/setup-uv@v3` step  
- 添加 Python 安装和依赖同步
- 使用 `uv run python` 执行脚本

## Verification

修复后，当 PR 合并时，workflow 将能够正确执行 issue state sync。

---

## Contributors

Claude Opus 4.6