### PR TITLE
docs: align 5 documents to current truth sources

### DIFF
--- a/docs/references/vibe-engine-design.md
+++ b/docs/references/vibe-engine-design.md
@@ -17,6 +17,13 @@ related_docs:
 
 本文档保留早期 Vibe Workflow Engine 的完整架构蓝图，供历史背景、设计演化和旧文档考据使用。
 
+**特别说明：本文档描述的以下概念已正式废弃，仅作为历史参考：**
+- **`Stage 1/2/3/4` (及其对应的 Scope/Plan/Execution/Review Gate)**
+- **`Unified Workflow Orchestrator` (旧引擎模型)**
+- **`MSC 拦截门` 范式**
+
+当前正式架构以 [vibe3-architecture-convergence-standard.md](../standards/vibe3-architecture-convergence-standard.md) 定义的 6 层模型（Server/Runtime/Domain/Execution/Environment/Role Adapters）为准。
+
 它不是现行标准真源。当前正式语义以以下文档为准：
 
 - `docs/standards/glossary.md`

--- a/docs/standards/doc-organization.md
+++ b/docs/standards/doc-organization.md
@@ -22,9 +22,9 @@ related_docs:
 
 # 文档组织标准
 
-本文档只定义目录结构、命名规范和文档落位。若涉及 `task`、`workflow`、`规范层`、`执行计划层`、`代码实现层`、`AI审计层` 等项目术语，其正式语义以 [glossary.md](glossary.md) 为准。
+本文档只定义目录结构、命名规范和文档落位。若涉及 `task`、`workflow`、`PRD`、`Spec`、`Plan`、`Code`、`Audit` 等项目术语，其正式语义以 [glossary.md](glossary.md) 为准。
 
-本文档定义 Vibe Center 的文档组织标准，与 Vibe Workflow Paradigm 的 Vibe Guard 范式对齐。
+本文档定义 Vibe Center 的文档组织标准，旨在建立清晰的文档交付链。
 任务身份以 GitHub issue 为准；正式 Spec / Plan / Report 分别落在 `docs/specs/`、`docs/plans/`、`docs/reports/`。
 旧的统一任务镜像目录不再作为默认组织方式；若历史文件仍存在，仅作为归档参考。
 
@@ -116,16 +116,16 @@ audit-{YYYY-MM-DD}.md
 - audit-2024-01-15.md
 ```
 
-## Vibe Guard 对应关系
+## 文档交付层级
 
-| 层级 | 文档类型 | 阶段 | 验证标准 |
+| 层级 | 文档类型 | 主要内容 | 验证标准 |
 |------|---------|------|---------|
-| PRD（认知层） | prd-*.md | Scope | 业务目标、绝对边界、核心数据流、成功判据 |
-| Spec（规范层） | spec-*.md | Spec | 接口契约、核心不变量、边界行为、非功能约束 |
-| Plan（执行计划层） | plan-*.md | Plan | 上下文圈定、任务拆分、风险对策 |
-| Test（测试层） | test-*.md | Test | 测试策略、断言来源、TDD 流程记录 |
-| Code（代码实现层） | code-*.md | Code | 实现概述、复杂度报告、AST 约束检查 |
-| Review（AI 审计层） | audit-*.md | Audit | 目标对齐、规范遵守、路径一致、架构纯洁 |
+| PRD（认知层） | prd-*.md | 业务目标、绝对边界、核心数据流、成功判据 | 语义完整、无歧义、符合 SOUL.md |
+| Spec（规范层） | spec-*.md | 接口契约、核心不变量、边界行为、非功能约束 | 逻辑自洽、技术可行、符合 PRD |
+| Plan（执行计划层） | plan-*.md | 上下文圈定、任务拆分、风险对策 | 步骤清晰、依赖明确、符合 Spec |
+| Test（测试层） | test-*.md | 测试策略、断言来源、TDD 流程记录 | 覆盖核心路径、边界条件完备 |
+| Code（代码实现层） | code-*.md | 实现概述、复杂度报告、AST 约束检查 | 结构清晰、符合规范、通过测试 |
+| Audit（审计层） | audit-*.md | 目标对齐、规范遵守、架构纯洁 | 满足 PRD/Spec 要求、无技术债引入 |
 
 ## 使用指南
 
@@ -145,7 +145,7 @@ audit-{YYYY-MM-DD}.md
 
 3. **替换占位符并填写内容**
 
-4. **按 Vibe Guard 流程逐步推进**
+4. **按文档交付层级逐步推进**
    - 临时草稿优先写入 `.agent/plans/`、`.agent/reports/`
    - 需要长期保留的正式版本写入 `docs/plans/`、`docs/reports/`
    - 长期结论写入 issue comment 或 PR comment

--- a/docs/standards/doc-quality-standards.md
+++ b/docs/standards/doc-quality-standards.md
@@ -20,7 +20,7 @@ related_docs:
 
 # Document Quality Standards
 
-本文档只定义文档质量、frontmatter 和文档类型 schema。若涉及 `workflow`、`task`、`规范层`、`执行计划层`、`AI审计层` 等项目术语，其正式语义以 [glossary.md](glossary.md) 为准。
+本文档只定义文档质量、frontmatter 和文档类型 schema。若涉及 `workflow`、`task`、`PRD`、`Spec`、`Plan`、`Audit` 等项目术语，其正式语义以 [glossary.md](glossary.md) 为准。
 
 ## 概述
 
@@ -483,9 +483,9 @@ related_docs:
 - 正文中的"当前状态"部分应使用指引文本：`见 frontmatter \`status\` 字段（唯一真源）`
 - 不要在正文中重复或冗余状态值，避免双头真源问题
 
-**`gates`**（仅用于 task-readme，*注：当前 Gate 范式已废弃，此字段为历史遗留/可选，具体见 glossary.md*）
-- 记录任务各个 Gate 的状态
-- 每个 Gate 包含：
+**`gates`**（历史遗留字段，仅用于 task-readme 兼容）
+- *注：该字段对应已废弃的 Gate 范式。当前任务进度追踪应使用 `current_layer` 字段。*
+- 历史语义：记录任务各个阶段的状态
   - `status`：`pending` / `passed` / `failed`
   - `timestamp`：ISO 8601 格式的时间戳
   - `reason`：通过或失败的原因

--- a/docs/standards/v3/git-workflow-standard.md
+++ b/docs/standards/v3/git-workflow-standard.md
@@ -52,8 +52,8 @@ related_docs:
 
 默认交付模型如下：
 
-- `GitHub issue` 负责来源层需求与讨论事实
-- `roadmap item` 负责规划窗口与 GitHub Project item 镜像，是 planning 中间层
+- `GitHub issue` 负责来源层需求与讨论事实，是当前治理与执行的**直接真源**
+- `roadmap item` 负责版本规划窗口的表达。状态：**历史兼容 / 规划参考语义**。不再作为执行层的强制中间层
 - `task` 负责 execution record，是 flow 建立后的 execution bridge
 - `flow` 负责当前交付切片与 runtime 现场
 - `pr` 负责当前交付产物
@@ -62,7 +62,7 @@ related_docs:
 
 默认关系：
 
-- 一个 `flow` 对应一个当前交付目标
+- 一个 `flow` 对应一个当前交付目标（对应一个 `GitHub issue`）
 - 一个当前交付目标默认对应一个当前 `pr`
 - 一个 `flow` 默认绑定一个当前 `branch`
 - 一个 `worktree` 可以承载当前 `flow`，但 `flow` 不等于目录
@@ -151,11 +151,11 @@ closeout 约束：
 
 内部桥接链：
 
-1. 从 `GitHub issue` 确认来源层目标
-2. 创建、选择或同步对应的 `roadmap item`
+1. 从 `GitHub issue` 确认来源层目标（直接真源）
+2. 若有必要，同步对应的 `roadmap item`（仅作规划参考）
 3. 通过 `vibe-new` 确认/创建目标 issue、创建/注册 flow、绑定 issue 并创建 PR draft
-4. 进入新 flow 后，通过 `vibe-start` 确认并补齐 flow 环境（恢复开发场景）
-5. 让该 `flow` 绑定本轮要交付的 `task`
+4. 进入新 flow 后，通过 `vibe-start` 确认并补齐 flow 环境
+5. 让该 `flow` 绑定本轮要交付的 `task` (execution record)
 6. 在该 `flow` 对应的 `branch` 上提交本地 commit
 7. 执行 `review`
 8. 提交 `pr`
@@ -164,10 +164,10 @@ closeout 约束：
 
 执行要求：
 
-- 一个 `type=feature` 的 roadmap item 默认对应一个主 `branch` 和一个主 `pr`
-- `task` 作为 execution record / execution bridge 服务于 roadmap item，不替代规划对象本身
-- `flow` 是用户主视角的默认执行锚点；roadmap item 与 task 继续保留为内部桥接对象
-- 同一 `flow` 内的 commit 应服务同一个当前交付目标
+- 交付链以 `GitHub issue` 为核心。`roadmap item` 继续保留为历史兼容与规划排期对象，不作为执行的必经关口。
+- `task` 作为 execution record / execution bridge 服务于执行过程，不替代规划对象本身。
+- `flow` 是用户主视角的默认执行锚点。
+- 同一 `flow` 内的 commit 应服务同一个当前交付目标。
 - 若一组 commit 已经不再服务当前目标，应停止继续堆在该 `flow`
 - `done` 只应发生在当前交付目标已经完成或明确废弃之后，通过 `/vibe-done` 编排收口动作。
 

--- a/docs/v3/infrastructure/02-architecture.md
+++ b/docs/v3/infrastructure/02-architecture.md
@@ -55,55 +55,44 @@ src/vibe3/
 
 ## 分层架构与职责 (强制)
 
-### Layer 1: CLI (cli.py)
-- **职责**：创建 Typer app，注册子命令。
-- **要求**：禁止包含任何业务逻辑，代码量 < 50 行。
+Vibe 3.0 采用 domain-first 架构，收敛为以下六层：
 
-### Layer 2: Commands (commands/)
-- **职责**：定义命令参数，参数验证（Pydantic），格式化输出（Rich）。
-- **要求**：禁止直接调用 subprocess 或操作数据库，每个文件 < 100 行。
+### Layer 1: Server (server/)
+- **职责**：HTTP/Webhook 暴露、进程级驱动装配、Runtime 启停。
+- **要求**：禁止包含业务判断或角色特定逻辑。
 
-### Layer 3: Services (services/)
-- **职责**：业务逻辑编排，调用 Client。
-- **要求**：禁止直接 I/O 或 UI 逻辑，每个文件 < 300 行。
+### Layer 2: Runtime (runtime/)
+- **职责**：Heartbeat、事件路由、将外部 Observation 翻译并交给 Domain。
+- **要求**：不持有角色编排逻辑。
 
-### Layer 4: Engine (engine/)
-- **职责**：DAG 流程定义、状态机管理。
-- **要求**：所有 flow 必须可追踪（--trace）。
+### Layer 3: Domain (domain/)
+- **职责**：定义领域事件、处理业务逻辑编排、驱动状态机。
+- **要求**：业务语义判断的唯一真源。
 
-### Layer 5: Runtime (runtime/)
-- **职责**：执行引擎、调度器、分发器。
-- **要求**：所有执行必须经过 runtime/，调用 Client。
+### Layer 4: Execution (execution/)
+- **职责**：统一执行控制面（Capacity, Lifecycle, Session, Agent Launch）。
+- **要求**：所有角色执行（Plan/Run/Review）的唯一启动入口。
 
-### Layer 6: Clients (clients/)
-- **职责**：封装外部系统（Git, GitHub, SQLite）。
-- **要求**：必须提供 Protocol 接口，支持单元测试 Mock。
-- **约束**：见 [github-remote-call-standard.md](../../standards/v3/github-remote-call-standard.md)
+### Layer 5: Environment (environment/)
+- **职责**：资源原语（Worktree 管理、Tmux Session 隔离）。
+- **要求**：不涉及业务状态逻辑。
 
-### Layer 7: Observability (observability/)
-- **职责**：日志、追踪、审计。
-- **要求**：支持 --trace 参数，输出调用链路。
-
-### Layer 8: Models (models/)
-- **职责**：Pydantic 数据验证模型。
-- **要求**：必须带有完整类型注解。
-
-### Layer 9: Exceptions (exceptions/)
-- **职责**：统一异常定义。
-- **要求**：所有异常继承 VibeError。
+### Layer 6: Role Adapters (manager/, orchestra/, etc.)
+- **职责**：角色特定输入/输出处理、Prompt 渲染。
+- **要求**：薄层适配器，不复写执行框架。
 
 ---
 
 ## 依赖流向
 
 ```
-CLI → Commands → Services → Clients → Models
-                ↓
-                UI
+Server → Runtime → Domain → Execution → Environment
+                            ↓
+                      Role Adapters
 ```
 
 - **禁止反向依赖**：高层不依赖低层具体实现。
-- **Client 隔离**：只有 Client 层允许执行外部系统调用（subprocess/SQL）。
+- **唯一入口原则**：业务编排必经 Domain，执行启动必经 Execution。
 
 ---
 
@@ -111,16 +100,12 @@ CLI → Commands → Services → Clients → Models
 
 | 层级 | 目录 | 职责 | 允许调用 | 禁止调用 |
 |------|------|------|---------|---------|
-| CLI | cli.py | 参数解析 | Commands, Models, UI | Services, Clients |
-| Commands | commands/ | 参数验证 | Services, Models, UI | Clients |
-| Services | services/ | 业务逻辑 | Engine, Runtime, Clients, Models | Commands, UI |
-| Engine | engine/ | DAG 流程定义 | Runtime, Models | Commands, Services |
-| Runtime | runtime/ | 执行引擎 | Clients, Models, Observability | Commands, Services |
-| Clients | clients/ | 外部封装 | Models | Commands, Services |
-| Observability | observability/ | 日志追踪审计 | 无 | 所有层 |
-| Models | models/ | 数据模型 | 无 | 所有层 |
-| Exceptions | exceptions/ | 异常定义 | 无 | 所有层 |
-| UI | ui/ | 输出展示 | Models | Services, Clients |
+| Server | server/ | 传输与驱动 | Runtime, Models | Domain, Execution |
+| Runtime | runtime/ | 调度与路由 | Domain, Models | Environment, Clients |
+| Domain | domain/ | 业务编排 | Execution, Models | Server, UI |
+| Execution | execution/ | 执行控制 | Environment, Role Adapters, Models | Server, UI |
+| Environment | environment/ | 资源原语 | Models | Domain, Execution |
+| Role Adapters | manager/ orchestra/ | 角色逻辑 | Models | Runtime, Server |
 
 ---
 


### PR DESCRIPTION
Align terminology and architecture models to current truth sources as requested in #572.
- Updated docs/standards/doc-quality-standards.md
- Updated docs/references/vibe-engine-design.md
- Updated docs/standards/doc-organization.md
- Updated docs/v3/infrastructure/02-architecture.md
- Updated docs/standards/v3/git-workflow-standard.md