### PR TITLE
[supervisor] Align stale documentation with current project structure

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -107,15 +107,16 @@ vibe-center/
 │   │   ├── DOC_ORGANIZATION.md  # 文档组织标准
 │   │   ├── cognition-spec-dominion.md  # 宪法大纲
 │   │   └── ...                         # 其他现行标准
+│   ├── specs/                   # 规范文档
 │   ├── prds/                    # 全局 PRD
 │   │   ├── vibe-workflow-paradigm.md   # 总 PRD
 │   │   └── ...
+│   ├── plans/                   # 执行计划
+│   ├── reports/                 # 报告和总结
 │   ├── references/              # 外部参考资料
 │   │   └── ...                  # 收集的外部文档、论文、资料等
 │   ├── archive/                 # 历史文档归档
 │   │   └── ...                  # 已退役设计与历史任务文档
-│   └── tasks/                   # 任务文档
-│       └── {Task_ID}/           # 各任务目录
 │
 └── .kiro/                       # Kiro Spec 工作区
     └── specs/                   # Spec 定义
@@ -401,23 +402,29 @@ ls ~/.vibe/
 
 **用途**：为项目决策和实现提供外部知识支持，不属于项目自身文档
 
-#### `docs/tasks/` - 任务文档
+#### `docs/specs/` - 规范文档
 
-**职责**：每个任务的完整 Vibe Guard 文档
+**职责**：按 issue / feature 组织的规范与实现约束文档
 
-**命名格式**：`YYYY-MM-DD-feature-name`
+**用途**：
+- 记录具体问题的接口契约、边界行为和实现约束
+- 与 `docs/prds/`、`docs/plans/`、`docs/reports/` 配合使用
 
-**文档结构**：
-```
-{Task_ID}/
-├── README.md               # 任务概述、状态、导航
-├── prd-v1-initial.md       # PRD 层
-├── spec-v1-initial.md      # Spec 层
-├── plan-v1-initial.md      # Plan 层
-├── test-strategy.md        # Test 层
-├── code-implementation.md  # Code 层
-└── audit-2024-01-15.md     # Review 层
-```
+#### `docs/plans/` - 执行计划
+
+**职责**：需要长期保留的计划文档与推进记录
+
+**用途**：
+- 记录正式计划、分解步骤和阶段性推进
+- 不再以统一任务镜像目录承载任务文档
+
+#### `docs/reports/` - 报告与总结
+
+**职责**：长期保留的报告、审计和复盘文档
+
+**用途**：
+- 记录结论、验证结果、审计摘要和阶段总结
+- 供后续会话和人类读者稳定引用
 
 ### `.kiro/` - Kiro Spec 工作区
 
@@ -506,7 +513,7 @@ ls ~/.vibe/
 ### 我要理解工作流
 1. 阅读 `docs/prds/vibe-workflow-paradigm.md` - Vibe Guard 范式
 2. 阅读 `docs/standards/cognition-spec-dominion.md` - 宪法大纲
-3. 查看 `docs/tasks/` 中的示例任务
+3. 查看 `docs/specs/`、`docs/plans/` 和 `docs/reports/` 中的现有文档
 4. 运行 `uv run python src/vibe3/cli.py flow --help` - 查看命令帮助
 
 ### 我要使用 V3 命令

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,13 +12,14 @@ docs/
 │   ├── cognition-spec-dominion.md  # 宪法大纲：Vibe Guard 流程定义
 │   ├── ...                         # 其他现行标准
 │   └── v3/                          # V3 命令、数据、技能与 handoff 标准
+├── specs/                           # 规范文档
 ├── prds/                           # 产品需求文档（全局 PRD）
 │   ├── vibe-workflow-paradigm.md   # 总 PRD：Vibe Guard 范式
 │   └── ...                         # 其他全局 PRD
+├── plans/                          # 执行计划
+├── reports/                        # 报告与总结
 ├── references/                     # 外部参考资料
 │   └── ...                         # 收集的外部文档、论文、资料等
-├── tasks/                          # 任务文档（按 issue 组织）
-│   └── {Task_ID}/                  # 任务镜像与导航
 ├── archive/                        # 历史归档
 └── ...                             # 其他现行文档
 ```
@@ -54,13 +55,27 @@ docs/
 
 **用途**：为项目决策和实现提供外部知识支持，不属于项目自身文档。
 
-### 任务文档 (`tasks/`)
-每个任务一个子目录，按 GitHub issue 组织任务镜像。
+### 规范文档 (`specs/`)
+按 issue / feature 组织的规范和实现约束文档。
 
 **原则**：
 - issue 是任务身份真源
-- task README 只做导航、状态和阶段记录
+- 规范文档记录接口契约、边界行为和实现约束
 - 需要长期保留的结论写到 issue comment 或 PR comment
+
+### 执行计划 (`plans/`)
+需要长期保留的计划文档与推进记录。
+
+**原则**：
+- 正式计划可以直接写入 `docs/plans/`
+- 临时草稿优先写入 `.agent/plans/`
+
+### 报告与总结 (`reports/`)
+长期保留的报告、审计和复盘文档。
+
+**原则**：
+- 正式报告可以直接写入 `docs/reports/`
+- 临时草稿优先写入 `.agent/reports/`
 
 ### 临时计划 (`.agent/plans/`)
 存放 Agent 生成的临时计划文档，不作为正式真源。
@@ -83,7 +98,7 @@ docs/
 
 **兼容说明**：
 - 旧任务目录里可能仍有 `plan-*` / `audit-*` 示例文件，它们只作为历史任务归档
-- 新的 plan / report 一律写入 `.agent/plans/` 和 `.agent/reports/`
+- 新的 plan / report 草稿写入 `.agent/plans/` 和 `.agent/reports/`，需要长期保留的正式版本写入 `docs/plans/` 和 `docs/reports/`
 
 ## 🚪 Vibe Guard 流程
 
@@ -102,27 +117,28 @@ docs/
 
 ### 创建新任务
 
-1. 创建任务目录：
+1. 创建对应目录：
    ```bash
-   mkdir -p docs/tasks/2024-01-15-feature-name
+   mkdir -p docs/specs docs/plans docs/reports
    ```
 
-2. 从模板创建文档（模板位于 `.agent/templates/`）：
+2. 从模板创建正式文档（模板位于 `.agent/templates/`）：
    ```bash
-   cp .agent/templates/task-readme.md docs/tasks/2024-01-15-feature-name/README.md
-   cp .agent/templates/prd.md docs/tasks/2024-01-15-feature-name/prd-v1-initial.md
+   cp .agent/templates/tech-spec.md docs/specs/<name>.md
+   cp .agent/templates/plan.md docs/plans/<name>.md
+   cp .agent/templates/prd.md docs/prds/<name>.md
    ```
 
 3. 替换占位符并填写内容
 
-4. 按 Vibe Guard 流程逐步推进，长期结论写入 issue comment 或 PR comment
+4. 按 Vibe Guard 流程逐步推进
+   - 临时草稿优先写入 `.agent/plans/`、`.agent/reports/`
+   - 需要长期保留的正式版本写入 `docs/plans/`、`docs/reports/`
+   - 长期结论写入 issue comment 或 PR comment
 
 ### 查看任务状态
 
-每个任务的 `README.md` 包含：
-- 当前所在层级
-- Vibe Guard 各 Gate 的通过状态
-- 文档导航链接
+对应文档可在 frontmatter 中记录当前层级、状态和 Gate 结果。
 
 ## 🔗 相关文档
 
@@ -135,14 +151,14 @@ docs/
 ## 📚 文档 vs AI 工作区
 
 **重要区分**：
-- **`docs/`** - 人类主权区，存放给人类阅读的正式规范、任务镜像和历史归档
+- **`docs/`** - 人类主权区，存放给人类阅读的正式规范、计划、报告和历史归档
 - **`.agent/`** - AI 工作区，存放 AI 使用的模板、规则、工作流和临时产物
 
-模板文件位于 `.agent/templates/`，临时计划与报告分别位于 `.agent/plans/` 和 `.agent/reports/`。
+模板文件位于 `.agent/templates/`，临时计划与报告分别位于 `.agent/plans/` 和 `.agent/reports/`；正式计划与报告分别位于 `docs/plans/` 和 `docs/reports/`。
 
 ## 🆘 需要帮助？
 
 - 阅读 [doc-organization.md](standards/doc-organization.md) 了解详细的文档组织标准
 - 阅读 [vibe-workflow-paradigm.md](prds/vibe-workflow-paradigm.md) 了解 Vibe Guard 范式
 - 阅读 [standards/v3/](standards/v3/) 了解 V3 的正式语义边界
-- 查看 `docs/tasks/` 中的现有任务作为参考
+- 查看 `docs/specs/`、`docs/plans/` 和 `docs/reports/` 中的现有文档作为参考

--- a/docs/standards/agent-document-lifecycle-standard.md
+++ b/docs/standards/agent-document-lifecycle-standard.md
@@ -33,7 +33,7 @@ related_docs:
 - `.agent/plans/` 是临时计划工作区。
 - `.agent/reports/` 是临时报告工作区。
 - 这两个目录下的文件都属于工作产物，不是长期规范真源。
-- 新的 plan / report 文档只应落在这两个目录中，不应再作为正式文档放入 `docs/plans/` 或 `docs/reports/`。
+- 临时草稿和过程证据可先写入这里；需要长期保留、供人类阅读的正式 plan / report，应落在 `docs/plans/` 和 `docs/reports/`。
 
 ## 3. 留存规则
 
@@ -42,14 +42,14 @@ related_docs:
 - 若该结论直接影响合并或审查，也应同步到 PR comment。
 - 本地临时文档只保留工作过程与证据，不承担长期沟通职责。
 
-## 4. 任务文档
+## 4. 正式文档落点
 
-- `docs/tasks/` 下的任务文档是任务镜像，不是任务身份真源。
-- 任务 README 可以记录导航、状态和阶段，但任务定义应以 issue 为准。
-- 若任务文档与 issue 冲突，以 issue 及其 comment 为准。
+- GitHub issue 是任务身份真源。
+- 与任务相关的正式 Spec / Plan / Report 文档，可分别落在 `docs/specs/`、`docs/plans/`、`docs/reports/`。
+- 不再维护统一任务镜像目录。
+- 若正式文档与 issue 冲突，以 issue 及其 comment 为准。
 
 ## 5. 兼容原则
 
-- 旧的 `docs/plans/` 和 `docs/reports/` 内容可作为历史参考保留。
-- 这些历史文件不应再被新的工作流当作默认落点。
+- `docs/plans/` 和 `docs/reports/` 既承载当前可用的正式文档，也保留历史参考内容。
 - 如果需要引用历史结论，应优先引用 issue comment，而不是复制旧计划或旧报告正文。

--- a/docs/standards/doc-organization.md
+++ b/docs/standards/doc-organization.md
@@ -24,9 +24,9 @@ related_docs:
 
 本文档只定义目录结构、命名规范和文档落位。若涉及 `task`、`workflow`、`规范层`、`执行计划层`、`代码实现层`、`AI审计层` 等项目术语，其正式语义以 [glossary.md](glossary.md) 为准。
 
-本文档定义 Vibe Center 2.0 的文档组织标准，与 Vibe Workflow Paradigm 的 Vibe Guard 范式完全对齐。
-任务身份以 GitHub issue 为准；需要长期留存的结论写入 issue comment 或 PR comment。
-旧任务目录里残留的 `plan-*` / `audit-*` 文件只作为历史归档，不改变新 plan / report 的默认落点。
+本文档定义 Vibe Center 的文档组织标准，与 Vibe Workflow Paradigm 的 Vibe Guard 范式对齐。
+任务身份以 GitHub issue 为准；正式 Spec / Plan / Report 分别落在 `docs/specs/`、`docs/plans/`、`docs/reports/`。
+旧的统一任务镜像目录不再作为默认组织方式；若历史文件仍存在，仅作为归档参考。
 
 ## 核心原则
 
@@ -43,20 +43,14 @@ docs/
 ├── standards/                       # 标准和规范文档
 │   ├── DOC_ORGANIZATION.md         # 本文档组织标准
 │   └── ...                         # 其他现行标准
+├── specs/                          # 规范文档
 ├── prds/                           # 产品需求文档（全局 PRD）
 │   ├── vibe-workflow-paradigm.md   # 总 PRD：Vibe Guard 范式
 │   └── ...                         # 其他全局 PRD
+├── plans/                         # 执行计划
+├── reports/                       # 报告与总结
 ├── archive/                        # 历史文档归档
 │   └── ...                         # 已退役设计与历史任务文档
-└── tasks/                          # 任务文档（按 issue 组织）
-    └── {Task_ID}/                  # 格式: YYYY-MM-DD-feature-name
-        ├── README.md               # 任务概述、状态和导航
-        ├── prd-v1-initial.md       # PRD 层文档
-        ├── spec-v1-initial.md      # Spec 层文档
-        ├── plan-v1-initial.md      # Plan 层文档
-        ├── test-strategy.md        # Test 层文档
-        ├── code-implementation.md  # Code 层文档
-        └── audit-2024-01-15.md     # Review 层文档（AI 审计）
 
 AI 工作区中的临时产物与模板：
 - `.agent/plans/` - AI 临时计划
@@ -137,33 +131,28 @@ audit-{YYYY-MM-DD}.md
 
 ### 创建新任务
 
-1. **创建任务目录**：
+1. **创建对应目录**：
    ```bash
-   mkdir -p docs/tasks/2024-01-15-feature-name
+   mkdir -p docs/specs docs/plans docs/reports
    ```
 
-2. **从模板创建 README**：
+2. **从模板创建正式文档**：
    ```bash
-   cp .agent/templates/task-readme.md docs/tasks/2024-01-15-feature-name/README.md
+   cp .agent/templates/tech-spec.md docs/specs/<name>.md
+   cp .agent/templates/plan.md docs/plans/<name>.md
+   cp .agent/templates/prd.md docs/prds/<name>.md
    ```
 
-3. **替换占位符**：
-   - `{{TASK_ID}}` → `2024-01-15-feature-name`
-   - `{{TASK_TITLE}}` → `Feature Name`
-   - `{{DATE}}` → `2024-01-15`
+3. **替换占位符并填写内容**
 
-4. **创建 PRD 文档**：
-   ```bash
-   cp .agent/templates/prd.md docs/tasks/2024-01-15-feature-name/prd-v1-initial.md
-   ```
-
-5. **按 Vibe Guard 流程逐步创建其他文档**
-   - 计划和报告优先落到 `.agent/plans/`、`.agent/reports/`
+4. **按 Vibe Guard 流程逐步推进**
+   - 临时草稿优先写入 `.agent/plans/`、`.agent/reports/`
+   - 需要长期保留的正式版本写入 `docs/plans/`、`docs/reports/`
    - 长期结论写入 issue comment 或 PR comment
 
 ### 更新任务状态
 
-在任务 README.md 的 frontmatter 中更新：
+在对应文档的 frontmatter 中更新：
 
 ```yaml
 current_layer: "spec"  # 当前所在层级
@@ -186,7 +175,7 @@ gates:
 **重要**：所有模板文件位于 `.agent/templates/`（AI 工作区），而不是 `docs/templates/`（人类主权区）。
 
 这是因为：
-- `docs/` - 人类阅读的文档（PRD、Spec、任务文档等）
+- `docs/` - 人类阅读的文档（PRD、Spec、Plan、Report、归档等）
 - `.agent/` - AI 使用的工具（模板、规则、工作流、临时 plan/report 等）
 
 模板是 AI 用来生成文档的工具，应该放在 AI 工作区。


### PR DESCRIPTION
This PR aligns the selected documentation with the current repository structure.

Scope:
- Remove `docs/tasks/` as the canonical task-docs location from the selected docs.
- Update `STRUCTURE.md` and `docs/README.md` to reflect the active `docs/specs/`, `docs/prds/`, `docs/plans/`, and `docs/reports/` directories.
- Update the lifecycle and organization standards so `.agent/*` remains temporary while `docs/plans/` and `docs/reports/` remain valid long-lived locations.

Verification:
- `git diff --check`
- `git push -u origin supervisor/issue-536-docs-alignment`
- Pre-push checks passed (typecheck + smoke tests)

Related issue: #536