### PR TITLE
docs: align 5 documents referencing deprecated standards (#575)

### DIFF
--- a/docs/references/flow-dependency.md
+++ b/docs/references/flow-dependency.md
@@ -260,6 +260,7 @@ vibe3 flow blocked --by 218
 
 ## 相关文档
 
-- [Task & Flow 操作指南](../standards/vibe3-user-guide.md)
+- [Task & Flow 操作指南](../standards/v3/command-standard.md)
+- [项目概览](../../README.md)
 - [Flow 状态转换计划](../plans/2026-03-23-flow-status-transitions.md)
 - [数据模型标准](../standards/v3/handoff-store-standard.md)

--- a/docs/standards/github-labels-standard.md
+++ b/docs/standards/github-labels-standard.md
@@ -19,7 +19,7 @@
 **本文档不回答的问题**:
 - 有哪些标签？→ 见 [github-labels-reference.md](github-labels-reference.md)
 - 如何用标签管理 roadmap？→ 见 [roadmap-label-management.md](roadmap-label-management.md)
-- 具体命令怎么用？→ 见 [vibe3-user-guide.md](vibe3-user-guide.md)
+- 具体命令怎么用？→ 见 [v3/command-standard.md](v3/command-standard.md)
 
 ---
 
@@ -318,5 +318,5 @@ agent 认领 issue 时：
 - [roadmap-label-management.md](roadmap-label-management.md) - 如何使用标签管理 roadmap
 - [vibe3-state-sync-standard.md](vibe3-state-sync-standard.md) - 状态同步标准
 - [issue-standard.md](issue-standard.md) - Issue 标准
-- [vibe3-command-standard.md](vibe3-command-standard.md) - 命令设计标准
-- [vibe3-user-guide.md](vibe3-user-guide.md) - 用户操作手册
+- [v3/command-standard.md](v3/command-standard.md) - 命令设计标准
+- [v3/handoff-store-standard.md](v3/handoff-store-standard.md) - Handoff 存储标准

--- a/docs/standards/issue-standard.md
+++ b/docs/standards/issue-standard.md
@@ -224,6 +224,6 @@ dependencies:
 ---
 
 **参考文档**：
-- [vibe3-command-standard.md](vibe3-command-standard.md)
+- [v3/command-standard.md](v3/command-standard.md)
 - [github-labels-standard.md](github-labels-standard.md)
 - [glossary.md](glossary.md)

--- a/docs/standards/quality-control-standard.md
+++ b/docs/standards/quality-control-standard.md
@@ -459,7 +459,7 @@ IGNORE_FILES=(
 - [SOUL.md](../../SOUL.md) - 项目宪法
 - [error-handling.md](./error-handling.md) - 错误处理规范
 - [github-code-review-standard.md](./github-code-review-standard.md) - 代码审查标准
-- [vibe3-command-standard.md](./vibe3-command-standard.md) - 命令设计标准
+- [v3/command-standard.md](./v3/command-standard.md) - 命令设计标准
 
 ---
 

--- a/docs/standards/vibe3-state-sync-standard.md
+++ b/docs/standards/vibe3-state-sync-standard.md
@@ -1,6 +1,9 @@
 # Vibe3 State Sync Standard
 
-状态：Active
+状态：Deprecated (已由 [v3/command-standard.md](v3/command-standard.md) 替代)
+
+> [!WARNING]
+> 本文档已废弃。现行规范真源请参考 [docs/standards/v3/command-standard.md](v3/command-standard.md)。
 
 ## 1. 目的
 


### PR DESCRIPTION
Aligns 5 documents that were referencing deprecated 'vibe3-command-standard.md' and 'vibe3-user-guide.md' to current truth sources. Also marks 'vibe3-state-sync-standard.md' as deprecated as per 'v3/command-standard.md'.