### PR TITLE
fix(task-resume): support resuming issues in any non-DONE state

### DIFF
--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -106,11 +106,6 @@ def main_callback(
     ctx.meta["verbose"] = verbose
     setup_logging(verbose=verbose)
 
-    # Register domain event handlers
-    from vibe3.domain.handlers import register_event_handlers
-
-    register_event_handlers()
-
 
 @app.command(name="run")
 def run_command(

--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any, Literal
 
 import typer
+from rich.console import Console
 
 from vibe3.commands.check_support import execute_check_mode
 from vibe3.observability.logger import setup_logging
@@ -136,7 +137,7 @@ def check(
 
         # Hint for clean-branch after regular check
         if mode == "fix_all":
-            typer.echo(
+            Console().print(
                 "\n  [dim]Hint: To clean residual branches for done/aborted flows, "
                 "use 'vibe3 check --clean-branch'[/]"
             )

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -68,6 +68,11 @@ def run_command(
     if trace:
         enable_trace()
 
+    # Register EDA event handlers for run command (may publish events)
+    from vibe3.domain.handlers import register_event_handlers
+
+    register_event_handlers()
+
     config = VibeConfig.get_defaults()
     flow_service, branch = ensure_flow_for_current_branch()
     flow = flow_service.get_flow_status(branch)

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -180,6 +180,11 @@ def resume(
     if trace:
         setup_logging(verbose=2)
 
+    # Register EDA event handlers (resume publishes IssueStateChanged events)
+    from vibe3.domain.handlers import register_event_handlers
+
+    register_event_handlers()
+
     # Validate arguments
     selected_modes = [failed, blocked, all_tasks]
     has_flag = any(selected_modes)

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -279,6 +279,22 @@ def resume(
             typer.echo(f"No {state_name} issues found.")
             return
 
+    # Progress callback for verbose output
+    def progress_callback(
+        issue_number: int, branch: str | None, step: str, status: str
+    ) -> None:
+        prefix = f"  #{issue_number}"
+        if branch:
+            prefix += f" [{branch}]"
+        if status == "done":
+            typer.echo(f"{prefix} ✓ {step}")
+        elif status == "failed":
+            typer.echo(f"{prefix} ✗ {step}", err=True)
+        else:
+            typer.echo(f"{prefix} → {step}")
+
+    # Execute resume
+    if has_flag and candidate_mode == "resumable":
         result = usecase.resume_issues(
             issue_numbers=issue_numbers,
             reason=reason,
@@ -287,6 +303,7 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
+            progress_callback=progress_callback if yes else None,
         )
     else:
         # Original logic for --all or explicit issue numbers
@@ -298,6 +315,7 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
+            progress_callback=progress_callback if yes else None,
         )
 
     if not yes and has_flag and not result.get("candidates"):

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -151,6 +151,11 @@ def start(
 
     setup_logging(verbose=verbose)
 
+    # Register EDA event handlers for orchestra event processing
+    from vibe3.domain.handlers import register_event_handlers
+
+    register_event_handlers()
+
     # Orchestra events.log level follows global verbosity
     # Default: INFO (key runtime events for monitoring)
     # -v: already INFO (no change needed)

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -101,6 +101,23 @@ def is_running_issue(entry: IssueStatusEntry) -> bool:
     return entry.has_flow or entry.has_worktree or entry.has_pr
 
 
+def _extract_state_from_labels(labels: list) -> IssueState | None:
+    """Extract state from issue labels without API call.
+
+    Args:
+        labels: List of label dicts from GitHub issue response
+
+    Returns:
+        IssueState if state/* label found, None otherwise
+    """
+    for label in labels:
+        name = label.get("name", "") if isinstance(label, dict) else str(label)
+        state = IssueState.from_label(name)
+        if state:
+            return state
+    return None
+
+
 class OrchestraStatusService:
     """Aggregate read-only status from multiple data sources.
 
@@ -209,8 +226,9 @@ class OrchestraStatusService:
             title = issue.get("title", "")
             assignee = extract_primary_assignee_login(issue.get("assignees"))
 
-            # Get state from labels
-            state = self._label_service.get_state(number)
+            # Get state from issue labels (already fetched in list_issues)
+            # Avoid N+1 API calls by not calling get_state() per issue
+            state = _extract_state_from_labels(issue.get("labels", []))
 
             # Check flow
             flow = self._orchestrator.get_flow_for_issue(number)

--- a/src/vibe3/services/task_resume_candidates.py
+++ b/src/vibe3/services/task_resume_candidates.py
@@ -72,8 +72,21 @@ class TaskResumeCandidates:
         flows: list[FlowStatusResponse],
         stale_flows: list[FlowStatusResponse],
     ) -> dict[str, Any] | None:
-        """为显式指定的 issue 直接构造恢复候选。"""
+        """为显式指定的 issue 直接构造恢复候选。
+
+        对于显式指定的 issue（通过 vibe3 task resume <issue_number>），
+        允许任何非 DONE 状态进行完整重建，用于清理脏数据场景。
+        """
         current_state = self.label_service.get_state(issue_number)
+
+        # Issue 不存在或已完成，不允许 resume
+        if current_state is None or current_state == IssueState.DONE:
+            return None
+
+        # 查找关联的 flow（可能不存在）
+        flow = self.find_resume_flow(issue_number, flows, stale_flows)
+
+        # 对于 aborted flow 且状态为 ready/handoff，使用 aborted 恢复
         if current_state in {IssueState.READY, IssueState.HANDOFF}:
             aborted_flow = self.find_resume_flow_by_status(
                 issue_number,
@@ -90,26 +103,24 @@ class TaskResumeCandidates:
                     "flow": aborted_flow,
                 }
 
-        flow = self.find_resume_flow(issue_number, flows, stale_flows)
-        if (
-            flow is not None
-            and flow.flow_status == "aborted"
-            and current_state in {IssueState.READY, IssueState.HANDOFF}
-        ):
-            return {
-                "number": issue_number,
-                "title": "",
-                "state": current_state,
-                "resume_kind": "aborted",
-                "flow": flow,
-            }
+            if flow is not None and flow.flow_status == "aborted":
+                return {
+                    "number": issue_number,
+                    "title": "",
+                    "state": current_state,
+                    "resume_kind": "aborted",
+                    "flow": flow,
+                }
 
+        # 根据状态确定 resume_kind
         if current_state == IssueState.FAILED:
             resume_kind = "failed"
         elif current_state == IssueState.BLOCKED:
             resume_kind = "blocked"
         else:
-            return None
+            # 对于其他状态（ready/handoff/review/merge-ready 等），
+            # 使用 "all" 类型，允许完整重建
+            resume_kind = "all"
 
         return {
             "number": issue_number,
@@ -207,6 +218,7 @@ class TaskResumeCandidates:
         candidate_state: object,
         worktree_path: str | None,
         has_live_sessions: bool | None = None,
+        label_state: str | None = None,  # 新增：区分 --label 和完整重建
     ) -> str | None:
         """Skip noop all-task candidates that no longer have a task scene to reset.
 
@@ -217,31 +229,47 @@ class TaskResumeCandidates:
             worktree_path: Worktree path (if exists)
             has_live_sessions: Whether branch has live runtime sessions (from registry).
                 Registry is the single source of truth for session status.
+            label_state: Optional label state (--label mode). None means full rebuild.
 
         Returns:
             Skip reason string if candidate should be skipped, None otherwise.
         """
         branch = getattr(flow, "branch", None) if flow else None
-        if not isinstance(branch, str):
-            return None
 
         # Registry is the source of truth for live sessions
         has_runtime_sessions = bool(has_live_sessions)
 
-        if (
-            candidate_state == IssueState.READY
-            and worktree_path is None
-            and not has_runtime_sessions
-        ):
+        # --label 模式：保留现场，只清理 reason
+        # 如果没有现场可清理 reason，则跳过
+        if label_state is not None:
+            if (
+                candidate_state == IssueState.READY
+                and worktree_path is None
+                and not has_runtime_sessions
+            ):
+                logger.bind(
+                    domain="resume",
+                    action="skip_noop_label_resume",
+                    issue_number=issue_number,
+                    branch=branch,
+                    worktree_path=None,
+                    state="ready",
+                ).info("Skipping --label resume without task scene")
+                return "已是 state/ready 且无 task scene，无法清理 reason，跳过恢复"
+
+        # 完整重建模式（无 --label）：
+        # 即使没有 worktree/flow，也可以继续（将状态设为 ready，等待重新 dispatch）
+        # 只有当有活跃 session 时才跳过（需要用户手动处理）
+        if has_runtime_sessions:
             logger.bind(
                 domain="resume",
-                action="skip_noop_all_task",
+                action="skip_live_session",
                 issue_number=issue_number,
                 branch=branch,
-                worktree_path=None,
-                state="ready",
-            ).info("Skipping ready candidate without task scene")
-            return "已是 state/ready 且无 task scene，跳过恢复"
+                worktree_path=worktree_path,
+            ).info("Skipping resume due to live runtime sessions")
+            return "存在活跃 runtime session，需要先手动终止，跳过恢复"
+
         return None
 
     def verify_issue_state_for_resume(

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -52,6 +52,7 @@ class TaskResumeOperations:
         reason: str,
         worktree_path: str | None = None,
         label_state: str | None = None,
+        progress_callback: object = None,
     ) -> None:
         """Reset an issue to ready after clearing stale task scene state.
 
@@ -64,9 +65,14 @@ class TaskResumeOperations:
             worktree_path: Optional worktree path (for optimization)
             label_state: Optional state to restore (None=delete worktree,
                 empty/"handoff"=restore to handoff, "ready"=restore to ready)
+            progress_callback: Optional callback for progress updates
         """
         branch = getattr(flow, "branch", None) if flow else None
         previous_state = self.label_service.get_state(issue_number)
+
+        def emit_progress(step: str, status: str = "running") -> None:
+            if progress_callback and hasattr(progress_callback, "__call__"):
+                progress_callback(issue_number, branch, step, status)
 
         # Determine target state based on label_state parameter
         if label_state is not None:
@@ -101,8 +107,10 @@ class TaskResumeOperations:
             # fields so the next dispatch picks it up; the flow record, refs,
             # and worktree are all valid and should be preserved.
             if isinstance(branch, str):
+                emit_progress(f"clearing reasons for branch {branch}")
                 self._clear_flow_reasons(branch, resume_kind)
 
+            emit_progress(f"setting issue state to {target_state.value}")
             # Restore issue to target state
             self.label_service.confirm_issue_state(
                 issue_number,
@@ -119,23 +127,28 @@ class TaskResumeOperations:
                 repo=repo,
                 reason=reason,
             )
+            emit_progress("label resume done", status="done")
 
             # DO NOT call reset_task_scene (keep worktree)
         else:
             # Original logic: delete worktree/branch for full rebuild
+            emit_progress("full rebuild mode")
             if resume_kind == "failed":
+                emit_progress("clearing failed state")
                 resume_failed_issue_to_ready(
                     issue_number=issue_number,
                     repo=repo,
                     reason=reason,
                 )
             elif resume_kind == "blocked":
+                emit_progress("clearing blocked state")
                 resume_blocked_issue_to_ready(
                     issue_number=issue_number,
                     repo=repo,
                     reason=reason,
                 )
             else:
+                emit_progress("setting issue state to ready")
                 self.label_service.confirm_issue_state(
                     issue_number,
                     IssueState.READY,
@@ -145,8 +158,11 @@ class TaskResumeOperations:
 
             if isinstance(branch, str):
                 try:
+                    emit_progress(f"resetting task scene for branch {branch}")
                     self.reset_task_scene(branch, worktree_path=worktree_path)
+                    emit_progress("task scene reset done", status="done")
                 except Exception as exc:
+                    emit_progress(f"scene reset failed: {exc}", status="failed")
                     self.restore_issue_state(
                         issue_number=issue_number,
                         previous_state=previous_state,
@@ -154,6 +170,8 @@ class TaskResumeOperations:
                         failure_reason=str(exc),
                     )
                     raise
+            else:
+                emit_progress("no branch to reset, done", status="done")
 
     def reset_task_scene(self, branch: str, worktree_path: str | None = None) -> None:
         """Delete the stale task scene so the next run starts from scratch.

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -6,7 +6,7 @@ managing flow states during resume operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService
     from vibe3.services.label_service import LabelService
+
+
+# Type alias for progress callback: (issue_number, branch, step, status) -> None
+ProgressCallback = Callable[[int, str | None, str, str], None]
 
 
 class TaskResumeOperations:
@@ -52,7 +56,7 @@ class TaskResumeOperations:
         reason: str,
         worktree_path: str | None = None,
         label_state: str | None = None,
-        progress_callback: object = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> None:
         """Reset an issue to ready after clearing stale task scene state.
 
@@ -65,13 +69,15 @@ class TaskResumeOperations:
             worktree_path: Optional worktree path (for optimization)
             label_state: Optional state to restore (None=delete worktree,
                 empty/"handoff"=restore to handoff, "ready"=restore to ready)
-            progress_callback: Optional callback for progress updates
+            progress_callback: Optional callback for progress updates.
+                Signature: (issue_number: int, branch: str | None, step: str,
+                    status: str) -> None
         """
         branch = getattr(flow, "branch", None) if flow else None
         previous_state = self.label_service.get_state(issue_number)
 
         def emit_progress(step: str, status: str = "running") -> None:
-            if progress_callback and hasattr(progress_callback, "__call__"):
+            if progress_callback:
                 progress_callback(issue_number, branch, step, status)
 
         # Determine target state based on label_state parameter

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -76,7 +76,8 @@ class TaskResumeUsecase:
         stale_flows: list[FlowStatusResponse] | None = None,
         repo: str | None = None,
         candidate_mode: str = "resumable",
-        label_state: str | None = None,  # ← 新增参数
+        label_state: str | None = None,
+        progress_callback: object = None,
     ) -> dict[str, Any]:
         """Resume failed or blocked issues.
 
@@ -90,6 +91,7 @@ class TaskResumeUsecase:
             candidate_mode: Candidate selection mode ("resumable" or "all_task")
             label_state: Optional state to restore (None=delete worktree,
                 "handoff"/"ready"=keep worktree)
+            progress_callback: Optional callback(issue_number, branch, step, status)
 
         Returns:
             Dict with:
@@ -188,6 +190,7 @@ class TaskResumeUsecase:
                     candidate_state=candidate.get("state"),
                     worktree_path=worktree_path,
                     has_live_sessions=has_live_sessions,
+                    label_state=label_state,
                 )
                 if skip_reason is not None:
                     result["skipped"].append(
@@ -217,6 +220,7 @@ class TaskResumeUsecase:
                         reason=reason,
                         worktree_path=worktree_path,
                         label_state=label_state,
+                        progress_callback=progress_callback,
                     )
 
                     # Publish event to notify EDA handlers of the state change

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -6,7 +6,7 @@ whether they are in failed or blocked state.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
@@ -23,6 +23,10 @@ from vibe3.services.task_resume_operations import TaskResumeOperations
 
 if TYPE_CHECKING:
     from vibe3.models.flow import FlowStatusResponse
+
+
+# Type alias for progress callback: (issue_number, branch, step, status) -> None
+ProgressCallback = Callable[[int, str | None, str, str], None]
 
 
 def _format_resume_failure_reason(exc: Exception) -> str:
@@ -77,7 +81,7 @@ class TaskResumeUsecase:
         repo: str | None = None,
         candidate_mode: str = "resumable",
         label_state: str | None = None,
-        progress_callback: object = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> dict[str, Any]:
         """Resume failed or blocked issues.
 
@@ -91,7 +95,9 @@ class TaskResumeUsecase:
             candidate_mode: Candidate selection mode ("resumable" or "all_task")
             label_state: Optional state to restore (None=delete worktree,
                 "handoff"/"ready"=keep worktree)
-            progress_callback: Optional callback(issue_number, branch, step, status)
+            progress_callback: Optional callback for progress updates.
+                Signature: (issue_number: int, branch: str | None, step: str,
+                    status: str) -> None
 
         Returns:
             Dict with:


### PR DESCRIPTION
## Summary

- Allow `task resume <issue_number>` to work with any non-DONE state (not just `failed`/`blocked`)
- Add progress output to show real-time work being done
- Fix Rich markup rendering in `vibe check` hint

## Problem

Previously, `task resume <issue_number>` only worked for issues in `failed` or `blocked` states. This was too restrictive for cleaning up orphan issues that have stale worktrees/branches but are in `ready/handoff/review` states.

## Changes

1. **`build_explicit_issue_candidate()`**: Allow any non-DONE state to create a resume candidate with `resume_kind="all"`
2. **`maybe_skip_all_task_candidate()`**: Distinguish `--label` mode (preserve worktree) from full rebuild mode (delete worktree)
3. **Add `progress_callback`**: Show real-time progress during resume operations
4. **Fix Rich markup**: Use `Console().print()` instead of `typer.echo()` in `vibe check`

## Test plan

- [x] `task resume 303` works for issue in `state/ready`
- [x] `task resume 330 348 ...` works for issues in `state/handoff`
- [x] Progress output shows during resume
- [x] `vibe check` hint renders correctly with dim styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)