### PR TITLE
docs: align deprecated 'repo issue' terminology

### DIFF
--- a/docs/references/codex-review.md
+++ b/docs/references/codex-review.md
@@ -259,8 +259,8 @@ Detect:
 
 你的流程：
 
-repo issue
-task issue
+GitHub issue
+task
 flow
 branch
 PR

--- a/docs/references/github_project.md
+++ b/docs/references/github_project.md
@@ -18,17 +18,17 @@
 
 ## 2. GitHub 标准语义
 
-### 2.1 Repo Issue
+### 2.1 GitHub Issue
 
 GitHub 仓库中的 issue 是需求、问题、讨论结果和追踪项的基础对象。
 
 在本项目里，后续统一称为：
 
 ```text
-repo issue
+GitHub issue
 ```
 
-这样可以避免把“GitHub repo issue”和我们本地的执行任务混叫成 `issue`。
+这样可以避免把“GitHub issue”和我们本地的执行任务混叫成 `issue`。
 
 ### 2.2 GitHub Project Item
 
@@ -99,13 +99,13 @@ PR 不负责需求建模，也不负责长期规划。
 
 ## 3. 我们项目里的对齐语义
 
-### 3.1 Repo Issue = 来源层对象
+### 3.1 GitHub Issue = 来源层对象
 
 在我们项目里：
 
-- `repo issue` 是来源
-- `repo issue` 是需求入口
-- `repo issue` 是讨论和追踪对象
+- `GitHub issue` 是来源
+- `GitHub issue` 是需求入口
+- `GitHub issue` 是讨论和追踪对象
 
 它不是本地执行单元，也不是 flow runtime 的主语。
 
@@ -225,7 +225,7 @@ sync local roadmap items <-> GitHub Project items
 
 - 维护 roadmap item
 - 维护 roadmap item 的 type
-- 维护 roadmap item 和 milestone / repo issue / task 的关系
+- 维护 roadmap item 和 milestone / GitHub issue / task 的关系
 - 决定哪些 item 应进入当前规划窗口
 
 ### 5.3 `vibe-task`
@@ -267,7 +267,7 @@ execution record for roadmap items
 如果按 GitHub 标准语义校正项目心智，推荐链路应为：
 
 ```text
-repo issue
+GitHub issue
   -> GitHub Project item
   -> local roadmap item
   -> local execution task
@@ -277,7 +277,7 @@ repo issue
 
 对应到我们项目：
 
-1. 创建或接收 `repo issue`
+1. 创建或接收 `GitHub issue`
 2. 将其纳入 GitHub Project
 3. `roadmap sync` 同步本地 roadmap item
 4. 明确该 item 的 `type`
@@ -303,7 +303,7 @@ repo issue
 这版参考文档的核心结论只有 4 句：
 
 ```text
-repo issue 是来源层对象
+GitHub issue 是来源层对象
 roadmap item 是 GitHub Project item 的本地镜像
 feature / task / bug 是 roadmap item 的 type
 flow 和 PR 是执行与交付层对象

--- a/docs/references/skill-loop-memo.md
+++ b/docs/references/skill-loop-memo.md
@@ -35,7 +35,7 @@ related_docs:
 
 ## 主链路
 
-`repo issue -> roadmap item -> vibe-new -> vibe-start -> spec execution -> PR -> review/integrate -> done`
+`GitHub issue -> roadmap item -> vibe-new -> vibe-start -> spec execution -> PR -> review/integrate -> done`
 
 对应常用 skill：
 

--- a/docs/references/v3_suggestion_openai.md
+++ b/docs/references/v3_suggestion_openai.md
@@ -35,8 +35,8 @@ flow wrapper = 流程记录
 
 以下信息永远通过 gh 实时获取：
 
-repo issue
-task issue
+GitHub issue
+task
 branch
 PR
 merge 状态
@@ -78,9 +78,9 @@ Flow 表示一条开发线。
 
 关系如下：
 
-Repo Issue
+GitHub Issue
    ↓
-Task Issue
+Task
    ↓
 Flow
    ↓
@@ -90,7 +90,7 @@ PR
 
 规则：
 
-1 task issue = 1 flow
+1 task = 1 flow
 1 flow = 1 main branch
 1 flow = 1 main PR
 
@@ -176,7 +176,7 @@ done	PR 已 merge
 推荐关系：
 
 Flow Stage	GitHub 状态
-plan	task issue 已创建
+plan	task 已创建
 execute	branch 存在 + draft PR
 review	PR open
 done	PR merged
@@ -399,8 +399,8 @@ flow show 124
 Flow 124
 Stage: execute
 
-Task Issue: #124
-Repo Issue: #120
+Task: #124
+GitHub Issue: #120
 
 Branch: flow/124-state-sync
 PR: #245

--- a/docs/standards/v3/git-workflow-standard.md
+++ b/docs/standards/v3/git-workflow-standard.md
@@ -23,8 +23,8 @@ related_docs:
 
 本文档定义本项目的 Git 交付流程标准，重点回答：
 
-- 用户主视角 `repo issue -> flow -> plan/spec -> commit -> PR -> done` 应如何推进
-- 内部桥接链 `repo issue -> roadmap item -> task -> flow` 应如何配合
+- 用户主视角 `GitHub issue -> flow -> plan/spec -> commit -> PR -> done` 应如何推进
+- 内部桥接链 `GitHub issue -> roadmap item -> task -> flow` 应如何配合
 - `flow`、`branch`、`worktree` 在交付中的职责如何分离
 - 何时继续当前 flow
 - 何时必须新开 branch / 新开 flow
@@ -52,7 +52,7 @@ related_docs:
 
 默认交付模型如下：
 
-- `repo issue` 负责来源层需求与讨论事实
+- `GitHub issue` 负责来源层需求与讨论事实
 - `roadmap item` 负责规划窗口与 GitHub Project item 镜像，是 planning 中间层
 - `task` 负责 execution record，是 flow 建立后的 execution bridge
 - `flow` 负责当前交付切片与 runtime 现场
@@ -136,7 +136,7 @@ related_docs:
 
 用户主视角：
 
-1. 从 `repo issue` 确认当前要推进的目标
+1. 从 `GitHub issue` 确认当前要推进的目标
 2. 进入或切换到对应 `flow`
 3. 在该 `flow` 中挂接 plan/spec 作为 execution spec
 4. 在对应 `branch` 上提交本地 commit
@@ -151,7 +151,7 @@ closeout 约束：
 
 内部桥接链：
 
-1. 从 `repo issue` 确认来源层目标
+1. 从 `GitHub issue` 确认来源层目标
 2. 创建、选择或同步对应的 `roadmap item`
 3. 通过 `vibe-new` 确认/创建目标 issue、创建/注册 flow、绑定 issue 并创建 PR draft
 4. 进入新 flow 后，通过 `vibe-start` 确认并补齐 flow 环境（恢复开发场景）
@@ -199,7 +199,7 @@ closeout 约束：
 
 默认恢复动作：
 
-- 保留上层 `roadmap item` / `repo issue`
+- 保留上层 `roadmap item` / `GitHub issue`
 - 将新的交付切片切到新的 `branch`
 - 让新的 `flow` 对应新的当前 `pr` 目标
 - 若复用当前目录，使用 `/vibe-new (skill)` 一类显式 flow 切换能力进入新 `flow`
@@ -265,7 +265,7 @@ closeout 约束：
 - 若该 PR 已完成且相关 follow-up 已收束，应进入 `vibe3-done` 或等价收口流程
 - 若当前 PR 已 merged，则该 PR 对应的 plan 进入 terminal state
 - merged 后只允许补记交付证据、审计说明、handoff 更正与 follow-up 链接，不允许把新需求继续写回旧 plan
-- merged 后若出现新的 feature、补丁或治理项，必须重新进入用户主链 `repo issue -> flow -> plan/spec -> commit -> PR -> done`，并按需重建内部桥接链 `repo issue -> roadmap item -> task -> flow`
+- merged 后若出现新的 feature、补丁或治理项，必须重新进入用户主链 `GitHub issue -> flow -> plan/spec -> commit -> PR -> done`，并按需重建内部桥接链 `GitHub issue -> roadmap item -> task -> flow`
 
 ### 6.3 一个 `flow` 中做了不同 feature，想拆成多个 `pr`
 


### PR DESCRIPTION
Aligns terminology across 5 documents to match glossary.md. Fixes #554