### PR TITLE
feat(noop-gate): add REQUIRED_REF_MUST_EXIST check to complete three-branch gate semantics

### DIFF
--- a/config/loc_limits.yaml
+++ b/config/loc_limits.yaml
@@ -171,6 +171,9 @@ code_limits:
       - path: "tests/vibe3/execution/test_codeagent_runner_gate.py"
         limit: 480
         reason: "Gate 集成测试，包含完整的 mock 设置和断言场景，拆分会破坏测试逻辑完整性"
+      - path: "tests/vibe3/execution/test_noop_gate_unit.py"
+        limit: 450
+        reason: "Noop gate 三分支语义测试，15 个测试围绕同一 gate 函数，共享 mock fixture，拆分收益低"
 
   total_file_loc:
     v2_shell: 3000         # Shell 核心代码总行数

--- a/docs/standards/vibe3-noop-gate-boundary-standard.md
+++ b/docs/standards/vibe3-noop-gate-boundary-standard.md
@@ -123,20 +123,27 @@ related_docs:
 
 对 `planner / executor / reviewer` 三类 worker，正确语义是：
 
-- agent 执行后 **state 未改变** → `blocked`
-- agent 执行后 **state 已改变**（由 agent 自己完成） → 通过
+- agent 执行后 **required_ref 缺失** → `blocked`（agent 未按 contract 产出 authoritative ref）
+- agent 执行后 **state 未改变** → `blocked`（agent 未按 contract 推进状态）
+- agent 执行后 **两项都满足** → 通过
 
 也就是说：
 
 - planner 跑完但还在 `state/claimed` → `blocked`
 - executor 跑完但还在 `state/in-progress` → `blocked`
 - reviewer 跑完但还在 `state/review` → `blocked`
+- planner 跑完但没有 `plan_ref` → `blocked`
+- executor 跑完但没有 `report_ref` → `blocked`
+- reviewer 跑完但没有 `audit_ref` → `blocked`
 
-gate 只检查 state change，不检查 ref 是否存在。ref 是 agent 的内部产出，
-ref 检查应由 agent 自身负责，不属于 orchestration 层的 gate 职责。
+gate 同时检查 required_ref 存在性和 state change：
+1. required_ref 缺失 → block（agent 未按 contract 产出 authoritative ref）
+2. state 未变 → block（agent 未按 contract 推进状态）
+3. 两项都满足 → pass
 
-如果只做”缺 ref 才 block”而忽略 state change，就会出现 silent hang：
-ref 存在但 agent 没改 state，dispatch 不再派发，系统也不 block，issue 停滞。
+manager 角色不受 ref 检查约束（只有 state change 检查）。
+
+保留原有的 “authoritative ref 不是成功推进的替代品” 原则不变。
 
 ### 3.2 manager 不再保留独立的 must-change completion gate
 

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -26,7 +26,7 @@ from vibe3.execution.execution_lifecycle import (
     persist_execution_lifecycle_event,
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate, extract_state_label
-from vibe3.execution.role_policy import get_role_section
+from vibe3.execution.role_policy import get_role_required_ref_key, get_role_section
 from vibe3.execution.session_service import load_session_id
 from vibe3.models.review_runner import AgentOptions
 from vibe3.services.handoff_service import HandoffService
@@ -194,6 +194,12 @@ class CodeagentExecutionService:
                 event_type=f"codeagent_{execution_prefix(command.role)}_completed",  # type: ignore[arg-type]
             )
 
+            # Read flow state ONCE here, used by both ref check and passive recording
+            flow_state = ctx.store.get_flow_state(ctx.branch) if ctx.store else {}
+
+            # Get required ref key for this role
+            required_ref_key = get_role_required_ref_key(command.role)
+
             # Unified no-op gate: single hard logic check after agent completion.
             # Executes ONLY for L3 worker roles (manager/planner/executor/reviewer).
             # Supervisor (L2) is lightweight: no flow, no state machine, skip gate.
@@ -207,6 +213,8 @@ class CodeagentExecutionService:
                     role=command.role,
                     before_state_label=ctx.before_state_label,
                     repo=getattr(self.config, "repo", None),
+                    required_ref_key=required_ref_key,
+                    flow_state=flow_state,
                 )
 
             # Supervisor success: remove state/handoff label to prevent re-dispatch.
@@ -221,10 +229,8 @@ class CodeagentExecutionService:
             # (i.e., agent did NOT call `handoff plan` or `handoff report`)
             if passive_kind and agent_result.stdout.strip() and handoff_file is None:
                 ref_field = f"{passive_kind}_ref"
-                existing_state = (
-                    ctx.store.get_flow_state(ctx.branch) if ctx.store else None
-                )
-                if existing_state and existing_state.get(ref_field):
+                # Reuse flow_state read above for gate, avoid duplicate SQLite read
+                if flow_state and flow_state.get(ref_field):
                     log.info(
                         f"Skipping passive {passive_kind} recording: "
                         f"{ref_field} already set"

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -30,6 +30,8 @@ def apply_unified_noop_gate(
     role: ExecutionRole,
     before_state_label: str | None,
     repo: str | None = None,
+    required_ref_key: str | None = None,
+    flow_state: dict | None = None,
 ) -> None:
     """Apply the single hard no-op gate after agent completion.
 
@@ -37,11 +39,13 @@ def apply_unified_noop_gate(
 
     Rules:
     - if the issue has no state/ label, skip (not managed by state machine)
+    - if required_ref is missing (for worker roles), block
     - if the agent did not change the issue's state/ label, block
     - if the agent changed the issue's state/ label, record and pass
     """
     from vibe3.utils.constants import (
         EVENT_CANNOT_VERIFY_REMOTE_STATE,
+        EVENT_REQUIRED_REF_MISSING,
         EVENT_STATE_TRANSITIONED,
         EVENT_STATE_UNCHANGED,
     )
@@ -150,6 +154,43 @@ def apply_unified_noop_gate(
             actor=actor,
         )
         return
+
+    # --- NEW: required_ref check ---
+    # Only check ref for worker roles (planner/executor/reviewer).
+    # Manager skips this check (required_ref_key is None).
+    if required_ref_key is not None and flow_state is not None:
+        ref_value = flow_state.get(required_ref_key)
+        if not ref_value:
+            logger.bind(
+                domain="codeagent",
+                role=role,
+                issue_number=issue_number,
+                branch=branch,
+            ).warning(
+                f"No-op gate BLOCK: required ref {required_ref_key} "
+                f"missing after {role}"
+            )
+            store.add_event(
+                branch,
+                EVENT_REQUIRED_REF_MISSING,
+                actor,
+                detail=(
+                    f"Required ref {required_ref_key} missing after {role}: "
+                    f"state was {before_state_label}"
+                ),
+                refs={
+                    "before_state": str(before_state_label or ""),
+                    "issue": str(issue_number),
+                    "required_ref": required_ref_key,
+                },
+            )
+            _block_fn(
+                issue_number=issue_number,
+                repo=repo,
+                reason=f"required ref missing: {required_ref_key}",
+                actor=actor,
+            )
+            return
 
     if before_state_label == after_state_label:
         state_desc = before_state_label or "(no state)"

--- a/src/vibe3/execution/role_policy.py
+++ b/src/vibe3/execution/role_policy.py
@@ -27,6 +27,24 @@ def get_role_section(
     return ROLE_TO_SECTION[role]
 
 
+# Role to required ref key mapping for no-op gate
+# Used by unified no-op gate to check if agent produced required ref
+ROLE_TO_REQUIRED_REF_KEY: dict[str, str | None] = {
+    "planner": "plan_ref",
+    "executor": "report_ref",
+    "reviewer": "audit_ref",
+    "manager": None,  # manager 不受 ref 检查约束
+}
+
+
+def get_role_required_ref_key(role: "ExecutionRole | str") -> str | None:
+    """Get the required ref key for a given role's no-op gate check.
+
+    Returns None for roles that should skip the ref check (e.g., manager).
+    """
+    return ROLE_TO_REQUIRED_REF_KEY.get(role)
+
+
 # Handoff kind to actor state key mapping
 # Used by handoff recorder to write latest_actor to flow state
 KIND_TO_ACTOR_KEY: dict[str, str] = {

--- a/src/vibe3/utils/constants.py
+++ b/src/vibe3/utils/constants.py
@@ -64,6 +64,7 @@ L3_AGENT_ROLES: Final[frozenset[str]] = frozenset({"manager", "plan", "run", "re
 EVENT_STATE_TRANSITIONED: Final[str] = "state_transitioned"
 EVENT_STATE_UNCHANGED: Final[str] = "state_unchanged"
 EVENT_CANNOT_VERIFY_REMOTE_STATE: Final[str] = "cannot_verify_remote_state"
+EVENT_REQUIRED_REF_MISSING: Final[str] = "required_ref_missing"
 
 # =============================================================================
 # Flow State Ref Fields

--- a/tests/vibe3/execution/test_noop_gate_unit.py
+++ b/tests/vibe3/execution/test_noop_gate_unit.py
@@ -301,3 +301,124 @@ class TestApplyUnifiedNoopGate:
         # Gate should skip, not block
         mock_block.assert_not_called()
         store.add_event.assert_not_called()
+
+    def test_blocks_when_required_ref_missing_even_if_state_changed(self) -> None:
+        """Gate blocks when required ref is missing, even if state changed."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_planner_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/in-progress"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=42,
+                branch="task/issue-42",
+                actor="agent:plan",
+                role="planner",
+                before_state_label="state/plan",
+                required_ref_key="plan_ref",
+                flow_state={},  # plan_ref missing
+            )
+
+        mock_block.assert_called_once()
+        call_kwargs = mock_block.call_args[1]
+        assert "required ref missing" in call_kwargs["reason"]
+        assert "plan_ref" in call_kwargs["reason"]
+        store.add_event.assert_called_once()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "required_ref_missing"
+
+    def test_passes_when_ref_present_and_state_changed(self) -> None:
+        """Gate passes when ref is present and state changed."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_executor_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/review"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=99,
+                branch="task/issue-99",
+                actor="agent:run",
+                role="executor",
+                before_state_label="state/run",
+                required_ref_key="report_ref",
+                flow_state={"report_ref": "path/to/report.md"},
+            )
+
+        mock_block.assert_not_called()
+        store.add_event.assert_called_once()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "state_transitioned"
+
+    def test_blocks_when_ref_present_but_state_unchanged(self) -> None:
+        """Gate blocks when ref is present but state unchanged."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_reviewer_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/review"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=55,
+                branch="task/issue-55",
+                actor="agent:review",
+                role="reviewer",
+                before_state_label="state/review",
+                required_ref_key="audit_ref",
+                flow_state={"audit_ref": "path/to/audit.md"},
+            )
+
+        mock_block.assert_called_once()
+        call_kwargs = mock_block.call_args[1]
+        assert "state unchanged" in call_kwargs["reason"]
+        store.add_event.assert_called_once()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "state_unchanged"
+
+    def test_manager_skips_ref_check_state_changed_passes(self) -> None:
+        """Manager role skips ref check; only state change matters."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_manager_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/handoff"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=42,
+                branch="task/issue-42",
+                actor="agent:manager",
+                role="manager",
+                before_state_label="state/ready",
+                required_ref_key=None,  # manager has no required ref
+                flow_state=None,
+            )
+
+        mock_block.assert_not_called()
+        store.add_event.assert_called_once()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "state_transitioned"


### PR DESCRIPTION
Closes #473

## Summary
- Add role-specific required reference existence check (`REQUIRED_REF_MUST_EXIST`) before state-change check in the unified no-op gate
- Complete the three-branch gate semantics as specified in the plan

## Changes
- **role_policy.py**: Add `ROLE_TO_REQUIRED_REF_KEY` mapping and `get_role_required_ref_key()` function for centralized role-to-ref lookup
- **noop_gate.py**: Add ref-existence check before state-change check in `apply_unified_noop_gate()`
- **codeagent_runner.py**: Read `flow_state` once for efficiency, pass `required_ref_key` and `flow_state` to gate
- **constants.py**: Add `EVENT_REQUIRED_REF_MISSING` constant for event tracking
- **test_noop_gate_unit.py**: Add 4 new test cases covering all three branches
- **vibe3-noop-gate-boundary-standard.md**: Update §3.1.1 with three-branch gate semantics

## Test plan
- [x] Unit tests: 4 new tests covering three-branch gate (all pass)
- [x] All pre-push checks: 62 tests passed
- [x] LOC limits: Python 44585/45000, Shell 1992/3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

opencode/deepseek/deepseek-v4-pro, claude/opus
