### PR TITLE
refactor(cli): unify CLI commands with --branch parameter and flow-centric design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ wt-*/
 .agent/plans/
 .agent/context/task.md
 .agent/reports/
+.sisyphus/
 docs/audits/
 docs/plans/
 docs/reports/

--- a/config/prompts.yaml
+++ b/config/prompts.yaml
@@ -451,7 +451,7 @@ plan:
 
   # Static: planner exit contract plus default planning guidance.
   # Target recipe section name: plan.exit_contract
-  # Can be overridden via CLI: vibe3 plan --issue 42
+  # Can be overridden via CLI: vibe3 plan --branch <b>
   plan_task: |
     Before starting, read the current task context:
     `uv run python src/vibe3/cli.py task show` — shows branch, flow, issue number, latest ref, and next step.

--- a/docs/specs/task-resume-blocked-recovery-implementation.md
+++ b/docs/specs/task-resume-blocked-recovery-implementation.md
@@ -15,7 +15,6 @@
 ### Side Effect 层 (Task #1)
 - **保留**:
   - `resume_failed_issue_to_handoff()` - failed + plan_ref → handoff
-  - `resume_failed_issue_to_ready()` - failed → ready
 - **新增**:
   - `resume_blocked_issue_to_ready()` - blocked → ready
   - comment 文案明确区分 failed vs blocked 来源

--- a/docs/standards/agent-debugging-standard.md
+++ b/docs/standards/agent-debugging-standard.md
@@ -342,7 +342,7 @@ uv run python src/vibe3/cli.py run --supervisor supervisor/issue-cleanup.md
 
 > **注意**：apply 由 `SupervisorHandoffService.on_tick()` 自动触发，无需手动命令。
 > 当检测到带有 `supervisor` + `state/handoff` labels 的 issue 时，服务会自动 dispatch apply agent。
-> 手动执行 `run --issue <n>` **不是**正确的触发方式，会绕过 on_tick 状态机，可能导致重复执行或状态不一致。
+> 手动执行 `run --branch <n>` **不是**正确的触发方式，会绕过 on_tick 状态机，可能导致重复执行或状态不一致。
 
 观察方式：
 
@@ -364,7 +364,7 @@ ls -lt temp/logs/vibe3-supervisor-issue-*.async.log | head -5
 - Session log 路径是否显示：`temp/logs/vibe3-supervisor-issue-{n}.async.log`
 
 > **调试用途**（仅限本地单步验证）：若需要隔离测试 apply 逻辑而不依赖 on_tick，
-> 可直接调用服务层，但不要通过 CLI `run --issue` 命令，该命令路径与 supervisor apply 逻辑不匹配。
+> 可直接调用服务层，但不要通过 CLI `run --branch` 命令，该命令路径与 supervisor apply 逻辑不匹配。
 
 #### 第四步：观察结果
 
@@ -384,7 +384,7 @@ ls -lt temp/logs/vibe3-supervisor-issue-*.async.log | head -5
 ### 5.4 治理链调试结论
 
 - 治理链通过 issue 交接，不通过 branch handoff 交接
-- apply 由 `SupervisorHandoffService.on_tick()` **自动触发**，检测 `supervisor+state/handoff` issue 后 dispatch；`run --issue` 不是 apply 的触发入口
+- apply 由 `SupervisorHandoffService.on_tick()` **自动触发**，检测 `supervisor+state/handoff` issue 后 dispatch；`run --branch` 不是 apply 的触发入口
 - async/tmux 与 session log 属于底层 codeagent 适配层，不属于上层 orchestration
 - 底层只负责触发；是否检查 `vibe3 task status`、是否创建 issue、是否 comment / close，全部由 supervisor prompt 决定
 
@@ -448,7 +448,7 @@ HeartbeatServer._tick_loop()
 |---|---|---|---|
 | `state/ready` | manager | Orchestra 自动调度 | `vibe3 serve start` 后观察 `temp/logs/issues/issue-{n}/manager.async.log` |
 | `state/handoff` | manager (resume) | Orchestra 自动调度 | `vibe3 serve start` 后观察 `temp/logs/issues/issue-{n}/manager.async.log` |
-| `state/claimed` | plan | 手动触发 | `vibe3 plan --issue {n}` |
+| `state/claimed` | plan | 手动触发 | `vibe plan --branch {n}` |
 | `state/in-progress` | run | 手动触发 | `vibe3 run` |
 | `state/review` | review | 手动触发 | `vibe3 review base` |
 

--- a/docs/standards/agent-workflow-standard.md
+++ b/docs/standards/agent-workflow-standard.md
@@ -61,10 +61,11 @@ Plan → Run → Review → Commit
 **Step 1: 创建 Plan**
 
 ```bash
-# 从 issue 创建 plan
-vibe3 plan --issue <issue_number>
+# 从 flow 创建 plan（需要已有 spec_ref）
+vibe3 plan --branch <branch_or_issue_number>
+vibe3 plan                    # 使用当前 branch
 
-# 从 spec 文件创建 plan
+# 从 spec 文件创建 plan（替换当前 flow 的 spec_ref）
 vibe3 plan --spec --file spec.md
 
 # 从 spec message 创建 plan
@@ -158,14 +159,14 @@ codeagent-wrapper cleanup
 git checkout -b feature/api-v2
 vibe3 flow update
 
-# 2. 绑定 task issue
-vibe3 flow bind <issue_number>
+# 2. 绑定 task issue（同时绑定为 spec）
+vibe flow bind <issue_number> --role task
 
 # 3. 创建 plan
-vibe3 plan --issue
+vibe plan --branch <issue_number>
 
 # 4. 执行 plan（agent 实现）
-vibe3 run --plan
+vibe run --branch <issue_number>
 
 # 5. 验证结果
 uv run pytest tests/vibe3

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -259,8 +259,8 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
    # 开始执行：优先通过 flow bind / manager 主链推进
    uv run python src/vibe3/cli.py flow bind 123
 
-   # 如需查看运行状态，优先检查 flow 状态
-   uv run python src/vibe3/cli.py flow show --issue 123
+    # 如需查看运行状态，优先检查 flow 状态
+    uv run python src/vibe3/cli.py flow show task/issue-123
    ```
 
 #### 版本结束

--- a/docs/standards/v3/python-capability-design.md
+++ b/docs/standards/v3/python-capability-design.md
@@ -166,11 +166,10 @@ Skill Layer 负责：
 
 好例子：
 
-- `task add`
-- `task update --issue-ref ...`
-- `task update --roadmap-item ...`
-- `flow new`
 - `flow bind`
+- `flow update --spec`
+- `handoff plan`
+- `handoff report`
 
 坏例子：
 

--- a/docs/standards/vibe3-state-sync-standard.md
+++ b/docs/standards/vibe3-state-sync-standard.md
@@ -455,8 +455,9 @@ manager 不应：
 
 1. 如果缺少 `spec_ref`
 - 当前轮不进入 `run` / `review`
-- 先补齐 spec 真源，例如执行：
-  - `uv run python src/vibe3/cli.py flow update --spec <...>`
+- 先补齐 spec 真源:
+  - 绑定 issue 为 spec: `vibe flow bind <issue-number> --role task`
+  - 或绑定 spec 文件: `vibe flow update --spec <file>`
 - 写 issue comment 说明当前缺失的是 spec 真源
 - 必要时写 handoff
 - `exit()`

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -70,65 +70,7 @@ no matter what. Do not include this section in your response until the very end.
 """
 
 
-def build_run_standard_sections(config: VibeConfig) -> list[str]:
-    """Run role-level hard-standard sections. All run paths must include these.
-
-    Includes: policy_file, common_rules, output_format, run_task (common contract).
-    Does NOT include path-specific content (plan, audit, skill, coding_task).
-    """
-    from vibe3.agents.review_prompt import build_tools_guide_section
-
-    sections: list[str] = []
-    run_config = getattr(config, "run", None)
-
-    # Policy file
-    if run_config and hasattr(run_config, "policy_file"):
-        policy_path = run_config.policy_file
-        if policy_path and Path(policy_path).exists():
-            sections.append(Path(policy_path).read_text(encoding="utf-8"))
-
-    # Common rules (shared conventions)
-    tools_guide = build_tools_guide_section(getattr(run_config, "common_rules", None))
-    if tools_guide:
-        sections.append(tools_guide)
-
-    # Output format (hard standard — placed before task so task is the LAST section)
-    output_format = getattr(run_config, "output_format", None) if run_config else None
-    sections.append(build_run_output_contract_section(output_format))
-
-    # Run task (hard standard: includes label-writing instruction — MUST be last)
-    run_task = getattr(run_config, "run_task", None) if run_config else None
-    sections.append(build_run_task_section(run_task))
-
-    return sections
-
-
 RunPromptMode = Literal["coding", "retry"]
-
-
-def build_run_mode_sections(config: VibeConfig, mode: RunPromptMode) -> list[str]:
-    """Mode-specific execution sections.
-
-    Injected ONLY for non-skill executor paths.
-    - ``coding``: regular implementation round
-    - ``retry``: focused retry round based on prior audit feedback
-    NOT included in skill/commit paths to avoid instruction conflicts.
-    """
-    run_config = getattr(config, "run", None)
-    if not run_config:
-        return []
-
-    section_text: str | None
-    if mode == "retry":
-        section_text = getattr(run_config, "retry_task", None) or getattr(
-            run_config, "coding_task", None
-        )
-    else:
-        section_text = getattr(run_config, "coding_task", None)
-
-    if not section_text:
-        return []
-    return [section_text]
 
 
 def _build_run_prompt_providers(
@@ -287,8 +229,7 @@ def make_skill_context_builder(
 ) -> PromptContextBuilder:
     """Create a PromptContextBuilder for skill execution mode.
 
-    Uses build_run_standard_sections() so the skill agent receives the common
-    contract (output_format, run_task exit step, policy, common_rules).
+    Uses run.skill recipe with standard providers (policy, output_format).
     coding_task is intentionally excluded — skills define their own execution guidance.
     """
     cfg = config or VibeConfig.get_defaults()

--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -119,10 +119,6 @@ def run_command(
             "--plan", "-p", help="Path to plan file (overrides flow plan_ref)"
         ),
     ] = None,
-    file: Annotated[
-        Optional[Path],
-        typer.Option("--file", "-f", help="Alias for --plan (deprecated)"),
-    ] = None,
     skill: Annotated[
         Optional[str],
         typer.Option("--skill", "-s", help="Run a skill from skills/<name>/SKILL.md"),
@@ -162,10 +158,9 @@ def run_command(
     ] = False,
 ) -> None:
     """Execute implementation plan or skill using codeagent-wrapper."""
-    resolved_plan = plan or file
     run.run_command(
         instructions=instructions,
-        plan=resolved_plan,
+        plan=plan,
         skill=skill,
         trace=trace,
         dry_run=dry_run,

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -41,12 +41,6 @@ from vibe3.clients.git_status_ops import (
 from vibe3.clients.git_status_ops import (
     has_uncommitted_changes as _has_uncommitted_changes,
 )
-from vibe3.clients.git_status_ops import (
-    stash_apply as _stash_apply,
-)
-from vibe3.clients.git_status_ops import (
-    stash_push as _stash_push,
-)
 from vibe3.clients.git_worktree_ops import (
     _parse_worktree_list,
 )
@@ -203,14 +197,6 @@ class GitClient:
     def get_untracked_files(self) -> list[str]:
         """Return untracked files in the worktree."""
         return _get_untracked_files(self._run)
-
-    def stash_push(self, message: str | None = None) -> str:
-        """Stash current changes, return stash ref."""
-        return _stash_push(self._run, message)
-
-    def stash_apply(self, stash_ref: str) -> None:
-        """Apply and drop stash."""
-        return _stash_apply(self._run, stash_ref)
 
     def has_uncommitted_changes(self) -> bool:
         """Check if working directory is dirty."""

--- a/src/vibe3/clients/git_status_ops.py
+++ b/src/vibe3/clients/git_status_ops.py
@@ -1,4 +1,4 @@
-"""Git status operations - 封装 diff、status、stash 相关 git 命令."""
+"""Git status operations - diff and status helpers."""
 
 from typing import TYPE_CHECKING, Callable
 
@@ -160,40 +160,6 @@ def _get_branch_files(
     """获取分支相对于 base 的改动文件."""
     output = run(["diff", "--name-only", f"{base}...{branch}"])
     return [f for f in output.splitlines() if f.strip()]
-
-
-def stash_push(run: Callable[[list[str]], str], message: str | None = None) -> str:
-    """Stash current changes, return stash ref.
-
-    Args:
-        run: Git command runner function
-        message: Optional stash message
-
-    Returns:
-        Stash reference (e.g., stash@{0})
-    """
-    args = ["stash", "push"]
-    if message:
-        args.extend(["-m", message])
-    run(args)
-    stash_ref = "stash@{0}"
-    logger.bind(
-        domain="git", action="stash_push", stash_ref=stash_ref, message=message
-    ).info("Stashed changes")
-    return stash_ref
-
-
-def stash_apply(run: Callable[[list[str]], str], stash_ref: str) -> None:
-    """Apply and drop stash.
-
-    Args:
-        run: Git command runner function
-        stash_ref: Stash reference to apply
-    """
-    run(["stash", "pop", stash_ref])
-    logger.bind(domain="git", action="stash_apply", stash_ref=stash_ref).info(
-        "Applied stash"
-    )
 
 
 def has_uncommitted_changes(run: Callable[[list[str]], str]) -> bool:

--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -4,25 +4,11 @@ import json
 import os
 import re
 import subprocess
-from dataclasses import dataclass
 from typing import Any, cast
 
 from loguru import logger
 
 from vibe3.clients.github_issue_admin_ops import IssueAdminMixin
-
-
-@dataclass(frozen=True)
-class MilestoneContext:
-    """Aggregated milestone context for a task issue."""
-
-    number: int
-    title: str
-    open_count: int
-    closed_count: int
-    issues: list[dict[str, Any]]
-    task_issue_number: int
-
 
 # Patterns GitHub uses to auto-close issues via PR body
 _LINKED_ISSUE_RE = re.compile(
@@ -282,38 +268,3 @@ class IssuesMixin(IssueAdminMixin):
             )
             return []
         return cast(list[dict[str, Any]], json.loads(result.stdout))
-
-    def get_milestone_context(self: Any, issue_number: int) -> MilestoneContext | None:
-        """Fetch milestone orchestration context for a task issue.
-
-        Args:
-            issue_number: GitHub issue number
-
-        Returns:
-            MilestoneContext if issue has milestone, None otherwise
-        """
-        try:
-            issue = self.view_issue(issue_number)
-            if not isinstance(issue, dict) or not issue.get("milestone"):
-                return None
-
-            ms = issue["milestone"]
-            ms_issues = self.get_milestone_issues(ms["number"])
-        except (FileNotFoundError, RuntimeError):
-            return None
-
-        open_count = sum(
-            1 for i in ms_issues if str(i.get("state", "")).upper() == "OPEN"
-        )
-        closed_count = sum(
-            1 for i in ms_issues if str(i.get("state", "")).upper() == "CLOSED"
-        )
-
-        return MilestoneContext(
-            number=ms["number"],
-            title=ms["title"],
-            open_count=open_count,
-            closed_count=closed_count,
-            issues=ms_issues,
-            task_issue_number=issue_number,
-        )

--- a/src/vibe3/commands/flow.py
+++ b/src/vibe3/commands/flow.py
@@ -163,21 +163,20 @@ def update(
                 # Clear spec_ref
                 flow_service.store.update_flow_state(flow.branch, spec_ref=None)
             else:
-                # Validate and bind spec
-                from vibe3.services.spec_ref_service import SpecRefService
+                # Validate file path exists
+                from pathlib import Path
 
-                spec_service = SpecRefService()
-                is_valid, error = spec_service.validate_spec_ref(spec)
-                if not is_valid:
-                    typer.echo(f"Error: {error}", err=True)
+                spec_path = Path(spec)
+                if not spec_path.exists() or not spec_path.is_file():
+                    typer.echo(f"Error: Spec file not found: {spec}", err=True)
                     typer.echo(
-                        "Use issue number (e.g., 123) or "
-                        "file path (e.g., docs/spec.md)",
+                        "Use a valid file path (e.g., docs/spec.md). "
+                        "For issue binding, use 'vibe flow bind <issue> --role task'.",
                         err=True,
                     )
                     raise typer.Exit(1)
-                resolved_spec = spec_service.resolve_spec_ref(spec)
-                flow_service.bind_spec(flow.branch, resolved_spec, actor)
+                # Bind spec (absolute path)
+                flow_service.bind_spec(flow.branch, str(spec_path.resolve()), actor)
 
         if json_output:
             typer.echo(json.dumps(flow.model_dump(), indent=2, default=str))

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -219,22 +219,17 @@ def default(
 @app.command(name="issue", hidden=True)
 def issue_command(
     issue: Annotated[int, typer.Argument(help="GitHub issue number")],
-    instructions: Annotated[
-        Optional[str],
-        typer.Argument(help="Additional task guidance"),
-    ] = None,
+    ctx: typer.Context,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
-    """Legacy: plan from issue number (use --branch instead)."""
-    _ = instructions
-    from vibe3.services.issue_flow_service import IssueFlowService
-
-    branch = IssueFlowService().canonical_branch_name(issue)
-    _plan_for_branch(
-        branch=branch,
+    """Legacy alias: plan --branch <issue>."""
+    default(
+        ctx=ctx,
+        branch=str(issue),
+        spec=None,
         trace=trace,
         dry_run=dry_run,
         no_async=no_async,

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -13,7 +13,6 @@ from vibe3.commands.command_options import (
     _MODEL_OPT,
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
-    ensure_flow_for_current_branch,
 )
 from vibe3.execution.issue_role_sync_runner import (
     run_issue_role_async,
@@ -21,11 +20,12 @@ from vibe3.execution.issue_role_sync_runner import (
 )
 from vibe3.roles.plan import (
     PLAN_SYNC_SPEC,
-    bind_plan_spec,
     execute_spec_plan_async,
     execute_spec_plan_sync,
     resolve_spec_plan_input,
 )
+from vibe3.services.flow_service import FlowService
+from vibe3.utils.branch_arg import resolve_branch_arg
 from vibe3.utils.trace import enable_trace
 
 app = typer.Typer(
@@ -35,27 +35,53 @@ app = typer.Typer(
     rich_markup_mode="rich",
 )
 
+BranchOption = Annotated[
+    str | None,
+    typer.Option("--branch", "-b", help="Branch name or issue number (e.g., 320)"),
+]
 
-def _plan_issue_impl(
-    issue: int,
-    instructions: str | None,
+
+def _plan_for_branch(
+    branch: str,
     trace: bool,
     dry_run: bool,
     no_async: bool,
     show_prompt: bool,
-    agent: str | None,
-    backend: str | None,
-    model: str | None,
 ) -> None:
-    """Create implementation plan for an issue."""
+    """Create implementation plan for a branch with spec_ref."""
     if trace:
         enable_trace()
 
-    _ = instructions, agent, backend, model
+    flow_service = FlowService()
+    flow = flow_service.get_flow_status(branch)
+
+    if not flow:
+        typer.echo(
+            f"Error: No flow for branch '{branch}'.\n" "Run 'vibe flow update' first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if not flow.spec_ref:
+        typer.echo(
+            "Error: No spec bound.\n"
+            "Run 'vibe flow bind <issue>' or 'vibe flow update --spec <file>'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    issue_number = flow.task_issue_number
+    if not issue_number:
+        typer.echo(
+            f"Error: No issue linked to flow '{branch}'.\n"
+            "Run 'vibe flow bind <issue>' first.",
+            err=True,
+        )
+        raise typer.Exit(1)
 
     if no_async:
         run_issue_role_sync(
-            issue_number=issue,
+            issue_number=issue_number,
             dry_run=dry_run,
             fresh_session=False,
             show_prompt=show_prompt,
@@ -63,15 +89,15 @@ def _plan_issue_impl(
         )
     else:
         run_issue_role_async(
-            issue_number=issue,
+            issue_number=issue_number,
             dry_run=dry_run,
             spec=PLAN_SYNC_SPEC,
         )
 
 
 def _plan_spec_impl(
+    branch: str,
     file: Path | None,
-    msg: str | None,
     instructions: str | None,
     trace: bool,
     dry_run: bool,
@@ -80,34 +106,46 @@ def _plan_spec_impl(
     backend: str | None,
     model: str | None,
 ) -> None:
-    """Create implementation plan from a specification."""
+    """Create implementation plan from a specification file."""
     if trace:
         enable_trace()
 
-    _ = agent, backend, model
+    _ = agent, backend, model, instructions
 
-    flow_service, branch = ensure_flow_for_current_branch()
-    try:
-        spec_input = resolve_spec_plan_input(branch, file=file, msg=msg)
-    except (ValueError, FileNotFoundError) as e:
-        typer.echo(f"Error: {e}", err=True)
+    flow_service = FlowService()
+    flow = flow_service.get_flow_status(branch)
+
+    if not flow:
+        typer.echo(f"Error: No flow for branch '{branch}'.", err=True)
         raise typer.Exit(1)
 
-    if not dry_run and spec_input.spec_path:
-        bind_plan_spec(branch, spec_input.spec_path)
+    if not file:
+        typer.echo("Error: --file is required for plan --spec.", err=True)
+        raise typer.Exit(1)
+
+    # Replace spec_ref with new file
+    spec_path = str(file.resolve())
+    flow_service.bind_spec(branch, spec_path, actor=None)
+    typer.echo(f"Spec updated: {spec_path}")
 
     if dry_run:
         typer.echo("Plan dry run for specification")
         return
 
-    flow = flow_service.get_flow_status(branch)
-    issue_number = flow.task_issue_number if flow else None
+    issue_number = flow.task_issue_number
 
     if not issue_number:
         typer.echo(
             "Warning: No issue linked to flow. Lifecycle events will be skipped.",
             err=True,
         )
+
+    # Build request from spec file
+    try:
+        spec_input = resolve_spec_plan_input(branch, file=file)
+    except (ValueError, FileNotFoundError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
 
     if no_async:
         execute_spec_plan_sync(
@@ -124,8 +162,6 @@ def _plan_spec_impl(
                 "plan",
                 "spec",
                 *(["--file", str(file)] if file else []),
-                *(["--msg", msg] if msg else []),
-                *([instructions] if instructions else []),
             ],
         )
 
@@ -133,23 +169,14 @@ def _plan_spec_impl(
 @app.callback(invoke_without_command=True)
 def default(
     ctx: typer.Context,
-    issue: Annotated[
-        Optional[int],
-        typer.Option("--issue", "-i", help="GitHub issue number"),
-    ] = None,
+    branch: BranchOption = None,
     spec: Annotated[
         bool,
-        typer.Option(
-            "--spec", help="Plan from specification (requires --file or --msg)"
-        ),
+        typer.Option("--spec", help="Plan from specification file (requires --file)"),
     ] = False,
     file: Annotated[
         Optional[Path],
         typer.Option("--file", "-f", help="Path to spec file"),
-    ] = None,
-    msg: Annotated[
-        Optional[str],
-        typer.Option("--msg", help="Spec description"),
     ] = None,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
@@ -161,26 +188,13 @@ def default(
 ) -> None:
     if ctx.invoked_subcommand is not None:
         return
-    if issue is not None and spec:
-        typer.echo("Error: --issue and --spec are mutually exclusive.", err=True)
-        raise typer.Exit(1)
-    if issue is not None:
-        _plan_issue_impl(
-            issue=issue,
-            instructions=None,
-            trace=trace,
-            dry_run=dry_run,
-            no_async=no_async,
-            show_prompt=show_prompt,
-            agent=agent,
-            backend=backend,
-            model=model,
-        )
-        return
+
+    target_branch = resolve_branch_arg(branch)
+
     if spec:
         _plan_spec_impl(
+            branch=target_branch,
             file=file,
-            msg=msg,
             instructions=None,
             trace=trace,
             dry_run=dry_run,
@@ -190,15 +204,22 @@ def default(
             model=model,
         )
         return
-    if file is not None or msg is not None:
-        typer.echo("Error: --file/--msg require --spec.", err=True)
+
+    if file is not None:
+        typer.echo("Error: --file requires --spec.", err=True)
         raise typer.Exit(1)
 
-    # If no issue or spec, show help
-    typer.echo(ctx.get_help())
+    # Default: plan for branch
+    _plan_for_branch(
+        branch=target_branch,
+        trace=trace,
+        dry_run=dry_run,
+        no_async=no_async,
+        show_prompt=show_prompt,
+    )
 
 
-@app.command(name="issue")
+@app.command(name="issue", hidden=True)
 def issue_command(
     issue: Annotated[int, typer.Argument(help="GitHub issue number")],
     instructions: Annotated[
@@ -213,16 +234,17 @@ def issue_command(
     backend: _BACKEND_OPT = None,
     model: _MODEL_OPT = None,
 ) -> None:
-    _plan_issue_impl(
-        issue=issue,
-        instructions=instructions,
+    """Legacy: plan from issue number (use --branch instead)."""
+    _ = instructions, agent, backend, model
+    from vibe3.services.issue_flow_service import IssueFlowService
+
+    branch = IssueFlowService().canonical_branch_name(issue)
+    _plan_for_branch(
+        branch=branch,
         trace=trace,
         dry_run=dry_run,
         no_async=no_async,
         show_prompt=show_prompt,
-        agent=agent,
-        backend=backend,
-        model=model,
     )
 
 
@@ -231,10 +253,6 @@ def spec(
     file: Annotated[
         Optional[Path],
         typer.Option("--file", "-f", help="Path to spec file"),
-    ] = None,
-    msg: Annotated[
-        Optional[str],
-        typer.Option("--msg", help="Spec description"),
     ] = None,
     instructions: Annotated[
         Optional[str],
@@ -247,9 +265,13 @@ def spec(
     backend: _BACKEND_OPT = None,
     model: _MODEL_OPT = None,
 ) -> None:
+    """Hidden: plan from spec file."""
+    from vibe3.clients.git_client import GitClient
+
+    branch = GitClient().get_current_branch()
     _plan_spec_impl(
+        branch=branch,
         file=file,
-        msg=msg,
         instructions=instructions,
         trace=trace,
         dry_run=dry_run,

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -6,11 +6,8 @@ from typing import Annotated, Optional
 import typer
 
 from vibe3.commands.command_options import (
-    _AGENT_OPT,
     _ASYNC_OPT,
-    _BACKEND_OPT,
     _DRY_RUN_OPT,
-    _MODEL_OPT,
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
 )
@@ -57,7 +54,8 @@ def _plan_for_branch(
 
     if not flow:
         typer.echo(
-            f"Error: No flow for branch '{branch}'.\n" "Run 'vibe flow update' first.",
+            f"Error: No flow for branch '{branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
             err=True,
         )
         raise typer.Exit(1)
@@ -97,36 +95,47 @@ def _plan_for_branch(
 
 def _plan_spec_impl(
     branch: str,
-    file: Path | None,
-    instructions: str | None,
+    spec_path: Path | None,
     trace: bool,
     dry_run: bool,
     no_async: bool,
-    agent: str | None,
-    backend: str | None,
-    model: str | None,
 ) -> None:
     """Create implementation plan from a specification file."""
     if trace:
         enable_trace()
 
-    _ = agent, backend, model, instructions
-
     flow_service = FlowService()
     flow = flow_service.get_flow_status(branch)
 
     if not flow:
-        typer.echo(f"Error: No flow for branch '{branch}'.", err=True)
+        typer.echo(
+            f"Error: No flow for branch '{branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
+            err=True,
+        )
         raise typer.Exit(1)
 
-    if not file:
-        typer.echo("Error: --file is required for plan --spec.", err=True)
-        raise typer.Exit(1)
-
-    # Replace spec_ref with new file
-    spec_path = str(file.resolve())
-    flow_service.bind_spec(branch, spec_path, actor=None)
-    typer.echo(f"Spec updated: {spec_path}")
+    # If spec_path provided, update flow's spec_ref
+    if spec_path:
+        if not spec_path.exists() or not spec_path.is_file():
+            typer.echo(f"Error: Spec file not found: {spec_path}", err=True)
+            raise typer.Exit(1)
+        resolved_spec = str(spec_path.resolve())
+        flow_service.bind_spec(branch, resolved_spec, actor=None)
+        typer.echo(f"Spec updated: {resolved_spec}")
+        spec_file = spec_path
+    else:
+        # Use existing spec_ref from flow
+        if not flow.spec_ref:
+            typer.echo(
+                "Error: No spec bound.\n"
+                "Use 'vibe3 plan --spec <file>' to bind a spec, or "
+                "'vibe3 flow bind <issue> --role task' first.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        spec_file = Path(flow.spec_ref)
+        typer.echo(f"Using flow spec: {flow.spec_ref}")
 
     if dry_run:
         typer.echo("Plan dry run for specification")
@@ -142,7 +151,7 @@ def _plan_spec_impl(
 
     # Build request from spec file
     try:
-        spec_input = resolve_spec_plan_input(branch, file=file)
+        spec_input = resolve_spec_plan_input(branch, file=spec_file)
     except (ValueError, FileNotFoundError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
@@ -154,14 +163,14 @@ def _plan_spec_impl(
             branch=branch,
         )
     else:
+        spec_arg = str(spec_path) if spec_path else None
         execute_spec_plan_async(
             request=spec_input.request,
             issue_number=issue_number,
             branch=branch,
             cli_args=[
                 "plan",
-                "spec",
-                *(["--file", str(file)] if file else []),
+                *(["--spec", spec_arg] if spec_arg else []),
             ],
         )
 
@@ -171,43 +180,31 @@ def default(
     ctx: typer.Context,
     branch: BranchOption = None,
     spec: Annotated[
-        bool,
-        typer.Option("--spec", help="Plan from specification file (requires --file)"),
-    ] = False,
-    file: Annotated[
         Optional[Path],
-        typer.Option("--file", "-f", help="Path to spec file"),
+        typer.Option(
+            "--spec",
+            help="Spec file path (replaces flow spec_ref; omit to use flow spec_ref)",
+        ),
     ] = None,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
-    agent: _AGENT_OPT = None,
-    backend: _BACKEND_OPT = None,
-    model: _MODEL_OPT = None,
 ) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
     target_branch = resolve_branch_arg(branch)
 
-    if spec:
+    if spec is not None:
         _plan_spec_impl(
             branch=target_branch,
-            file=file,
-            instructions=None,
+            spec_path=spec,
             trace=trace,
             dry_run=dry_run,
             no_async=no_async,
-            agent=agent,
-            backend=backend,
-            model=model,
         )
         return
-
-    if file is not None:
-        typer.echo("Error: --file requires --spec.", err=True)
-        raise typer.Exit(1)
 
     # Default: plan for branch
     _plan_for_branch(
@@ -230,12 +227,9 @@ def issue_command(
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
-    agent: _AGENT_OPT = None,
-    backend: _BACKEND_OPT = None,
-    model: _MODEL_OPT = None,
 ) -> None:
     """Legacy: plan from issue number (use --branch instead)."""
-    _ = instructions, agent, backend, model
+    _ = instructions
     from vibe3.services.issue_flow_service import IssueFlowService
 
     branch = IssueFlowService().canonical_branch_name(issue)
@@ -245,38 +239,4 @@ def issue_command(
         dry_run=dry_run,
         no_async=no_async,
         show_prompt=show_prompt,
-    )
-
-
-@app.command(hidden=True)
-def spec(
-    file: Annotated[
-        Optional[Path],
-        typer.Option("--file", "-f", help="Path to spec file"),
-    ] = None,
-    instructions: Annotated[
-        Optional[str],
-        typer.Argument(help="Additional task guidance"),
-    ] = None,
-    trace: _TRACE_OPT = False,
-    dry_run: _DRY_RUN_OPT = False,
-    no_async: _ASYNC_OPT = False,
-    agent: _AGENT_OPT = None,
-    backend: _BACKEND_OPT = None,
-    model: _MODEL_OPT = None,
-) -> None:
-    """Hidden: plan from spec file."""
-    from vibe3.clients.git_client import GitClient
-
-    branch = GitClient().get_current_branch()
-    _plan_spec_impl(
-        branch=branch,
-        file=file,
-        instructions=instructions,
-        trace=trace,
-        dry_run=dry_run,
-        no_async=no_async,
-        agent=agent,
-        backend=backend,
-        model=model,
     )

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -68,7 +68,8 @@ def _review_branch_impl(
 
     if not flow:
         typer.echo(
-            f"Error: No flow for branch '{branch}'.\n" "Run 'vibe flow update' first.",
+            f"Error: No flow for branch '{branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
             err=True,
         )
         raise typer.Exit(1)
@@ -103,10 +104,6 @@ def _review_branch_impl(
 def default(
     ctx: typer.Context,
     branch: BranchOption = None,
-    report_ref: Annotated[
-        Optional[str],
-        typer.Option("--report-ref", help="Report reference for context"),
-    ] = None,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
@@ -115,8 +112,6 @@ def default(
     """Review with --branch for orchestra-driven review, or use pr/base subcommands."""
     if ctx.invoked_subcommand is not None:
         return
-
-    _ = report_ref
 
     if branch is not None or ctx.args:
         # --branch provided or positional arg (legacy issue number)
@@ -135,17 +130,12 @@ def default(
 @app.command(name="issue", hidden=True)
 def issue_command(
     issue: Annotated[int, typer.Argument(help="GitHub issue number")],
-    report_ref: Annotated[
-        Optional[str],
-        typer.Option("--report-ref", help="Report reference for context"),
-    ] = None,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
     """Legacy: review by issue number (use --branch instead)."""
-    _ = report_ref
     from vibe3.services.issue_flow_service import IssueFlowService
 
     branch = IssueFlowService().canonical_branch_name(issue)

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -24,16 +24,23 @@ from vibe3.roles.review import (
     execute_manual_review_async,
     execute_manual_review_sync,
 )
+from vibe3.services.flow_service import FlowService
+from vibe3.utils.branch_arg import resolve_branch_arg
 from vibe3.utils.trace import enable_trace
 
 app = typer.Typer(
     name="review",
     help="Code review with three modes:\n\n"
-    "  --issue <n>  - Review issue implementation (orchestra-driven)\n"
+    "  --branch <b> - Review issue implementation (orchestra-driven)\n"
     "  pr <number>  - Review existing PR from GitHub (analyzes PR diff)\n"
     "  base [branch] - Review local changes vs base branch (compares snapshots)",
     rich_markup_mode="rich",
 )
+
+BranchOption = Annotated[
+    str | None,
+    typer.Option("--branch", "-b", help="Branch name or issue number (e.g., 320)"),
+]
 
 
 def _emit_review_result(verdict: str, handoff_file: str | None) -> None:
@@ -42,26 +49,43 @@ def _emit_review_result(verdict: str, handoff_file: str | None) -> None:
         return
     typer.echo(f"\n=== Verdict: {verdict} ===")
     if handoff_file:
-        typer.echo(f"→ Review saved to: {handoff_file}")
+        typer.echo(f"-> Review saved to: {handoff_file}")
 
 
-def _review_issue_impl(
-    issue: int,
-    report_ref: str | None,
+def _review_branch_impl(
+    branch: str,
     trace: bool,
     dry_run: bool,
     no_async: bool,
     show_prompt: bool,
 ) -> None:
-    """Review implementation for an issue via role sync runner."""
+    """Review implementation for a branch via role sync runner."""
     if trace:
         enable_trace()
 
-    _ = report_ref
+    flow_service = FlowService()
+    flow = flow_service.get_flow_status(branch)
+
+    if not flow:
+        typer.echo(
+            f"Error: No flow for branch '{branch}'.\n" "Run 'vibe flow update' first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    issue_number = flow.task_issue_number
+
+    if not issue_number:
+        typer.echo(
+            f"Error: No issue linked to flow '{branch}'.\n"
+            "Run 'vibe flow bind <issue>' first.",
+            err=True,
+        )
+        raise typer.Exit(1)
 
     if no_async:
         run_issue_role_sync(
-            issue_number=issue,
+            issue_number=issue_number,
             dry_run=dry_run,
             fresh_session=False,
             show_prompt=show_prompt,
@@ -69,7 +93,7 @@ def _review_issue_impl(
         )
     else:
         run_issue_role_async(
-            issue_number=issue,
+            issue_number=issue_number,
             dry_run=dry_run,
             spec=REVIEW_SYNC_SPEC,
         )
@@ -78,10 +102,7 @@ def _review_issue_impl(
 @app.callback(invoke_without_command=True)
 def default(
     ctx: typer.Context,
-    issue: Annotated[
-        Optional[int],
-        typer.Option("--issue", "-i", help="Review issue implementation"),
-    ] = None,
+    branch: BranchOption = None,
     report_ref: Annotated[
         Optional[str],
         typer.Option("--report-ref", help="Report reference for context"),
@@ -91,13 +112,17 @@ def default(
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
-    """Review with --issue for orchestra-driven review, or use pr/base subcommands."""
+    """Review with --branch for orchestra-driven review, or use pr/base subcommands."""
     if ctx.invoked_subcommand is not None:
         return
-    if issue is not None:
-        _review_issue_impl(
-            issue=issue,
-            report_ref=report_ref,
+
+    _ = report_ref
+
+    if branch is not None or ctx.args:
+        # --branch provided or positional arg (legacy issue number)
+        target_branch = resolve_branch_arg(branch)
+        _review_branch_impl(
+            branch=target_branch,
             trace=trace,
             dry_run=dry_run,
             no_async=no_async,
@@ -107,7 +132,7 @@ def default(
     typer.echo(ctx.get_help())
 
 
-@app.command(name="issue")
+@app.command(name="issue", hidden=True)
 def issue_command(
     issue: Annotated[int, typer.Argument(help="GitHub issue number")],
     report_ref: Annotated[
@@ -119,10 +144,13 @@ def issue_command(
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
-    """Review implementation for a specific issue (orchestra-driven)."""
-    _review_issue_impl(
-        issue=issue,
-        report_ref=report_ref,
+    """Legacy: review by issue number (use --branch instead)."""
+    _ = report_ref
+    from vibe3.services.issue_flow_service import IssueFlowService
+
+    branch = IssueFlowService().canonical_branch_name(issue)
+    _review_branch_impl(
+        branch=branch,
         trace=trace,
         dry_run=dry_run,
         no_async=no_async,
@@ -157,7 +185,7 @@ def pr(
 
     log = logger.bind(domain="review", action="pr", pr_number=pr_number)
     log.info("Starting PR review")
-    typer.echo(f"→ Review: PR #{pr_number}")
+    typer.echo(f"-> Review: PR #{pr_number}")
     request, issue_number, head_branch = build_pr_review_request(pr_number)
 
     if not head_branch and not dry_run:
@@ -235,7 +263,7 @@ def base(
         raise typer.Exit(1) from error
 
     if resolved_base.auto_detected:
-        typer.echo(f"→ Auto-detected parent branch: {resolved_base.base_branch}")
+        typer.echo(f"-> Auto-detected parent branch: {resolved_base.base_branch}")
 
     log = logger.bind(
         domain="review",
@@ -244,7 +272,7 @@ def base(
         base_branch=resolved_base.base_branch,
     )
     log.info("Starting branch review")
-    typer.echo(f"→ Review: {current_branch} vs {resolved_base.base_branch}")
+    typer.echo(f"-> Review: {current_branch} vs {resolved_base.base_branch}")
 
     request, issue_number, _ = build_base_review_request(
         current_branch,

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -130,17 +130,16 @@ def default(
 @app.command(name="issue", hidden=True)
 def issue_command(
     issue: Annotated[int, typer.Argument(help="GitHub issue number")],
+    ctx: typer.Context,
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
     show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
-    """Legacy: review by issue number (use --branch instead)."""
-    from vibe3.services.issue_flow_service import IssueFlowService
-
-    branch = IssueFlowService().canonical_branch_name(issue)
-    _review_branch_impl(
-        branch=branch,
+    """Legacy alias: review --branch <issue>."""
+    default(
+        ctx=ctx,
+        branch=str(issue),
         trace=trace,
         dry_run=dry_run,
         no_async=no_async,

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -91,7 +91,11 @@ def run_command(
     flow = flow_service.get_flow_status(target_branch)
 
     if not flow:
-        typer.echo(f"Error: No flow for branch '{target_branch}'.", err=True)
+        typer.echo(
+            f"Error: No flow for branch '{target_branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
+            err=True,
+        )
         raise typer.Exit(1)
 
     issue_number = (

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -14,7 +14,6 @@ from vibe3.commands.command_options import (
     _MODEL_OPT,
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
-    ensure_flow_for_current_branch,
 )
 from vibe3.config.settings import VibeConfig
 from vibe3.roles.run import (
@@ -23,6 +22,8 @@ from vibe3.roles.run import (
     find_skill_file,
     resolve_run_mode,
 )
+from vibe3.services.flow_service import FlowService
+from vibe3.utils.branch_arg import resolve_branch_arg
 from vibe3.utils.trace import enable_trace
 
 app = typer.Typer(
@@ -33,8 +34,14 @@ app = typer.Typer(
     rich_markup_mode="rich",
 )
 
+BranchOption = Annotated[
+    str | None,
+    typer.Option("--branch", "-b", help="Branch name or issue number (e.g., 320)"),
+]
+
 
 def run_command(
+    branch: BranchOption = None,
     instructions: Annotated[
         Optional[str],
         typer.Argument(help="Instructions to pass to codeagent"),
@@ -63,6 +70,10 @@ def run_command(
             help="Skip session resume and start a fresh agent session",
         ),
     ] = False,
+    publish: Annotated[
+        bool,
+        typer.Option("--publish", help="Publish mode: create commit + PR"),
+    ] = False,
 ) -> None:
     """Execute implementation plan or skill."""
     if trace:
@@ -74,11 +85,26 @@ def run_command(
     register_event_handlers()
 
     config = VibeConfig.get_defaults()
-    flow_service, branch = ensure_flow_for_current_branch()
-    flow = flow_service.get_flow_status(branch)
+    target_branch = resolve_branch_arg(branch)
+
+    flow_service = FlowService()
+    flow = flow_service.get_flow_status(target_branch)
+
+    if not flow:
+        typer.echo(f"Error: No flow for branch '{target_branch}'.", err=True)
+        raise typer.Exit(1)
+
     issue_number = (
         str(flow.task_issue_number) if flow and flow.task_issue_number else None
     )
+
+    if publish and skill:
+        typer.echo("Error: --publish and --skill are mutually exclusive.", err=True)
+        raise typer.Exit(1)
+
+    if publish:
+        skill = "vibe-commit"
+        typer.echo("-> Publish mode: creating commit + PR")
 
     if skill:
         skill_file = find_skill_file(skill)
@@ -92,23 +118,28 @@ def run_command(
         typer.echo(f"-> Skill: {skill_file}")
         execute_manual_run(
             config=config,
-            branch=branch,
+            branch=target_branch,
             issue_number=int(issue_number) if issue_number else None,
             instructions=instructions,
             plan_file=None,
             skill=skill,
-            summary=resolve_run_mode(flow_service, branch, instructions, None, skill),
+            summary=resolve_run_mode(
+                flow_service, target_branch, instructions, None, skill
+            ),
             dry_run=dry_run,
             no_async=no_async,
             show_prompt=show_prompt,
             agent=agent,
             backend=backend,
             model=model,
+            fresh_session=fresh_session,
         )
         return
 
     try:
-        summary = resolve_run_mode(flow_service, branch, instructions, plan, skill)
+        summary = resolve_run_mode(
+            flow_service, target_branch, instructions, plan, skill
+        )
     except ValueError as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(1) from error
@@ -136,9 +167,10 @@ def run_command(
     except FileNotFoundError as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(1) from error
+
     execute_manual_run(
         config=config,
-        branch=branch,
+        branch=target_branch,
         issue_number=int(issue_number) if issue_number else None,
         instructions=instructions,
         plan_file=plan_file,
@@ -150,12 +182,14 @@ def run_command(
         agent=agent,
         backend=backend,
         model=model,
+        fresh_session=fresh_session,
     )
 
 
 @app.callback(invoke_without_command=True)
 def default(
     ctx: typer.Context,
+    branch: BranchOption = None,
     instructions: Annotated[
         Optional[str],
         typer.Argument(help="Instructions to pass to codeagent"),
@@ -177,19 +211,33 @@ def default(
     agent: _AGENT_OPT = None,
     backend: _BACKEND_OPT = None,
     model: _MODEL_OPT = None,
+    fresh_session: Annotated[
+        bool,
+        typer.Option(
+            "--fresh-session",
+            help="Skip session resume and start a fresh agent session",
+        ),
+    ] = False,
+    publish: Annotated[
+        bool,
+        typer.Option("--publish", help="Publish mode: create commit + PR"),
+    ] = False,
 ) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
     run_command(
-        instructions,
-        plan,
-        skill,
-        trace,
-        dry_run,
-        no_async,
-        show_prompt,
-        agent,
-        backend,
-        model,
+        branch=branch,
+        instructions=instructions,
+        plan=plan,
+        skill=skill,
+        trace=trace,
+        dry_run=dry_run,
+        no_async=no_async,
+        show_prompt=show_prompt,
+        agent=agent,
+        backend=backend,
+        model=model,
+        fresh_session=fresh_session,
+        publish=publish,
     )

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -201,7 +201,7 @@ class InvalidTransitionError(UserError):
 # Usage:
 #   from vibe3.exceptions.error_tracking import ErrorTrackingService
 #   from vibe3.exceptions.error_classification import (
-#       classify_error, should_trigger_failed_gate
+#       classify_error
 #   )
 #   from vibe3.exceptions.error_codes import (
 #       E_MODEL_NOT_FOUND, E_API_RATE_LIMIT, etc.

--- a/src/vibe3/exceptions/error_classification.py
+++ b/src/vibe3/exceptions/error_classification.py
@@ -18,10 +18,7 @@ from vibe3.exceptions.error_codes import (
     E_MODEL_CONFIG,
     E_MODEL_NOT_FOUND,
     E_MODEL_PERMISSION,
-    is_api_error,
-    is_model_error,
 )
-from vibe3.exceptions.error_tracking import ErrorTrackingService
 
 
 def classify_error(error_output: str) -> str:
@@ -77,72 +74,3 @@ def classify_error(error_output: str) -> str:
         error_output=error_output[:100],  # Truncate for logging
     ).warning("Unclassified error, defaulting to E_EXEC_UNKNOWN")
     return E_EXEC_UNKNOWN
-
-
-def should_trigger_failed_gate(
-    error_code: str,
-    error_tracking: ErrorTrackingService | None = None,
-) -> tuple[bool, str]:
-    """Determine if error should trigger global failed gate.
-
-    Args:
-        error_code: Error code from classify_error()
-        error_tracking: ErrorTrackingService instance (defaults to global instance)
-
-    Returns:
-        (trigger_gate: bool, reason: str)
-
-    Logic:
-    - E_MODEL_* → immediate failed gate (config error)
-    - E_API_* → check threshold (2+ in 3 ticks)
-    - E_EXEC_* → local blocked only
-    """
-    effective_tracking = error_tracking or ErrorTrackingService.get_instance()
-
-    # Model config errors → immediate failed gate
-    if is_model_error(error_code):
-        logger.bind(
-            domain="error_tracking",
-            error_code=error_code,
-        ).warning("Model config error → failed gate")
-        return True, f"Model config error: {error_code}"
-
-    # API errors → check threshold
-    if is_api_error(error_code):
-        threshold_reached, count = effective_tracking.record_error(
-            error_code, error_message=""  # Empty message for threshold check
-        )
-
-        if threshold_reached:
-            logger.bind(
-                domain="error_tracking",
-                error_code=error_code,
-                window_count=count,
-            ).error("API error threshold reached → failed gate")
-            return (
-                True,
-                (
-                    f"API error threshold: {count} errors in "
-                    f"{ErrorTrackingService.TIME_WINDOW_MINUTES} minutes"
-                ),
-            )
-        else:
-            logger.bind(
-                domain="error_tracking",
-                error_code=error_code,
-                window_count=count,
-            ).info("Sporadic API error → local blocked")
-            return (
-                False,
-                (
-                    f"Sporadic API error: {error_code} "
-                    f"(count: {count}/{ErrorTrackingService.THRESHOLD_COUNT})"
-                ),
-            )
-
-    # Execution errors → local blocked only
-    logger.bind(
-        domain="error_tracking",
-        error_code=error_code,
-    ).info("Execution error → local blocked")
-    return False, f"Execution error: {error_code}"

--- a/src/vibe3/exceptions/error_codes.py
+++ b/src/vibe3/exceptions/error_codes.py
@@ -35,8 +35,3 @@ def is_model_error(error_code: str) -> bool:
 def is_api_error(error_code: str) -> bool:
     """Check if error is an API error."""
     return error_code.startswith("E_API_")
-
-
-def is_exec_error(error_code: str) -> bool:
-    """Check if error is an execution error."""
-    return error_code.startswith("E_EXEC_")

--- a/src/vibe3/execution/actor_support.py
+++ b/src/vibe3/execution/actor_support.py
@@ -1,7 +1,5 @@
 """Shared actor formatting helpers for execution and handoff."""
 
-from typing import Any
-
 from vibe3.agents.backends.codeagent_config import resolve_effective_agent_options
 from vibe3.exceptions import AgentPresetNotFoundError
 from vibe3.models.review_runner import AgentOptions
@@ -82,54 +80,3 @@ def extract_role_from_actor(actor: str) -> str:
 
     # Default to "agent"
     return "agent"
-
-
-def infer_role_from_flow_state(
-    store: Any,
-    branch: str,
-    actor: str,
-) -> str:
-    """Infer role from flow state by matching actor against role-specific actor fields.
-
-    This function attempts to determine which role (planner/executor/reviewer)
-    a given actor is associated with in the current flow.
-
-    Args:
-        store: SQLiteClient instance for database access
-        branch: Branch name for flow state lookup
-        actor: Actor identifier (e.g., "claude/claude-sonnet-4-6")
-
-    Returns:
-        Role string: "planner", "executor", "reviewer", or "unknown"
-    """
-    if not actor or not store or not branch:
-        return "unknown"
-
-    try:
-        flow_data_raw = store.get_flow_state(branch)
-        flow_data = flow_data_raw if isinstance(flow_data_raw, dict) else {}
-    except Exception:
-        # Database access failed; return unknown rather than crash
-        return "unknown"
-
-    if not flow_data:
-        return "unknown"
-
-    # Normalize actor for comparison
-    normalized_actor = actor.strip().lower()
-
-    # Check role-specific actor fields
-    role_actor_map = {
-        "planner_actor": "planner",
-        "executor_actor": "executor",
-        "reviewer_actor": "reviewer",
-    }
-
-    for field, role in role_actor_map.items():
-        field_value = flow_data.get(field)
-        if field_value and isinstance(field_value, str):
-            if field_value.strip().lower() == normalized_actor:
-                return role
-
-    # Could not determine role from flow state
-    return "unknown"

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -199,26 +199,37 @@ class CodeagentExecutionService:
                 )
 
             passive_kind = {"planner": "plan", "executor": "run"}.get(command.role)
-            # Passive recording: record if NO active handoff happened this round
+            # Passive recording: ONLY as fallback when primary ref is missing
+            # (i.e., agent did NOT call `handoff plan` or `handoff report`)
             if passive_kind and agent_result.stdout.strip() and handoff_file is None:
-                try:
-                    handoff_file = HandoffService(
-                        store=ctx.store
-                    ).record_passive_artifact(
-                        kind=passive_kind,
-                        content=agent_result.stdout,
-                        actor=ctx.actor,
-                        metadata=(
-                            {"session_id": effective_session_id}
-                            if effective_session_id
-                            else None
-                        ),
-                        branch=ctx.branch,
+                ref_field = f"{passive_kind}_ref"
+                existing_state = (
+                    ctx.store.get_flow_state(ctx.branch) if ctx.store else None
+                )
+                if existing_state and existing_state.get(ref_field):
+                    log.info(
+                        f"Skipping passive {passive_kind} recording: "
+                        f"{ref_field} already set"
                     )
-                except Exception as exc:
-                    log.warning(
-                        f"Failed to record passive {passive_kind} artifact: {exc}"
-                    )
+                else:
+                    try:
+                        handoff_file = HandoffService(
+                            store=ctx.store
+                        ).record_passive_artifact(
+                            kind=passive_kind,
+                            content=agent_result.stdout,
+                            actor=ctx.actor,
+                            metadata=(
+                                {"session_id": effective_session_id}
+                                if effective_session_id
+                                else None
+                            ),
+                            branch=ctx.branch,
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            f"Failed to record passive {passive_kind} artifact: {exc}"
+                        )
 
         return handoff_file
 

--- a/src/vibe3/execution/role_policy.py
+++ b/src/vibe3/execution/role_policy.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Callable, Literal
 
 if TYPE_CHECKING:
     from vibe3.agents.models import ExecutionRole
-    from vibe3.models.handoff import HandoffKind
 
 # Role to config section mapping
 # Note: Uses str instead of ExecutionRole because it includes "manager"
@@ -35,16 +34,6 @@ KIND_TO_ACTOR_KEY: dict[str, str] = {
     "run": "executor_actor",
     "review": "reviewer_actor",
 }
-
-
-def get_kind_actor_key(kind: "HandoffKind") -> str:
-    """Get the actor state key for a given handoff kind."""
-    return KIND_TO_ACTOR_KEY[kind]
-
-
-def get_optional_kind_actor_key(kind: "HandoffKind") -> str | None:
-    """Get the actor state key for a handoff kind when one exists."""
-    return KIND_TO_ACTOR_KEY.get(kind)
 
 
 # Lazy import to avoid circular dependencies

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -300,7 +300,7 @@ def resolve_spec_plan_input(
         "Use one of:\n"
         "  vibe flow bind <issue> --role task # Bind issue as spec\n"
         "  vibe flow update --spec <file>    # Bind spec file to flow\n"
-        "  vibe3 plan spec --file <path>     # From spec file (replaces current spec)\n"
+        "  vibe3 plan --spec <path>          # Override flow spec_ref with file\n"
         "Or ensure flow has an existing spec_ref."
     )
 

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -160,11 +160,12 @@ def build_plan_request(
     actor: str = "orchestra:planner",
 ) -> ExecutionRequest:
     """Build the planner async execution request for dispatch."""
+    target_branch = branch or f"task/issue-{issue.number}"
     return build_role_async_request(
         role="planner",
         config=config,
         issue=issue,
-        command_args=["plan", "--issue", str(issue.number), "--no-async"],
+        command_args=["plan", "--branch", target_branch, "--no-async"],
         worktree_requirement=PLANNER_ROLE.worktree,
         branch=branch,
         repo_path=repo_path,
@@ -237,20 +238,16 @@ def resolve_spec_plan_input(
     branch: str,
     *,
     file: Path | None = None,
-    msg: str | None = None,
 ) -> PlanSpecInput:
-    """Resolve spec planning input from file, inline message, or flow spec_ref.
+    """Resolve spec planning input from file or flow spec_ref.
 
     Priority:
-    1. Explicit --file or --msg from CLI
+    1. Explicit --file from CLI
     2. Flow's existing spec_ref (if available)
     3. Error if none available
     """
     from vibe3.services.flow_service import FlowService
     from vibe3.services.spec_ref_service import SpecRefService
-
-    if file and msg:
-        raise ValueError("Provide either --file or --msg, not both.")
 
     # Case 1: Explicit file provided
     if file:
@@ -266,19 +263,7 @@ def resolve_spec_plan_input(
             spec_path=spec_path,
         )
 
-    # Case 2: Explicit message provided
-    if msg:
-        description = msg
-        spec_path = None  # Already defined with str | None type in Case 1
-        request = PlanRequest(scope=PlanScope.for_spec(description))
-        return PlanSpecInput(
-            branch=branch,
-            request=request,
-            description=description,
-            spec_path=spec_path,
-        )
-
-    # Case 3: Try flow's spec_ref as default
+    # Case 2: Try flow's spec_ref as default
     flow_service = FlowService()
     flow = flow_service.get_flow_status(branch)
 
@@ -309,22 +294,15 @@ def resolve_spec_plan_input(
             spec_path=spec_path,
         )
 
-    # Case 4: No spec available
+    # Case 3: No spec available
     raise ValueError(
         "No spec provided.\n"
         "Use one of:\n"
-        "  vibe3 plan spec --file <path>     # From spec file\n"
-        "  vibe3 plan spec --msg <text>      # From inline message\n"
-        "  vibe3 flow update --spec <ref>    # Bind spec to flow first\n"
+        "  vibe flow bind <issue> --role task # Bind issue as spec\n"
+        "  vibe flow update --spec <file>    # Bind spec file to flow\n"
+        "  vibe3 plan spec --file <path>     # From spec file (replaces current spec)\n"
         "Or ensure flow has an existing spec_ref."
     )
-
-
-def bind_plan_spec(branch: str, spec_path: str) -> None:
-    """Bind resolved spec path to current flow."""
-    from vibe3.services.flow_service import FlowService
-
-    FlowService().bind_spec(branch, spec_path, "user")
 
 
 def execute_spec_plan_async(

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -157,7 +157,7 @@ def build_issue_review_request(
     async_refs: dict[str, str] = {"issue_number": str(issue.number)}
     if report_ref:
         async_refs["report_ref"] = report_ref
-    command_args = ["review", "--issue", str(issue.number), "--no-async"]
+    command_args = ["review", "--branch", target_branch, "--no-async"]
     if report_ref:
         command_args.extend(["--report-ref", report_ref])
 

--- a/src/vibe3/roles/run.py
+++ b/src/vibe3/roles/run.py
@@ -90,13 +90,29 @@ def build_run_request(
         refs["plan_ref"] = plan_ref
     if audit_ref:
         refs["audit_ref"] = audit_ref
+
+    target_branch = branch or f"task/issue-{issue.number}"
     if commit_mode:
-        command_args = ["run", "--skill", "vibe-commit", "--no-async"]
+        command_args = [
+            "run",
+            "--branch",
+            target_branch,
+            "--skill",
+            "vibe-commit",
+            "--no-async",
+        ]
         refs["commit_mode"] = "true"
     elif plan_ref:
-        command_args = ["run", "--plan", plan_ref, "--no-async"]
+        command_args = [
+            "run",
+            "--branch",
+            target_branch,
+            "--plan",
+            plan_ref,
+            "--no-async",
+        ]
     else:
-        command_args = ["run", "--no-async"]
+        command_args = ["run", "--branch", target_branch, "--no-async"]
 
     return build_role_async_request(
         role="executor",
@@ -351,6 +367,7 @@ def execute_manual_run(
     agent: str | None,
     backend: str | None,
     model: str | None,
+    fresh_session: bool = False,
 ) -> CodeagentResult | None:
     """Execute manual run command via role-owned facade."""
     if skill:
@@ -414,7 +431,11 @@ def execute_manual_run(
                     report_ref = str(flow_state["report_ref"])
                 if flow_state.get("audit_ref"):
                     audit_file = str(flow_state["audit_ref"])
-                retry_session_id = load_session_id("executor", branch=branch)
+                retry_session_id = (
+                    None
+                    if fresh_session
+                    else load_session_id("executor", branch=branch)
+                )
                 meta = build_prompt_meta(
                     flow_state,
                     ref_keys=("plan_ref", "report_ref", "audit_ref"),

--- a/src/vibe3/roles/run.py
+++ b/src/vibe3/roles/run.py
@@ -207,7 +207,7 @@ def publish_run_command_success(
     """Record run command success. State transitions are the agent's responsibility.
 
     The agent receives run_task / output_format from settings.yaml (via
-    build_run_standard_sections), which includes the instruction to change
+    run.skill recipe with standard providers), which includes the instruction to change
     issue label to state/handoff. Code layer MUST NOT auto-transition state
     (noop-gate-boundary-standard).
     """

--- a/src/vibe3/services/flow_write_mixin.py
+++ b/src/vibe3/services/flow_write_mixin.py
@@ -215,6 +215,14 @@ class FlowWriteMixin(FlowReadMixin):
             spec_ref: Spec file reference
             actor: Actor performing the bind
         """
+        # Idempotency check: skip if spec_ref is already bound
+        existing = self.store.get_flow_state(branch)
+        if existing and existing.get("spec_ref") == spec_ref:
+            logger.bind(branch=branch, spec=spec_ref).debug(
+                "Spec already bound, skipping"
+            )
+            return
+
         effective_actor = SignatureService.resolve_for_branch(
             self.store,
             branch,

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -17,6 +17,7 @@ from vibe3.services.artifact_parser import ArtifactParser
 from vibe3.services.handoff_storage import HandoffStorage
 from vibe3.services.signature_service import SignatureService
 from vibe3.utils.path_helpers import (
+    _SHARED_HANDOFF_PREFIX,
     GitClientProtocol,
 )
 
@@ -326,11 +327,17 @@ class HandoffService:
         )
         event_type = f"{kind}_recorded"
         git_common = Path(self.git_client.get_git_common_dir())
-        ref_value = (
+        relative_ref = (
             str(artifact_path.relative_to(git_common))
             if artifact_path.is_absolute()
             else str(artifact_path)
         )
+        # Normalize to @ prefix format for shared handoff artifacts
+        # vibe3/handoff/task-xxx/plan.md → @task-xxx/plan.md
+        if relative_ref.startswith(_SHARED_HANDOFF_PREFIX):
+            ref_value = "@" + relative_ref[len(_SHARED_HANDOFF_PREFIX) :]
+        else:
+            ref_value = relative_ref
         refs: dict[str, str | list[str]] = {"ref": ref_value}
         refs.update(extra_refs)
         self.store.add_event(

--- a/src/vibe3/services/issue_failure_service.py
+++ b/src/vibe3/services/issue_failure_service.py
@@ -316,7 +316,7 @@ def resume_issue(
     )
 
 
-# Backward compatibility wrappers (can be removed later if all callers updated)
+# Role-specific convenience wrappers for fail_issue/block_issue
 def fail_reviewer_issue(
     *, issue_number: int, reason: str, actor: str = "agent:review"
 ) -> None:
@@ -396,23 +396,6 @@ def block_reviewer_noop_issue(
         actor=actor,
         repo=repo,
         is_noop=True,
-    )
-
-
-def resume_failed_issue_to_ready(
-    *, issue_number: int, repo: str | None, reason: str, actor: str = "human:resume"
-) -> None:
-    """Resume from failed/blocked to ready.
-
-    Note: FAILED is now unified to BLOCKED. This function remains for
-    backward compatibility but uses from_state="blocked".
-    """
-    resume_issue(
-        issue_number=issue_number,
-        reason=reason,
-        from_state="blocked",
-        repo=repo,
-        actor=actor,
     )
 
 

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -101,20 +101,47 @@ class TaskService:
         # Now add the new link
         self.store.add_issue_link(normalized_branch, issue_number, role)
 
+        # Fetch existing events for idempotent checks
+        existing_events = self.store.get_events(normalized_branch)
+
         if role == "task":
-            # task_issue_number is no longer stored in flow_state.
-            # We only update latest_actor to track activity.
+            # Write spec_ref for task role (issue number as spec)
             self.store.update_flow_state(
                 normalized_branch,
                 latest_actor=effective_actor,
+                spec_ref=f"#{issue_number}",
             )
+            # Add spec_bound event (idempotent)
+            already_bound = any(
+                e.get("event_type") == "spec_bound"
+                and str((e.get("refs") or {}).get("issue_number") or "")
+                == str(issue_number)
+                for e in existing_events
+            )
+            if not already_bound:
+                self.store.add_event(
+                    normalized_branch,
+                    "spec_bound",
+                    effective_actor,
+                    f"Spec bound: #{issue_number}",
+                    refs={"issue_number": issue_number},
+                )
 
-        self.store.add_event(
-            normalized_branch,
-            "issue_linked",
-            effective_actor,
-            f"Issue #{issue_number} linked as {role}",
+        # Add issue_linked event (idempotent)
+        already_linked = any(
+            e.get("event_type") == "issue_linked"
+            and str((e.get("refs") or {}).get("issue_number") or "")
+            == str(issue_number)
+            for e in existing_events
         )
+        if not already_linked:
+            self.store.add_event(
+                normalized_branch,
+                "issue_linked",
+                effective_actor,
+                f"Issue #{issue_number} linked as {role}",
+                refs={"issue_number": issue_number, "role": role},
+            )
 
         # Demote superseded flows AFTER successful link
         if role == "task" and superseded_flows:

--- a/src/vibe3/ui/handoff_ui.py
+++ b/src/vibe3/ui/handoff_ui.py
@@ -3,42 +3,11 @@
 from pathlib import Path
 
 from rich.panel import Panel
-from rich.table import Table
 
 from vibe3.ui.console import console
-
-
-def render_handoff_list(branch: str, handoffs: list[dict[str, str]]) -> None:
-    """Render handoff events as a compact table."""
-    table = Table(title=f"Handoff Artifacts: {branch}")
-    table.add_column("Time", style="cyan")
-    table.add_column("Kind", style="magenta")
-    table.add_column("Actor", style="green")
-    table.add_column("Detail", style="white")
-
-    for handoff in handoffs:
-        table.add_row(
-            handoff.get("timestamp", ""),
-            handoff.get("kind", ""),
-            handoff.get("actor", ""),
-            handoff.get("detail", ""),
-        )
-
-    console.print(table)
 
 
 def render_handoff_detail(artifact_path: Path) -> None:
     """Display a single handoff artifact file content."""
     content = artifact_path.read_text(encoding="utf-8")
     console.print(Panel(content, title=artifact_path.name))
-
-
-def render_handoff_summary(branch: str, stats: dict[str, int]) -> None:
-    """Render handoff event count summary."""
-    console.print(f"\n[bold]Handoff Summary: {branch}[/bold]")
-    console.print(f"  Total artifacts: {stats.get('total', 0)}")
-    console.print(f"  Plans: {stats.get('plans', 0)}")
-    console.print(f"  Runs: {stats.get('runs', 0)}")
-    console.print(f"  Reviews: {stats.get('reviews', 0)}")
-    if stats.get("indicates", 0):
-        console.print(f"  Indicates: {stats.get('indicates', 0)}")

--- a/src/vibe3/utils/branch_arg.py
+++ b/src/vibe3/utils/branch_arg.py
@@ -1,7 +1,12 @@
-"""Branch argument resolution for CLI commands."""
+"""Branch argument resolution for CLI commands.
+
+Reuses issue_branch_resolver for numeric resolution with flow lookup,
+adds current-branch fallback for None input.
+"""
 
 from vibe3.clients.git_client import GitClient
-from vibe3.services.issue_flow_service import IssueFlowService
+from vibe3.services.flow_service import FlowService
+from vibe3.utils.issue_branch_resolver import resolve_issue_branch_input
 
 
 def resolve_branch_arg(branch_arg: str | None) -> str:
@@ -12,6 +17,10 @@ def resolve_branch_arg(branch_arg: str | None) -> str:
     - digits only → canonical task branch (task/issue-N)
     - otherwise → return as-is (explicit branch name)
 
+    Unlike resolve_issue_branch_input:
+    - Returns current branch for None (not None)
+    - Falls back to canonical name if no flow exists (not original digits)
+
     Args:
         branch_arg: Branch argument from CLI (may be None, digits, or branch name)
 
@@ -21,7 +30,13 @@ def resolve_branch_arg(branch_arg: str | None) -> str:
     if branch_arg is None:
         return GitClient().get_current_branch()
 
-    stripped = branch_arg.strip()
-    if stripped.isdigit():
-        return IssueFlowService().canonical_branch_name(int(stripped))
-    return stripped
+    # Delegate to existing resolver (checks flow store for task/dev patterns)
+    resolved = resolve_issue_branch_input(branch_arg, FlowService())
+    if resolved is None:
+        return GitClient().get_current_branch()
+
+    # If resolver returned original digits (no flow), convert to canonical
+    if resolved.isdigit():
+        return f"task/issue-{resolved}"
+
+    return resolved

--- a/src/vibe3/utils/branch_arg.py
+++ b/src/vibe3/utils/branch_arg.py
@@ -1,0 +1,27 @@
+"""Branch argument resolution for CLI commands."""
+
+from vibe3.clients.git_client import GitClient
+from vibe3.services.issue_flow_service import IssueFlowService
+
+
+def resolve_branch_arg(branch_arg: str | None) -> str:
+    """Resolve --branch argument to a canonical branch name.
+
+    Rules:
+    - None → current git branch
+    - digits only → canonical task branch (task/issue-N)
+    - otherwise → return as-is (explicit branch name)
+
+    Args:
+        branch_arg: Branch argument from CLI (may be None, digits, or branch name)
+
+    Returns:
+        Resolved branch name
+    """
+    if branch_arg is None:
+        return GitClient().get_current_branch()
+
+    stripped = branch_arg.strip()
+    if stripped.isdigit():
+        return IssueFlowService().canonical_branch_name(int(stripped))
+    return stripped

--- a/src/vibe3/utils/path_helpers.py
+++ b/src/vibe3/utils/path_helpers.py
@@ -404,6 +404,14 @@ def resolve_handoff_target(
     if target.startswith("@"):
         return _resolve_shared_artifact(target, git_client)
 
+    # Namespace 1.5: vibe3/handoff/ prefix → shared handoff store (no @ needed)
+    # This handles refs stored by record_passive_artifact that don't have @ prefix
+    if target.startswith(_SHARED_HANDOFF_PREFIX):
+        # Convert vibe3/handoff/task-xxx/run.md → @task-xxx/run.md
+        return _resolve_shared_artifact(
+            "@" + target[len(_SHARED_HANDOFF_PREFIX) :], git_client
+        )
+
     target_path = Path(target)
 
     # Namespace 3: absolute path → passthrough

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -42,7 +42,8 @@ Allowed:
 - `pr_ref`: read (审核 executor 提交的 PR)
 - `scene`: read
 - `code`: read (质量审查时可阅读代码，但不得修改)
-- `flow.update`: 允许执行 `flow update --spec` 操作，仅用于更新 flow 的 spec_ref 元数据
+- `flow.update`: 允许执行 `flow update --spec <file>` 操作（仅文件路径），用于更新 flow 的 spec_ref 为 spec 文件
+- `flow.bind`: 允许执行 `vibe flow bind <issue-number> --role task` 绑定 issue 为 spec
 
 **Comment 格式要求**：
 
@@ -214,7 +215,7 @@ uv run python src/vibe3/cli.py handoff show @task-xxx/run-yyy.md
 
 允许：
 
-- 当缺少 spec_ref 时，执行 `uv run python src/vibe3/cli.py flow update --spec <...>` 更新 spec_ref 元数据
+- 当缺少 spec_ref 时，优先执行 `vibe flow bind <issue-number> --role task` 绑定 issue 为 spec；若需补充 spec 文件，执行 `vibe flow update --spec <file>`
 
 ## Pseudo Functions
 
@@ -456,9 +457,11 @@ Steps:
 Decision sketch:
 
 - 无 `spec_ref`：
-  - comment 当前 issue，指出缺少 spec 真源
-  - 如需修复，先执行 `uv run python src/vibe3/cli.py flow update --spec <...>`
-  - 必要时写 handoff append
+  - 优先用 issue 号绑定：`vibe flow bind <issue-number> --role task`
+  - 若 issue 描述不清楚，写 docs/specs/ 下的 spec 文件，再 `vibe flow update --spec docs/specs/xxx.md`
+  - 禁止用 plan 文件路径作为 spec（plan_ref 是输出，spec_ref 是输入）
+  - 禁止用 `vibe flow update --spec <issue-id>`（应使用 `vibe flow bind`）
+  - 必要时写 handoff append 说明 spec 绑定决策
   - `exit()`
 - 已有 `plan_ref`，无 `report_ref`：
   - **实质审查 plan**: 读 plan_ref 内容，判断质量是否达标（是否完整、是否可执行、是否有遗漏）

--- a/tests/vibe3/commands/test_flow_update_spec.py
+++ b/tests/vibe3/commands/test_flow_update_spec.py
@@ -27,77 +27,58 @@ def test_update_clear_spec_ref_with_empty_string() -> None:
     )
 
 
-def test_update_with_issue_number() -> None:
-    """Test --spec 123 writes resolved issue reference."""
+def test_update_with_issue_number_rejected() -> None:
+    """Test --spec 123 (issue number) is rejected with helpful error."""
     mock_flow_service = MagicMock()
     mock_flow = MagicMock()
     mock_flow.branch = "test/branch"
     mock_flow_service.ensure_flow_for_branch.return_value = mock_flow
     mock_flow_service.get_current_branch.return_value = "test/branch"
 
-    mock_spec_service = MagicMock()
-    mock_spec_service.validate_spec_ref.return_value = (True, "")
-    mock_spec_service.resolve_spec_ref.return_value = "#123"
-
     with patch("vibe3.commands.flow.FlowService", return_value=mock_flow_service):
         with patch("vibe3.commands.flow.trace_scope"):
-            with patch(
-                "vibe3.services.spec_ref_service.SpecRefService",
-                return_value=mock_spec_service,
-            ):
+            with pytest.raises(typer.Exit) as exc_info:
                 update(branch="test/branch", spec="123")
 
-    # Verify: bind_spec called with resolved spec
-    mock_flow_service.bind_spec.assert_called_once_with("test/branch", "#123", None)
+    # Verify: exit code 1
+    assert exc_info.value.exit_code == 1
 
 
 def test_update_with_valid_file_path() -> None:
-    """Test --spec with existing file path."""
+    """Test --spec with existing file path binds successfully."""
     mock_flow_service = MagicMock()
     mock_flow = MagicMock()
     mock_flow.branch = "test/branch"
     mock_flow_service.ensure_flow_for_branch.return_value = mock_flow
 
-    mock_spec_service = MagicMock()
-    mock_spec_service.validate_spec_ref.return_value = (True, "")
-    mock_spec_service.resolve_spec_ref.return_value = "docs/spec.md"
-
-    # Create temp file for validation
     with patch("vibe3.commands.flow.FlowService", return_value=mock_flow_service):
         with patch("vibe3.commands.flow.trace_scope"):
-            with patch(
-                "vibe3.services.spec_ref_service.SpecRefService",
-                return_value=mock_spec_service,
-            ):
-                with patch.object(Path, "exists", return_value=True):
-                    with patch.object(Path, "is_file", return_value=True):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(Path, "is_file", return_value=True):
+                    with patch.object(
+                        Path, "resolve", return_value=Path("/abs/docs/spec.md")
+                    ):
                         update(branch="test/branch", spec="docs/spec.md")
 
-    # Verify: bind_spec called
+    # Verify: bind_spec called with absolute path
     mock_flow_service.bind_spec.assert_called_once()
 
 
-def test_update_with_invalid_spec_raises_error() -> None:
+def test_update_with_invalid_file_path_raises_error() -> None:
     """Test --spec with non-existent file raises error."""
     mock_flow_service = MagicMock()
     mock_flow = MagicMock()
     mock_flow.branch = "test/branch"
     mock_flow_service.ensure_flow_for_branch.return_value = mock_flow
 
-    mock_spec_service = MagicMock()
-    mock_spec_service.validate_spec_ref.return_value = (
-        False,
-        "Spec reference not found: nonexistent.md",
-    )
-
     with patch("vibe3.commands.flow.FlowService", return_value=mock_flow_service):
         with patch("vibe3.commands.flow.trace_scope"):
-            with patch(
-                "vibe3.services.spec_ref_service.SpecRefService",
-                return_value=mock_spec_service,
-            ):
-                with pytest.raises(typer.Exit):
+            with patch.object(Path, "exists", return_value=False):
+                with pytest.raises(typer.Exit) as exc_info:
                     update(branch="test/branch", spec="nonexistent.md")
+
+    # Verify: exit code 1
+    assert exc_info.value.exit_code == 1
 
 
 def test_update_without_spec_does_not_modify() -> None:

--- a/tests/vibe3/commands/test_plan.py
+++ b/tests/vibe3/commands/test_plan.py
@@ -1,7 +1,7 @@
 """Tests for plan command."""
 
-import re
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -10,110 +10,132 @@ from vibe3.commands.plan import app as plan_app
 runner = CliRunner(env={"NO_COLOR": "1"})
 
 
-def strip_ansi(text: str) -> str:
-    ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
-    return ansi_escape.sub("", text)
+def _make_mock_flow(
+    branch: str = "task/issue-42",
+    spec_ref: str | None = "#42",
+    issue_number: int = 42,
+) -> MagicMock:
+    mock_flow = MagicMock()
+    mock_flow.branch = branch
+    mock_flow.spec_ref = spec_ref
+    mock_flow.task_issue_number = issue_number
+    return mock_flow
 
 
-def _patch_issue_runtime(monkeypatch) -> MagicMock:
-    """Patch issue mode to use mocked run_issue_role_async (default behavior)."""
+def _patch_plan_deps(monkeypatch, mock_flow: MagicMock | None = None) -> MagicMock:
+    """Patch all plan command external dependencies."""
+    if mock_flow is None:
+        mock_flow = _make_mock_flow()
+
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = mock_flow
+
     mock_async = MagicMock()
     mock_sync = MagicMock()
+
+    monkeypatch.setattr("vibe3.commands.plan.run_issue_role_async", mock_async)
+    monkeypatch.setattr("vibe3.commands.plan.run_issue_role_sync", mock_sync)
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
     monkeypatch.setattr(
-        "vibe3.commands.plan.run_issue_role_async",
-        mock_async,
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
     )
-    monkeypatch.setattr(
-        "vibe3.commands.plan.run_issue_role_sync",
-        mock_sync,
-    )
-    # Return async mock (default path for test)
     return mock_async
-
-
-def _patch_spec_runtime(monkeypatch) -> MagicMock:
-    """Patch spec mode dependencies."""
-    monkeypatch.setattr(
-        "vibe3.commands.command_options.ensure_flow_for_current_branch",
-        lambda: (MagicMock(), "task/test-branch"),
-    )
-    monkeypatch.setattr(
-        "vibe3.commands.plan.resolve_spec_plan_input",
-        MagicMock(),
-    )
-    monkeypatch.setattr(
-        "vibe3.commands.plan.bind_plan_spec",
-        MagicMock(),
-    )
-    mock_execute = MagicMock()
-    monkeypatch.setattr(
-        "vibe3.commands.plan.execute_spec_plan_async",
-        mock_execute,
-    )
-    monkeypatch.setattr(
-        "vibe3.commands.plan.execute_spec_plan_sync",
-        mock_execute,
-    )
-    return mock_execute
 
 
 def test_plan_help_shows_options() -> None:
     result = runner.invoke(plan_app, ["--help"])
-    output = strip_ansi(result.output)
     assert result.exit_code == 0
-    assert "--issue" in output
-    assert "--spec" in output
+    assert "--branch" in result.output
+    assert "--spec" in result.output
 
 
-def test_plan_issue_exclusive_with_spec() -> None:
-    result = runner.invoke(plan_app, ["--issue", "42", "--spec"])
+def test_plan_spec_requires_file() -> None:
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = _make_mock_flow()
+
+    with patch("vibe3.commands.plan.FlowService", return_value=mock_flow_service):
+        with patch(
+            "vibe3.commands.plan.resolve_branch_arg",
+            lambda _: "task/issue-42",
+        ):
+            result = runner.invoke(plan_app, ["--spec"])
+
     assert result.exit_code != 0
-    assert "Error: --issue and --spec are mutually exclusive" in result.output
+    assert "--file is required" in result.output
 
 
-def test_plan_spec_requires_file_or_msg() -> None:
-    result = runner.invoke(plan_app, ["--spec"])
-    assert result.exit_code != 0
-
-
-def test_plan_issue_basic_flow(monkeypatch) -> None:
-    """Test basic plan issue flow delegates to run_issue_role_mode."""
-    mock_runner = _patch_issue_runtime(monkeypatch)
-    result = runner.invoke(plan_app, ["issue", "42"])
+def test_plan_branch_basic_flow(monkeypatch) -> None:
+    """Test plan --branch delegates to run_issue_role_async."""
+    mock_runner = _patch_plan_deps(monkeypatch)
+    result = runner.invoke(plan_app, ["--branch", "42"])
     assert result.exit_code == 0
     mock_runner.assert_called_once()
     call_kwargs = mock_runner.call_args[1]
     assert call_kwargs["issue_number"] == 42
 
 
-def test_plan_spec_msg_basic_flow(monkeypatch) -> None:
-    """Test basic plan spec flow."""
-    _patch_spec_runtime(monkeypatch)
-    result = runner.invoke(plan_app, ["spec", "--msg", "Add dark mode"])
+def test_plan_branch_no_flow_error(monkeypatch) -> None:
+    """Test plan --branch with no flow shows error."""
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = None
+
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
+    )
+
+    result = runner.invoke(plan_app, ["--branch", "42"])
+    assert result.exit_code != 0
+    assert "No flow for branch" in result.output
+
+
+def test_plan_branch_no_spec_error(monkeypatch) -> None:
+    """Test plan --branch with no spec shows error."""
+    mock_flow = _make_mock_flow(spec_ref=None)
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = mock_flow
+
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
+    )
+
+    result = runner.invoke(plan_app, ["--branch", "42"])
+    assert result.exit_code != 0
+    assert "No spec bound" in result.output
+
+
+def test_plan_spec_file_basic_flow(monkeypatch) -> None:
+    """Test plan --spec --file flow."""
+    mock_flow = _make_mock_flow()
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = mock_flow
+    mock_execute = MagicMock()
+
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
+    )
+    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_async", mock_execute)
+    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_sync", mock_execute)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_spec_plan_input",
+        MagicMock(),
+    )
+
+    with patch.object(Path, "exists", return_value=True):
+        with patch.object(Path, "is_file", return_value=True):
+            with patch.object(Path, "resolve", return_value=Path("/abs/docs/spec.md")):
+                result = runner.invoke(
+                    plan_app, ["--spec", "--file", "docs/spec.md", "--branch", "42"]
+                )
     assert result.exit_code == 0
 
 
-def test_plan_spec_file_not_found(monkeypatch) -> None:
-    _patch_spec_runtime(monkeypatch)
-    monkeypatch.setattr(
-        "vibe3.commands.plan.resolve_spec_plan_input",
-        MagicMock(side_effect=FileNotFoundError("File not found")),
-    )
+def test_plan_issue_subcommand_works(monkeypatch) -> None:
+    """Test that hidden 'issue' subcommand still works for backward compat."""
+    mock_runner = _patch_plan_deps(monkeypatch)
 
-    result = runner.invoke(plan_app, ["spec", "--file", "nonexistent.md"])
-    assert result.exit_code != 0
-
-
-def test_plan_issue_subcommand_still_works(monkeypatch) -> None:
-    """Test that the 'issue' subcommand works."""
-    mock_runner = _patch_issue_runtime(monkeypatch)
     result = runner.invoke(plan_app, ["issue", "42"])
     assert result.exit_code == 0
     mock_runner.assert_called_once()
-
-
-def test_plan_spec_subcommand_still_works(monkeypatch) -> None:
-    """Test that the 'spec' subcommand works."""
-    _patch_spec_runtime(monkeypatch)
-    result = runner.invoke(plan_app, ["spec", "--msg", "Add dark mode"])
-    assert result.exit_code == 0

--- a/tests/vibe3/commands/test_plan.py
+++ b/tests/vibe3/commands/test_plan.py
@@ -49,19 +49,28 @@ def test_plan_help_shows_options() -> None:
     assert "--spec" in result.output
 
 
-def test_plan_spec_requires_file() -> None:
+def test_plan_spec_uses_flow_spec_ref(monkeypatch) -> None:
+    """Test plan without --spec uses flow's spec_ref."""
+    mock_flow = _make_mock_flow(spec_ref="@task-42/spec.md")
     mock_flow_service = MagicMock()
-    mock_flow_service.get_flow_status.return_value = _make_mock_flow()
+    mock_flow_service.get_flow_status.return_value = mock_flow
+    mock_execute = MagicMock()
 
-    with patch("vibe3.commands.plan.FlowService", return_value=mock_flow_service):
-        with patch(
-            "vibe3.commands.plan.resolve_branch_arg",
-            lambda _: "task/issue-42",
-        ):
-            result = runner.invoke(plan_app, ["--spec"])
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
+    )
+    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_async", mock_execute)
+    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_sync", mock_execute)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_spec_plan_input",
+        MagicMock(),
+    )
 
-    assert result.exit_code != 0
-    assert "--file is required" in result.output
+    result = runner.invoke(plan_app, ["--branch", "42"])
+    # When no --spec provided, default action is _plan_for_branch (not _plan_spec_impl)
+    # This test now validates that behavior
+    assert result.exit_code == 0
 
 
 def test_plan_branch_basic_flow(monkeypatch) -> None:
@@ -106,7 +115,7 @@ def test_plan_branch_no_spec_error(monkeypatch) -> None:
 
 
 def test_plan_spec_file_basic_flow(monkeypatch) -> None:
-    """Test plan --spec --file flow."""
+    """Test plan --spec <file> flow."""
     mock_flow = _make_mock_flow()
     mock_flow_service = MagicMock()
     mock_flow_service.get_flow_status.return_value = mock_flow
@@ -127,7 +136,7 @@ def test_plan_spec_file_basic_flow(monkeypatch) -> None:
         with patch.object(Path, "is_file", return_value=True):
             with patch.object(Path, "resolve", return_value=Path("/abs/docs/spec.md")):
                 result = runner.invoke(
-                    plan_app, ["--spec", "--file", "docs/spec.md", "--branch", "42"]
+                    plan_app, ["--spec", "docs/spec.md", "--branch", "42"]
                 )
     assert result.exit_code == 0
 

--- a/tests/vibe3/commands/test_plan.py
+++ b/tests/vibe3/commands/test_plan.py
@@ -45,32 +45,22 @@ def _patch_plan_deps(monkeypatch, mock_flow: MagicMock | None = None) -> MagicMo
 def test_plan_help_shows_options() -> None:
     result = runner.invoke(plan_app, ["--help"])
     assert result.exit_code == 0
-    assert "--branch" in result.output
-    assert "--spec" in result.output
+    # Strip ANSI codes for reliable assertion
+    clean_output = result.output.replace("\x1b[1m", "").replace("\x1b[0m", "")
+    assert "--branch" in clean_output
+    assert "--spec" in clean_output
 
 
 def test_plan_spec_uses_flow_spec_ref(monkeypatch) -> None:
-    """Test plan without --spec uses flow's spec_ref."""
-    mock_flow = _make_mock_flow(spec_ref="@task-42/spec.md")
-    mock_flow_service = MagicMock()
-    mock_flow_service.get_flow_status.return_value = mock_flow
-    mock_execute = MagicMock()
-
-    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
-    monkeypatch.setattr(
-        "vibe3.commands.plan.resolve_branch_arg", lambda _: "task/issue-42"
+    """Test plan --branch without --spec delegates to _plan_for_branch."""
+    # _plan_for_branch requires spec_ref and issue_number,
+    # then calls run_issue_role_async/sync
+    mock_runner = _patch_plan_deps(
+        monkeypatch, mock_flow=_make_mock_flow(spec_ref="@task-42/spec.md")
     )
-    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_async", mock_execute)
-    monkeypatch.setattr("vibe3.commands.plan.execute_spec_plan_sync", mock_execute)
-    monkeypatch.setattr(
-        "vibe3.commands.plan.resolve_spec_plan_input",
-        MagicMock(),
-    )
-
     result = runner.invoke(plan_app, ["--branch", "42"])
-    # When no --spec provided, default action is _plan_for_branch (not _plan_spec_impl)
-    # This test now validates that behavior
     assert result.exit_code == 0
+    mock_runner.assert_called_once()
 
 
 def test_plan_branch_basic_flow(monkeypatch) -> None:

--- a/tests/vibe3/roles/test_resolve_spec_plan_defaults.py
+++ b/tests/vibe3/roles/test_resolve_spec_plan_defaults.py
@@ -22,14 +22,6 @@ class TestResolveSpecPlanInputDefaultSpecRef:
         assert result.description == "Explicit spec content"
         assert result.spec_path == str(spec_file.resolve())
 
-    def test_explicit_msg_works(self) -> None:
-        """Explicit --msg should work normally."""
-        # Explicit msg input never queries flow
-        result = resolve_spec_plan_input("test-branch", msg="Inline spec")
-
-        assert result.description == "Inline spec"
-        assert result.spec_path is None
-
     def test_no_explicit_input_uses_flow_spec_ref_file(self, tmp_path: Path) -> None:
         """When no --file or --msg, use flow.spec_ref (file type)."""
         spec_file = tmp_path / "flow-spec.md"

--- a/tests/vibe3/services/test_flow_binding.py
+++ b/tests/vibe3/services/test_flow_binding.py
@@ -13,6 +13,7 @@ class TestFlowBinding:
 
     def test_bind_flow_success(self, mock_store) -> None:
         """Test binding a task issue to a flow via TaskService.link_issue."""
+        mock_store.get_events.return_value = []
         service = TaskService(store=mock_store)
         result = service.link_issue(
             branch="test-branch",
@@ -28,16 +29,14 @@ class TestFlowBinding:
         mock_store.update_flow_state.assert_called_once_with(
             "test-branch",
             latest_actor="test-actor",
+            spec_ref="#123",
         )
-        mock_store.add_event.assert_called_once_with(
-            "test-branch",
-            "issue_linked",
-            "test-actor",
-            "Issue #123 linked as task",
-        )
+        # Should have both spec_bound and issue_linked events
+        assert mock_store.add_event.call_count == 2
 
     def test_bind_flow_already_bound(self, mock_store) -> None:
         """Binding again overwrites — link_issue is idempotent at store level."""
+        mock_store.get_events.return_value = []
         service = TaskService(store=mock_store)
         result = service.link_issue(
             branch="test-branch",
@@ -50,6 +49,7 @@ class TestFlowBinding:
 
     def test_bind_related_role(self, mock_store) -> None:
         """Related role should remain local-only."""
+        mock_store.get_events.return_value = []
         service = TaskService(store=mock_store)
 
         result = service.link_issue("test-branch", 219, "related")
@@ -59,6 +59,7 @@ class TestFlowBinding:
 
     def test_reclassify_issue_role(self, mock_store) -> None:
         """Existing issue link can be reclassified without deleting the flow."""
+        mock_store.get_events.return_value = []
         mock_store.update_issue_link_role.return_value = True
         service = TaskService(store=mock_store)
 
@@ -90,6 +91,7 @@ class TestFlowBinding:
     def test_bind_task_demotes_previous_task_flow_and_notifies_supervisor(
         self, mock_store
     ) -> None:
+        mock_store.get_events.return_value = []
         mock_store.update_issue_link_role.return_value = True
         mock_store.get_flows_by_issue.return_value = [
             {"branch": "debug/new-attempt", "flow_status": "active"},
@@ -166,6 +168,7 @@ class TestFlowBinding:
     def test_bind_task_demotes_previous_task_flow_without_remote_nudge_for_noncanonical(
         self, mock_store
     ) -> None:
+        mock_store.get_events.return_value = []
         mock_store.update_issue_link_role.return_value = True
         mock_store.get_flows_by_issue.return_value = [
             {"branch": "task/issue-467", "flow_status": "active"},


### PR DESCRIPTION
## Summary

- **CLI 统一使用 --branch 参数**: plan/run/review 命令从 `--issue` 迁移到 `--branch`，支持分支名或 issue 号（如 `--branch 320`）
- **参数简化**: 移除冗余的 `--file` alias 和历史残留 `--report-ref`
- **Flow 绑定优化**: 命令默认从 flow 获取 spec_ref/plan_ref，`--spec`/`--plan` 变为可选（提供时覆盖）
- **Passive recording 改进**: 避免在已有 plan_ref/report_ref 时重复记录
- **错误提示优化**: "No flow" 错误显示 `vibe3 flow update` / `vibe3 flow bind` 帮助

## Changes

| 命令 | 变更 |
|------|------|
| `plan` | `--file` 移除，`--spec <path>` 可选（默认用 flow spec_ref） |
| `run` | `--file` alias 移除，`--plan <path>` 可选（默认用 flow plan_ref） |
| `review` | `--report-ref` 移除 |
| `flow update --spec` | 简化为仅接受文件路径，拒绝 issue 号 |

## Test plan

- [x] `uv run pytest tests/vibe3` 全部通过 (1420 passed)
- [x] `uv run mypy src/vibe3` 类型检查通过
- [x] pre-commit hooks 通过
- [x] 验证 `vibe3 plan --help`/`run --help`/`review --help` 输出正确