### PR TITLE
feat(check): add progress indication for vibe3 check command

### DIFF
--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -81,6 +81,13 @@ def check(
             ),
         ),
     ] = False,
+    no_progress: Annotated[
+        bool,
+        typer.Option(
+            "--no-progress",
+            help="Disable progress bar for 'all' and 'fix_all' modes.",
+        ),
+    ] = False,
     trace: Annotated[
         bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
     ] = False,
@@ -125,7 +132,9 @@ def check(
         else:
             mode = "fix_all"
 
-        result = execute_check_mode(service, mode, verbose=trace)
+        result = execute_check_mode(
+            service, mode, verbose=trace, show_progress=not no_progress
+        )
 
         if result.success:
             typer.echo(f"✓ {result.summary}")

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 import typer
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+)
 
 from vibe3.services.check_remote import InitResult
 from vibe3.services.check_service import CheckResult, CheckService
@@ -21,6 +28,42 @@ class ExecuteCheckResult:
     details: dict = field(default_factory=dict)
 
 
+def _run_with_progress(
+    service: CheckService,
+    status: str | list[str],
+) -> list[CheckResult]:
+    """Run verify_all_flows with Rich Progress display.
+
+    Args:
+        service: CheckService instance.
+        status: Status filter for verify_all_flows.
+
+    Returns:
+        List of CheckResult objects.
+    """
+    results = []
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+    ) as progress:
+        task_id = progress.add_task("Checking flows", total=None)
+
+        def on_progress(current: int, total: int, branch: str) -> None:
+            if total > 0:
+                progress.update(
+                    task_id,
+                    total=total,
+                    advance=1,
+                    description=f"Checking {branch}",
+                )
+
+        results = service.verify_all_flows(status=status, on_progress=on_progress)
+
+    return results
+
+
 def execute_check_mode(
     service: CheckService,
     mode: Literal[
@@ -29,9 +72,18 @@ def execute_check_mode(
     *,
     branch: str | None = None,
     verbose: bool = False,
+    show_progress: bool = True,
 ) -> ExecuteCheckResult:
     """Run command-oriented check modes
-    using CheckService primitives."""
+    using CheckService primitives.
+
+    Args:
+        service: CheckService instance.
+        mode: Check mode to execute.
+        branch: Branch to check (for single-branch modes).
+        verbose: Enable verbose output.
+        show_progress: Show progress bar for 'all' and 'fix_all' modes.
+    """
     if mode == "init":
         init_result: InitResult = service.init_remote_index()
         summary = (
@@ -66,7 +118,11 @@ def execute_check_mode(
         )
 
     if mode == "all":
-        results = service.verify_all_flows(status="active")
+        if show_progress:
+            results = _run_with_progress(service, status="active")
+        else:
+            results = service.verify_all_flows(status="active")
+
         invalid = [r for r in results if not r.is_valid]
         return ExecuteCheckResult(
             mode="all",
@@ -80,7 +136,11 @@ def execute_check_mode(
         )
 
     if mode == "fix_all":
-        results = service.verify_all_flows(status=["active", "stale"])
+        if show_progress:
+            results = _run_with_progress(service, status=["active", "stale"])
+        else:
+            results = service.verify_all_flows(status=["active", "stale"])
+
         invalid_fix: list[CheckResult] = [r for r in results if not r.is_valid]
         if not invalid_fix:
             return ExecuteCheckResult(

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -41,7 +41,7 @@ def run_full_check_shortcut() -> None:
     from vibe3.services.check_service import CheckService
 
     try:
-        result = execute_check_mode(CheckService(), "fix_all")
+        result = execute_check_mode(CheckService(), "fix_all", show_progress=False)
     except Exception as exc:
         typer.echo(
             f"Warning: vibe3 check failed before status: {exc}",

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -499,9 +500,17 @@ class CheckService(CheckRemote):
         )
 
     def verify_all_flows(
-        self, status: str | list[str] | None = "active"
+        self,
+        status: str | list[str] | None = "active",
+        on_progress: Callable[[int, int, str], None] | None = None,
     ) -> list[CheckResult]:
-        """Run consistency checks for flows in the store."""
+        """Run consistency checks for flows in the store.
+
+        Args:
+            status: Filter flows by status(es). None checks all flows.
+            on_progress: Optional callback invoked after each branch check.
+                Receives (current_index, total_count, branch_name).
+        """
         # Initialize PR cache (optimization: 1 API call instead of N)
         self._initialize_pr_cache()
 
@@ -520,8 +529,11 @@ class CheckService(CheckRemote):
         ]
 
         results = []
-        for flow in all_flows:
+        total = len(all_flows)
+        for i, flow in enumerate(all_flows):
             results.append(self._check_branch(flow["branch"]))
+            if on_progress:
+                on_progress(i, total, flow["branch"])
         return results
 
     def auto_fix(self, issues: list[str], *, branch: str | None = None) -> FixResult:

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -252,7 +252,10 @@ class TestAutoFix:
             result = execute_check_mode(check_service, "fix_all")
 
         assert result.success
-        mock_verify.assert_called_once_with(status=["active", "stale"])
+        mock_verify.assert_called_once()
+        call_kwargs = mock_verify.call_args.kwargs
+        assert call_kwargs["status"] == ["active", "stale"]
+        assert "on_progress" in call_kwargs
 
     def test_auto_fix_creates_handoff_file(self, check_service, mock_git_client):
         """Test that auto_fix creates missing handoff file."""


### PR DESCRIPTION
## Summary
- Add Rich progress bar for `vibe3 check` when running `all` and `fix_all` modes
- Add `--no-progress` CLI option to disable progress bar
- Add `on_progress` callback to `CheckService.verify_all_flows()`
- Suppress progress bar in status dashboard (`vibe3 status --check`) to avoid UI clutter

## Implementation Details
- New helper function `_run_with_progress()` in `check_support.py` manages Rich Progress display
- Progress bar shows checking flow status with branch name updates
- Callback-based architecture allows future extensibility for other progress indicators

## Testing
- All existing tests pass (50 tests in test suite)
- Updated `test_check_merge_fix.py` to verify `on_progress` parameter behavior
- Manual testing confirms progress bar displays correctly for `vibe3 check --all` and `vibe3 check --fix-all`
- No regressions in `vibe3 status` output (progress bar correctly suppressed)

## Demo
```bash
# Progress bar enabled (default)
$ vibe3 check --all
⠋ Checking task/issue-526 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 3/3

# Progress bar disabled
$ vibe3 check --all --no-progress
✓ All 3 active flows passed
```

Closes #526

---

## Contributors

claude/opus
