### PR TITLE
refactor(cleanup): unified flow scene cleanup with done/aborted differentiation

### DIFF
--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -47,8 +47,14 @@ def execute_check_mode(
         )
 
     if mode == "clean_branch":
-        # Check and clean residual branches for done/aborted flows
-        result = service.clean_residual_branches()
+        # Use dedicated cleanup service for --clean-branch
+        from vibe3.services.check_cleanup_service import CheckCleanupService
+
+        cleanup_service = CheckCleanupService(
+            store=service.store,
+            git_client=service.git_client,
+        )
+        result = cleanup_service.clean_residual_branches()
         return ExecuteCheckResult(
             mode="clean_branch",
             success=True,

--- a/src/vibe3/services/check_cleanup_service.py
+++ b/src/vibe3/services/check_cleanup_service.py
@@ -1,0 +1,181 @@
+"""Check cleanup service - handles --clean-branch logic for terminal flows.
+
+This service is separated from check_service.py to keep responsibilities clear:
+- check_service.py: Consistency verification and auto-fix
+- check_cleanup_service.py: Physical resource cleanup for terminal flows
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.flow_cleanup_service import FlowCleanupService
+
+
+class CheckCleanupService:
+    """Service for cleaning up terminal flow resources.
+
+    Handles the --clean-branch functionality:
+    - done/merged: Clean physical resources, keep flow record as history
+    - aborted: Clean everything including flow record (allows issue to restart)
+    """
+
+    # Terminal flow statuses that indicate completed flows
+    TERMINAL_FLOW_STATUSES = ("done", "aborted", "merged")
+
+    def __init__(
+        self,
+        store: "SQLiteClient",
+        git_client: "GitClient",
+    ) -> None:
+        self.store = store
+        self.git_client = git_client
+
+    def clean_residual_branches(self) -> dict[str, object]:
+        """Check and clean residual branches for terminal flows.
+
+        Different handling based on flow status:
+        - done/merged: Clean physical resources, keep flow record as history
+        - aborted: Clean everything including flow record (allows issue to restart)
+
+        Returns:
+            Dict with summary and details of cleaned branches.
+        """
+        from vibe3.services.flow_cleanup_service import FlowCleanupService
+
+        logger.bind(domain="check", action="clean_residual").info(
+            "Checking for residual branches"
+        )
+
+        # Get all terminal flows (done/aborted/merged)
+        all_flows = self.store.get_all_flows()
+        terminal_flows = [
+            f for f in all_flows if f.get("flow_status") in self.TERMINAL_FLOW_STATUSES
+        ]
+
+        cleanup_service = FlowCleanupService(
+            git_client=self.git_client,
+            store=self.store,
+        )
+
+        cleaned: list[str] = []
+        kept_records: list[str] = []
+        removed_invalid: list[str] = []
+        failed: list[str] = []
+
+        for flow in terminal_flows:
+            branch = flow["branch"]
+            flow_status = flow.get("flow_status", "")
+
+            # Remove invalid branch records (e.g., HEAD)
+            if self._is_invalid_branch_name(branch):
+                if self._remove_invalid_flow_record(branch):
+                    removed_invalid.append(branch)
+                continue
+
+            # Process valid terminal flow
+            self._process_terminal_flow(
+                branch=branch,
+                flow_status=flow_status,
+                cleanup_service=cleanup_service,
+                cleaned=cleaned,
+                kept_records=kept_records,
+                failed=failed,
+            )
+
+        summary = f"Cleaned {len(cleaned)} aborted flows"
+        if kept_records:
+            summary += f", preserved {len(kept_records)} done/merged records"
+        if removed_invalid:
+            summary += f", removed {len(removed_invalid)} invalid records"
+        if failed:
+            summary += f", failed {len(failed)}"
+
+        return {
+            "summary": summary,
+            "cleaned": cleaned,
+            "kept_records": kept_records,
+            "removed_invalid": removed_invalid,
+            "failed": failed,
+            "total_flows_checked": len(terminal_flows),
+        }
+
+    def _is_invalid_branch_name(self, branch: str) -> bool:
+        """Check if branch name is invalid (e.g., HEAD, HEAD~1)."""
+        return branch == "HEAD" or branch.startswith("HEAD")
+
+    def _remove_invalid_flow_record(self, branch: str) -> bool:
+        """Remove invalid flow record from database.
+
+        Returns:
+            True if successfully removed, False otherwise.
+        """
+        try:
+            self.store.delete_flow(branch)
+            logger.bind(domain="check", branch=branch).info(
+                "Removed invalid flow record"
+            )
+            return True
+        except Exception as exc:
+            logger.bind(domain="check", branch=branch).warning(
+                f"Failed to remove invalid flow record: {exc}"
+            )
+            return False
+
+    def _process_terminal_flow(
+        self,
+        branch: str,
+        flow_status: str,
+        cleanup_service: "FlowCleanupService",
+        cleaned: list[str],
+        kept_records: list[str],
+        failed: list[str],
+    ) -> None:
+        """Process a single terminal flow with appropriate cleanup.
+
+        Args:
+            branch: Branch name
+            flow_status: Flow status (done/merged/aborted)
+            cleanup_service: Cleanup service instance
+            cleaned: List to append successfully cleaned aborted flows
+            kept_records: List to append done/merged flows with preserved records
+            failed: List to append failure messages
+        """
+        # done/merged: keep record as history (issue is closed)
+        # aborted: delete record (issue may still be open, allow restart)
+        keep_flow_record = flow_status in ("done", "merged")
+
+        try:
+            results = cleanup_service.cleanup_flow_scene(
+                branch,
+                include_remote=True,
+                terminate_sessions=True,
+                keep_flow_record=keep_flow_record,
+            )
+
+            if keep_flow_record:
+                # done/merged: success if physical resources cleaned
+                if results.get("worktree", False) or results.get("local_branch", False):
+                    kept_records.append(branch)
+                    logger.bind(domain="check", branch=branch).info(
+                        "Cleaned done/merged flow resources, kept record"
+                    )
+            else:
+                # aborted: success if flow record deleted
+                if results.get("flow_record", False):
+                    cleaned.append(branch)
+                    logger.bind(domain="check", branch=branch).info(
+                        "Cleaned aborted flow completely"
+                    )
+                else:
+                    failed.append(f"{branch}: flow record deletion failed")
+        except Exception as exc:
+            failed.append(f"{branch}: {exc}")
+            logger.bind(domain="check", branch=branch).warning(
+                f"Failed to clean terminal flow resources: {exc}"
+            )

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -536,13 +536,9 @@ class CheckService(CheckRemote):
     def clean_residual_branches(self) -> dict[str, object]:
         """Check and clean residual branches for terminal flows.
 
-        Flows marked as done/aborted/merged should have their resources cleaned:
-        - Worktree removed
-        - Local/remote branches deleted
-        - Handoff files cleared
-        - Flow record deleted from database
-
-        This allows issues to be cleanly re-dispatched if they are still open.
+        Different handling based on flow status:
+        - done/merged: Clean physical resources, keep flow record as history
+        - aborted: Clean everything including flow record (allows issue to restart)
 
         Returns:
             Dict with summary and details of cleaned branches.
@@ -565,11 +561,13 @@ class CheckService(CheckRemote):
         )
 
         cleaned: list[str] = []
+        kept_records: list[str] = []
         removed_invalid: list[str] = []
         failed: list[str] = []
 
         for flow in terminal_flows:
             branch = flow["branch"]
+            flow_status = flow.get("flow_status", "")
 
             # Remove invalid branch records (e.g., HEAD)
             if branch == "HEAD" or branch.startswith("HEAD"):
@@ -585,29 +583,48 @@ class CheckService(CheckRemote):
                     )
                 continue
 
-            # Use unified cleanup service for all terminal flows
+            # Determine whether to keep flow record based on status
+            # done/merged: keep record as history (issue is closed)
+            # aborted: delete record (issue may still be open, allow restart)
+            keep_flow_record = flow_status in ("done", "merged")
+
+            # Use unified cleanup service
             try:
                 results = cleanup_service.cleanup_flow_scene(
                     branch,
                     include_remote=True,
                     terminate_sessions=True,
+                    keep_flow_record=keep_flow_record,
                 )
 
-                # Consider cleanup successful if flow record was deleted
-                if results.get("flow_record", False):
-                    cleaned.append(branch)
-                    logger.bind(domain="check", branch=branch).info(
-                        "Cleaned terminal flow resources"
-                    )
+                # Track results
+                if keep_flow_record:
+                    # done/merged: success if physical resources cleaned
+                    if results.get("worktree", False) or results.get(
+                        "local_branch", False
+                    ):
+                        kept_records.append(branch)
+                        logger.bind(domain="check", branch=branch).info(
+                            "Cleaned done/merged flow resources, kept record"
+                        )
                 else:
-                    failed.append(f"{branch}: flow record deletion failed")
+                    # aborted: success if flow record deleted
+                    if results.get("flow_record", False):
+                        cleaned.append(branch)
+                        logger.bind(domain="check", branch=branch).info(
+                            "Cleaned aborted flow completely"
+                        )
+                    else:
+                        failed.append(f"{branch}: flow record deletion failed")
             except Exception as exc:
                 failed.append(f"{branch}: {exc}")
                 logger.bind(domain="check", branch=branch).warning(
                     f"Failed to clean terminal flow resources: {exc}"
                 )
 
-        summary = f"Cleaned {len(cleaned)} terminal flows"
+        summary = f"Cleaned {len(cleaned)} aborted flows"
+        if kept_records:
+            summary += f", preserved {len(kept_records)} done/merged records"
         if removed_invalid:
             summary += f", removed {len(removed_invalid)} invalid records"
         if failed:
@@ -616,6 +633,7 @@ class CheckService(CheckRemote):
         return {
             "summary": summary,
             "cleaned": cleaned,
+            "kept_records": kept_records,
             "removed_invalid": removed_invalid,
             "failed": failed,
             "total_flows_checked": len(terminal_flows),

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -534,26 +534,35 @@ class CheckService(CheckRemote):
             )
 
     def clean_residual_branches(self) -> dict[str, object]:
-        """Check and clean residual branches for done/aborted flows.
+        """Check and clean residual branches for terminal flows.
 
-        Flows marked as done/aborted should have their branches cleaned.
-        This method uses the shared _cleanup_local_scene() method which
-        checks existence before deletion.
+        Flows marked as done/aborted/merged should have their resources cleaned:
+        - Worktree removed
+        - Local/remote branches deleted
+        - Handoff files cleared
+        - Flow record deleted from database
 
-        Performance optimization: Batch check resources to minimize git calls.
+        This allows issues to be cleanly re-dispatched if they are still open.
 
         Returns:
             Dict with summary and details of cleaned branches.
         """
+        from vibe3.services.flow_cleanup_service import FlowCleanupService
+
         logger.bind(domain="check", action="clean_residual").info(
             "Checking for residual branches"
         )
 
-        # Get all done/aborted flows
+        # Get all terminal flows (done/aborted/merged)
         all_flows = self.store.get_all_flows()
         terminal_flows = [
             f for f in all_flows if f.get("flow_status") in self.TERMINAL_FLOW_STATUSES
         ]
+
+        cleanup_service = FlowCleanupService(
+            git_client=self.git_client,
+            store=self.store,
+        )
 
         cleaned: list[str] = []
         removed_invalid: list[str] = []
@@ -576,27 +585,29 @@ class CheckService(CheckRemote):
                     )
                 continue
 
-            # Check if there's anything to clean (using extracted helper)
+            # Use unified cleanup service for all terminal flows
             try:
-                has_local, has_remote, has_worktree = self._check_branch_resources(
-                    branch
+                results = cleanup_service.cleanup_flow_scene(
+                    branch,
+                    include_remote=True,
+                    terminate_sessions=True,
                 )
 
-                if not (has_local or has_remote or has_worktree):
-                    continue  # Nothing to clean
-
-                self._cleanup_local_scene(branch, force_delete=True)
-                cleaned.append(branch)
-                logger.bind(domain="check", branch=branch).info(
-                    "Cleaned residual resources"
-                )
+                # Consider cleanup successful if flow record was deleted
+                if results.get("flow_record", False):
+                    cleaned.append(branch)
+                    logger.bind(domain="check", branch=branch).info(
+                        "Cleaned terminal flow resources"
+                    )
+                else:
+                    failed.append(f"{branch}: flow record deletion failed")
             except Exception as exc:
                 failed.append(f"{branch}: {exc}")
                 logger.bind(domain="check", branch=branch).warning(
-                    f"Failed to clean residual resources: {exc}"
+                    f"Failed to clean terminal flow resources: {exc}"
                 )
 
-        summary = f"Cleaned {len(cleaned)} flows"
+        summary = f"Cleaned {len(cleaned)} terminal flows"
         if removed_invalid:
             summary += f", removed {len(removed_invalid)} invalid records"
         if failed:

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -101,6 +101,22 @@ class CheckService(CheckRemote):
         except Exception:
             return False
 
+    def _count_commits_behind_main(self, branch: str) -> int | None:
+        """Count how many commits the branch is behind origin/main.
+
+        Returns None if cannot determine (e.g., no common ancestor).
+        """
+        try:
+            # Fetch origin/main to get latest
+            self.git_client._run(["fetch", "origin", "main", "--quiet"])
+            # Count commits in origin/main not in branch
+            output = self.git_client._run(
+                ["rev-list", "--count", f"{branch}..origin/main"]
+            )
+            return int(output.strip()) if output.strip() else None
+        except Exception:
+            return None
+
     def _has_local_branch(self, branch: str) -> bool:
         """Check if local branch exists."""
         try:
@@ -262,6 +278,24 @@ class CheckService(CheckRemote):
                 branch, f"Branch '{branch}' no longer exists locally"
             )
             return CheckResult(is_valid=True, branch=branch, issues=[])
+
+        # Handle orphaned active flow: no task issue + no worktree + stale
+        # Only clean up flows that have no issue binding and are significantly behind
+        if (
+            flow_status == "active"
+            and not task_issue
+            and not self._has_worktree(branch)
+        ):
+            try:
+                behind_count = self._count_commits_behind_main(branch)
+                if behind_count and behind_count > 100:
+                    self._mark_flow_aborted(
+                        branch,
+                        f"Orphaned flow '{branch}' is {behind_count} commits behind main",
+                    )
+                    return CheckResult(is_valid=True, branch=branch, issues=[])
+            except Exception:
+                pass
 
         # Handle empty active ready flow
         if (

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Check service implementation for verifying handoff store consistency."""
 
 from __future__ import annotations
@@ -49,10 +48,10 @@ class FixResult:
 class CheckService(CheckRemote):
     """Service for verifying handoff store consistency and auto-fixing issues."""
 
-    # Terminal flow statuses that indicate completed flows
-    TERMINAL_FLOW_STATUSES = ("done", "aborted", "merged")
     # Flow statuses that should be skipped for handoff/ref checks
     INACTIVE_FLOW_STATUSES = ("done", "aborted", "stale")
+    # Threshold for orphaned flow detection (commits behind main)
+    ORPHAN_FLOW_BEHIND_THRESHOLD = 100
 
     def __init__(
         self,
@@ -116,36 +115,6 @@ class CheckService(CheckRemote):
             return int(output.strip()) if output.strip() else None
         except Exception:
             return None
-
-    def _has_local_branch(self, branch: str) -> bool:
-        """Check if local branch exists."""
-        try:
-            output = self.git_client._run(["branch", "--list", branch])
-            return bool(output.strip())
-        except Exception:
-            return False
-
-    def _has_remote_branch(self, branch: str) -> bool:
-        """Check if remote branch exists."""
-        try:
-            remote_output = self.git_client._run(
-                ["branch", "-r", "--list", f"origin/{branch}"]
-            )
-            return bool(remote_output.strip())
-        except Exception:
-            return False
-
-    def _check_branch_resources(self, branch: str) -> tuple[bool, bool, bool]:
-        """Check if branch has local, remote, and worktree resources.
-
-        Returns:
-            Tuple of (has_local, has_remote, has_worktree)
-        """
-        return (
-            self._has_local_branch(branch),
-            self._has_remote_branch(branch),
-            self._has_worktree(branch),
-        )
 
     def _handle_closed_pr(self, branch: str, pr: "PRResponse") -> CheckResult | None:
         """Handle closed/merged PR by marking flow done.
@@ -288,14 +257,17 @@ class CheckService(CheckRemote):
         ):
             try:
                 behind_count = self._count_commits_behind_main(branch)
-                if behind_count and behind_count > 100:
+                if behind_count and behind_count > self.ORPHAN_FLOW_BEHIND_THRESHOLD:
                     self._mark_flow_aborted(
                         branch,
-                        f"Orphaned flow '{branch}' is {behind_count} commits behind main",
+                        f"Orphaned flow '{branch}' is {behind_count} "
+                        "commits behind main",
                     )
                     return CheckResult(is_valid=True, branch=branch, issues=[])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.bind(domain="check", branch=branch).debug(
+                    f"Could not count commits behind main: {exc}"
+                )
 
         # Handle empty active ready flow
         if (
@@ -330,7 +302,8 @@ class CheckService(CheckRemote):
                         # Provide actionable suggestion for damaged flow
                         issues.append(
                             f"{ref_field} file not found: {ref_value}. "
-                            f"Suggestion: Run 'vibe3 task resume --blocked {task_issue}' to reset."
+                            f"Suggestion: Run 'vibe3 task resume --blocked "
+                            f"{task_issue}' to reset."
                         )
 
         # shared current.md
@@ -347,45 +320,6 @@ class CheckService(CheckRemote):
             "Check completed"
         )
         return CheckResult(is_valid=is_valid, issues=issues, branch=branch)
-
-    def _cleanup_local_scene(self, branch: str, *, force_delete: bool) -> None:
-        """Best-effort cleanup of worktree, local branch, and remote branch.
-
-        Checks existence before attempting deletion to avoid noisy warnings.
-        Uses extracted helper methods for consistency.
-        """
-        # 1. Clean up worktree
-        if self._has_worktree(branch):
-            try:
-                worktree_path = self.git_client.find_worktree_path_for_branch(branch)
-                if worktree_path:
-                    self.git_client.remove_worktree(worktree_path, force=True)
-            except Exception as exc:
-                logger.bind(domain="check", branch=branch).warning(
-                    f"Failed to remove worktree during local scene cleanup: {exc}"
-                )
-
-        # 2. Clean up local branch
-        if self._has_local_branch(branch):
-            try:
-                self.git_client.delete_branch(
-                    branch,
-                    force=force_delete,
-                    skip_if_worktree=True,
-                )
-            except Exception as exc:
-                logger.bind(domain="check", branch=branch).warning(
-                    f"Failed to delete branch during local scene cleanup: {exc}"
-                )
-
-        # 3. Clean up remote branch
-        if self._has_remote_branch(branch):
-            try:
-                self.git_client.delete_remote_branch(branch)
-            except Exception as exc:
-                logger.bind(domain="check", branch=branch).warning(
-                    f"Failed to delete remote branch during local scene cleanup: {exc}"
-                )
 
     def _rebuild_stale_ready_flow(
         self,
@@ -531,7 +465,10 @@ class CheckService(CheckRemote):
 
         unfixed = [i for i in issues if i not in fixed]
         if unfixed:
-            hint = "  Some issues cannot be auto-fixed. Try 'vibe3 check --init' or check manually."
+            hint = (
+                "  Some issues cannot be auto-fixed. "
+                "Try 'vibe3 check --init' or check manually."
+            )
             error = (
                 "Could not auto-fix:\n"
                 + "\n".join(f"  - {i}" for i in unfixed)
@@ -566,109 +503,3 @@ class CheckService(CheckRemote):
             logger.bind(domain="check", branch=branch).warning(
                 f"Failed to update PR cache: {e}"
             )
-
-    def clean_residual_branches(self) -> dict[str, object]:
-        """Check and clean residual branches for terminal flows.
-
-        Different handling based on flow status:
-        - done/merged: Clean physical resources, keep flow record as history
-        - aborted: Clean everything including flow record (allows issue to restart)
-
-        Returns:
-            Dict with summary and details of cleaned branches.
-        """
-        from vibe3.services.flow_cleanup_service import FlowCleanupService
-
-        logger.bind(domain="check", action="clean_residual").info(
-            "Checking for residual branches"
-        )
-
-        # Get all terminal flows (done/aborted/merged)
-        all_flows = self.store.get_all_flows()
-        terminal_flows = [
-            f for f in all_flows if f.get("flow_status") in self.TERMINAL_FLOW_STATUSES
-        ]
-
-        cleanup_service = FlowCleanupService(
-            git_client=self.git_client,
-            store=self.store,
-        )
-
-        cleaned: list[str] = []
-        kept_records: list[str] = []
-        removed_invalid: list[str] = []
-        failed: list[str] = []
-
-        for flow in terminal_flows:
-            branch = flow["branch"]
-            flow_status = flow.get("flow_status", "")
-
-            # Remove invalid branch records (e.g., HEAD)
-            if branch == "HEAD" or branch.startswith("HEAD"):
-                try:
-                    self.store.delete_flow(branch)
-                    removed_invalid.append(branch)
-                    logger.bind(domain="check", branch=branch).info(
-                        "Removed invalid flow record"
-                    )
-                except Exception as exc:
-                    logger.bind(domain="check", branch=branch).warning(
-                        f"Failed to remove invalid flow record: {exc}"
-                    )
-                continue
-
-            # Determine whether to keep flow record based on status
-            # done/merged: keep record as history (issue is closed)
-            # aborted: delete record (issue may still be open, allow restart)
-            keep_flow_record = flow_status in ("done", "merged")
-
-            # Use unified cleanup service
-            try:
-                results = cleanup_service.cleanup_flow_scene(
-                    branch,
-                    include_remote=True,
-                    terminate_sessions=True,
-                    keep_flow_record=keep_flow_record,
-                )
-
-                # Track results
-                if keep_flow_record:
-                    # done/merged: success if physical resources cleaned
-                    if results.get("worktree", False) or results.get(
-                        "local_branch", False
-                    ):
-                        kept_records.append(branch)
-                        logger.bind(domain="check", branch=branch).info(
-                            "Cleaned done/merged flow resources, kept record"
-                        )
-                else:
-                    # aborted: success if flow record deleted
-                    if results.get("flow_record", False):
-                        cleaned.append(branch)
-                        logger.bind(domain="check", branch=branch).info(
-                            "Cleaned aborted flow completely"
-                        )
-                    else:
-                        failed.append(f"{branch}: flow record deletion failed")
-            except Exception as exc:
-                failed.append(f"{branch}: {exc}")
-                logger.bind(domain="check", branch=branch).warning(
-                    f"Failed to clean terminal flow resources: {exc}"
-                )
-
-        summary = f"Cleaned {len(cleaned)} aborted flows"
-        if kept_records:
-            summary += f", preserved {len(kept_records)} done/merged records"
-        if removed_invalid:
-            summary += f", removed {len(removed_invalid)} invalid records"
-        if failed:
-            summary += f", failed {len(failed)}"
-
-        return {
-            "summary": summary,
-            "cleaned": cleaned,
-            "kept_records": kept_records,
-            "removed_invalid": removed_invalid,
-            "failed": failed,
-            "total_flows_checked": len(terminal_flows),
-        }

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -1,0 +1,266 @@
+"""Flow cleanup service - unified scene cleanup for terminal flows.
+
+This service provides complete cleanup of flow scenes including:
+- Worktree removal
+- Local/remote branch deletion
+- Handoff cleanup
+- Flow record deletion
+
+Used by both `task resume` and `check --clean-branch` to ensure consistent behavior.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.flow_service import FlowService
+    from vibe3.services.issue_flow_service import IssueFlowService
+
+
+class FlowCleanupService:
+    """Unified service for complete flow scene cleanup.
+
+    This service coordinates the full cleanup of a flow scene:
+    1. Terminate tmux sessions (if any)
+    2. Remove worktree
+    3. Delete local branch
+    4. Delete remote branch
+    5. Clear handoff files
+    6. Delete flow record from database
+
+    The cleanup is best-effort - failures are logged but don't stop
+    the process from attempting remaining steps.
+    """
+
+    def __init__(
+        self,
+        git_client: GitClient | None = None,
+        store: SQLiteClient | None = None,
+        flow_service: FlowService | None = None,
+        issue_flow_service: IssueFlowService | None = None,
+    ) -> None:
+        """Initialize flow cleanup service.
+
+        Args:
+            git_client: Git client for branch/worktree operations
+            store: SQLite client for database operations
+            flow_service: Service for flow lifecycle
+            issue_flow_service: Service for issue-flow mapping
+        """
+        from vibe3.clients.git_client import GitClient
+        from vibe3.clients.sqlite_client import SQLiteClient
+
+        self.git_client = git_client or GitClient()
+        self.store = store or SQLiteClient()
+        self._flow_service = flow_service
+        self._issue_flow_service = issue_flow_service
+
+    @property
+    def flow_service(self) -> FlowService:
+        """Lazy-initialized flow service."""
+        if self._flow_service is None:
+            from vibe3.services.flow_service import FlowService
+
+            self._flow_service = FlowService(store=self.store)
+        return self._flow_service
+
+    @property
+    def issue_flow_service(self) -> IssueFlowService:
+        """Lazy-initialized issue-flow service."""
+        if self._issue_flow_service is None:
+            from vibe3.services.issue_flow_service import IssueFlowService
+
+            self._issue_flow_service = IssueFlowService(store=self.store)
+        return self._issue_flow_service
+
+    def cleanup_flow_scene(
+        self,
+        branch: str,
+        *,
+        include_remote: bool = True,
+        terminate_sessions: bool = True,
+    ) -> dict[str, bool]:
+        """Complete cleanup of a flow scene.
+
+        This method performs all cleanup steps for a terminal flow.
+        Failures in individual steps are logged but don't prevent
+        other steps from being attempted.
+
+        Args:
+            branch: Branch name for the flow to clean up
+            include_remote: Whether to also delete remote branch
+            terminate_sessions: Whether to terminate tmux sessions
+
+        Returns:
+            Dict with success status for each step:
+                - worktree: True if removed or didn't exist
+                - local_branch: True if deleted or didn't exist
+                - remote_branch: True if deleted, didn't exist, or skipped
+                - handoff: True if cleared or didn't exist
+                - flow_record: True if deleted
+        """
+        results: dict[str, bool] = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+
+        logger.bind(
+            domain="cleanup",
+            action="cleanup_flow_scene",
+            branch=branch,
+            include_remote=include_remote,
+        ).info("Starting flow scene cleanup")
+
+        # Step 1: Terminate tmux sessions (for task branches)
+        if terminate_sessions and self.issue_flow_service.is_task_branch(branch):
+            self._terminate_task_sessions(branch)
+
+        # Step 2: Remove worktree
+        try:
+            worktree_path = self.git_client.find_worktree_path_for_branch(branch)
+            if worktree_path:
+                self.git_client.remove_worktree(str(worktree_path), force=True)
+                logger.bind(domain="cleanup", branch=branch).debug("Removed worktree")
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to remove worktree: {exc}"
+            )
+            results["worktree"] = False
+
+        # Step 3: Delete local branch
+        try:
+            if self.git_client.branch_exists(branch):
+                self.git_client.delete_branch(branch, force=True, skip_if_worktree=True)
+                logger.bind(domain="cleanup", branch=branch).debug(
+                    "Deleted local branch"
+                )
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to delete local branch: {exc}"
+            )
+            results["local_branch"] = False
+
+        # Step 4: Delete remote branch
+        if include_remote:
+            try:
+                if self._has_remote_branch(branch):
+                    self.git_client.delete_remote_branch(branch)
+                    logger.bind(domain="cleanup", branch=branch).debug(
+                        "Deleted remote branch"
+                    )
+            except Exception as exc:
+                logger.bind(domain="cleanup", branch=branch).warning(
+                    f"Failed to delete remote branch: {exc}"
+                )
+                results["remote_branch"] = False
+
+        # Step 5: Clear handoff files
+        try:
+            from vibe3.services.handoff_service import HandoffService
+
+            HandoffService(
+                store=self.store, git_client=self.git_client
+            ).storage.clear_handoff_for_branch(branch)
+            logger.bind(domain="cleanup", branch=branch).debug("Cleared handoff files")
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to clear handoff: {exc}"
+            )
+            results["handoff"] = False
+
+        # Step 6: Delete flow record (always do this, even if other steps failed)
+        try:
+            self.flow_service.delete_flow(branch)
+            logger.bind(domain="cleanup", branch=branch).info("Deleted flow record")
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to delete flow record: {exc}"
+            )
+            results["flow_record"] = False
+
+        success_count = sum(1 for v in results.values() if v)
+        logger.bind(
+            domain="cleanup",
+            branch=branch,
+            success_count=success_count,
+            total_steps=len(results),
+        ).info(f"Flow scene cleanup completed ({success_count}/{len(results)} steps)")
+
+        return results
+
+    def _has_remote_branch(self, branch: str) -> bool:
+        """Check if remote branch exists."""
+        try:
+            result = self.git_client._run(
+                ["branch", "-r", "--list", f"origin/{branch}"]
+            )
+            return bool(result.strip())
+        except Exception:
+            return False
+
+    def _terminate_task_sessions(self, branch: str) -> None:
+        """Kill lingering tmux sessions for a task issue."""
+        import subprocess
+
+        from vibe3.environment.session_naming import get_manager_session_name
+
+        issue_number = self.issue_flow_service.parse_issue_number(branch)
+        if issue_number is None:
+            return
+
+        prefixes = (
+            get_manager_session_name(issue_number),
+            f"vibe3-plan-issue-{issue_number}",
+            f"vibe3-run-issue-{issue_number}",
+            f"vibe3-review-issue-{issue_number}",
+        )
+
+        try:
+            result = subprocess.run(
+                ["tmux", "ls"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except FileNotFoundError:
+            return
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to inspect tmux sessions: {exc}"
+            )
+            return
+
+        if result.returncode != 0:
+            return
+
+        active_sessions: list[str] = []
+        for line in result.stdout.splitlines():
+            session_name = line.split(":", 1)[0].strip()
+            if any(
+                session_name == prefix or session_name.startswith(f"{prefix}-")
+                for prefix in prefixes
+            ):
+                active_sessions.append(session_name)
+
+        for session_name in active_sessions:
+            subprocess.run(
+                ["tmux", "kill-session", "-t", session_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+
+        if active_sessions:
+            logger.bind(domain="cleanup", branch=branch).debug(
+                f"Terminated {len(active_sessions)} tmux sessions"
+            )

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -128,7 +128,28 @@ class FlowCleanupService:
         if terminate_sessions and self.issue_flow_service.is_task_branch(branch):
             self._terminate_task_sessions(branch)
 
-        # Step 2: Remove worktree
+        # Step 2-5: Clean physical resources
+        self._remove_worktree(branch, results)
+        self._delete_local_branch(branch, results)
+        if include_remote:
+            self._delete_remote_branch(branch, results)
+        self._clear_handoff(branch, results)
+
+        # Step 6: Handle flow record based on keep_flow_record parameter
+        self._handle_flow_record(branch, keep_flow_record, results)
+
+        success_count = sum(1 for v in results.values() if v)
+        logger.bind(
+            domain="cleanup",
+            branch=branch,
+            success_count=success_count,
+            total_steps=len(results),
+        ).info(f"Flow scene cleanup completed ({success_count}/{len(results)} steps)")
+
+        return results
+
+    def _remove_worktree(self, branch: str, results: dict[str, bool]) -> None:
+        """Remove worktree if exists."""
         try:
             worktree_path = self.git_client.find_worktree_path_for_branch(branch)
             if worktree_path:
@@ -140,7 +161,8 @@ class FlowCleanupService:
             )
             results["worktree"] = False
 
-        # Step 3: Delete local branch
+    def _delete_local_branch(self, branch: str, results: dict[str, bool]) -> None:
+        """Delete local branch if exists."""
         try:
             if self.git_client.branch_exists(branch):
                 self.git_client.delete_branch(branch, force=True, skip_if_worktree=True)
@@ -153,21 +175,22 @@ class FlowCleanupService:
             )
             results["local_branch"] = False
 
-        # Step 4: Delete remote branch
-        if include_remote:
-            try:
-                if self._has_remote_branch(branch):
-                    self.git_client.delete_remote_branch(branch)
-                    logger.bind(domain="cleanup", branch=branch).debug(
-                        "Deleted remote branch"
-                    )
-            except Exception as exc:
-                logger.bind(domain="cleanup", branch=branch).warning(
-                    f"Failed to delete remote branch: {exc}"
+    def _delete_remote_branch(self, branch: str, results: dict[str, bool]) -> None:
+        """Delete remote branch if exists."""
+        try:
+            if self._has_remote_branch(branch):
+                self.git_client.delete_remote_branch(branch)
+                logger.bind(domain="cleanup", branch=branch).debug(
+                    "Deleted remote branch"
                 )
-                results["remote_branch"] = False
+        except Exception as exc:
+            logger.bind(domain="cleanup", branch=branch).warning(
+                f"Failed to delete remote branch: {exc}"
+            )
+            results["remote_branch"] = False
 
-        # Step 5: Clear handoff files
+    def _clear_handoff(self, branch: str, results: dict[str, bool]) -> None:
+        """Clear handoff files for the branch."""
         try:
             from vibe3.services.handoff_service import HandoffService
 
@@ -181,15 +204,16 @@ class FlowCleanupService:
             )
             results["handoff"] = False
 
-        # Step 6: Handle flow record based on keep_flow_record parameter
+    def _handle_flow_record(
+        self, branch: str, keep_flow_record: bool, results: dict[str, bool]
+    ) -> None:
+        """Handle flow record deletion or preservation."""
         if keep_flow_record:
-            # Keep flow record as completion history (for done/merged flows)
             logger.bind(domain="cleanup", branch=branch).info(
                 "Keeping flow record as completion history"
             )
             results["flow_record"] = True
         else:
-            # Delete flow record (for aborted flows - allows issue to restart)
             try:
                 self.flow_service.delete_flow(branch)
                 logger.bind(domain="cleanup", branch=branch).info("Deleted flow record")
@@ -198,16 +222,6 @@ class FlowCleanupService:
                     f"Failed to delete flow record: {exc}"
                 )
                 results["flow_record"] = False
-
-        success_count = sum(1 for v in results.values() if v)
-        logger.bind(
-            domain="cleanup",
-            branch=branch,
-            success_count=success_count,
-            total_steps=len(results),
-        ).info(f"Flow scene cleanup completed ({success_count}/{len(results)} steps)")
-
-        return results
 
     def _has_remote_branch(self, branch: str) -> bool:
         """Check if remote branch exists."""

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -84,6 +84,7 @@ class FlowCleanupService:
         *,
         include_remote: bool = True,
         terminate_sessions: bool = True,
+        keep_flow_record: bool = False,
     ) -> dict[str, bool]:
         """Complete cleanup of a flow scene.
 
@@ -95,6 +96,9 @@ class FlowCleanupService:
             branch: Branch name for the flow to clean up
             include_remote: Whether to also delete remote branch
             terminate_sessions: Whether to terminate tmux sessions
+            keep_flow_record: Whether to keep flow record in database
+                - False (default): Delete flow record (for aborted flows)
+                - True: Keep flow record as completion history (for done/merged flows)
 
         Returns:
             Dict with success status for each step:
@@ -102,7 +106,7 @@ class FlowCleanupService:
                 - local_branch: True if deleted or didn't exist
                 - remote_branch: True if deleted, didn't exist, or skipped
                 - handoff: True if cleared or didn't exist
-                - flow_record: True if deleted
+                - flow_record: True if deleted (or kept when keep_flow_record=True)
         """
         results: dict[str, bool] = {
             "worktree": True,
@@ -117,6 +121,7 @@ class FlowCleanupService:
             action="cleanup_flow_scene",
             branch=branch,
             include_remote=include_remote,
+            keep_flow_record=keep_flow_record,
         ).info("Starting flow scene cleanup")
 
         # Step 1: Terminate tmux sessions (for task branches)
@@ -176,15 +181,23 @@ class FlowCleanupService:
             )
             results["handoff"] = False
 
-        # Step 6: Delete flow record (always do this, even if other steps failed)
-        try:
-            self.flow_service.delete_flow(branch)
-            logger.bind(domain="cleanup", branch=branch).info("Deleted flow record")
-        except Exception as exc:
-            logger.bind(domain="cleanup", branch=branch).warning(
-                f"Failed to delete flow record: {exc}"
+        # Step 6: Handle flow record based on keep_flow_record parameter
+        if keep_flow_record:
+            # Keep flow record as completion history (for done/merged flows)
+            logger.bind(domain="cleanup", branch=branch).info(
+                "Keeping flow record as completion history"
             )
-            results["flow_record"] = False
+            results["flow_record"] = True
+        else:
+            # Delete flow record (for aborted flows - allows issue to restart)
+            try:
+                self.flow_service.delete_flow(branch)
+                logger.bind(domain="cleanup", branch=branch).info("Deleted flow record")
+            except Exception as exc:
+                logger.bind(domain="cleanup", branch=branch).warning(
+                    f"Failed to delete flow record: {exc}"
+                )
+                results["flow_record"] = False
 
         success_count = sum(1 for v in results.values() if v)
         logger.bind(

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -164,6 +164,9 @@ class TaskResumeOperations:
 
         This method uses FlowCleanupService for consistent cleanup behavior
         across `task resume` and `check --clean-branch`.
+
+        Note: Always deletes flow record (keep_flow_record=False) because
+        the purpose of `task resume` is to restart the flow from scratch.
         """
         from vibe3.services.flow_cleanup_service import FlowCleanupService
 
@@ -183,8 +186,9 @@ class TaskResumeOperations:
 
         results = cleanup_service.cleanup_flow_scene(
             branch,
-            include_remote=True,  # Also delete remote branch for clean restart
+            include_remote=True,  # Delete remote branch for clean restart
             terminate_sessions=True,
+            keep_flow_record=False,  # Delete flow record to allow fresh start
         )
 
         # Log if any step failed

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -6,14 +6,11 @@ managing flow states during resume operations.
 
 from __future__ import annotations
 
-import subprocess
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.environment.session_naming import get_manager_session_name
 from vibe3.models.orchestration import IssueState
-from vibe3.services.handoff_service import HandoffService
 from vibe3.services.issue_failure_service import (
     resume_blocked_issue_to_ready,
     resume_failed_issue_to_ready,
@@ -164,98 +161,40 @@ class TaskResumeOperations:
         Flow record deletion is guaranteed even if worktree/branch/handoff
         cleanup fails partially — a stale flow record is the root cause of
         phantom downstream dispatches (issue #301).
+
+        This method uses FlowCleanupService for consistent cleanup behavior
+        across `task resume` and `check --clean-branch`.
         """
-        is_task = self.issue_flow_service.is_task_branch(branch)
+        from vibe3.services.flow_cleanup_service import FlowCleanupService
 
-        try:
-            if is_task:
-                self.terminate_task_sessions(branch)
+        logger.bind(
+            domain="resume",
+            action="reset_task_scene",
+            branch=branch,
+            worktree_path=worktree_path,
+        ).info("Resetting task scene")
 
-                resolved_path = worktree_path
-                if resolved_path is None:
-                    found_path = self.git_client.find_worktree_path_for_branch(branch)
-                    resolved_path = str(found_path) if found_path is not None else None
-                logger.bind(
-                    domain="resume",
-                    action="reset_task_scene",
-                    branch=branch,
-                    worktree_path=resolved_path,
-                ).info("Resetting task scene")
-                if resolved_path is not None:
-                    self.git_client.remove_worktree(resolved_path, force=True)
-                if self.git_client.branch_exists(branch):
-                    self.git_client.delete_branch(
-                        branch,
-                        force=True,
-                        skip_if_worktree=True,
-                    )
-                HandoffService(
-                    store=self.flow_service.store,
-                    git_client=self.git_client,
-                ).storage.clear_handoff_for_branch(branch)
-        except Exception as exc:
+        cleanup_service = FlowCleanupService(
+            git_client=self.git_client,
+            store=self.flow_service.store,
+            flow_service=self.flow_service,
+            issue_flow_service=self.issue_flow_service,
+        )
+
+        results = cleanup_service.cleanup_flow_scene(
+            branch,
+            include_remote=True,  # Also delete remote branch for clean restart
+            terminate_sessions=True,
+        )
+
+        # Log if any step failed
+        failed_steps = [k for k, v in results.items() if not v]
+        if failed_steps:
             logger.bind(
                 domain="resume",
                 action="reset_task_scene_partial",
                 branch=branch,
-            ).warning(
-                f"Partial scene cleanup failed (flow will still be deleted): {exc}"
-            )
-
-        # Always delete the flow record — stale flows cause phantom dispatches
-        self.flow_service.delete_flow(branch)
-
-    def terminate_task_sessions(self, branch: str) -> None:
-        """Kill lingering tmux sessions for a task issue before resume."""
-        issue_number = self.issue_flow_service.parse_issue_number(branch)
-        if issue_number is None:
-            return
-
-        prefixes = (
-            get_manager_session_name(issue_number),
-            f"vibe3-plan-issue-{issue_number}",
-            f"vibe3-run-issue-{issue_number}",
-            f"vibe3-review-issue-{issue_number}",
-        )
-
-        try:
-            result = subprocess.run(
-                ["tmux", "ls"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-        except FileNotFoundError:
-            return
-        except Exception as exc:
-            logger.bind(
-                domain="resume",
-                action="terminate_task_sessions",
-                branch=branch,
-            ).warning(f"Failed to inspect tmux sessions: {exc}")
-            return
-
-        if result.returncode != 0:
-            return
-
-        active_sessions: list[str] = []
-        for line in result.stdout.splitlines():
-            session_name = line.split(":", 1)[0].strip()
-            if any(
-                session_name == prefix or session_name.startswith(f"{prefix}-")
-                for prefix in prefixes
-            ):
-                active_sessions.append(session_name)
-
-        for session_name in active_sessions:
-            subprocess.run(
-                ["tmux", "kill-session", "-t", session_name],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
+            ).warning(f"Some cleanup steps failed: {', '.join(failed_steps)}")
 
     def restore_issue_state(
         self,

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -280,7 +280,7 @@ class TestCleanResidualBranches:
     def test_clean_residual_branches_removes_done_flow_branches(
         self, check_service, mock_store, mock_git_client
     ):
-        """Should clean branches for done/aborted flows."""
+        """Should clean physical resources for done flows but keep flow record."""
         mock_store.get_all_flows.return_value = [
             {"branch": "feature/done-branch", "flow_status": "done"},
             {"branch": "feature/active-branch", "flow_status": "active"},
@@ -291,17 +291,18 @@ class TestCleanResidualBranches:
 
         result = check_service.clean_residual_branches()
 
-        assert "feature/done-branch" in result["cleaned"]
-        assert len(result["cleaned"]) == 1
+        # Done flow should be in kept_records (physical resources cleaned, record kept)
+        assert "feature/done-branch" in result["kept_records"]
+        assert len(result["cleaned"]) == 0  # cleaned is for aborted flows only
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_skips_when_no_resources(
         self, check_service, mock_store, mock_git_client
     ):
-        """Should still delete flow record even when no physical resources exist.
+        """Should preserve done/merged flow records even without physical resources.
 
-        This is the key behavior change: flow records are always deleted for
-        terminal flows, allowing issues to be cleanly re-dispatched.
+        Done/merged flows keep their records as completion history.
+        Only aborted flows have their records deleted.
         """
         mock_store.get_all_flows.return_value = [
             {"branch": "feature/done-branch", "flow_status": "done"},
@@ -312,9 +313,29 @@ class TestCleanResidualBranches:
 
         result = check_service.clean_residual_branches()
 
-        # Flow record should still be cleaned (deleted from database)
+        # Done flow record should be preserved (in kept_records, not cleaned)
+        assert len(result["kept_records"]) == 1
+        assert "feature/done-branch" in result["kept_records"]
+        assert len(result["cleaned"]) == 0  # cleaned is for aborted flows
+        assert result["total_flows_checked"] == 1
+
+    def test_clean_residual_branches_aborted_deletes_record(
+        self, check_service, mock_store, mock_git_client
+    ):
+        """Should delete aborted flow records to allow issue restart."""
+        mock_store.get_all_flows.return_value = [
+            {"branch": "feature/aborted-branch", "flow_status": "aborted"},
+        ]
+        # Simulate no resources exist
+        mock_git_client._run.return_value = ""
+        mock_git_client.find_worktree_path_for_branch.return_value = None
+
+        result = check_service.clean_residual_branches()
+
+        # Aborted flow record should be deleted (in cleaned)
         assert len(result["cleaned"]) == 1
-        assert "feature/done-branch" in result["cleaned"]
+        assert "feature/aborted-branch" in result["cleaned"]
+        assert len(result["kept_records"]) == 0  # kept_records is for done/merged
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_removes_invalid_records(

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -298,7 +298,11 @@ class TestCleanResidualBranches:
     def test_clean_residual_branches_skips_when_no_resources(
         self, check_service, mock_store, mock_git_client
     ):
-        """Should skip when no local/remote/worktree exists."""
+        """Should still delete flow record even when no physical resources exist.
+
+        This is the key behavior change: flow records are always deleted for
+        terminal flows, allowing issues to be cleanly re-dispatched.
+        """
         mock_store.get_all_flows.return_value = [
             {"branch": "feature/done-branch", "flow_status": "done"},
         ]
@@ -308,7 +312,9 @@ class TestCleanResidualBranches:
 
         result = check_service.clean_residual_branches()
 
-        assert len(result["cleaned"]) == 0
+        # Flow record should still be cleaned (deleted from database)
+        assert len(result["cleaned"]) == 1
+        assert "feature/done-branch" in result["cleaned"]
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_removes_invalid_records(

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -11,6 +11,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.models.orchestration import IssueState
 from vibe3.models.pr import PRResponse, PRState
+from vibe3.services.check_cleanup_service import CheckCleanupService
 from vibe3.services.check_service import CheckService
 
 
@@ -44,6 +45,15 @@ def check_service(mock_store, mock_git_client, mock_github_client):
         store=mock_store,
         git_client=mock_git_client,
         github_client=mock_github_client,
+    )
+
+
+@pytest.fixture
+def cleanup_service(mock_store, mock_git_client):
+    """Create a CheckCleanupService instance with mocked dependencies."""
+    return CheckCleanupService(
+        store=mock_store,
+        git_client=mock_git_client,
     )
 
 
@@ -275,10 +285,10 @@ class TestAutoFix:
 
 
 class TestCleanResidualBranches:
-    """Tests for clean_residual_branches method."""
+    """Tests for clean_residual_branches method in CheckCleanupService."""
 
     def test_clean_residual_branches_removes_done_flow_branches(
-        self, check_service, mock_store, mock_git_client
+        self, cleanup_service, mock_store, mock_git_client
     ):
         """Should clean physical resources for done flows but keep flow record."""
         mock_store.get_all_flows.return_value = [
@@ -289,7 +299,7 @@ class TestCleanResidualBranches:
         mock_git_client._run.return_value = "feature/done-branch"
         mock_git_client.find_worktree_path_for_branch.return_value = None
 
-        result = check_service.clean_residual_branches()
+        result = cleanup_service.clean_residual_branches()
 
         # Done flow should be in kept_records (physical resources cleaned, record kept)
         assert "feature/done-branch" in result["kept_records"]
@@ -297,7 +307,7 @@ class TestCleanResidualBranches:
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_skips_when_no_resources(
-        self, check_service, mock_store, mock_git_client
+        self, cleanup_service, mock_store, mock_git_client
     ):
         """Should preserve done/merged flow records even without physical resources.
 
@@ -311,7 +321,7 @@ class TestCleanResidualBranches:
         mock_git_client._run.return_value = ""
         mock_git_client.find_worktree_path_for_branch.return_value = None
 
-        result = check_service.clean_residual_branches()
+        result = cleanup_service.clean_residual_branches()
 
         # Done flow record should be preserved (in kept_records, not cleaned)
         assert len(result["kept_records"]) == 1
@@ -320,7 +330,7 @@ class TestCleanResidualBranches:
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_aborted_deletes_record(
-        self, check_service, mock_store, mock_git_client
+        self, cleanup_service, mock_store, mock_git_client
     ):
         """Should delete aborted flow records to allow issue restart."""
         mock_store.get_all_flows.return_value = [
@@ -330,7 +340,7 @@ class TestCleanResidualBranches:
         mock_git_client._run.return_value = ""
         mock_git_client.find_worktree_path_for_branch.return_value = None
 
-        result = check_service.clean_residual_branches()
+        result = cleanup_service.clean_residual_branches()
 
         # Aborted flow record should be deleted (in cleaned)
         assert len(result["cleaned"]) == 1
@@ -339,7 +349,7 @@ class TestCleanResidualBranches:
         assert result["total_flows_checked"] == 1
 
     def test_clean_residual_branches_removes_invalid_records(
-        self, check_service, mock_store, mock_git_client
+        self, cleanup_service, mock_store, mock_git_client
     ):
         """Should remove HEAD records from database."""
         mock_store.get_all_flows.return_value = [
@@ -347,13 +357,13 @@ class TestCleanResidualBranches:
             {"branch": "HEAD~1", "flow_status": "aborted"},
         ]
 
-        result = check_service.clean_residual_branches()
+        result = cleanup_service.clean_residual_branches()
 
         assert len(result["removed_invalid"]) == 2
         assert mock_store.delete_flow.call_count == 2
 
     def test_clean_residual_branches_handles_partial_failures(
-        self, check_service, mock_store, mock_git_client
+        self, cleanup_service, mock_store, mock_git_client
     ):
         """Should continue cleaning even if some fail."""
         mock_store.get_all_flows.return_value = [
@@ -374,7 +384,7 @@ class TestCleanResidualBranches:
         mock_git_client._run.side_effect = mock_run
         mock_git_client.find_worktree_path_for_branch.return_value = None
 
-        result = check_service.clean_residual_branches()
+        result = cleanup_service.clean_residual_branches()
 
         # Should have some result despite failures
         assert "failed" in result

--- a/tests/vibe3/services/test_task_resume_operations.py
+++ b/tests/vibe3/services/test_task_resume_operations.py
@@ -55,6 +55,7 @@ def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
             "task/issue-329",
             include_remote=True,
             terminate_sessions=True,
+            keep_flow_record=False,  # Resume always deletes flow record
         )
 
 

--- a/tests/vibe3/services/test_task_resume_operations.py
+++ b/tests/vibe3/services/test_task_resume_operations.py
@@ -25,6 +25,7 @@ def _make_operations() -> TaskResumeOperations:
 
 
 def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
+    """Test that reset_task_scene uses FlowCleanupService for complete cleanup."""
     operations = _make_operations()
     operations.git_client.find_worktree_path_for_branch.return_value = Path(
         "/tmp/issue-329"
@@ -32,32 +33,29 @@ def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
     operations.git_client.branch_exists.return_value = True
 
     with patch(
-        "vibe3.services.task_resume_operations.HandoffService"
-    ) as mock_handoff_cls:
-        # Mock the HandoffService instance and its storage attribute
-        mock_handoff_instance = MagicMock()
-        mock_storage = MagicMock()
-        mock_handoff_instance.storage = mock_storage
-        mock_handoff_cls.return_value = mock_handoff_instance
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
 
         operations.reset_task_scene("task/issue-329")
 
-    operations.git_client.remove_worktree.assert_called_once_with(
-        "/tmp/issue-329", force=True
-    )
-    operations.git_client.delete_branch.assert_called_once_with(
-        "task/issue-329",
-        force=True,
-        skip_if_worktree=True,
-    )
-    # Verify HandoffService was instantiated with correct parameters
-    mock_handoff_cls.assert_called_once_with(
-        store=operations.flow_service.store,
-        git_client=operations.git_client,
-    )
-    # Verify storage.clear_handoff_for_branch was called
-    mock_storage.clear_handoff_for_branch.assert_called_once_with("task/issue-329")
-    operations.flow_service.delete_flow.assert_called_once_with("task/issue-329")
+        # Verify FlowCleanupService was instantiated
+        mock_cleanup_cls.assert_called_once()
+
+        # Verify cleanup_flow_scene was called with correct parameters
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-329",
+            include_remote=True,
+            terminate_sessions=True,
+        )
 
 
 def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
@@ -73,10 +71,17 @@ def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
     mock_flow.branch = "task/issue-303"
 
     with patch(
-        "vibe3.services.task_resume_operations.HandoffService"
-    ) as mock_handoff_cls:
-        handoff_service = MagicMock()
-        mock_handoff_cls.return_value = handoff_service
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
 
         operations.reset_issue_to_ready(
             issue_number=303,
@@ -88,9 +93,8 @@ def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
             label_state=None,  # ← No --label
         )
 
-    # Verify: worktree deleted (reset_task_scene called)
-    operations.git_client.remove_worktree.assert_called_once()
-    operations.git_client.delete_branch.assert_called_once()
+        # Verify: cleanup_flow_scene was called (via reset_task_scene)
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
 
 
 def test_reset_issue_to_ready_with_label_keeps_worktree() -> None:


### PR DESCRIPTION
## Summary

统一 flow 清理逻辑，区分 done/merged 和 aborted 的处理方式。

### 问题
- `check --clean-branch` 和 `task resume` 有重复的清理代码
- `check --clean-branch` 只清理物理资源（branch/worktree），不删除 flow record
- 导致 aborted flows 残留在数据库，阻止 issue 重新开始

### 解决方案

**创建 `FlowCleanupService` 统一清理逻辑**：
- 终止 tmux sessions
- 删除 worktree
- 删除 local + remote branch
- 清理 handoff files
- 可选删除 flow record

**区分处理**：
- `done`/`merged`: 清物理资源，保留 flow record 作为历史记录
- `aborted`: 完全清理（包括 flow record），允许 issue 重新开始

**孤儿 flow 处理**：
- Active flow + 无 task_issue + 无 worktree + 落后 >100 commits → 标记为 aborted

## Changes

1. `FlowCleanupService` - 新建统一清理服务
2. `check --clean-branch` - 使用新服务，区分 done/merged vs aborted
3. `task resume` - 使用新服务，完全清理（fresh start）
4. 孤儿 flow 检测 - 温和条件（落后 >100 commits）

## Test Plan

- [x] 单元测试通过
- [x] pre-commit 检查通过
- [ ] 实际运行 `vibe3 check --clean-branch` 清理 aborted flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)