### PR TITLE
feat(check): add multi-flow binding protection and extend auto-close coverage

### DIFF
--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -219,6 +219,59 @@ PR closed (GitHub webhook)
 - keep_flow_record = False（删除记录）
 - 恢复 issue 到 READY（被动清理）
 
+### 5.4 Issue 自动关闭机制
+
+**与 GitHub 原生关闭关键字的区别**：
+
+GitHub 原生关闭关键字（`closes #N`、`fixes #N` 在 PR body 中）与 vibe3 flow done 是**两个独立机制**：
+
+| 机制 | 触发时机 | 控制方式 |
+|------|----------|----------|
+| GitHub 原生关键字 | PR merge 时自动触发 | PR body 中的关键字 |
+| vibe3 flow done | `vibe check` 检测到 merged PR | `close_issue_if_open` API 调用 |
+
+两者**互不干扰**：
+- PR body 不会被 vibe3 修改以注入关闭关键字
+- vibe3 通过 GitHub API 独立执行关闭操作
+- 如果 PR body 已有关闭关键字，issue 会被 GitHub 先关闭，vibe3 检测到 `already_closed` 状态
+
+**vibe3 自动关闭条件**：
+
+`_mark_flow_done` 在以下全部满足时才自动关闭 task issue：
+
+1. **Flow 有 `role=task` 的 issue 链接**
+   - `role=related` 或 `role=dependency` 的 issue 不会被关闭
+2. **无其他 active flow 绑定同一 issue**（多 flow 保护）
+   - 如果 issue #123 同时绑定 `task/issue-123` 和 `dev/issue-123`，只有当两者都完成时才关闭
+   - 防止因一个分支合并而过早关闭还在其他分支上工作的 issue
+3. **Issue 在 GitHub 上仍处于 open 状态**
+   - 如果已被关闭（通过 GitHub 关键字或其他方式），返回 `already_closed`
+
+**多 Flow 绑定保护**：
+
+```
+Issue #123 绑定两个 flow:
+  ├─ task/issue-123 (flow_status: active)
+  └─ dev/issue-123   (flow_status: active)
+
+当 task/issue-123 的 PR merged:
+  ├─ flow_status → done
+  └─ Issue #123 NOT closed (因为 dev/issue-123 仍 active)
+
+当 dev/issue-123 的 PR 也 merged:
+  ├─ flow_status → done
+  └─ Issue #123 closed ✅ (无其他 active flow)
+```
+
+**幂等性保证**：
+
+`close_issue_if_open` 返回值：
+- `"closed"`: 本次成功关闭
+- `"already_closed"`: issue 已处于关闭状态
+- `"failed"`: 关闭失败（API 错误等）
+
+实现不关心返回值类型，只保证无副作用重复调用。
+
 ## 6. 资源回收机制
 
 ### 6.1 统一清理入口

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -121,7 +121,7 @@ class CheckService(CheckRemote):
         Returns CheckResult if PR is merged or closed, None otherwise.
 
         - PR MERGED: flow is successfully completed → mark done.
-          If branch is task/issue-N, also auto-close the linked issue.
+          Also auto-closes any linked task issues when no other active flows exist.
         - PR CLOSED (without merge): PR was abandoned → mark aborted.
         """
         result_issues: list[str] = []
@@ -408,8 +408,12 @@ class CheckService(CheckRemote):
     ) -> dict[str, int | None]:
         """Mark a flow as done and record the event.
 
-        For task/issue-N auto-flow branches, also closes the linked
-        GitHub issue since the PR was successfully merged.
+        For flows with role=task issue links, auto-closes the linked GitHub issue
+        when no other active flows exist for the same issue.
+
+        Multi-flow binding protection: If the same task issue is linked to multiple
+        active flows (e.g., task/issue-123 and dev/issue-123), the issue is NOT
+        closed until all active flows are done.
 
         Note: Branch cleanup is deferred to 'vibe3 check --clean-branch'.
         This keeps check fast and allows code reuse.
@@ -432,24 +436,45 @@ class CheckService(CheckRemote):
         suggestions: dict[str, int | None] = {"issue_to_close": None}
         issue_links = self.store.get_issue_links(branch)
         task_issues = [lnk for lnk in issue_links if lnk["issue_role"] == "task"]
-        if task_issues:
-            task_issue = task_issues[0]["issue_number"]
-            if self._is_task_branch(branch):
-                self.github_client.close_issue_if_open(
-                    issue_number=task_issue,
-                    closing_comment=(
-                        f"PR merged. Flow '{branch}' completed. "
-                        "Closed automatically by vibe check."
-                    ),
-                )
-            else:
-                issue = self.github_client.view_issue(task_issue)
-                if (
-                    issue
-                    and isinstance(issue, dict)
-                    and str(issue.get("state", "")).upper() != "CLOSED"
-                ):
-                    suggestions["issue_to_close"] = task_issue
+        if not task_issues:
+            return suggestions
+
+        task_issue = task_issues[0]["issue_number"]
+
+        # Multi-flow binding protection: Check if other active flows exist
+        # for the same task issue before closing.
+        all_task_flows = self.store.get_flows_by_issue(task_issue, role="task")
+        other_active_flows = [
+            f
+            for f in all_task_flows
+            if f["branch"] != branch and f.get("flow_status") == "active"
+        ]
+
+        if other_active_flows:
+            logger.bind(
+                domain="check",
+                action="auto_complete_flow",
+                branch=branch,
+                issue_number=task_issue,
+                other_active_count=len(other_active_flows),
+            ).warning(
+                f"Skipping auto-close for issue #{task_issue}: "
+                f"other active flows exist ({len(other_active_flows)}"
+            )
+            return suggestions
+
+        # Safe to close: this is the only active flow for this task issue
+        close_result = self.github_client.close_issue_if_open(
+            issue_number=task_issue,
+            closing_comment=(
+                f"PR merged. Flow '{branch}' completed. "
+                "Closed automatically by vibe check."
+            ),
+        )
+
+        # Track if issue was actually closed (vs already_closed)
+        if close_result == "closed":
+            suggestions["issue_to_close"] = task_issue
 
         return suggestions
 

--- a/tests/vibe3/services/test_check_issue_close.py
+++ b/tests/vibe3/services/test_check_issue_close.py
@@ -1,0 +1,295 @@
+"""Tests for issue auto-close behavior in _mark_flow_done.
+
+Tests cover:
+- Idempotent close (already closed vs freshly closed)
+- Multi-flow binding protection
+- Role filtering (task vs related vs dependency)
+- Non-task branch auto-close (extension beyond task/issue-N)
+"""
+
+from unittest.mock import MagicMock
+
+from vibe3.clients import SQLiteClient
+from vibe3.clients.git_client import GitClient
+from vibe3.clients.github_client import GitHubClient
+from vibe3.services.check_service import CheckService
+
+
+class TestMarkFlowDoneIssueClose:
+    """Test _mark_flow_done issue closing behavior."""
+
+    def test_mark_flow_done_closes_task_issue(self, tmp_path):
+        """Single active flow, task issue open → issue closed."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/issue-123"
+        issue_number = 123
+
+        store.update_flow_state(branch, flow_status="active")
+        store.add_issue_link(branch, issue_number, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        github_client.close_issue_if_open.return_value = "closed"
+        github_client.view_issue.return_value = {
+            "state": "open",
+            "number": issue_number,
+        }
+
+        # Create handoff file
+        from vibe3.utils.git_helpers import get_branch_handoff_dir
+
+        handoff_dir = get_branch_handoff_dir(tmp_path, branch)
+        handoff_dir.mkdir(parents=True, exist_ok=True)
+        (handoff_dir / "current.md").touch()
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT
+        assert suggestions["issue_to_close"] == issue_number
+        github_client.close_issue_if_open.assert_called_once_with(
+            issue_number=issue_number,
+            closing_comment=(
+                "PR merged. Flow 'task/issue-123' completed. "
+                "Closed automatically by vibe check."
+            ),
+        )
+
+        flow = store.get_flow_state(branch)
+        assert flow["flow_status"] == "done"
+
+    def test_mark_flow_done_already_closed_idempotent(self, tmp_path):
+        """Issue already closed → returns 'already_closed', no close call made."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/issue-123"
+        issue_number = 123
+
+        store.update_flow_state(branch, flow_status="active")
+        store.add_issue_link(branch, issue_number, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        # close_issue_if_open returns "already_closed" when issue is already closed
+        github_client.close_issue_if_open.return_value = "already_closed"
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: suggestions should NOT have issue_to_close since it was already closed
+        assert suggestions["issue_to_close"] is None
+        github_client.close_issue_if_open.assert_called_once()
+
+    def test_mark_flow_done_skips_close_when_other_active_flows(self, tmp_path):
+        """Same issue has another active flow → issue NOT closed."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        issue_number = 123
+
+        # Current branch being marked done
+        branch_done = "task/issue-123"
+        store.update_flow_state(branch_done, flow_status="active")
+        store.add_issue_link(branch_done, issue_number, role="task")
+
+        # Another active flow for the same issue
+        branch_active = "dev/issue-123"
+        store.update_flow_state(branch_active, flow_status="active")
+        store.add_issue_link(branch_active, issue_number, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        github_client.close_issue_if_open.return_value = "closed"
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch_done, "PR merged")
+
+        # ASSERT: Issue should NOT be closed because other active flow exists
+        assert suggestions["issue_to_close"] is None
+        # close_issue_if_open should NOT be called
+        github_client.close_issue_if_open.assert_not_called()
+
+    def test_mark_flow_done_closes_when_other_flows_are_done(self, tmp_path):
+        """Other flows done/stale/aborted → issue closed (only active flows block)."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        issue_number = 123
+
+        # Current branch being marked done
+        branch_done = "task/issue-123"
+        store.update_flow_state(branch_done, flow_status="active")
+        store.add_issue_link(branch_done, issue_number, role="task")
+
+        # Another flow for the same issue, but already done
+        branch_done2 = "dev/issue-123"
+        store.update_flow_state(branch_done2, flow_status="done")
+        store.add_issue_link(branch_done2, issue_number, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        github_client.close_issue_if_open.return_value = "closed"
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch_done, "PR merged")
+
+        # ASSERT: Issue SHOULD be closed because no other ACTIVE flows
+        assert suggestions["issue_to_close"] == issue_number
+        github_client.close_issue_if_open.assert_called_once()
+
+    def test_mark_flow_done_ignores_related_issue(self, tmp_path):
+        """Flow has role=related link → related issue NOT closed."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/issue-456"
+
+        store.update_flow_state(branch, flow_status="active")
+        # Link with role=related (NOT role=task)
+        store.add_issue_link(branch, 456, role="related")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: Issue should NOT be closed because role is "related" not "task"
+        assert suggestions["issue_to_close"] is None
+        github_client.close_issue_if_open.assert_not_called()
+
+    def test_mark_flow_done_ignores_dependency_issue(self, tmp_path):
+        """Flow has role=dependency link → dependency issue NOT closed."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/issue-789"
+
+        store.update_flow_state(branch, flow_status="active")
+        # Link with role=dependency (NOT role=task)
+        store.add_issue_link(branch, 789, role="dependency")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: Issue should NOT be closed because role is "dependency" not "task"
+        assert suggestions["issue_to_close"] is None
+        github_client.close_issue_if_open.assert_not_called()
+
+    def test_mark_flow_done_non_task_branch_closes_issue(self, tmp_path):
+        """Branch dev/issue-123 with task issue → issue closed (no branch check)."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "dev/issue-123"  # Non-canonical branch name
+        issue_number = 123
+
+        store.update_flow_state(branch, flow_status="active")
+        store.add_issue_link(branch, issue_number, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        github_client.close_issue_if_open.return_value = "closed"
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: Issue SHOULD be closed even though branch is not task/issue-N
+        assert suggestions["issue_to_close"] == issue_number
+        github_client.close_issue_if_open.assert_called_once()
+
+    def test_mark_flow_done_no_task_issue_succeeds(self, tmp_path):
+        """Flow has no task issue → no close attempt, flow marked done."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/feature-xyz"
+
+        store.update_flow_state(branch, flow_status="active")
+        # No issue links
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: Flow marked done, no issue close attempted
+        assert suggestions["issue_to_close"] is None
+        github_client.close_issue_if_open.assert_not_called()
+
+        flow = store.get_flow_state(branch)
+        assert flow["flow_status"] == "done"
+
+    def test_mark_flow_done_multiple_task_issues_closes_one(self, tmp_path):
+        """Flow has multiple task issues → closes one of them."""
+        # ARRANGE
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        branch = "task/issue-multi"
+
+        store.update_flow_state(branch, flow_status="active")
+        store.add_issue_link(branch, 111, role="task")
+        store.add_issue_link(branch, 222, role="task")
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_git_common_dir.return_value = tmp_path
+
+        github_client = MagicMock(spec=GitHubClient)
+        github_client.close_issue_if_open.return_value = "closed"
+
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        # ACT
+        suggestions = service._mark_flow_done(branch, "PR merged")
+
+        # ASSERT: One of the task issues should be closed (order depends on SQLite)
+        assert suggestions["issue_to_close"] in (111, 222)
+        github_client.close_issue_if_open.assert_called_once()


### PR DESCRIPTION
Closes #320

## Summary

- Enhanced `_mark_flow_done` in `CheckService` to add multi-flow binding protection: before closing a task issue, checks if other active flows exist for the same issue; skips closing if so
- Extended auto-close coverage from `task/issue-N` branches to ANY flow with a `role=task` issue link
- Fixed docstring inconsistency in `_handle_closed_pr` to reflect role-based logic

## Test plan

- [x] Added comprehensive tests for idempotent close scenarios
- [x] Added tests for multi-flow binding protection
- [x] Added tests for role filtering (task vs related vs dependency)
- [x] Added tests for non-task branch auto-close
- [x] All pre-push checks passed (45 tests)
- [x] MyPy type check clean
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

opencode/deepseek/deepseek-v4-pro, claude/sonnet
