### PR TITLE
fix(schema): add missing 'indicate_ref' field to SQLite schema

### DIFF
--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -19,6 +19,7 @@ class SQLiteFlowStateRepo:
         "plan_ref",
         "report_ref",
         "audit_ref",
+        "indicate_ref",
         "pr_ref",  # PR URL as proof of PR creation
         "planner_actor",
         "executor_actor",

--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -20,6 +20,7 @@ _CREATE_FLOW_STATE = """
         plan_ref TEXT,
         report_ref TEXT,
         audit_ref TEXT,
+        indicate_ref TEXT,
         pr_ref TEXT,
         planner_actor TEXT,
         executor_actor TEXT,
@@ -254,6 +255,13 @@ def init_schema(conn: sqlite3.Connection) -> None:
         cursor.execute("ALTER TABLE flow_state ADD COLUMN latest_indicate_action TEXT")
         logger.bind(external="sqlite", operation="migration").info(
             "Added latest_indicate_action column to flow_state"
+        )
+
+    # Migration: add indicate_ref column for indicate handoff tracking
+    if "indicate_ref" not in existing:
+        cursor.execute("ALTER TABLE flow_state ADD COLUMN indicate_ref TEXT")
+        logger.bind(external="sqlite", operation="migration").info(
+            "Added indicate_ref column to flow_state"
         )
 
     # Migration: migrate existing blocked_by data to new fields


### PR DESCRIPTION
Closes #564

## Summary

This PR fixes issue #564 by adding the missing `indicate_ref` field to the SQLite flow state schema.

**Changes:**
- Added `indicate_ref` to `VALID_FLOW_STATE_FIELDS` set in `sqlite_flow_state_repo.py`
- Added `indicate_ref TEXT` column to `flow_state` table DDL in `sqlite_schema.py`
- Added idempotent migration for existing databases

**Problem:**
The `vibe3 handoff indicate` command was failing because the `indicate_ref` field was not included in the field validation set or database schema.

**Solution:**
Following the established pattern used for other handoff ref fields (`spec_ref`, `plan_ref`, `report_ref`, `audit_ref`), this PR adds the missing `indicate_ref` field to both the validation whitelist and the database schema.

## Test plan
- [x] Pre-commit checks pass (black, ruff, mypy, shellcheck)
- [x] Pre-push checks pass (type check, tests, LOC limits)
- [x] All 135 tests pass
- [x] Migration is idempotent and safe for existing databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
