### PR TITLE
feat(inspect): add YAML output option to inspect analysis commands

### DIFF
--- a/.agent/policies/run.md
+++ b/.agent/policies/run.md
@@ -97,7 +97,7 @@
 执行前优先用项目工具确认影响面：
 - `uv run python src/vibe3/cli.py handoff status`
 - `vibe3 inspect symbols`
-- `vibe3 inspect structure`
+- `vibe3 inspect files`
 - `vibe3 inspect base --json`
 
 如果改动触及公开入口、关键路径或 prompt contract，验证强度必须随之提高。

--- a/src/vibe3/commands/inspect.py
+++ b/src/vibe3/commands/inspect.py
@@ -4,6 +4,7 @@ import json
 from typing import Annotated, Any, cast
 
 import typer
+import yaml
 
 from vibe3.analysis import command_analyzer, dag_service, structure_service
 from vibe3.analysis.command_analyzer_helpers import find_command_file
@@ -74,6 +75,7 @@ register_change(app)
 def files_(
     file: Annotated[str, typer.Argument(help="File to analyze")] = "",
     json_out: _JSON_OPT = False,
+    yaml_out: Annotated[bool, typer.Option("--yaml", help="Output as YAML")] = False,
     quiet: Annotated[
         bool, typer.Option("--quiet", help="Suppress next step suggestions")
     ] = False,
@@ -105,6 +107,12 @@ def files_(
 
         if json_out:
             typer.echo(json.dumps(result.model_dump(), indent=2))
+        elif yaml_out:
+            typer.echo(
+                yaml.dump(
+                    result.model_dump(), default_flow_style=False, allow_unicode=True
+                )
+            )
         else:
             typer.echo(f"=== File: {file} ===")
             typer.echo(f"  Language  : {result.language}")
@@ -130,6 +138,8 @@ def files_(
 
         if json_out:
             typer.echo(json.dumps(results, indent=2))
+        elif yaml_out:
+            typer.echo(yaml.dump(results, default_flow_style=False, allow_unicode=True))
         else:
             typer.echo("=== Python Files Summary ===")
             for r in results:

--- a/src/vibe3/commands/inspect_base.py
+++ b/src/vibe3/commands/inspect_base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
+import yaml
 from loguru import logger
 
 from vibe3.commands.inspect_base_helpers import (
@@ -33,6 +34,9 @@ def register(app: typer.Typer) -> None:
         ] = None,
         json_out: Annotated[
             bool, typer.Option("--json", help="Output as JSON")
+        ] = False,
+        yaml_out: Annotated[
+            bool, typer.Option("--yaml", help="Output as YAML")
         ] = False,
         quiet: Annotated[
             bool, typer.Option("--quiet", help="Suppress next step suggestions")
@@ -133,6 +137,24 @@ def register(app: typer.Typer) -> None:
                 changed_lines=changed_lines,
             )
             typer.echo(json.dumps(result, indent=2, default=str))
+            return
+        elif yaml_out:
+            result = build_json_output(
+                git=git,
+                source=source,
+                current_branch=current_branch,
+                base_branch=resolved_base,
+                all_changed_files=all_changed_files,
+                existing_files=existing_files,
+                deleted_files=deleted_files,
+                core_files=core_files,
+                changed_lines=changed_lines,
+            )
+            # Convert to JSON-serializable dict first (handles enums, etc.)
+            clean_result = json.loads(json.dumps(result, default=str))
+            typer.echo(
+                yaml.dump(clean_result, default_flow_style=False, allow_unicode=True)
+            )
             return
 
         # Human-readable output

--- a/src/vibe3/commands/inspect_change.py
+++ b/src/vibe3/commands/inspect_change.py
@@ -1,8 +1,10 @@
 """Inspect change commands."""
 
+import json
 from typing import Annotated
 
 import typer
+import yaml
 
 from vibe3.analysis.inspect_query_service import (
     build_change_analysis,
@@ -20,12 +22,14 @@ def register(app: typer.Typer) -> None:
         json_out: Annotated[
             bool, typer.Option("--json", help="Output as JSON")
         ] = False,
+        yaml_out: Annotated[
+            bool, typer.Option("--yaml", help="Output as YAML")
+        ] = False,
         trace: Annotated[
             bool, typer.Option("--trace", help="Enable call tracing + DEBUG logs")
         ] = False,
     ) -> None:
         """Run PR change analysis."""
-        import json
 
         if trace:
             enable_trace()
@@ -37,6 +41,13 @@ def register(app: typer.Typer) -> None:
         if json_out:
             typer.echo(json.dumps(result, indent=2, default=str))
             return
+        elif yaml_out:
+            # Convert to JSON-serializable dict first (handles enums, etc.)
+            clean_result = json.loads(json.dumps(result, default=str))
+            typer.echo(
+                yaml.dump(clean_result, default_flow_style=False, allow_unicode=True)
+            )
+            return
 
         _print_change_analysis("pr", str(pr_number), result)
 
@@ -46,12 +57,14 @@ def register(app: typer.Typer) -> None:
         json_out: Annotated[
             bool, typer.Option("--json", help="Output as JSON")
         ] = False,
+        yaml_out: Annotated[
+            bool, typer.Option("--yaml", help="Output as YAML")
+        ] = False,
         trace: Annotated[
             bool, typer.Option("--trace", help="Enable call tracing + DEBUG logs")
         ] = False,
     ) -> None:
         """Run commit change analysis."""
-        import json
 
         if trace:
             enable_trace()
@@ -61,6 +74,13 @@ def register(app: typer.Typer) -> None:
         if json_out:
             typer.echo(json.dumps(result, indent=2, default=str))
             return
+        elif yaml_out:
+            # Convert to JSON-serializable dict first (handles enums, etc.)
+            clean_result = json.loads(json.dumps(result, default=str))
+            typer.echo(
+                yaml.dump(clean_result, default_flow_style=False, allow_unicode=True)
+            )
+            return
 
         _print_change_analysis("commit", sha, result)
 
@@ -69,12 +89,14 @@ def register(app: typer.Typer) -> None:
         json_out: Annotated[
             bool, typer.Option("--json", help="Output as JSON")
         ] = False,
+        yaml_out: Annotated[
+            bool, typer.Option("--yaml", help="Output as YAML")
+        ] = False,
         trace: Annotated[
             bool, typer.Option("--trace", help="Enable call tracing + DEBUG logs")
         ] = False,
     ) -> None:
         """Run analysis for uncommitted working tree changes."""
-        import json
 
         if trace:
             enable_trace()
@@ -83,6 +105,13 @@ def register(app: typer.Typer) -> None:
 
         if json_out:
             typer.echo(json.dumps(result, indent=2, default=str))
+            return
+        elif yaml_out:
+            # Convert to JSON-serializable dict first (handles enums, etc.)
+            clean_result = json.loads(json.dumps(result, default=str))
+            typer.echo(
+                yaml.dump(clean_result, default_flow_style=False, allow_unicode=True)
+            )
             return
 
         _print_change_analysis("uncommitted", "working-tree", result)

--- a/src/vibe3/commands/inspect_symbols.py
+++ b/src/vibe3/commands/inspect_symbols.py
@@ -6,6 +6,7 @@ from io import StringIO
 from typing import Annotated
 
 import typer
+import yaml
 from loguru import logger
 
 from vibe3.analysis.serena_service import SerenaService
@@ -23,6 +24,9 @@ def register(app: typer.Typer) -> None:
         ] = "",
         json_out: Annotated[
             bool, typer.Option("--json", help="Output as JSON")
+        ] = False,
+        yaml_out: Annotated[
+            bool, typer.Option("--yaml", help="Output as YAML")
         ] = False,
         quiet: Annotated[
             bool, typer.Option("--quiet", help="Suppress next step suggestions")
@@ -92,6 +96,11 @@ def register(app: typer.Typer) -> None:
             if json_out:
                 typer.echo(json.dumps(result, indent=2))
                 return
+            elif yaml_out:
+                typer.echo(
+                    yaml.dump(result, default_flow_style=False, allow_unicode=True)
+                )
+                return
 
             if "symbols" in result:
                 _print_symbols_table(result)
@@ -134,7 +143,7 @@ def _print_symbol_references(result: dict) -> None:
 
 
 def _print_symbols_table(result: dict) -> None:
-    """Print file symbols in simple format (like inspect structure)."""
+    """Print file symbols in simple format (like inspect files)."""
     typer.echo(f"=== Symbols: {result['file']} ===")
     symbols = result.get("symbols", [])
     typer.echo(f"  Total symbols: {len(symbols)}")

--- a/tests/vibe3/commands/test_inspect_contract.py
+++ b/tests/vibe3/commands/test_inspect_contract.py
@@ -1,0 +1,259 @@
+"""Contract tests for inspect subcommands output format options.
+
+This test module enforces the design contract that all inspect subcommands should
+support --json and --yaml output options to prevent future drift.
+
+Reference: docs/v3/design/trace-inspect-output-format.md
+"""
+
+import subprocess
+
+import yaml
+
+
+def get_inspect_subcommands():
+    """Get all inspect subcommands from help output."""
+    result = subprocess.run(
+        ["uv", "run", "python", "src/vibe3/cli.py", "inspect", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse help output to find subcommands
+    lines = result.stdout.split("\n")
+    subcommands = []
+
+    for line in lines:
+        # Look for lines like "  files [<file>]             Structure of one file"
+        if (
+            line.strip()
+            and not line.startswith("Usage:")
+            and not line.startswith("Options:")
+        ):
+            parts = line.strip().split()
+            if parts and parts[0] not in ["When", "Subcommands:", "For", "Examples:"]:
+                # Extract command name (first word)
+                cmd = parts[0].rstrip("]")
+                if cmd and not cmd.startswith("[") and cmd not in ["vibe3", "inspect"]:
+                    subcommands.append(cmd)
+
+    return subcommands
+
+
+def test_all_inspect_subcommands_have_json_option():
+    """Verify all inspect subcommands support --json output."""
+    subcommands = get_inspect_subcommands()
+
+    # Commands that already have --json (verified by existing tests)
+    commands_with_json = [
+        "files",
+        "symbols",
+        "base",
+        "pr",
+        "commit",
+        "uncommit",
+        "commands",
+        "dead-code",
+    ]
+
+    for cmd in subcommands:
+        if cmd in commands_with_json:
+            # Check that --json appears in help
+            result = subprocess.run(
+                ["uv", "run", "python", "src/vibe3/cli.py", "inspect", cmd, "--help"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert "--json" in result.stdout, f"inspect {cmd} missing --json option"
+
+
+def test_all_inspect_subcommands_have_yaml_option():
+    """Verify all inspect subcommands support --yaml output."""
+    subcommands = get_inspect_subcommands()
+
+    # Commands that now have --yaml (this issue's implementation)
+    commands_with_yaml = [
+        "files",
+        "symbols",
+        "base",
+        "pr",
+        "commit",
+        "uncommit",
+        "commands",
+    ]
+
+    # Note: dead-code has a different output model and doesn't need --yaml
+    for cmd in subcommands:
+        if cmd in commands_with_yaml:
+            # Check that --yaml appears in help
+            result = subprocess.run(
+                ["uv", "run", "python", "src/vibe3/cli.py", "inspect", cmd, "--help"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert "--yaml" in result.stdout, f"inspect {cmd} missing --yaml option"
+
+
+def test_inspect_files_yaml_produces_valid_yaml():
+    """Verify inspect files --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "src/vibe3/cli.py",
+            "inspect",
+            "files",
+            "src/vibe3/cli.py",
+            "--yaml",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert (
+        "file" in data or "function_count" in data
+    ), "YAML should contain file analysis data"
+
+
+def test_inspect_base_yaml_produces_valid_yaml():
+    """Verify inspect base --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "src/vibe3/cli.py",
+            "inspect",
+            "base",
+            "main",
+            "--yaml",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert "current_branch" in data, "YAML should contain current_branch"
+    assert "score" in data, "YAML should contain score"
+
+
+def test_inspect_symbols_yaml_produces_valid_yaml():
+    """Verify inspect symbols --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "src/vibe3/cli.py",
+            "inspect",
+            "symbols",
+            "src/vibe3/cli.py",
+            "--yaml",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert "file" in data, "YAML should contain file field"
+    assert "symbols" in data, "YAML should contain symbols list"
+
+
+def test_inspect_commit_yaml_produces_valid_yaml():
+    """Verify inspect commit --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "src/vibe3/cli.py",
+            "inspect",
+            "commit",
+            "HEAD",
+            "--yaml",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert "score" in data, "YAML should contain score"
+    assert "dag" in data, "YAML should contain dag"
+
+
+def test_inspect_commands_yaml_produces_valid_yaml():
+    """Verify inspect commands --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        ["uv", "run", "python", "src/vibe3/cli.py", "inspect", "commands", "--yaml"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert "command" in data, "YAML should contain command field"
+
+
+def test_inspect_json_and_yaml_both_available():
+    """Verify that where --json is available, --yaml is also available.
+
+    This is a contract alignment requirement.
+    """
+    subcommands = get_inspect_subcommands()
+
+    # Commands that should have both --json and --yaml
+    commands_with_both = [
+        "files",
+        "symbols",
+        "base",
+        "pr",
+        "commit",
+        "uncommit",
+        "commands",
+    ]
+
+    for cmd in subcommands:
+        if cmd in commands_with_both:
+            result = subprocess.run(
+                ["uv", "run", "python", "src/vibe3/cli.py", "inspect", cmd, "--help"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            has_json = "--json" in result.stdout
+            has_yaml = "--yaml" in result.stdout
+
+            # Both should be present (contract requirement)
+            assert (
+                has_json and has_yaml
+            ), f"inspect {cmd} should have both --json and --yaml (contract alignment)"

--- a/tests/vibe3/commands/test_inspect_contract.py
+++ b/tests/vibe3/commands/test_inspect_contract.py
@@ -126,7 +126,11 @@ def test_inspect_files_yaml_produces_valid_yaml():
 
 
 def test_inspect_base_yaml_produces_valid_yaml():
-    """Verify inspect base --yaml produces valid parseable YAML."""
+    """Verify inspect base --yaml produces valid parseable YAML.
+
+    Uses HEAD as base to work in both local and CI environments
+    (CI uses shallow clones where remote branch refs may not exist).
+    """
     result = subprocess.run(
         [
             "uv",
@@ -135,7 +139,7 @@ def test_inspect_base_yaml_produces_valid_yaml():
             "src/vibe3/cli.py",
             "inspect",
             "base",
-            "main",
+            "HEAD",
             "--yaml",
         ],
         capture_output=True,


### PR DESCRIPTION
## Summary
- Add YAML output format option to inspect files, symbols, base, pr, commit, uncommit, and commands
- Fix documentation drift in .agent/policies/run.md by replacing the stale inspect structure reference
- Add contract tests to prevent future format option drift for the covered inspect commands
- Leave inspect dead-code YAML support to follow-up issue #657

## Test Plan
- Existing inspect tests pass
- New contract tests verify the covered subcommands support both JSON and YAML
- Type checking clean for src/vibe3/commands/inspect modules
- Ruff clean for src/vibe3/commands/inspect modules
- Manual validation confirms YAML outputs are parseable

## Key Design Decisions
- Backward compatibility: YAML is opt-in, default output unchanged
- Consistent pattern: covered subcommands follow the existing JSON-first output format branch
- Scope control: inspect dead-code has a different output model and is tracked separately in #657

Closes #405

---

## Contributors

claude/opus
Codex