### PR TITLE
feat(orchestra): add async_execution config for manager dispatch mode

### DIFF
--- a/docs/directives/issue-410-publish.md
+++ b/docs/directives/issue-410-publish.md
@@ -1,0 +1,109 @@
+# Issue #410 Executor Publish Directive
+
+## Context
+
+Review completed with PASS verdict. Issue is transitioning to merge-ready state.
+
+## Implementation Summary
+
+**Feature**: Added `async_execution` config to `OrchestraConfig` for controlling manager dispatch mode.
+
+**Files Modified**:
+- `src/vibe3/models/orchestra_config.py`: Added `async_execution: bool = Field(default=True, ...)`
+- `src/vibe3/roles/manager.py`: 
+  - Added dispatch mode switching logic based on `async_execution`
+  - Fixed environment injection bug for both sync and async modes
+
+**Baseline Changes**: +34 LOC, 2 files modified
+
+## Publish Instructions
+
+### Commit Message
+
+```
+feat(orchestra): add async_execution config for manager dispatch mode
+
+- Add async_execution: bool field to OrchestraConfig (default=True)
+- Support both sync (blocking) and async (tmux) dispatch modes
+- Fix environment injection bug for both modes
+- Maintain backward compatibility with default=True
+
+Closes #410
+```
+
+### PR Title
+
+```
+feat(orchestra): add async_execution config for manager dispatch mode
+```
+
+### PR Description
+
+```markdown
+## Summary
+
+- Added `async_execution: bool` config field to `OrchestraConfig` to control manager dispatch mode
+- When `True` (default): manager dispatch runs via tmux (non-blocking, existing behavior)
+- When `False`: manager dispatch runs synchronously (blocking, for debugging)
+- Fixed environment injection bug that prevented manager token/config vars from being injected in sync mode
+
+## Changes
+
+**OrchestraConfig** (`src/vibe3/models/orchestra_config.py`):
+- Added `async_execution: bool = Field(default=True, ...)` field
+- Maintains backward compatibility with default=True
+
+**Manager Request Builder** (`src/vibe3/roles/manager.py`):
+- Added dispatch mode switching based on `async_execution` config
+- Fixed environment variable injection for both sync and async modes:
+  - Sync mode: properly initializes `request.env` when None
+  - Async mode: properly merges manager-built env vars
+- Ensures manager token (`GH_TOKEN`) and backend/model config are injected in both modes
+
+## Testing
+
+- ✅ Unit tests: 3/3 pass (async_execution config tests)
+- ✅ Manager tests: 8/8 pass
+- ✅ mypy: pass
+- ✅ ruff: pass
+
+## Backward Compatibility
+
+- Default value `True` maintains existing async behavior
+- No breaking changes to public API
+- Config field is additive
+
+## Minor Note
+
+Test coverage gap identified: dispatch behavior and environment injection not covered by integration tests. Recommend adding in future PR (non-blocking).
+
+Closes #410
+```
+
+### PR Labels
+
+- `type/feature`
+- `priority/medium`
+- `roadmap/p1`
+- `component/orchestra`
+
+### Draft Status
+
+Create as **ready PR** (not draft) - all tests pass and review completed.
+
+## Quality Checklist
+
+Before creating PR, verify:
+- [ ] All tests pass locally
+- [ ] mypy passes
+- [ ] ruff passes
+- [ ] Commit message follows conventional commits format
+- [ ] PR description complete and accurate
+- [ ] No breaking changes introduced
+
+## Execution Notes
+
+- Use `vibe-commit` skill to commit changes
+- Use `gh pr create` to create PR
+- PR will be reviewed by human after merge-ready state
+- Monitor CI checks after PR creation

--- a/src/vibe3/models/orchestra_config.py
+++ b/src/vibe3/models/orchestra_config.py
@@ -213,6 +213,13 @@ class OrchestraConfig(BaseModel):
     scene_base_ref: str = Field(default="origin/main", min_length=1)
     repo: str | None = None
     max_concurrent_flows: int = Field(default=3, ge=1)
+    async_execution: bool = Field(
+        default=True,
+        description=(
+            "If True, manager dispatch runs via tmux (non-blocking). "
+            "If False, runs synchronously (blocking, for debugging)."
+        ),
+    )
 
     # Per-role capacity configuration
     governance_max_concurrent: int = Field(

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -178,6 +178,31 @@ def build_manager_request(
                 "Failed to resolve manager agent options, using defaults"
             )
 
+    # Check async_execution config to determine dispatch mode
+    if not config.async_execution:
+        # Sync mode: blocking execution for debugging
+        logger.bind(domain="manager", issue_number=issue.number).info(
+            "Using synchronous execution mode (async_execution=False)"
+        )
+        options = resolve_manager_options(config)
+        request = build_manager_sync_request(
+            config=config,
+            issue=issue,
+            branch=flow_branch,
+            flow_state=None,
+            session_id=None,
+            options=options,
+            actor=actor,
+            dry_run=False,
+            show_prompt=False,
+        )
+        if request.env is None:
+            request.env = env
+        else:
+            request.env.update(env)
+        return request
+
+    # Async mode: non-blocking tmux execution (default)
     request = build_issue_async_cli_request(
         role="manager",
         issue=issue,
@@ -189,7 +214,9 @@ def build_manager_request(
         worktree_requirement=MANAGER_ROLE.worktree,
         repo_path=repo_path,
     )
-    if request.env is not None:
+    if request.env is None:
+        request.env = env
+    else:
         request.env.update(env)
     return request
 

--- a/tests/vibe3/models/test_orchestra_config_async_execution.py
+++ b/tests/vibe3/models/test_orchestra_config_async_execution.py
@@ -1,0 +1,21 @@
+"""Tests for async_execution config field."""
+
+from vibe3.models.orchestra_config import OrchestraConfig
+
+
+def test_async_execution_default_is_true() -> None:
+    """Default value of async_execution should be True."""
+    config = OrchestraConfig()
+    assert config.async_execution is True
+
+
+def test_async_execution_can_be_set_to_false() -> None:
+    """async_execution can be explicitly set to False."""
+    config = OrchestraConfig(async_execution=False)
+    assert config.async_execution is False
+
+
+def test_async_execution_can_be_set_via_kwargs() -> None:
+    """async_execution can be set via kwargs (simulating YAML/settings loading)."""
+    config = OrchestraConfig(**{"async_execution": False})
+    assert config.async_execution is False


### PR DESCRIPTION
## Summary

- Added `async_execution: bool` config field to `OrchestraConfig` to control manager dispatch mode
- When `True` (default): manager dispatch runs via tmux (non-blocking, existing behavior)
- When `False`: manager dispatch runs synchronously (blocking, for debugging)
- Fixed environment injection bug that prevented manager token/config vars from being injected in sync mode

## Changes

**OrchestraConfig** (`src/vibe3/models/orchestra_config.py`):
- Added `async_execution: bool = Field(default=True, ...)` field
- Maintains backward compatibility with default=True

**Manager Request Builder** (`src/vibe3/roles/manager.py`):
- Added dispatch mode switching based on `async_execution` config
- Fixed environment variable injection for both sync and async modes:
  - Sync mode: properly initializes `request.env` when None
  - Async mode: properly merges manager-built env vars
- Ensures manager token (`GH_TOKEN`) and backend/model config are injected in both modes

## Testing

- ✅ Unit tests: 3/3 pass (async_execution config tests)
- ✅ Manager tests: 8/8 pass
- ✅ mypy: pass
- ✅ ruff: pass

## Backward Compatibility

- Default value `True` maintains existing async behavior
- No breaking changes to public API
- Config field is additive

## Minor Note

Test coverage gap identified: dispatch behavior and environment injection not covered by integration tests. Recommend adding in future PR (non-blocking).

Closes #410

---

## Contributors

claude/opus
