### PR TITLE
refactor: unify GitHub label system and remove status labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,11 +28,12 @@ scope/python:
   - changed-files:
     - any-glob-to-any-file: 'src/vibe3/**/*.py'
 
-scope/shell-script:
+scope/shell:
   - changed-files:
     - any-glob-to-any-file:
       - 'lib/**/*.sh'
       - 'scripts/**/*.sh'
+      - 'bin/**'
 
 scope/documentation:
   - changed-files:

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -118,6 +118,21 @@ jobs:
               labels: nextLabels,
             });
 
+      - name: Remove trigger label if skipped
+        if: steps.check-review.outputs.already_reviewed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const readyLabel = 'trigger/ai-review';
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const nextLabels = labels.filter(label => label !== readyLabel);
+            await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: nextLabels,
+            });
+
   # Copilot 代码审查 (用于 fix)
   copilot-review:
     needs: determine-strategy
@@ -134,7 +149,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check if review already requested
+        id: check-review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REVIEWS=$(gh pr view ${{ github.event.pull_request.number }} --json reviews --jq '.reviews[] | select(.user.login == "copilot")')
+          if [ -n "$REVIEWS" ]; then
+            echo "already_reviewed=true" >> $GITHUB_OUTPUT
+            echo "⚠️ Copilot review already requested, skipping"
+          else
+            echo "already_reviewed=false" >> $GITHUB_OUTPUT
+            echo "✅ No previous Copilot review found, will request"
+          fi
+
       - name: Request Copilot Review
+        if: steps.check-review.outputs.already_reviewed == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -148,6 +178,21 @@ jobs:
               reviewers: ['copilot']
             });
 
+            const nextLabels = labels.filter(label => label !== readyLabel);
+            await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: nextLabels,
+            });
+
+      - name: Remove trigger label if skipped
+        if: steps.check-review.outputs.already_reviewed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const readyLabel = 'trigger/ai-review';
+            const labels = context.payload.pull_request.labels.map(l => l.name);
             const nextLabels = labels.filter(label => label !== readyLabel);
             await github.rest.issues.setLabels({
               issue_number: context.issue.number,
@@ -173,6 +218,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const readyLabel = 'trigger/ai-review';
             const labels = context.payload.pull_request.labels.map(l => l.name);
             let changeType = '未知类型';
 
@@ -185,4 +231,13 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `📋 **此 PR 标记为 ${changeType} 变更**\n\n请手动决定是否需要测试：\n- 如果需要测试，请手动触发 CI 工作流\n- 如果不需要测试，请直接进行人工审查\n\n感谢您的贡献！ 🎉`
+            });
+
+            // Remove trigger label
+            const nextLabels = labels.filter(label => label !== readyLabel);
+            await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: nextLabels,
             });

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -70,7 +70,7 @@ jobs:
     needs: determine-strategy
     if: |
       needs.determine-strategy.outputs.review_type == 'codex' && (
-        github.event.label.name == 'status/ready-for-review' ||
+        github.event.label.name == 'trigger/ai-review' ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
@@ -86,10 +86,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
-          if echo "$LABELS" | grep -q "^status/ai-review-requested$"; then
+          COMMENTS=$(gh pr view ${{ github.event.pull_request.number }} --comments --json comments --jq '.comments[].body')
+          if echo "$COMMENTS" | grep -q "@codex review"; then
             echo "already_reviewed=true" >> $GITHUB_OUTPUT
-            echo "⚠️ AI review already requested, skipping"
+            echo "⚠️ Codex review already requested (found @codex review comment), skipping"
           else
             echo "already_reviewed=false" >> $GITHUB_OUTPUT
             echo "✅ No previous Codex review found, will request"
@@ -100,25 +100,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const requestedLabel = 'status/ai-review-requested';
-            const readyLabel = 'status/ready-for-review';
+            const readyLabel = 'trigger/ai-review';
             const labels = context.payload.pull_request.labels.map(l => l.name);
-
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: requestedLabel,
-              });
-            } catch (error) {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: requestedLabel,
-                color: '5319e7',
-                description: 'AI review already requested once',
-              });
-            }
 
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -128,9 +111,6 @@ jobs:
             });
 
             const nextLabels = labels.filter(label => label !== readyLabel);
-            if (!nextLabels.includes(requestedLabel)) {
-              nextLabels.push(requestedLabel);
-            }
             await github.rest.issues.setLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -143,7 +123,7 @@ jobs:
     needs: determine-strategy
     if: |
       needs.determine-strategy.outputs.review_type == 'copilot' && (
-        github.event.label.name == 'status/ready-for-review' ||
+        github.event.label.name == 'trigger/ai-review' ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
@@ -158,30 +138,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const requestedLabel = 'status/ai-review-requested';
-            const readyLabel = 'status/ready-for-review';
+            const readyLabel = 'trigger/ai-review';
             const labels = context.payload.pull_request.labels.map(l => l.name);
-
-            if (labels.includes(requestedLabel)) {
-              core.notice('AI review already requested once, skipping duplicate Copilot request.');
-              return;
-            }
-
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: requestedLabel,
-              });
-            } catch (error) {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: requestedLabel,
-                color: '5319e7',
-                description: 'AI review already requested once',
-              });
-            }
 
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
@@ -191,9 +149,6 @@ jobs:
             });
 
             const nextLabels = labels.filter(label => label !== readyLabel);
-            if (!nextLabels.includes(requestedLabel)) {
-              nextLabels.push(requestedLabel);
-            }
             await github.rest.issues.setLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -206,7 +161,7 @@ jobs:
     needs: determine-strategy
     if: |
       needs.determine-strategy.outputs.review_type == 'manual' && (
-        github.event.label.name == 'status/ready-for-review' ||
+        github.event.label.name == 'trigger/ai-review' ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest

--- a/config/models.json
+++ b/config/models.json
@@ -9,8 +9,8 @@
   },
   "agents": {
     "vibe-manager": {
-      "backend": "gemini",
-      "model": "gemini-3-flash-preview",
+      "backend": "claude",
+      "model": "sonnet",
       "yolo": true,
       "description": "Orchestra manager: dispatch coordination and execution supervision"
     },
@@ -32,14 +32,14 @@
       "description": "Code reviewer: quality assurance and best practices"
     },
     "vibe-supervisor": {
-      "backend": "gemini",
-      "model": "gemini-3-flash-preview",
+      "backend": "claude",
+      "model": "sonnet",
       "yolo": true,
       "description": "Governance supervisor: periodic scans and issue management"
     },
     "vibe-governance": {
       "backend": "claude",
-      "model": "sonnet",
+      "model": "haiku",
       "description": "Governance agent: policy enforcement and cleanup"
     },
     "code-explorer": {

--- a/docs/standards/github-labels-reference.md
+++ b/docs/standards/github-labels-reference.md
@@ -33,14 +33,22 @@
 | `type/test` | 测试 | `gh issue edit 123 --add-label "type/test"` |
 | `type/chore` | 杂项 | `gh issue edit 123 --add-label "type/chore"` |
 | `type/task` | 综合型任务 | `gh issue edit 123 --add-label "type/task"` |
+| `type/perf` | 性能优化 | `gh issue edit 123 --add-label "type/perf"` |
 
 #### 优先级标签 (priority/*)
 
 | 标签名称 | 描述 | 示例命令 |
 |---------|------|----------|
+| `priority/critical` | 紧急阻断性问题 | `gh issue edit 123 --add-label "priority/critical"` |
 | `priority/high` | 高优先级 | `gh issue edit 123 --add-label "priority/high"` |
 | `priority/medium` | 中优先级 | `gh issue edit 123 --add-label "priority/medium"` |
 | `priority/low` | 低优先级 | `gh issue edit 123 --add-label "priority/low"` |
+| `priority/0` ~ `priority/9` | 数值优先级（推荐） | `gh issue edit 123 --add-label "priority/7"` |
+
+**说明**：
+- 数值优先级（`priority/0-9`）为推荐格式，更精确
+- Legacy 文本优先级（`priority/critical/high/medium/low`）保持兼容
+- 数值越大优先级越高
 
 #### 范围标签 (scope/*)
 
@@ -64,7 +72,20 @@
 | `component/client` | Client 层 | `gh issue edit 123 --add-label "component/client"` |
 | `component/config` | 配置层 | `gh issue edit 123 --add-label "component/config"` |
 
-### 2.2 路线图标签 (roadmap/*)
+### 2.2 特殊用途标签
+
+| 标签名称 | 描述 | 使用场景 |
+|---------|------|----------|
+| `supervisor` | Supervisor-governed orchestration issue | 标记需要 Supervisor 治理的编排问题 |
+| `orchestra` | Orchestra scheduling and automation | 标记 Orchestra 调度和自动化相关 issue |
+| `tech-debt` | Technical debt tracking | 追踪技术债务和需要优化的代码 |
+| `improvement` | Non-urgent improvements | 非紧急的改进和增强项 |
+
+**说明**：
+- 这些标签用于特定的治理和追踪场景
+- 可以与 `type/*`、`scope/*` 等标签组合使用
+
+### 2.3 路线图标签 (roadmap/*)
 
 | 标签名称 | 描述 | 示例命令 |
 |---------|------|----------|
@@ -75,7 +96,7 @@
 | `roadmap/future` | 未来考虑 | `gh issue edit 123 --add-label "roadmap/future"` |
 | `roadmap/rfc` | RFC/设计阶段 | `gh issue edit 123 --add-label "roadmap/rfc"` |
 
-### 2.3 关系镜像标签
+### 2.4 关系镜像标签
 
 | 标签名称 | 描述 | 示例命令 |
 |---------|------|----------|
@@ -85,7 +106,7 @@
 - `vibe-task` 是 `vibe3 flow bind` 绑定的自动镜像（副作用）。
 - 它不是 Governance 判定的真源，仅用于 GitHub 视角过滤。
 
-### 2.4 编排状态标签 (state/*)
+### 2.5 编排状态标签 (state/*)
 
 | 标签名称 | 含义 | 示例命令 |
 |---------|------|----------|
@@ -101,6 +122,28 @@
 **说明**：
 - `state/*` 标签是执行状态的**可选镜像**，不是执行态主真源。
 - `assignee issue` 的真实执行状态优先以 flow 状态与 orchestration scene 为准。
+
+### 2.6 触发器标签 (trigger/*)
+
+| 标签名称 | 描述 | 使用场景 |
+|---------|------|----------|
+| `trigger/ai-review` | 触发 AI PR 审查流程 | 开发者完成 PR 后手动添加，触发自动审查 |
+
+**说明**：
+- Trigger 标签是**一次性触发器**，由开发者手动添加
+- Workflow 完成后会自动移除 trigger 标签
+- 用于触发自动化流程，不作为长期状态标记
+
+**使用流程**：
+1. 开发者完成 PR，添加 `trigger/ai-review` 标签
+2. 触发 `ai-pr-review.yml` workflow
+3. Workflow 发送 AI 审查请求（`@codex review` 或 `@copilot review`）
+4. Workflow 自动移除 `trigger/ai-review` 标签
+5. 后续再次添加标签时，workflow 会检查 PR comments 防止重复请求
+
+**防重复机制**：
+- Workflow 检查 PR comments 是否已有 `@codex review`
+- 已发送过审查请求的 PR 不会重复触发
 
 ---
 
@@ -151,16 +194,37 @@ gh issue edit 123 --milestone "Phase 1: 基础设施"
 gh issue list --milestone "Phase 1: 基础设施"
 ```
 
+### 3.4 标签同步
+
+**自动同步标准标签**：
+
+```bash
+# 同步所有标准标签到 repo（幂等，不删除现有标签）
+./scripts/sync-labels.sh
+```
+
+**脚本特性**：
+- ✅ **幂等性**：可以重复运行，不会重复创建
+- ✅ **非破坏性**：只创建/更新标签，从不删除
+- ✅ **自动更新**：更新已存在标签的描述和颜色
+- ✅ **保留默认**：保留 GitHub 默认标签（bug、documentation、enhancement、question）
+
 ---
 
 ## 4. 标签组合速查表
 
 | 场景 | 推荐标签组合 |
 |------|-------------|
-| 高优先级功能开发 | `type/feature` + `priority/high` + `roadmap/p0` |
-| 中优先级 bug 修复 | `type/fix` + `priority/medium` + `roadmap/p1` |
-| 低优先级文档更新 | `type/docs` + `priority/low` + `roadmap/p2` |
+| 高优先级功能开发 | `type/feature` + `priority/9` + `roadmap/p0` |
+| 中优先级 bug 修复 | `type/fix` + `priority/5` + `roadmap/p1` |
+| 低优先级文档更新 | `type/docs` + `priority/3` + `roadmap/p2` |
 | 需要讨论的设计 | `type/feature` + `roadmap/rfc` |
+| 性能优化 | `type/perf` + `priority/7` + `roadmap/p0` |
+| 技术债务清理 | `tech-debt` + `priority/5` + `roadmap/p1` |
+| 编排系统改进 | `orchestra` + `type/feature` + `roadmap/p1` |
+| Supervisor 治理问题 | `supervisor` + `priority/7` + `roadmap/p0` |
+| 非紧急改进 | `improvement` + `priority/3` + `roadmap/p2` |
+| 完成 PR 需要AI审查 | `trigger/ai-review`（手动添加，workflow自动移除） |
 | 正在执行的任务 | `vibe-task`（flow bind 自动镜像）+ `state/in-progress`（可选） |
 | 被阻塞的任务 | `vibe-task`（flow bind 自动镜像）+ `state/blocked`（可选） |
 | 待 review 的任务 | `vibe-task`（flow bind 自动镜像）+ `state/review`（可选） |

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -126,24 +126,27 @@ gh issue edit <issue_number> --add-label "priority/3"
 **Legacy Priority (兼容支持)**:
 
 ```bash
-# 高优先级 - 核心功能、关键 bug 修复
+# 紧急阻断性问题 - 等同于 priority/9
+gh issue edit <issue_number> --add-label "priority/critical"
+
+# 高优先级 - 核心功能、关键 bug 修复，等同于 priority/7
 gh issue edit <issue_number> --add-label "priority/high"
 
-# 中优先级 - 重要但非紧急的功能
+# 中优先级 - 重要但非紧急的功能，等同于 priority/5
 gh issue edit <issue_number> --add-label "priority/medium"
 
-# 低优先级 - 优化、改进等非关键任务
+# 低优先级 - 优化、改进等非关键任务，等同于 priority/3
 gh issue edit <issue_number> --add-label "priority/low"
-
-# 紧急问题 - 等同于 priority/9
-gh issue edit <issue_number> --add-label "priority/critical"
 ```
 
-**Legacy 标签映射**:
-- `priority/critical` → 等同于 `priority/9`
-- `priority/high` → 等同于 `priority/7`
-- `priority/medium` → 等同于 `priority/5`
-- `priority/low` → 等同于 `priority/3`
+**优先级映射表**:
+
+| Legacy 标签 | 映射到 Numeric | 说明 |
+|-------------|---------------|------|
+| `priority/critical` | `priority/9` | 紧急阻断性问题、系统崩溃 |
+| `priority/high` | `priority/7` | 核心功能、关键 bug 修复 |
+| `priority/medium` | `priority/5` | 重要但非紧急的功能 |
+| `priority/low` | `priority/3` | 优化、改进等非关键任务 |
 
 **决策标准**:
 - 9: 紧急阻断性问题、系统崩溃、核心功能失效
@@ -296,10 +299,14 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 | 优先级 | 使用场景 | 示例 |
 |--------|----------|------|
 | `priority/9` | 紧急阻断性问题、系统崩溃、核心功能失效 | 支付功能失效、数据库损坏 |
-| `priority/7-8` | 核心功能、关键 bug 修复、影响大量用户 | 登录失败、性能严重下降 |
-| `priority/5-6` | 重要但非紧急的功能 | 性能优化、用户体验改进 |
-| `priority/3-4` | 一般功能、改进项 | 代码清理、小优化 |
-| `priority/1-2` | 低优先级改进 | 次要文档完善、边缘 case 处理 |
+| `priority/8` | 极高优先级、重要功能阻断 | 关键 API 失效 |
+| `priority/7` | 核心功能、关键 bug 修复、影响大量用户 | 登录失败、性能严重下降 |
+| `priority/6` | 重要功能改进、影响部分用户 | 功能缺失、用户体验问题 |
+| `priority/5` | 重要但非紧急的功能 | 性能优化、用户体验改进 |
+| `priority/4` | 一般功能改进 | 功能增强、小改进 |
+| `priority/3` | 一般功能、改进项 | 代码清理、小优化 |
+| `priority/2` | 低优先级改进 | 次要改进 |
+| `priority/1` | 最低优先级改进 | nice-to-have |
 | `priority/0` | 默认优先级（无标签） | - |
 
 **Legacy Priority (兼容支持)**:
@@ -440,31 +447,162 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 
 ---
 
-## 8. 最佳实践
+## 8. 特殊用途标签
 
-### 8.1 定期审查
+### 8.1 治理与编排标签
+
+除了常规的 roadmap、priority、type 标签，项目还使用以下特殊用途标签：
+
+#### supervisor 标签
+
+**用途**：标记需要 Supervisor 治理的编排问题
+
+**使用场景**：
+- Supervisor 层的架构决策
+- 治理流程改进
+- Policy/rules 变更
+- 编排系统的治理级问题
+
+**示例**：
+```bash
+# 标记 Supervisor 治理问题
+gh issue edit 123 --add-label "supervisor" --add-label "priority/7" --add-label "roadmap/p0"
+```
+
+#### orchestra 标签
+
+**用途**：标记 Orchestra 谘度和自动化相关 issue
+
+**使用场景**：
+- Orchestra 谘度逻辑改进
+- 分诊和 dispatch 机制
+- Queue ordering 优化
+- 自动化流程改进
+
+**示例**：
+```bash
+# 标记 Orchestra 谘度问题
+gh issue edit 124 --add-label "orchestra" --add-label "type/feature" --add-label "roadmap/p1"
+```
+
+#### tech-debt 标签
+
+**用途**：追踪技术债务和需要优化的代码
+
+**使用场景**：
+- 代码重构需求
+- 架构优化
+- 依赖更新
+- 代码质量问题
+
+**示例**：
+```bash
+# 标记技术债务
+gh issue edit 125 --add-label "tech-debt" --add-label "priority/5" --add-label "roadmap/p1"
+```
+
+#### improvement 标签
+
+**用途**：标记非紧急的改进和增强项
+
+**使用场景**：
+- 用户体验改进
+- 边缘 case 处理
+- 小功能增强
+- 非阻断性改进
+
+**示例**：
+```bash
+# 标记非紧急改进
+gh issue edit 126 --add-label "improvement" --add-label "priority/3" --add-label "roadmap/p2"
+```
+
+### 8.2 触发器标签 (trigger/*)
+
+**用途**：触发自动化工作流
+
+**与常规标签的区别**：
+- 常规标签：长期状态标记，手动添加/移除
+- 触发器标签：一次性触发器，workflow 自动移除
+
+#### trigger/ai-review 标签
+
+**用途**：触发 AI PR 审查流程
+
+**使用场景**：
+- 开发者完成 PR 后手动添加
+- 触发 Codex/Copilot 自动审查
+- Workflow 完成后自动移除
+
+**工作流程**：
+1. 开发者添加 `trigger/ai-review` 标签
+2. 触发 `.github/workflows/ai-pr-review.yml`
+3. Workflow 发送审查请求（`@codex review` 或 `@copilot review`）
+4. Workflow 移除 `trigger/ai-review`
+5. Workflow 检查 PR comments 防止重复请求（无需额外标签）
+
+**示例**：
+```bash
+# 完成 PR 后触发 AI 审查
+gh pr edit <pr_number> --add-label "trigger/ai-review"
+# Workflow 会自动移除此标签
+```
+
+**防重复机制**：
+- Workflow 直接检查 PR comments 是否已有 `@codex review`
+- 不需要额外的辅助标签
+- 利用 GitHub 现有数据（comments）而非创建新标签
+
+### 8.3 与常规标签的关系
+
+**组合使用原则**：
+- 特殊用途标签可以与 `type/*`、`scope/*`、`roadmap/*`、`priority/*` 组合
+- `supervisor` 和 `orchestra` 通常配合 `roadmap/p0` 或 `roadmap/p1`
+- `tech-debt` 和 `improvement` 通常配合 `roadmap/p1` 或 `roadmap/p2`
+
+**标签层级**：
+```
+特殊用途标签 (治理维度)
+    ↓
+roadmap/* (何时做)
+    ↓
+priority/* (多紧急)
+    ↓
+type/* (做什么)
+    ↓
+scope/* (影响范围)
+```
+
+---
+
+## 9. 最佳实践
+
+### 9.1 定期审查
 
 - **每周**: 审查 `roadmap/p0` issues，确保按计划推进
 - **每月**: 审查 `roadmap/p1` 和 `roadmap/p2` issues，调整优先级
 - **每季度**: 审查 `roadmap/future` issues，评估是否纳入规划
+- **定期**: 审查 `tech-debt` 和 `improvement` issues，评估是否需要提升优先级
 
-### 8.2 标签维护
+### 9.2 标签维护
 
 - 保持标签的准确性和时效性
 - 及时更新已完成 issues 的状态
 - 定期清理过时标签
+- 检查特殊用途标签（`supervisor`、`orchestra`、`tech-debt`、`improvement`）是否准确
 
-### 8.3 沟通协作
+### 9.3 沟通协作
 
 - 在 issue 中说明标签变更的原因
 - 使用 handoff 记录标签变更的上下文
 - 与团队成员共享 roadmap 状态
+- 特殊用途标签的变更需要团队讨论
 
 ---
 
-## 9. 故障处理
+## 10. 故障处理
 
-### 9.1 标签冲突
+### 10.1 标签冲突
 
 当发现标签冲突时：
 
@@ -473,7 +611,7 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 3. 添加正确的标签
 4. 记录变更原因
 
-### 9.2 状态不一致
+### 10.2 状态不一致
 
 当发现本地状态与 GitHub 标签不一致时：
 
@@ -481,7 +619,7 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 2. 更新本地状态
 3. 检查同步机制
 
-### 9.3 查询失败
+### 10.3 查询失败
 
 当查询命令失败时：
 
@@ -489,9 +627,18 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 2. 验证 GitHub CLI 配置
 3. 使用备选查询方式
 
+### 10.4 特殊用途标签误用
+
+当发现特殊用途标签误用时：
+
+1. 确认 issue 的实际性质
+2. 移除不合适的特殊标签（`supervisor`、`orchestra` 等）
+3. 添加合适的 `type/*` 和 `scope/*` 标签
+4. 在 issue comment 中说明变更原因
+
 ---
 
-## 10. 参考文档
+## 11. 参考文档
 
 - [github-labels-reference.md](github-labels-reference.md) - 标签速查手册（有哪些标签）
 - [github-labels-standard.md](github-labels-standard.md) - 标签语义和真源标准

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Sync repository labels to project standards
+# Idempotent: creates missing labels, updates existing labels' description/color
+# Non-destructive: never deletes labels
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== Label Sync Script ===${NC}"
+echo "Ensuring all standard labels exist with correct descriptions and colors"
+echo "Mode: Idempotent, non-destructive (no deletion)"
+echo ""
+
+# Check if gh CLI is available
+if ! command -v gh &> /dev/null; then
+    echo -e "${RED}Error: gh CLI not found${NC}"
+    echo "Please install GitHub CLI: https://cli.github.com/"
+    exit 1
+fi
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}Error: jq not found${NC}"
+    echo "Please install jq: https://stedolan.github.io/jq/"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Pre-flight checks passed${NC}"
+echo ""
+
+# Function to create or update label (idempotent)
+sync_label() {
+    local name="$1"
+    local description="$2"
+    local color="$3"
+
+    # Try to create label, if exists, update it (--force)
+    if gh label create "$name" --description "$description" --color "$color" --force 2>/dev/null; then
+        echo -e "${GREEN}✓${NC} $name"
+    else
+        echo -e "${YELLOW}⚠${NC} $name (synced)"
+    fi
+}
+
+echo -e "${BLUE}=== Type Labels ===${NC}"
+sync_label "type/feature" "新功能开发" "0075CA"
+sync_label "type/fix" "Bug 修复" "D73A4A"
+sync_label "type/refactor" "代码重构" "E99695"
+sync_label "type/docs" "文档更新" "0075CA"
+sync_label "type/test" "测试相关" "FBCA04"
+sync_label "type/chore" "杂项改动" "C2E0C6"
+sync_label "type/task" "综合性任务（包含多种类型改动）" "D4C5F9"
+sync_label "type/perf" "性能优化" "FF9900"
+
+echo ""
+echo -e "${BLUE}=== Priority Labels (Numeric) ===${NC}"
+sync_label "priority/0" "默认优先级（无标签时）" "DDDDDD"
+sync_label "priority/1" "最低优先级改进（nice-to-have）" "C2E0C6"
+sync_label "priority/2" "低优先级改进（nice-to-have）" "BFD4B8"
+sync_label "priority/3" "一般功能、改进项（等同于 priority/low）" "9FD4AD"
+sync_label "priority/4" "一般功能、改进项" "7ED196"
+sync_label "priority/5" "重要但非紧急的功能（等同于 priority/medium）" "E3F286"
+sync_label "priority/6" "重要但非紧急的功能" "F2E786"
+sync_label "priority/7" "核心功能、关键 bug 修复（等同于 priority/high）" "F2B686"
+sync_label "priority/8" "极高优先级、重要功能阻断" "F29986"
+sync_label "priority/9" "紧急阻断性问题、系统崩溃（等同于 priority/critical）" "D73A4A"
+
+echo ""
+echo -e "${BLUE}=== Priority Labels (Legacy) ===${NC}"
+sync_label "priority/critical" "紧急阻断性问题（等同于 priority/9）" "D73A4A"
+sync_label "priority/high" "高优先级（等同于 priority/7）" "F2B686"
+sync_label "priority/medium" "中等优先级（等同于 priority/5）" "E3F286"
+sync_label "priority/low" "低优先级（等同于 priority/3）" "9FD4AD"
+
+echo ""
+echo -e "${BLUE}=== Roadmap Labels ===${NC}"
+sync_label "roadmap/p0" "当前迭代必须完成" "FF0000"
+sync_label "roadmap/p1" "下个迭代优先完成" "FF6600"
+sync_label "roadmap/p2" "有容量时完成" "FFCC00"
+sync_label "roadmap/next" "下个迭代规划中" "99CCFF"
+sync_label "roadmap/future" "未来考虑" "CCCCFF"
+sync_label "roadmap/rfc" "RFC/设计阶段" "CC99FF"
+
+echo ""
+echo -e "${BLUE}=== Scope Labels ===${NC}"
+sync_label "scope/python" "Python 代码改动" "0075CA"
+sync_label "scope/shell" "Shell 层改动" "E99695"
+sync_label "scope/documentation" "文档改动" "0075CA"
+sync_label "scope/infrastructure" "基础设施改动" "D4C5F9"
+sync_label "scope/skill" "Skill 层改动" "FBCA04"
+sync_label "scope/supervisor" "Supervisor 层改动" "9933FF"
+
+echo ""
+echo -e "${BLUE}=== Component Labels ===${NC}"
+sync_label "component/cli" "CLI 入口" "0075CA"
+sync_label "component/client" "Client 封装" "E99695"
+sync_label "component/config" "配置管理" "FBCA04"
+sync_label "component/flow" "Flow 管理" "C2E0C6"
+sync_label "component/logger" "Logger 模块" "D4C5F9"
+sync_label "component/orchestra" "Orchestra 谘度和自动化" "FF9933"
+sync_label "component/pr" "PR 管理" "7057FF"
+sync_label "component/task" "Task 管理" "5319E7"
+
+echo ""
+echo -e "${BLUE}=== State Labels (Orchestration) ===${NC}"
+sync_label "state/ready" "Ready for manager dispatch" "EEEEEE"
+sync_label "state/claimed" "已认领，待进入执行" "BFDADC"
+sync_label "state/in-progress" "执行中" "0052CC"
+sync_label "state/blocked" "阻塞中" "D73A4A"
+sync_label "state/handoff" "待交接" "FBCA04"
+sync_label "state/review" "待 review" "5319E7"
+sync_label "state/merge-ready" "已满足合并条件" "0E8A16"
+sync_label "state/done" "已完成" "0E8A16"
+sync_label "state/failed" "Execution failed and needs recovery" "B60205"
+
+echo ""
+echo -e "${BLUE}=== Trigger Labels ===${NC}"
+sync_label "trigger/ai-review" "触发 AI PR 审查流程（一次性触发器）" "FF9933"
+
+echo ""
+echo -e "${BLUE}=== Special Purpose Labels ===${NC}"
+sync_label "supervisor" "Supervisor-governed orchestration issue" "9933FF"
+sync_label "orchestra" "Orchestra scheduling and automation" "FF9933"
+sync_label "tech-debt" "Technical debt tracking" "CC6666"
+sync_label "improvement" "Non-urgent improvements and enhancements" "66CC99"
+sync_label "breaking-change" "破坏性变更" "B60205"
+
+echo ""
+echo -e "${BLUE}=== Mirror Labels ===${NC}"
+sync_label "vibe-task" "Track issues intended for vibe roadmap/task intake" "5319E7"
+
+echo ""
+echo -e "${BLUE}=== GitHub Default Labels (Keep if exists) ===${NC}"
+# These are GitHub default labels, we don't create them but check if they exist
+for label in "bug" "documentation" "enhancement" "question"; do
+    if gh label list --json name | jq -e ".[] | select(.name == \"$label\")" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} $label (GitHub default, preserved)"
+    else
+        echo -e "${BLUE}○${NC} $label (not present, skipped)"
+    fi
+done
+
+echo ""
+echo -e "${GREEN}=== Label Sync Complete ===${NC}"
+echo ""
+echo "Summary:"
+echo "  - All standard labels synced (created or updated)"
+echo "  - Existing labels preserved (no deletion)"
+echo "  - GitHub default labels preserved if present"
+echo ""
+echo "Total labels in repo:"
+gh label list --limit 100 --json name | jq 'length'
+echo ""
+echo -e "${GREEN}✓ Done${NC}"

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -34,6 +34,9 @@ fi
 echo -e "${GREEN}✓ Pre-flight checks passed${NC}"
 echo ""
 
+# Track sync failures
+FAILURES=0
+
 # Function to create or update label (idempotent)
 sync_label() {
     local name="$1"
@@ -44,7 +47,8 @@ sync_label() {
     if gh label create "$name" --description "$description" --color "$color" --force 2>/dev/null; then
         echo -e "${GREEN}✓${NC} $name"
     else
-        echo -e "${YELLOW}⚠${NC} $name (synced)"
+        echo -e "${RED}✗${NC} $name (FAILED)"
+        FAILURES=$((FAILURES + 1))
     fi
 }
 
@@ -157,4 +161,11 @@ echo ""
 echo "Total labels in repo:"
 gh label list --limit 100 --json name | jq 'length'
 echo ""
-echo -e "${GREEN}✓ Done${NC}"
+
+# Report failures and exit with appropriate code
+if [ $FAILURES -gt 0 ]; then
+    echo -e "${RED}✗ Failed to sync $FAILURES label(s)${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✓ All labels synced successfully${NC}"
+fi

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -210,7 +210,6 @@ Steps:
 1. 读取当前 running issues 与 queue / flow 现场
 2. **依赖过滤**：从候选中排除不可进入 ready queue 的 issue：
    - 检查 issue body 和 comments 中的依赖引用（如 "Depends on #123"）
-   - 检查 `dependency/*` labels
    - 若被依赖的 issue 未关闭或未处于 `state/done`，从候选中排除
    - 已有有效 flow / live dispatch 的 issue，从候选中排除
    - 被硬规则阻塞的 issue，从候选中排除

--- a/supervisor/issue-cleanup.md
+++ b/supervisor/issue-cleanup.md
@@ -92,11 +92,6 @@
 - `Report`
 - `Why`
 
-## Label Rule
-
-- 默认只使用非破坏性治理标签，例如 `cleanup/candidate`
-- 如果仓库没有该标签，可先建议而不是臆造更多动作
-- 不要移除 `state/*`，除非上下文明显要求
 
 ## Polluted Scene Rule
 
@@ -119,3 +114,24 @@
   - 先执行查重，确认不会重复发布
   - 再使用 `gh issue create` 创建治理 issue
   - 输出每条 issue 的 title、labels、创建结果或跳过原因
+
+## Cleanup Action Rule
+
+**确定性判断**：
+- 如果通过现场核查（flow state、worktree 状态、git 历史、issue 内容）可以明确判断为陈旧/污染现场
+- **直接关闭 issue**，不需要任何标签或中间步骤
+
+**不确定性判断**：
+- 如果需要人工复核或现场证据不足
+- **在 issue 中添加 governance suggest comment**，建议人类关闭或进一步核查
+- Comment 格式：`[governance suggest] 建议 close 或进一步核查，理由：...`
+
+**禁止行为**：
+- ❌ 不使用 `cleanup/candidate` 或任何其他 cleanup 相关标签
+- ❌ 不创建治理 issue 来处理可以直接关闭的陈旧 issue
+- ❌ 不保留明显污染的现场继续承担新语义
+
+**原则**：
+- 确定性优先：宁可直接关闭，也不要通过标签或治理 issue 延长不确定状态
+- 证据为王：基于现场事实（flow state、worktree、git）而非猜测
+- 简单直接：能用关闭解决的不创建治理 issue，能用建议解决的不等待确认

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -335,7 +335,6 @@ Steps:
 
 4.5. **依赖检查**：检查 Issue 是否有未解决的依赖：
    - 检查 issue body 和 comments 中引用的其他 issue（如 "Depends on #123"、"blocked by #456"）
-   - 检查 issue labels 中是否有依赖标记（如 `dependency/*`）
    - 对每个被依赖的 issue，检查其状态是否已关闭或处于 `state/done`
    - 如果存在未解除的依赖：
      - comment 当前 issue，列出未解除的依赖项


### PR DESCRIPTION
## Summary

统一 GitHub 标签系统，移除 status 标签类别，改用 trigger 标签触发自动化流程。

### 主要变更

1. **标签系统重构**
   - 移除 `status/ai-review-requested` 标签
   - 新增 `trigger/ai-review` 触发器标签
   - 新增数值优先级标签 `priority/0-9`
   - 新增特殊用途标签：`supervisor`、`orchestra`、`tech-debt`、`improvement`
   - 新增 `type/perf` 性能优化标签

2. **自动化改进**
   - 创建 `scripts/sync-labels.sh` 幂等标签同步脚本
   - 更新 `ai-pr-review.yml` workflow，改用 comment 检查防重复
   - 简化 labeler.yml 配置，统一 shell 脚本范围

3. **文档更新**
   - 更新 `github-labels-reference.md` 标签速查手册
   - 更新 `roadmap-label-management.md` 标签管理指南
   - 更新 supervisor 文档，移除 dependency label 检查
   - 简化 issue-cleanup 规则，改用直接关闭或建议 comment

4. **Agent 配置调整**
   - `vibe-manager` 和 `vibe-supervisor` 改用 Claude Sonnet
   - `vibe-governance` 改用 Claude Haiku

### 设计原则

- **确定性优先**：基于现场事实（flow state、worktree、git）而非猜测
- **简单直接**：能用关闭解决的不创建治理 issue
- **幂等性**：标签同步脚本可重复运行，不破坏现有标签
- **防重复**：利用 GitHub comments 数据而非创建辅助标签

## Test plan

- [ ] 验证 `scripts/sync-labels.sh` 能正确创建所有标签
- [ ] 验证标签同步脚本幂等性（重复运行不报错）
- [ ] 测试 `trigger/ai-review` workflow 能正确触发
- [ ] 验证 workflow 防重复机制（检查 PR comments）
- [ ] 验证 labeler.yml 新的 shell scope 能正确匹配文件
- [ ] 验证 supervisor 文档更新后的流程正确性

🤖 Generated with [Claude Code](https://claude.com/claude-code)