### PR TITLE
fix(manager): suppress duplicate comments and add token fallback chain

### DIFF
--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -94,8 +94,10 @@ def _resolve_manager_token(config: OrchestraConfig) -> str | None:
                             f"Manager token loaded from {keys_path}"
                         )
                         return value
-    except Exception:
-        pass
+    except (OSError, UnicodeDecodeError) as e:
+        logger.bind(domain="manager").debug(
+            f"Failed to read keys.env for manager token: {e}"
+        )
 
     return None
 

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -67,6 +67,39 @@ MANAGER_BRANCH_RESOLVER = build_task_flow_branch_resolver(
 )
 
 
+def _resolve_manager_token(config: OrchestraConfig) -> str | None:
+    """Resolve manager token with fallback: env var (.zshrc) → keys.env → None."""
+    token_env = config.assignee_dispatch.token_env
+    if not token_env:
+        return None
+
+    # 1. Environment variable (set via .zshrc / direnv)
+    token = os.getenv(token_env)
+    if token:
+        return token
+
+    # 2. Fallback to config/keys.env
+    try:
+        from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+
+        keys_path = resolve_orchestra_repo_root() / "config" / "keys.env"
+        if keys_path.exists():
+            prefix = f"{token_env}="
+            for line in keys_path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped.startswith(prefix) and not stripped.startswith("#"):
+                    value = stripped[len(prefix) :].strip().strip("\"'")
+                    if value:
+                        logger.bind(domain="manager").debug(
+                            f"Manager token loaded from {keys_path}"
+                        )
+                        return value
+    except Exception:
+        pass
+
+    return None
+
+
 def _make_section_provider(
     manager_sections: dict[str, Any], section_key: str
 ) -> PromptProvider:
@@ -113,20 +146,19 @@ def build_manager_request(
     env = dict(os.environ)
 
     # Inject manager-specific token if configured (Phase 4)
-    if config.assignee_dispatch.token_env:
-        manager_token = os.getenv(config.assignee_dispatch.token_env)
-        if manager_token:
-            env["GH_TOKEN"] = manager_token
-            token_env_name = config.assignee_dispatch.token_env
-            logger.bind(domain="manager", issue_number=issue.number).info(
-                f"Using manager-specific token from {token_env_name}"
-            )
-        else:
-            # Bug 5: Log warning about fallback to user identity
-            logger.bind(domain="manager", issue_number=issue.number).warning(
-                f"Manager token {config.assignee_dispatch.token_env} not set. "
-                "Falling back to user identity (GH_TOKEN). Isolation is degraded."
-            )
+    manager_token = _resolve_manager_token(config)
+    if manager_token:
+        env["GH_TOKEN"] = manager_token
+        logger.bind(domain="manager", issue_number=issue.number).info(
+            f"Using manager-specific token from {config.assignee_dispatch.token_env}"
+        )
+    elif config.assignee_dispatch.token_env:
+        # Token configured but not available anywhere
+        logger.bind(domain="manager", issue_number=issue.number).warning(
+            f"Manager token {config.assignee_dispatch.token_env} not set "
+            "in env or keys.env. Falling back to user identity (GH_TOKEN). "
+            "Isolation is degraded."
+        )
 
     # Inject manager backend/model if not already set
     if not env.get("VIBE3_MANAGER_BACKEND"):

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -811,6 +811,16 @@ Steps:
 - 若无新增事实，不重复发布几乎相同的长 comment
 - 若最新评论已给出明确方向，不再输出 `Option A/B/C`
 - 若当前 state 是 `ready` 且无明确阻止推进的指示，本轮 comment 应写”已认领、当前风险、下一阶段 handoff”
+- **去重与修正优先编辑**：
+  - 发 comment 前必须检查上一条 `[manager]` 评论是否已包含本轮核心论点（状态转换、关键发现、质量判断）
+  - 若上一条 `[manager]` 评论内容截断或信息不完整，**编辑上一条评论**而非发新评论：
+    ```bash
+    # 获取上一条 manager 评论的 comment_id
+    gh issue view <issue-number> --json comments --jq '.comments | map(select(.author.login == “<bot_username>” or .body | startswith(“[manager]”))) | last | .id'
+    # 编辑该评论
+    gh api repos/{owner}/{repo}/issues/comments/<comment_id> -X PATCH -f body=”<修正后的完整内容>”
+    ```
+  - 禁止为纠正自身输出格式问题而发新评论
 
 ## Handoff Contract
 


### PR DESCRIPTION
## Summary
- Fix duplicate `[manager]` comments by adding "edit instead of repost" rules to Comment Contract in `supervisor/manager.md`
- Add `_resolve_manager_token()` fallback chain: env var (.zshrc) → config/keys.env → human GH_TOKEN, fixing manager always using human identity

## Root Cause (from #509 investigation)
1. **Duplicate comments**: Manager output gets truncated, next cycle detects corrupted comment and re-posts instead of editing
2. **Token not used**: `VIBE_MANAGER_GITHUB_TOKEN` was only checked via `os.getenv()`, missing fallback to `config/keys.env` for multi-branch setups where `.zshrc` provides the token

## Changes
- `supervisor/manager.md`: Added 3 dedup rules to Comment Contract (check before post, edit instead of repost, no new comment for format fixes)
- `src/vibe3/roles/manager.py`: New `_resolve_manager_token()` with env var → keys.env → None fallback

## Test plan
- [ ] Verify `_resolve_manager_token` reads from env var when set
- [ ] Verify fallback to `config/keys.env` when env var not set
- [ ] Verify warning logged when neither source has the token
- [ ] Manager agent follows new "edit instead of repost" rules on next dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)