### PR TITLE
fix(pre-push): skip full suite for top-level unmapped sources

### DIFF
--- a/src/vibe3/analysis/pre_push_test_selector.py
+++ b/src/vibe3/analysis/pre_push_test_selector.py
@@ -81,6 +81,19 @@ def select_pre_push_tests(
             test_dir = root / "tests" / "vibe3" / src_rel.parent
             if test_dir.exists() and any(test_dir.glob("test_*.py")):
                 dir_targets.add(test_dir.relative_to(root).as_posix())
+        # Guard: if any resolved directory is the full test suite root,
+        # skip local pytest instead of running everything.
+        if "tests/vibe3" in dir_targets:
+            return PrePushTestSelection(
+                mode="skip",
+                tests=[],
+                reason=(
+                    f"unmapped source(s) resolve to full test suite root, "
+                    f"skipping local run (CI covers full suite): "
+                    f"{', '.join(sorted(unmapped_sources))}"
+                ),
+                unmapped_sources=sorted(unmapped_sources),
+            )
         if dir_targets:
             return PrePushTestSelection(
                 mode="incremental",

--- a/tests/vibe3/analysis/test_pre_push_test_selector.py
+++ b/tests/vibe3/analysis/test_pre_push_test_selector.py
@@ -80,3 +80,15 @@ def test_maps_hook_changes_to_hook_regression_tests() -> None:
 
     assert selection.mode == "smoke"
     assert selection.tests == ["tests/vibe3/analysis/test_pre_push_scope.py"]
+
+
+def test_top_level_unmapped_source_skips_full_suite() -> None:
+    # src/vibe3/__init__.py has no direct test file mapping.
+    # Its directory fallback would resolve to tests/vibe3 (the full suite root).
+    # Must return mode=skip instead of running everything locally.
+    selection = select_pre_push_tests(["src/vibe3/__init__.py"])
+
+    assert selection.mode == "skip"
+    assert selection.tests == []
+    assert selection.unmapped_sources == ["src/vibe3/__init__.py"]
+    assert "tests/vibe3" not in selection.tests


### PR DESCRIPTION
## Summary
This PR prevents the pre-push hook from falling back to the full \`tests/vibe3\` suite when unmapped top-level source files (e.g., \`src/vibe3/__init__.py\`) are modified. Instead, it now returns \`mode="skip"\`, significantly speeding up the local push process while leaving full verification to the CI.

## Changes
- Added a guard in \`pre_push_test_selector.py\` to detect if the resolved test directory is the root suite.
- Added a regression test \`test_top_level_unmapped_source_skips_full_suite\`.

## Verification
- Audit Verdict: PASS (docs/reports/issue-303-audit-report.md)
- Unit tests pass: \`uv run pytest tests/vibe3/analysis/test_pre_push_test_selector.py\`
- Lint and type checks pass.

Closes #303

---

## Contributors

opencode/my-provider/gpt-4o, gemini/gemini-3-flash-preview, claude/sonnet

---

## Contributors

claude/sonnet, opencode/my-provider/gpt-4o
