### PR TITLE
fix(governance): add required task parameter and allow state/ready compensation

### DIFF
--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -125,7 +125,7 @@ def check(
         else:
             mode = "fix_all"
 
-        result = execute_check_mode(service, mode)
+        result = execute_check_mode(service, mode, verbose=trace)
 
         if result.success:
             typer.echo(f"✓ {result.summary}")

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+import typer
+
 from vibe3.services.check_remote import InitResult
 from vibe3.services.check_service import CheckResult, CheckService
 
@@ -26,6 +28,7 @@ def execute_check_mode(
     ] = "default",
     *,
     branch: str | None = None,
+    verbose: bool = False,
 ) -> ExecuteCheckResult:
     """Run command-oriented check modes
     using CheckService primitives."""
@@ -86,9 +89,14 @@ def execute_check_mode(
                 summary=f"All {len(results)} active flows passed",
             )
 
+        if not verbose:
+            typer.echo(f"Checking {len(invalid_fix)} flows with issues...")
+
         fixed_count = 0
         failed: list[str] = []
-        for check_result in invalid_fix:
+        for idx, check_result in enumerate(invalid_fix, 1):
+            if verbose:
+                typer.echo(f"  [{idx}/{len(invalid_fix)}] {check_result.branch}")
             fix_result = service.auto_fix(
                 check_result.issues, branch=check_result.branch
             )

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -76,6 +76,7 @@ def run_governance_sync(
         result = CodeagentBackend().run(
             prompt=prompt_content,
             options=options,
+            task="governance scan",
             dry_run=False,
             session_id=session_id,
             cwd=None,  # Governance runs in current worktree

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -490,6 +490,9 @@ class CheckService(CheckRemote):
             branch, "stale", reason, "flow_auto_staled", "auto_stale_flow"
         )
 
+    # Reserved branches that should never be checked as flows
+    RESERVED_BRANCHES = {"main", "master", "develop", "staging", "production"}
+
     def verify_all_flows(
         self, status: str | list[str] | None = "active"
     ) -> list[CheckResult]:
@@ -501,6 +504,14 @@ class CheckService(CheckRemote):
         if status:
             statuses = [status] if isinstance(status, str) else status
             all_flows = [f for f in all_flows if f.get("flow_status") in statuses]
+
+        # Filter out reserved branches (main, master, develop, etc.)
+        all_flows = [
+            f
+            for f in all_flows
+            if f.get("branch") not in self.RESERVED_BRANCHES
+            and not str(f.get("branch", "")).startswith("origin/")
+        ]
 
         results = []
         for flow in all_flows:

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -11,6 +11,7 @@ from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.settings import VibeConfig
 from vibe3.models.orchestration import IssueState
 from vibe3.models.pr import PRState
 from vibe3.services.check_remote import (
@@ -62,6 +63,13 @@ class CheckService(CheckRemote):
         self.git_client = git_client or GitClient()
         self.github_client = github_client or GitHubClient()
         self._branch_to_pr: dict[str, PRResponse] = {}
+        # Load config for protected branches
+        self._vibe_config = VibeConfig()
+
+    @property
+    def protected_branches(self) -> set[str]:
+        """Get protected branches from config (main, master, develop, etc.)."""
+        return set(self._vibe_config.flow.protected_branches)
 
     def _initialize_pr_cache(self) -> None:
         """Initialize PR cache with batch fetch (1 API call instead of N).
@@ -490,9 +498,6 @@ class CheckService(CheckRemote):
             branch, "stale", reason, "flow_auto_staled", "auto_stale_flow"
         )
 
-    # Reserved branches that should never be checked as flows
-    RESERVED_BRANCHES = {"main", "master", "develop", "staging", "production"}
-
     def verify_all_flows(
         self, status: str | list[str] | None = "active"
     ) -> list[CheckResult]:
@@ -505,11 +510,12 @@ class CheckService(CheckRemote):
             statuses = [status] if isinstance(status, str) else status
             all_flows = [f for f in all_flows if f.get("flow_status") in statuses]
 
-        # Filter out reserved branches (main, master, develop, etc.)
+        # Filter out protected branches (main, master, develop, etc.)
+        # These should never be treated as flow branches
         all_flows = [
             f
             for f in all_flows
-            if f.get("branch") not in self.RESERVED_BRANCHES
+            if f.get("branch") not in self.protected_branches
             and not str(f.get("branch", "")).startswith("origin/")
         ]
 

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -41,16 +41,24 @@ Allowed:
 - `handoff`: read（读取交接上下文）
 - `scene`: read（读取现场信息）
 - `comment.write`: 写治理建议评论（格式为 `[governance suggest]`）
-- `state/labels.write`: 仅限一个极窄补偿动作：
-  - 当前 issue 已在 `state/blocked`
-  - `blocked_reason` 明确为 `state unchanged`
-  - `flow show` 能确认 authoritative ref 已存在
-  - 仅允许把 state 恢复到 `state/handoff`
-  - 恢复后必须写 comment 说明是 governance 自动补偿
+- `state/labels.write`: 仅限两个极窄补偿动作：
+  1. **漏改 blocked 恢复**：
+     - 当前 issue 已在 `state/blocked`
+     - `blocked_reason` 明确为 `state unchanged`
+     - `flow show` 能确认 authoritative ref 已存在
+     - 仅允许把 state 恢复到 `state/handoff`
+     - 恢复后必须写 comment 说明是 governance 自动补偿
+  2. **遗漏 state/ready 补齐**：
+     - 当前 issue 有 manager assignee
+     - 缺少任何 `state/*` label
+     - 没有活跃的 flow scene（`has_flow=False`）
+     - 仅允许设置为 `state/ready`
+     - 设置后必须写 comment 说明原因
+     - 如果认为前一个 agent 判断错误或不值得执行，写 `[governance suggest]` 建议而非直接拒绝
 
 Forbidden:
 
-- `state/labels.write`: 除上面的单一补偿动作外，其他任何 `state/*` label 的修改都禁止（包括设置 `state/ready`、`state/claimed`、`state/in-progress`、`state/blocked`、`state/done`）
+- `state/labels.write`: 除上面的两个补偿动作外，其他任何 `state/*` label 的修改都禁止（包括设置 `state/claimed`、`state/in-progress`、`state/blocked`、`state/done`）
 - `issue.resume`: 恢复 blocked 或 failed issue（这是人类专属动作，通过 `vibe3 task resume`）
 - `issue.close`: 关闭 issue（只建议关闭，由 Manager 执行）
 - `code.write`: 任何形式的代码修改
@@ -89,7 +97,9 @@ Forbidden:
 - 最小 non-state label 调整建议（仅 `milestone`、`roadmap/*`、`priority/[0-9]`）
 - start / wait / defer recommendations with short reasons
 - `[governance suggest]` 格式的治理建议评论
-- 极窄的 `state unchanged` 自动补偿恢复（仅 `state/blocked` → `state/handoff`）
+- 极窄的自动补偿动作：
+  - `state unchanged` 恢复（`state/blocked` → `state/handoff`）
+  - 遗漏 `state/ready` 补齐（有 assignee 但无 state label → `state/ready`）
 
 ## Hard Boundary
 
@@ -104,7 +114,9 @@ Forbidden:
 - 不负责写代码
 - **不负责一般性的 `state/*` label 修改**
 - **不负责一般性的 blocked/failed resume**
-- **只允许修正一种明确的漏改 state 场景：`state unchanged` 且 authoritative ref 已存在**
+- **只允许修正两种明确的漏改 state 场景**：
+  1. `state unchanged` 且 authoritative ref 已存在
+  2. 有 manager assignee 但缺少 state label 且无活跃 flow
 
 ## Execution Pattern
 


### PR DESCRIPTION
## Summary

- Fix "task required" error in governance scan by adding `task="governance scan"` parameter to `CodeagentBackend.run()` call
- Update governance material (`assignee-pool.md`) to allow second compensation action: set `state/ready` for issues with manager assignee but missing state label
- Fix `vibe3 check` incorrectly checking reserved branches (main, master, develop) as flow branches
- Add progress indication when checking flows with issues

## Root Cause

1. **Code issue**: `governance_sync_runner.py` was not passing `task` parameter to `CodeagentBackend.run()`, but codeagent-wrapper requires it as a positional argument

2. **Process issue**: Governance material had overly restrictive rules preventing governance from setting `state/ready` for issues that were correctly intake'd (assigned) but lacked state label

3. **Check issue**: `verify_all_flows()` was checking all flow records including reserved branches like `main`, which should never be treated as flow branches

## Changes

- `src/vibe3/execution/governance_sync_runner.py`: Add `task="governance scan"` parameter
- `supervisor/governance/assignee-pool.md`: Add second compensation action allowing governance to set `state/ready` for assigned issues without state label
- `src/vibe3/services/check_service.py`: Add RESERVED_BRANCHES filter to skip main/master/develop
- `src/vibe3/commands/check_support.py`: Add progress indication (shows count without -v, shows branches with -v)

## Test Plan

- [x] Governance scan runs without "task required" error
- [ ] Governance can observe issues with assignee but no state label
- [ ] Governance can set `state/ready` for valid candidates
- [x] `vibe3 check` no longer checks reserved branches
- [x] `vibe3 check` shows progress when fixing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)