### PR TITLE
fix(runtime): prevent cross-agent worktree branch hijacking

### DIFF
--- a/src/vibe3/clients/sqlite_session_repo.py
+++ b/src/vibe3/clients/sqlite_session_repo.py
@@ -176,3 +176,33 @@ class SQLiteSessionRepo:
                     except (ValueError, TypeError):
                         pass
         return result
+
+    def get_worktree_owner_session(self, worktree_path: str) -> dict[str, Any] | None:
+        """Return the most recent live session owning this worktree.
+
+        Queries runtime_session for sessions with matching worktree_path
+        and status in ('starting', 'running'), ordered by updated_at DESC.
+
+        Args:
+            worktree_path: Absolute path to the worktree directory.
+
+        Returns:
+            Session dict if a live owner exists, None otherwise.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT * FROM runtime_session
+                WHERE worktree_path = ?
+                  AND status IN ('starting', 'running')
+                ORDER BY updated_at DESC
+                LIMIT 1
+                """,
+                (worktree_path,),
+            )
+            row = cursor.fetchone()
+            if row:
+                return dict(row)
+            return None

--- a/src/vibe3/commands/flow.py
+++ b/src/vibe3/commands/flow.py
@@ -12,6 +12,10 @@ from vibe3.commands.flow_lifecycle import blocked
 from vibe3.commands.flow_status import show, status
 from vibe3.services.flow_service import FlowService
 from vibe3.services.task_service import TaskService
+from vibe3.services.worktree_ownership_guard import (
+    WorktreeOwnerMismatchError,
+    ensure_worktree_ownership,
+)
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui import render_flow_created
 
@@ -135,6 +139,21 @@ def update(
         if not branch:
             branch = flow_service.get_current_branch()
 
+        # Verify worktree ownership before modifying flow state
+        try:
+            from vibe3.utils.path_helpers import find_worktree_path_for_branch
+
+            wt_path = find_worktree_path_for_branch(branch)
+            if wt_path:
+                ensure_worktree_ownership(flow_service.store, str(wt_path))
+        except (ImportError, ValueError):
+            # find_worktree_path_for_branch may fail for branches without worktrees
+            # In such cases, skip ownership check (legacy behavior)
+            pass
+        except WorktreeOwnerMismatchError as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1) from e
+
         # Register/Ensure flow
         flow = flow_service.ensure_flow_for_branch(branch=branch, slug=name)
 
@@ -208,6 +227,21 @@ def bind(
             flow_service = FlowService()
             task_service = TaskService()
             target_branch = _resolve_bind_branch(flow_service, branch)
+
+            # Verify worktree ownership before binding issues
+            try:
+                from vibe3.utils.path_helpers import find_worktree_path_for_branch
+
+                wt_path = find_worktree_path_for_branch(target_branch)
+                if wt_path:
+                    ensure_worktree_ownership(flow_service.store, str(wt_path))
+            except (ImportError, ValueError):
+                # find_worktree_path_for_branch may fail for branches without worktrees
+                # In such cases, skip ownership check (legacy behavior)
+                pass
+            except WorktreeOwnerMismatchError as e:
+                typer.echo(f"Error: {e}", err=True)
+                raise typer.Exit(1) from e
 
             links = []
             for ref in refs:

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -146,6 +146,13 @@ def resume(
         ),
     ] = None,
     reason: Annotated[str, typer.Option("--reason", help="Reason for resume")] = "",
+    takeover: Annotated[
+        bool,
+        typer.Option(
+            "--takeover",
+            help="Explicitly take over worktree ownership from another session",
+        ),
+    ] = False,
     yes: Annotated[
         bool, typer.Option("--yes", "-y", help="Execute the resume (default dry-run)")
     ] = False,
@@ -324,6 +331,7 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
+            allow_takeover=takeover,
             progress_callback=progress_callback if yes else None,
         )
     else:
@@ -336,6 +344,7 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
+            allow_takeover=takeover,
             progress_callback=progress_callback if yes else None,
         )
 

--- a/src/vibe3/services/check_ownership_service.py
+++ b/src/vibe3/services/check_ownership_service.py
@@ -1,0 +1,89 @@
+"""Worktree ownership checking for flow consistency verification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
+
+
+def check_worktree_ownership(
+    store: "SQLiteClient",
+    branch: str,
+    flow_status: str,
+    inactive_flow_statuses: tuple[str, ...],
+) -> list[str]:
+    """Check worktree ownership consistency for a branch.
+
+    Args:
+        store: SQLite client instance.
+        branch: Branch name to check.
+        flow_status: Current flow status.
+        inactive_flow_statuses: Tuple of inactive flow statuses to skip.
+
+    Returns:
+        List of ownership-related issues found.
+    """
+    if flow_status in inactive_flow_statuses:
+        return []  # Skip inactive flows
+
+    from vibe3.services.worktree_ownership_guard import (
+        get_current_session_id,
+        get_worktree_owner,
+    )
+    from vibe3.utils.path_helpers import find_worktree_path_for_branch
+
+    try:
+        worktree_path = find_worktree_path_for_branch(branch)
+        if worktree_path is None:
+            return []  # No worktree, skip ownership check
+
+        owner_session = get_worktree_owner(store, str(worktree_path))
+        if owner_session is None:
+            # Unowned worktree with active flow
+            # This could indicate a new flow that hasn't registered ownership yet
+            # or a flow created outside of the standard dispatch path
+            return [
+                f"Worktree for branch '{branch}' has no registered owner session. "
+                "This may indicate a flow created outside standard dispatch. "
+                "If intentional, no action needed. Otherwise, investigate session "
+                "registration."
+            ]
+
+        # Check if owner session is still live
+        owner_tmux_session = owner_session.get("tmux_session")
+        if not owner_tmux_session:
+            return []  # Owner session has no tmux_session field (legacy)
+
+        # Check tmux liveness
+        from vibe3.agents.backends.async_launcher import has_tmux_session
+
+        if not has_tmux_session(owner_tmux_session):
+            # Orphaned ownership: session died but worktree still claimed
+            return [
+                f"ORPHANED_OWNERSHIP: Worktree for branch '{branch}' is claimed "
+                f"by dead session '{owner_tmux_session}'. "
+                "Use 'vibe3 task resume --takeover' to take over ownership, "
+                "or manually investigate if the session should still be active."
+            ]
+
+        # Check if current session matches owner (only if in tmux)
+        current_session_id = get_current_session_id()
+        if current_session_id and current_session_id != owner_tmux_session:
+            # Session mismatch: different session trying to use the worktree
+            return [
+                f"Session mismatch: Worktree for branch '{branch}' is owned by "
+                f"session '{owner_tmux_session}', but current session is "
+                f"'{current_session_id}'. "
+                "Use 'vibe3 task resume --takeover' to take over if authorized."
+            ]
+
+        return []  # Ownership is consistent
+    except Exception as exc:
+        logger.bind(domain="check", branch=branch).debug(
+            f"Could not verify worktree ownership: {exc}"
+        )
+        return []  # Skip on errors (non-critical check)

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -124,77 +124,6 @@ class CheckService(CheckRemote):
         except Exception:
             return None
 
-    def _check_worktree_ownership(self, branch: str, flow_status: str) -> list[str]:
-        """Check worktree ownership consistency for a branch.
-
-        Args:
-            branch: Branch name to check.
-            flow_status: Current flow status.
-
-        Returns:
-            List of ownership-related issues found.
-        """
-        if flow_status in self.INACTIVE_FLOW_STATUSES:
-            return []  # Skip inactive flows
-
-        from vibe3.services.worktree_ownership_guard import (
-            get_current_session_id,
-            get_worktree_owner,
-        )
-        from vibe3.utils.path_helpers import find_worktree_path_for_branch
-
-        try:
-            worktree_path = find_worktree_path_for_branch(branch)
-            if worktree_path is None:
-                return []  # No worktree, skip ownership check
-
-            owner_session = get_worktree_owner(self.store, str(worktree_path))
-            if owner_session is None:
-                # Unowned worktree with active flow
-                # This could indicate a new flow that hasn't registered ownership yet
-                # or a flow created outside of the standard dispatch path
-                return [
-                    f"Worktree for branch '{branch}' has no registered owner session. "
-                    "This may indicate a flow created outside standard dispatch. "
-                    "If intentional, no action needed. Otherwise, investigate session "
-                    "registration."
-                ]
-
-            # Check if owner session is still live
-            owner_tmux_session = owner_session.get("tmux_session")
-            if not owner_tmux_session:
-                return []  # Owner session has no tmux_session field (legacy)
-
-            # Check tmux liveness
-            from vibe3.agents.backends.async_launcher import has_tmux_session
-
-            if not has_tmux_session(owner_tmux_session):
-                # Orphaned ownership: session died but worktree still claimed
-                return [
-                    f"ORPHANED_OWNERSHIP: Worktree for branch '{branch}' is claimed "
-                    f"by dead session '{owner_tmux_session}'. "
-                    "Use 'vibe3 task resume --takeover' to take over ownership, "
-                    "or manually investigate if the session should still be active."
-                ]
-
-            # Check if current session matches owner (only if in tmux)
-            current_session_id = get_current_session_id()
-            if current_session_id and current_session_id != owner_tmux_session:
-                # Session mismatch: different session trying to use the worktree
-                return [
-                    f"Session mismatch: Worktree for branch '{branch}' is owned by "
-                    f"session '{owner_tmux_session}', but current session is "
-                    f"'{current_session_id}'. "
-                    "Use 'vibe3 task resume --takeover' to take over if authorized."
-                ]
-
-            return []  # Ownership is consistent
-        except Exception as exc:
-            logger.bind(domain="check", branch=branch).debug(
-                f"Could not verify worktree ownership: {exc}"
-            )
-            return []  # Skip on errors (non-critical check)
-
     def _handle_closed_pr(self, branch: str, pr: "PRResponse") -> CheckResult | None:
         """Handle PR state changes detected during check.
 
@@ -416,7 +345,11 @@ class CheckService(CheckRemote):
                 issues.append(f"Shared handoff file not found: {handoff_path}")
 
         # Check worktree ownership consistency
-        ownership_issues = self._check_worktree_ownership(branch, flow_status)
+        from vibe3.services.check_ownership_service import check_worktree_ownership
+
+        ownership_issues = check_worktree_ownership(
+            self.store, branch, flow_status, self.INACTIVE_FLOW_STATUSES
+        )
         issues.extend(ownership_issues)
 
         is_valid = len(issues) == 0

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -124,6 +124,77 @@ class CheckService(CheckRemote):
         except Exception:
             return None
 
+    def _check_worktree_ownership(self, branch: str, flow_status: str) -> list[str]:
+        """Check worktree ownership consistency for a branch.
+
+        Args:
+            branch: Branch name to check.
+            flow_status: Current flow status.
+
+        Returns:
+            List of ownership-related issues found.
+        """
+        if flow_status in self.INACTIVE_FLOW_STATUSES:
+            return []  # Skip inactive flows
+
+        from vibe3.services.worktree_ownership_guard import (
+            get_current_session_id,
+            get_worktree_owner,
+        )
+        from vibe3.utils.path_helpers import find_worktree_path_for_branch
+
+        try:
+            worktree_path = find_worktree_path_for_branch(branch)
+            if worktree_path is None:
+                return []  # No worktree, skip ownership check
+
+            owner_session = get_worktree_owner(self.store, str(worktree_path))
+            if owner_session is None:
+                # Unowned worktree with active flow
+                # This could indicate a new flow that hasn't registered ownership yet
+                # or a flow created outside of the standard dispatch path
+                return [
+                    f"Worktree for branch '{branch}' has no registered owner session. "
+                    "This may indicate a flow created outside standard dispatch. "
+                    "If intentional, no action needed. Otherwise, investigate session "
+                    "registration."
+                ]
+
+            # Check if owner session is still live
+            owner_tmux_session = owner_session.get("tmux_session")
+            if not owner_tmux_session:
+                return []  # Owner session has no tmux_session field (legacy)
+
+            # Check tmux liveness
+            from vibe3.agents.backends.async_launcher import has_tmux_session
+
+            if not has_tmux_session(owner_tmux_session):
+                # Orphaned ownership: session died but worktree still claimed
+                return [
+                    f"ORPHANED_OWNERSHIP: Worktree for branch '{branch}' is claimed "
+                    f"by dead session '{owner_tmux_session}'. "
+                    "Use 'vibe3 task resume --takeover' to take over ownership, "
+                    "or manually investigate if the session should still be active."
+                ]
+
+            # Check if current session matches owner (only if in tmux)
+            current_session_id = get_current_session_id()
+            if current_session_id and current_session_id != owner_tmux_session:
+                # Session mismatch: different session trying to use the worktree
+                return [
+                    f"Session mismatch: Worktree for branch '{branch}' is owned by "
+                    f"session '{owner_tmux_session}', but current session is "
+                    f"'{current_session_id}'. "
+                    "Use 'vibe3 task resume --takeover' to take over if authorized."
+                ]
+
+            return []  # Ownership is consistent
+        except Exception as exc:
+            logger.bind(domain="check", branch=branch).debug(
+                f"Could not verify worktree ownership: {exc}"
+            )
+            return []  # Skip on errors (non-critical check)
+
     def _handle_closed_pr(self, branch: str, pr: "PRResponse") -> CheckResult | None:
         """Handle PR state changes detected during check.
 
@@ -343,6 +414,10 @@ class CheckService(CheckRemote):
             handoff_path = get_branch_handoff_dir(git_dir, branch) / "current.md"
             if not handoff_path.exists():
                 issues.append(f"Shared handoff file not found: {handoff_path}")
+
+        # Check worktree ownership consistency
+        ownership_issues = self._check_worktree_ownership(branch, flow_status)
+        issues.extend(ownership_issues)
 
         is_valid = len(issues) == 0
         logger.bind(branch=branch, is_valid=is_valid, issues_count=len(issues)).debug(

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -57,6 +57,7 @@ class TaskResumeOperations:
         reason: str,
         worktree_path: str | None = None,
         label_state: str | None = None,
+        allow_takeover: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> None:
         """Reset an issue to ready after clearing stale task scene state.
@@ -70,6 +71,7 @@ class TaskResumeOperations:
             worktree_path: Optional worktree path (for optimization)
             label_state: Optional state to restore (None=delete worktree,
                 empty/"handoff"=restore to handoff, "ready"=restore to ready)
+            allow_takeover: If True, allow taking over worktree ownership
             progress_callback: Optional callback for progress updates.
                 Signature: (issue_number: int, branch: str | None, step: str,
                     status: str) -> None
@@ -91,6 +93,28 @@ class TaskResumeOperations:
                     "Use 'vibe check --clean-branch' to clean physical resources, "
                     "or close the linked issue manually if still open."
                 )
+
+        # Verify worktree ownership before modifying flow state
+        if isinstance(branch, str):
+            try:
+                from vibe3.utils.path_helpers import find_worktree_path_for_branch
+
+                wt_path = worktree_path or find_worktree_path_for_branch(branch)
+                if wt_path:
+                    from vibe3.services.worktree_ownership_guard import (
+                        ensure_worktree_ownership,
+                    )
+
+                    ensure_worktree_ownership(
+                        self.flow_service.store,
+                        str(wt_path),
+                        allow_takeover=allow_takeover,
+                        takeover_reason=reason or "task resume",
+                    )
+            except (ImportError, ValueError):
+                # find_worktree_path_for_branch may fail for branches without worktrees
+                # In such cases, skip ownership check (legacy behavior)
+                pass
 
         def emit_progress(step: str, status: str = "running") -> None:
             if progress_callback:

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -81,6 +81,7 @@ class TaskResumeUsecase:
         repo: str | None = None,
         candidate_mode: str = "resumable",
         label_state: str | None = None,
+        allow_takeover: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> dict[str, Any]:
         """Resume failed or blocked issues.
@@ -95,6 +96,7 @@ class TaskResumeUsecase:
             candidate_mode: Candidate selection mode ("resumable" or "all_task")
             label_state: Optional state to restore (None=delete worktree,
                 "handoff"/"ready"=keep worktree)
+            allow_takeover: If True, allow taking over worktree ownership
             progress_callback: Optional callback for progress updates.
                 Signature: (issue_number: int, branch: str | None, step: str,
                     status: str) -> None
@@ -226,6 +228,7 @@ class TaskResumeUsecase:
                         reason=reason,
                         worktree_path=worktree_path,
                         label_state=label_state,
+                        allow_takeover=allow_takeover,
                         progress_callback=progress_callback,
                     )
 

--- a/src/vibe3/services/worktree_ownership_guard.py
+++ b/src/vibe3/services/worktree_ownership_guard.py
@@ -1,0 +1,177 @@
+"""Worktree ownership guard to prevent cross-agent conflicts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from vibe3.exceptions import UserError
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
+
+
+class WorktreeOwnerMismatchError(UserError):
+    """Raised when current session doesn't own the worktree."""
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def get_current_session_id() -> str | None:
+    """Return the current tmux session name, or None if outside tmux.
+
+    Uses tmux display-message to get the actual session name (e.g.,
+    'vibe3-executor-issue-42') rather than the TMUX env var which is
+    a socket path format.
+
+    Returns:
+        Session name if in tmux, None otherwise (direct user).
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-p", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def get_worktree_owner(
+    store: SQLiteClient, worktree_path: str
+) -> dict[str, Any] | None:
+    """Return the session dict that owns this worktree, or None if unowned.
+
+    Args:
+        store: SQLite client instance.
+        worktree_path: Absolute path to the worktree directory.
+
+    Returns:
+        Session dict if a live owner exists, None otherwise.
+    """
+    return store.get_worktree_owner_session(worktree_path)
+
+
+def ensure_worktree_ownership(
+    store: SQLiteClient,
+    worktree_path: str,
+    *,
+    allow_takeover: bool = False,
+    takeover_reason: str = "",
+) -> None:
+    """Validate that the current session owns this worktree.
+
+    Guards are NO-OP when:
+    - The worktree has no registered owner (first use).
+    - Running outside tmux (direct user, TMUX env var absent).
+    - The current tmux session matches the recorded owner.
+
+    Args:
+        store: SQLite client instance.
+        worktree_path: Absolute path to the worktree directory.
+        allow_takeover: If True, allow taking over ownership.
+        takeover_reason: Reason for takeover (for audit logging).
+
+    Raises:
+        WorktreeOwnerMismatchError: When session mismatch and takeover not allowed.
+    """
+    current_session_id = get_current_session_id()
+
+    # Outside tmux → always authorized (direct user)
+    if current_session_id is None:
+        return
+
+    # Look up the worktree owner
+    owner_session = get_worktree_owner(store, worktree_path)
+
+    # No owner → first use, allow
+    if owner_session is None:
+        return
+
+    # Extract owner's tmux session identifier
+    owner_tmux_session = owner_session.get("tmux_session")
+    owner_session_name = owner_session.get("session_name", "unknown")
+
+    # If owner has no tmux_session recorded, treat as unowned
+    if not owner_tmux_session:
+        return
+
+    # Check if current session matches owner
+    if current_session_id == owner_tmux_session:
+        return  # Current session owns it
+
+    # Mismatch: current session doesn't own the worktree
+    if allow_takeover:
+        takeover_worktree(
+            store,
+            worktree_path,
+            current_session_id,
+            takeover_reason,
+        )
+        return
+
+    # Build actionable error message
+    current_branch = store.get_flow_state(worktree_path.split("/")[-1])
+    branch_hint = ""
+    if current_branch:
+        branch_name = current_branch.get("branch", "unknown")
+        branch_hint = f"\n  Branch: {branch_name}"
+
+    raise WorktreeOwnerMismatchError(
+        f"Worktree ownership mismatch detected:\n"
+        f"  Worktree: {worktree_path}{branch_hint}\n"
+        f"  Current session: {current_session_id}\n"
+        f"  Owner session: {owner_tmux_session} ({owner_session_name})\n\n"
+        f"This worktree is in use by another session. Options:\n"
+        f"  1. Wait for the other session to complete and release the worktree\n"
+        f"  2. Use `vibe3 task resume --takeover` to explicitly take over\n"
+        f"  3. Switch to a different worktree: `vibe3 task resume <issue>`"
+    )
+
+
+def takeover_worktree(
+    store: SQLiteClient,
+    worktree_path: str,
+    new_owner_id: str,
+    reason: str,
+) -> None:
+    """Log a worktree takeover event and update session binding.
+
+    Args:
+        store: SQLite client instance.
+        worktree_path: Absolute path to the worktree directory.
+        new_owner_id: The tmux session ID taking ownership.
+        reason: Reason for takeover (for audit logging).
+    """
+    from vibe3.services.signature_service import SignatureService
+
+    # Get the branch name from worktree path (last component)
+    branch = worktree_path.split("/")[-1]
+    actor = SignatureService.get_worktree_actor()
+
+    # Log the takeover event
+    store.add_event(
+        branch,
+        "worktree_takeover",
+        actor,
+        detail=f"Worktree takeover: {reason}" if reason else "Worktree takeover",
+        refs={
+            "new_owner_id": new_owner_id,
+            "worktree_path": worktree_path,
+        },
+    )
+
+    # Update the owning session's tmux_session field
+    # Find the most recent live session for this worktree and update it
+    owner_session = store.get_worktree_owner_session(worktree_path)
+    if owner_session:
+        session_id = owner_session.get("id")
+        if session_id:
+            store.update_runtime_session(
+                session_id,
+                tmux_session=new_owner_id,
+            )

--- a/tests/vibe3/services/test_task_resume_operations.py
+++ b/tests/vibe3/services/test_task_resume_operations.py
@@ -92,15 +92,20 @@ def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
         }
         mock_cleanup_cls.return_value = mock_cleanup_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state=None,  # ← No --label
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state=None,  # ← No --label
+            )
 
         # Verify: cleanup_flow_scene was called (via reset_task_scene)
         mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
@@ -120,15 +125,20 @@ def test_reset_issue_to_ready_with_label_keeps_worktree() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="handoff",  # ← --label (defaults to handoff)
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="handoff",  # ← --label (defaults to handoff)
+            )
 
         # Verify: worktree NOT deleted (reset_task_scene NOT called)
         operations.git_client.remove_worktree.assert_not_called()
@@ -155,15 +165,20 @@ def test_reset_issue_to_ready_with_label_ready_restores_to_ready() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="ready",  # ← --label ready
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="ready",  # ← --label ready
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()
@@ -194,15 +209,20 @@ def test_reset_issue_to_ready_with_label_handoff_explicit() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="handoff",  # ← --label handoff (explicit)
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="handoff",  # ← --label handoff (explicit)
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()
@@ -228,15 +248,20 @@ def test_reset_issue_to_ready_with_label_claimed() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="claimed",  # ← --label claimed
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="claimed",  # ← --label claimed
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()
@@ -259,15 +284,20 @@ def test_reset_issue_to_ready_with_label_in_progress() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="in-progress",  # ← --label in-progress
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="in-progress",  # ← --label in-progress
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()
@@ -290,15 +320,20 @@ def test_reset_issue_to_ready_with_label_review() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="review",  # ← --label review
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="review",  # ← --label review
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()
@@ -321,15 +356,20 @@ def test_reset_issue_to_ready_with_label_merge_ready() -> None:
         mock_label_instance.confirm_issue_state = MagicMock()
         mock_label_cls.return_value = mock_label_instance
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state="merge-ready",  # ← --label merge-ready
-        )
+        with patch(
+            "vibe3.services.worktree_ownership_guard.get_current_session_id"
+        ) as mock_session:
+            mock_session.return_value = None  # Outside tmux
+
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state="merge-ready",  # ← --label merge-ready
+            )
 
         # Verify: worktree NOT deleted
         operations.git_client.remove_worktree.assert_not_called()

--- a/tests/vibe3/services/test_worktree_ownership_guard.py
+++ b/tests/vibe3/services/test_worktree_ownership_guard.py
@@ -1,0 +1,209 @@
+"""Unit tests for WorktreeOwnershipGuard."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vibe3.services.worktree_ownership_guard import (
+    WorktreeOwnerMismatchError,
+    ensure_worktree_ownership,
+    get_current_session_id,
+    get_worktree_owner,
+    takeover_worktree,
+)
+
+
+class TestGetCurrentSessionId:
+    """Tests for get_current_session_id."""
+
+    def test_returns_none_outside_tmux(self) -> None:
+        """Outside tmux, returns None (subprocess fails)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("tmux not found")
+            assert get_current_session_id() is None
+
+    def test_returns_session_name_in_tmux(self) -> None:
+        """When in tmux, returns the session name."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "vibe3-executor-issue-42\n"
+            result = get_current_session_id()
+            assert result == "vibe3-executor-issue-42"
+            mock_run.assert_called_once_with(
+                ["tmux", "display-message", "-p", "#{session_name}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+
+class TestGetWorktreeOwner:
+    """Tests for get_worktree_owner."""
+
+    def test_returns_none_when_no_owner(self) -> None:
+        """When worktree has no registered owner, returns None."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = None
+
+        result = get_worktree_owner(mock_store, "/path/to/worktree")
+        assert result is None
+        mock_store.get_worktree_owner_session.assert_called_once_with(
+            "/path/to/worktree"
+        )
+
+    def test_returns_session_dict_when_owner_exists(self) -> None:
+        """When worktree has a registered owner, returns session dict."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        result = get_worktree_owner(mock_store, "/path/to/worktree")
+        assert result == {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+
+class TestEnsureWorktreeOwnership:
+    """Tests for ensure_worktree_ownership."""
+
+    def test_passes_when_no_owner(self) -> None:
+        """Unowned worktree allows any session."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = None
+
+        # Should not raise
+        ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
+    def test_passes_when_tmux_matches(self) -> None:
+        """Matching tmux session passes."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "vibe3-executor-issue-42\n"
+            # Should not raise
+            ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
+    def test_raises_when_tmux_mismatches(self) -> None:
+        """Different tmux session raises WorktreeOwnerMismatchError."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+        mock_store.get_flow_state.return_value = None
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "vibe3-executor-issue-99\n"
+            with pytest.raises(WorktreeOwnerMismatchError) as exc_info:
+                ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
+            assert "Worktree ownership mismatch detected" in str(exc_info.value)
+            assert "Current session: vibe3-executor-issue-99" in str(exc_info.value)
+            assert "Owner session: vibe3-executor-issue-42" in str(exc_info.value)
+
+    def test_raises_with_actionable_message(self) -> None:
+        """Error message includes takeover instructions."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+        mock_store.get_flow_state.return_value = None
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "vibe3-executor-issue-99\n"
+            with pytest.raises(WorktreeOwnerMismatchError) as exc_info:
+                ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
+            error_msg = str(exc_info.value)
+            assert "vibe3 task resume --takeover" in error_msg
+
+    def test_passes_outside_tmux(self) -> None:
+        """Outside tmux (direct user), always passes."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("tmux not found")
+            # Should not raise
+            ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
+    def test_allows_takeover_when_requested(self) -> None:
+        """When allow_takeover=True, takeover is performed."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "vibe3-executor-issue-99\n"
+            with patch(
+                "vibe3.services.worktree_ownership_guard.takeover_worktree"
+            ) as mock_takeover:
+                # Should not raise
+                ensure_worktree_ownership(
+                    mock_store,
+                    "/path/to/worktree",
+                    allow_takeover=True,
+                    takeover_reason="test",
+                )
+
+                # Verify takeover was called
+                mock_takeover.assert_called_once_with(
+                    mock_store,
+                    "/path/to/worktree",
+                    "vibe3-executor-issue-99",
+                    "test",
+                )
+
+
+class TestTakeoverWorktree:
+    """Tests for takeover_worktree."""
+
+    def test_logs_event_and_updates_owner(self) -> None:
+        """Takeover creates event and updates session binding."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        with patch("vibe3.services.signature_service.SignatureService") as mock_sig:
+            mock_sig.get_worktree_actor.return_value = "test-actor"
+
+            takeover_worktree(
+                mock_store,
+                "/path/to/worktree",
+                "vibe3-executor-issue-99",
+                "test takeover",
+            )
+
+            # Verify event was logged
+            mock_store.add_event.assert_called_once()
+            call_args = mock_store.add_event.call_args
+            assert call_args[0][1] == "worktree_takeover"
+
+            # Verify session was updated
+            mock_store.update_runtime_session.assert_called_once_with(
+                1, tmux_session="vibe3-executor-issue-99"
+            )


### PR DESCRIPTION
## Summary

Implements session-based worktree ownership tracking to prevent cross-agent branch hijacking when multiple vibe3 agents run concurrently in different tmux sessions.

## Problem

When multiple vibe3 agents run in parallel (e.g., executor-issue-42 in one tmux session and executor-issue-43 in another), both operating on worktrees with the same branch name, one agent could accidentally hijack the other's worktree/branch, causing session conflicts and data corruption.

## Solution

### Core Implementation

1. **Worktree Ownership Guard** (`worktree_ownership_guard.py`)
   - `ensure_worktree_ownership()` - Core guard function
   - `get_current_session_id()` - Returns tmux session name (not socket path)
   - `takeover_worktree()` - Authorized branch handover mechanism
   - Raises `WorktreeOwnerMismatchError` when sessions mismatch

2. **Integration Points**
   - `flow update` - Checks ownership before updating
   - `flow bind` - Checks ownership before binding
   - `task resume --takeover` - Authorized handover with explicit flag
   - `vibe3 check` - Detects ownership conflicts

3. **Database Support** (`sqlite_session_repo.py`)
   - `get_worktree_owner_session()` - Query worktree owner from runtime_session table

### Key Design Fix

**Previous flaw**: Used TMUX environment variable (socket path format: `/private/tmp/tmux-501/default,4658,123`)
**Fixed**: Use `tmux display-message -p '#{session_name}'` to get actual session names (e.g., `vibe3-executor-issue-42`)

This ensures session name comparison works correctly with database records.

## Testing

- **New tests**: 11 comprehensive unit tests for ownership guard
- **Fixed tests**: 8 previously failing tests in task_resume_operations (now properly mock tmux calls)
- **All tests pass**: 21 total tests passing
- **Quality checks**: mypy clean, ruff clean

## Verification Steps

1. Outside tmux: Guard allows access (direct user)
2. No owner registered: Guard allows access (first use)
3. Session matches: Guard allows access (legitimate owner)
4. Session mismatch: Guard raises `WorktreeOwnerMismatchError`
5. With `--takeover`: Guard allows authorized handover

## Files Changed

**Modified** (7 files):
- Integration in flow commands, task resume, and check service
- Fixed tests with proper tmux mocking

**New** (2 files):
- Core ownership guard implementation
- Comprehensive test suite

Fixes #356

---

## Contributors

claude/opus
