### PR TITLE
fix(orchestra): prevent concurrent multi-role dispatch and improve session lifecycle

### DIFF
--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -79,13 +79,18 @@ class OrchestrationFacade(ServiceBase):
         self._failed_gate = failed_gate
 
         if self._dispatch_services and self._capacity is not None:
+            from vibe3.environment.session_registry import SessionRegistryService
             from vibe3.orchestra.global_dispatch_coordinator import (
                 GlobalDispatchCoordinator,
             )
 
+            store = self._capacity._store
+            backend = self._capacity._backend
+            registry = SessionRegistryService(store, backend)
             self._coordinator = GlobalDispatchCoordinator(
                 capacity=self._capacity,
                 dispatch_services=self._dispatch_services,
+                registry=registry,
             )
 
     async def on_tick(self) -> None:
@@ -141,6 +146,9 @@ class OrchestrationFacade(ServiceBase):
             store = self._capacity._store
             backend = self._capacity._backend
             registry = SessionRegistryService(store, backend)
+            # Mark worker sessions as done (not orphaned) when tmux exits
+            registry.mark_worker_sessions_done_when_tmux_gone()
+            # Then orphan any remaining dead sessions (failed launches)
             registry.reconcile_live_state()
 
         await self._coordinator.coordinate()

--- a/src/vibe3/environment/session_registry.py
+++ b/src/vibe3/environment/session_registry.py
@@ -55,6 +55,45 @@ class SessionRegistryService:
             return True
         return self._backend.has_tmux_session(tmux)
 
+    def _handle_stale_starting_session(
+        self, session: dict[str, Any], now: datetime.datetime
+    ) -> bool:
+        """Check if a starting session without tmux is stale.
+
+        If stale (created > STARTING_TIMEOUT_SECONDS ago), marks as orphaned.
+        Returns True if session was marked orphaned (should skip counting).
+        Returns False if session is fresh or has no timestamp (count as live).
+        """
+        created_at_str = session.get("created_at")
+        if not created_at_str:
+            return False  # No timestamp, assume fresh
+
+        try:
+            created_at = datetime.datetime.fromisoformat(created_at_str)
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds <= STARTING_TIMEOUT_SECONDS:
+                return False  # Still fresh, count as live
+
+            session_id = session.get("id")
+            if session_id:
+                self._store.update_runtime_session(
+                    session_id, status="orphaned", ended_at=now.isoformat()
+                )
+                logger.bind(
+                    domain="session_registry",
+                    session_id=session_id,
+                    age_seconds=age_seconds,
+                ).warning(
+                    f"Session {session_id} marked orphaned: "
+                    f"no tmux after {age_seconds:.0f}s"
+                )
+            return True  # Marked orphaned, skip counting
+        except (ValueError, TypeError) as exc:
+            logger.bind(domain="session_registry", session=session).warning(
+                f"Failed to parse created_at timestamp: {exc}"
+            )
+            return False
+
     def reserve(
         self,
         role: str,
@@ -130,7 +169,6 @@ class SessionRegistryService:
         sessions = self._store.list_live_runtime_sessions(role=role)
         count = 0
         now = datetime.datetime.now()
-        starting_timeout_seconds = STARTING_TIMEOUT_SECONDS
 
         for session in sessions:
             session_role = session.get("role", "")
@@ -145,35 +183,8 @@ class SessionRegistryService:
                     count += 1
             else:
                 # No tmux_session - check if it's a stale session
-                created_at_str = session.get("created_at")
-                if created_at_str:
-                    try:
-                        created_at = datetime.datetime.fromisoformat(created_at_str)
-                        age_seconds = (now - created_at).total_seconds()
-                        if age_seconds > starting_timeout_seconds:
-                            # Mark stale session as orphaned
-                            session_id = session.get("id")
-                            if session_id:
-                                self._store.update_runtime_session(
-                                    session_id,
-                                    status="orphaned",
-                                    ended_at=now.isoformat(),
-                                )
-                                logger.bind(
-                                    domain="session_registry",
-                                    session_id=session_id,
-                                    age_seconds=age_seconds,
-                                ).warning(
-                                    f"Session {session_id} marked orphaned: "
-                                    f"no tmux after {age_seconds:.0f}s"
-                                )
-                            # Don't count - it's failed, not starting
-                            continue
-                    except (ValueError, TypeError) as exc:
-                        logger.bind(
-                            domain="session_registry",
-                            session=session,
-                        ).warning(f"Failed to parse created_at timestamp: {exc}")
+                if self._handle_stale_starting_session(session, now):
+                    continue
                 # Recently created, no tmux yet - count as live
                 count += 1
         return count
@@ -367,7 +378,6 @@ class SessionRegistryService:
         sessions = self._store.list_live_runtime_sessions()
         truly_live: list[dict[str, Any]] = []
         now = datetime.datetime.now()
-        starting_timeout_seconds = STARTING_TIMEOUT_SECONDS
 
         for session in sessions:
             if session.get("branch") != branch:
@@ -377,36 +387,8 @@ class SessionRegistryService:
                 if self._has_tmux_session(tmux):
                     truly_live.append(session)
             else:
-                # No tmux_session field - check if it's truly still starting
-                created_at_str = session.get("created_at")
-                if created_at_str:
-                    try:
-                        created_at = datetime.datetime.fromisoformat(created_at_str)
-                        age_seconds = (now - created_at).total_seconds()
-                        if age_seconds > starting_timeout_seconds:
-                            # Mark stale session as orphaned
-                            session_id = session.get("id")
-                            if session_id:
-                                self._store.update_runtime_session(
-                                    session_id,
-                                    status="orphaned",
-                                    ended_at=now.isoformat(),
-                                )
-                                logger.bind(
-                                    domain="session_registry",
-                                    session_id=session_id,
-                                    age_seconds=age_seconds,
-                                ).warning(
-                                    f"Session {session_id} marked orphaned: "
-                                    f"no tmux after {age_seconds:.0f}s"
-                                )
-                            continue
-                    except (ValueError, TypeError) as exc:
-                        logger.bind(
-                            domain="session_registry",
-                            session=session,
-                        ).warning(f"Failed to parse created_at timestamp: {exc}")
-                # Recently created, no tmux yet - count as live
+                if self._handle_stale_starting_session(session, now):
+                    continue
                 truly_live.append(session)
         return truly_live
 
@@ -427,13 +409,8 @@ class SessionRegistryService:
             List of session dicts that are truly live and match all criteria.
         """
         sessions = self._store.list_live_runtime_sessions(role=role)
-        from loguru import logger
-
         truly_live: list[dict[str, Any]] = []
         now = datetime.datetime.now()
-        # Timeout threshold: sessions without tmux for longer than this are
-        # considered failed launches, not "still starting"
-        starting_timeout_seconds = STARTING_TIMEOUT_SECONDS
 
         for session in sessions:
             if session.get("branch") != branch:
@@ -445,41 +422,8 @@ class SessionRegistryService:
                 if self._has_tmux_session(tmux):
                     truly_live.append(session)
             else:
-                # No tmux_session field - check if it's truly still starting
-                # or if it's a stale session from a failed launch
-                created_at_str = session.get("created_at")
-                if created_at_str:
-                    try:
-                        created_at = datetime.datetime.fromisoformat(created_at_str)
-                        age_seconds = (now - created_at).total_seconds()
-                        if age_seconds > starting_timeout_seconds:
-                            # Session created too long ago without tmux - failed launch
-                            # Mark as orphaned to prevent future false positives
-                            session_id = session.get("id")
-                            if session_id:
-                                self._store.update_runtime_session(
-                                    session_id,
-                                    status="orphaned",
-                                    ended_at=now.isoformat(),
-                                )
-                                logger.bind(
-                                    domain="session_registry",
-                                    session_id=session_id,
-                                    role=role,
-                                    target_id=target_id,
-                                    age_seconds=age_seconds,
-                                ).warning(
-                                    f"Session {session_id} marked orphaned: "
-                                    f"no tmux after {age_seconds:.0f}s"
-                                )
-                            # Don't add to truly_live - it's failed, not starting
-                            continue
-                    except (ValueError, TypeError) as exc:
-                        logger.bind(
-                            domain="session_registry",
-                            session=session,
-                        ).warning(f"Failed to parse created_at timestamp: {exc}")
-                # Recently created, no tmux yet - count as live (still starting)
+                if self._handle_stale_starting_session(session, now):
+                    continue
                 truly_live.append(session)
         return truly_live
 

--- a/src/vibe3/environment/session_registry.py
+++ b/src/vibe3/environment/session_registry.py
@@ -242,6 +242,31 @@ class SessionRegistryService:
                 done_ids.append(session_id)
         return done_ids
 
+    def mark_worker_sessions_done_when_tmux_gone(self) -> list[int]:
+        """Mark worker sessions whose tmux is gone as done.
+
+        Called before reconcile_live_state() so worker completions are
+        recorded as 'done' rather than 'orphaned'.
+
+        Returns:
+            List of session_ids transitioned to done.
+        """
+        worker_roles = ["manager", "planner", "executor", "reviewer"]
+        done_ids: list[int] = []
+        for role in worker_roles:
+            sessions = self._store.list_live_runtime_sessions(role=role)
+            for session in sessions:
+                tmux = session.get("tmux_session")
+                if not tmux:
+                    continue
+                if not self._has_tmux_session(tmux):
+                    session_id = session["id"]
+                    self._store.update_runtime_session(
+                        session_id, status="done", ended_at=_now_iso()
+                    )
+                    done_ids.append(session_id)
+        return done_ids
+
     def reconcile_live_state(self) -> list[int]:
         """Mark starting|running sessions whose tmux is gone as orphaned.
 
@@ -295,6 +320,34 @@ class SessionRegistryService:
         except Exception:
             # Best-effort cleanup only; orphan reconciliation should still succeed.
             pass
+
+    def get_live_sessions_for_issue(
+        self,
+        issue_number: int,
+        roles: list[str],
+    ) -> list[dict[str, Any]]:
+        """Return truly live sessions for a given issue number across specified roles.
+
+        Checks tmux liveness to avoid counting stale DB records.
+        Does not filter by branch — issue_number is the dispatch key.
+
+        Args:
+            issue_number: The issue number to filter sessions by.
+            roles: List of roles to check (e.g., ["manager", "planner", "executor"]).
+
+        Returns:
+            List of session dicts that are truly live and match the issue number.
+        """
+        result: list[dict[str, Any]] = []
+        for role in roles:
+            sessions = self._store.list_live_runtime_sessions(role=role)
+            for session in sessions:
+                if str(session.get("target_id", "")) != str(issue_number):
+                    continue
+                tmux = session.get("tmux_session")
+                if tmux and self._has_tmux_session(tmux):
+                    result.append(session)
+        return result
 
     def get_truly_live_sessions_for_branch(self, branch: str) -> list[dict[str, Any]]:
         """Return truly live sessions for a branch, confirming tmux liveness.

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -21,6 +21,7 @@ from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.utils.label_utils import should_skip_from_queue
 
 if TYPE_CHECKING:
+    from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.orchestra.services.state_label_dispatch import StateLabelDispatchService
 
 
@@ -40,9 +41,11 @@ class GlobalDispatchCoordinator:
         self,
         capacity: CapacityService,
         dispatch_services: list[StateLabelDispatchService],
+        registry: "SessionRegistryService | None" = None,
     ) -> None:
         self._capacity = capacity
         self._dispatch_services = dispatch_services
+        self._registry = registry
         self._frozen_queue: list[QueueEntry] | None = None
         self._github = (
             dispatch_services[0]._github if dispatch_services else None  # noqa: SLF001
@@ -142,6 +145,22 @@ class GlobalDispatchCoordinator:
             if entry.waiting_state is not None:
                 index += 1
                 continue
+
+            # Per-issue active session gate:
+            # Prevent dispatch if ANY worker role session is still live for this issue.
+            if self._registry is not None:
+                active = self._registry.get_live_sessions_for_issue(
+                    issue_number=entry.issue_number,
+                    roles=["manager", "planner", "executor", "reviewer"],
+                )
+                if active:
+                    append_orchestra_event(
+                        "dispatcher",
+                        f"GlobalDispatchCoordinator: skipped #{entry.issue_number} "
+                        f"(active session: role={active[0].get('role')})",
+                    )
+                    index += 1
+                    continue
 
             # For BLOCKED issues: run qualify gate at intent time (lazy evaluation)
             if issue.state == IssueState.BLOCKED:

--- a/src/vibe3/orchestra/services/state_label_dispatch.py
+++ b/src/vibe3/orchestra/services/state_label_dispatch.py
@@ -130,6 +130,23 @@ class StateLabelDispatchService(ServiceBase):
         from vibe3.domain import publish
         from vibe3.roles.registry import build_label_dispatch_event
 
+        # Pre-dispatch cleanup: remove conflicting state/* labels
+        # This ensures a single state label before dispatch.
+        old_state_labels = [
+            lb
+            for lb in issue.labels
+            if lb.startswith("state/") and lb != self.role_def.trigger_state.to_label()
+        ]
+        if old_state_labels:
+            try:
+                label_port = GhIssueLabelPort(repo=self.config.repo)
+                for old_lb in old_state_labels:
+                    label_port.remove_issue_label(issue.number, old_lb)
+            except Exception as exc:
+                logger.bind(domain="orchestra").warning(
+                    f"Failed to clean old state labels for #{issue.number}: {exc}"
+                )
+
         branch, _ = self._flow_context(issue.number)
         publish(
             build_label_dispatch_event(


### PR DESCRIPTION
## Summary

- **Per-issue active session gate**: Before dispatching any role, check if the issue has any live worker session via tmux. Prevents race condition where Manager and Executor run concurrently.
- **Worker session completion detection**: Add `mark_worker_sessions_done_when_tmux_gone()` called before `reconcile_live_state()` so worker sessions get 'done' status instead of 'orphaned'.
- **Pre-dispatch label cleanup**: Remove stale `state/*` labels before emitting dispatch intent to prevent multi-label accumulation.

## Root Cause Analysis

Issue #320 was dispatched twice (manager at 08:26 and 11:08, executor at 08:32 and 11:13) due to:
1. `waiting_state` tracks state label changes, not previous role session completion
2. State transitions done via `gh` CLI add new labels but don't remove old ones
3. Worker sessions ended as `orphaned` instead of `done` due to missing cleanup call

## Test Plan

- [x] Targeted regression tests pass: `uv run pytest tests/vibe3/ -k "dispatch or session or registry"` (172 passed)
- [ ] CI full test suite
- [ ] Manual verification: start manager session, verify next tick skips executor dispatch
- [ ] Kill tmux, verify session transitions to `done` (not `orphaned`) on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)