### PR TITLE
refactor: extract normalize_actor to utils layer

### DIFF
--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
-from vibe3.services.signature_service import SignatureService
+from vibe3.utils.actor_utils import normalize_actor
 
 
 class PRState(str, Enum):
@@ -47,7 +47,7 @@ class PRMetadata(BaseModel):
         field_order: list[str] = []
 
         for raw in (self.planner, self.executor, self.reviewer, self.latest):
-            normalized = SignatureService.normalize_actor(raw) if raw else None
+            normalized = normalize_actor(raw) if raw else None
             if not normalized:
                 continue
             backend = normalized.split("/")[0]
@@ -64,7 +64,7 @@ class PRMetadata(BaseModel):
             try:
                 worktree_actor = GitClient().get_config("user.name")
                 if worktree_actor:
-                    normalized = SignatureService.normalize_actor(worktree_actor)
+                    normalized = normalize_actor(worktree_actor)
                     if normalized:
                         return [normalized]
             except Exception:

--- a/src/vibe3/services/signature_service.py
+++ b/src/vibe3/services/signature_service.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from vibe3.clients.git_client import GitClient
+from vibe3.utils.actor_utils import normalize_actor as _normalize_actor_for_display
 
 WORKFLOW_ACTOR = "workflow"
 AI_ASSISTANT_ACTORS = {"ai-assistant", "ai_assistant"}
@@ -13,21 +14,6 @@ MANUAL_INITIATOR = "manual"
 # Placeholder actors for FLOW OPERATIONS (resolve_actor / _is_placeholder).
 # These signal "no meaningful actor has claimed this operation."
 _PLACEHOLDER_ACTORS = {"", "unknown", "server", "system", "workflow"}
-
-# Placeholder actors for DISPLAY / PR BODY (normalize_actor).
-# Wider set: also includes generic AI labels that carry no specific identity.
-_DISPLAY_PLACEHOLDER_ACTORS = frozenset(
-    {*_PLACEHOLDER_ACTORS, "ai_assistant", "ai-assistant"}
-)
-
-# Actor alias → normalized identifier (for display layer).
-_ACTOR_ALIAS_MAP: dict[str, str] = {
-    "agent-claude": "claude",
-    "claude-ai": "claude",
-    "agent-codex": "codex",
-    "openai-code-agent[bot]": "openai",
-    "openai-code-agent": "openai",
-}
 
 
 class SignatureService:
@@ -76,15 +62,10 @@ class SignatureService:
         This is the single source of truth for actor normalisation at the
         display / PR-body layer.  Use ``resolve_actor`` / ``resolve_for_branch``
         for flow-state mutations.
+
+        Delegates to utils.actor_utils.normalize_actor for implementation.
         """
-        if not actor or not actor.strip():
-            return None
-        key = actor.strip().lower()
-        if key in _DISPLAY_PLACEHOLDER_ACTORS:
-            return None
-        if key in _ACTOR_ALIAS_MAP:
-            return _ACTOR_ALIAS_MAP[key]
-        return actor.strip()
+        return _normalize_actor_for_display(actor)
 
     @classmethod
     def get_worktree_actor(cls) -> str:

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -36,12 +36,12 @@ def display_actor(actor: str | None) -> tuple[str, bool]:
     - If actor is set and normalizes to a meaningful value → (normalized, False)
     - Else → (worktree git user.name, True)
 
-    Uses ``SignatureService.normalize_actor`` which maps legacy aliases and
+    Uses ``normalize_actor`` from utils.actor_utils which maps legacy aliases and
     filters placeholders, giving consistent output across PR body and UI.
     """
-    from vibe3.services.signature_service import SignatureService
+    from vibe3.utils.actor_utils import normalize_actor
 
-    normalized = SignatureService.normalize_actor(actor)
+    normalized = normalize_actor(actor)
     if normalized is not None:
         return normalized, False
 

--- a/src/vibe3/utils/actor_utils.py
+++ b/src/vibe3/utils/actor_utils.py
@@ -1,0 +1,46 @@
+"""Actor normalization utilities for display and PR body rendering.
+
+This module provides pure functions for normalizing actor identifiers,
+extracted from SignatureService to maintain proper architecture layering.
+"""
+
+# Placeholder actors for FLOW OPERATIONS (used in signature_service._is_placeholder).
+# These signal "no meaningful actor has claimed this operation."
+_PLACEHOLDER_ACTORS = {"", "unknown", "server", "system", "workflow"}
+
+# Placeholder actors for DISPLAY / PR BODY (normalize_actor).
+# Wider set: also includes generic AI labels that carry no specific identity.
+_DISPLAY_PLACEHOLDER_ACTORS = frozenset(
+    {*_PLACEHOLDER_ACTORS, "ai_assistant", "ai-assistant"}
+)
+
+# Actor alias → normalized identifier (for display layer).
+_ACTOR_ALIAS_MAP: dict[str, str] = {
+    "agent-claude": "claude",
+    "claude-ai": "claude",
+    "agent-codex": "codex",
+    "openai-code-agent[bot]": "openai",
+    "openai-code-agent": "openai",
+}
+
+
+def normalize_actor(actor: str | None) -> str | None:
+    """Normalize an actor identifier for display (PR body, UI).
+
+    Handles:
+    - ``None`` / empty / whitespace-only → ``None``
+    - Placeholder values (unknown, system, workflow, ai-assistant, …) → ``None``
+    - Actor aliases (``Agent-Claude``) → standard backend (``claude``)
+    - Already-standard format (``claude/sonnet-4.6``) → pass through, trimmed
+
+    This is the single source of truth for actor normalisation at the
+    display / PR-body layer.
+    """
+    if not actor or not actor.strip():
+        return None
+    key = actor.strip().lower()
+    if key in _DISPLAY_PLACEHOLDER_ACTORS:
+        return None
+    if key in _ACTOR_ALIAS_MAP:
+        return _ACTOR_ALIAS_MAP[key]
+    return actor.strip()


### PR DESCRIPTION
## Summary

Fixes architecture violation where models layer imported from services layer, violating the dependency direction principle.

## Background

Issue #501 identified that `models/pr.py` was directly importing from `services/signature_service.py`, which violates the architecture layering:

```
┌─────────────┐
│   CLI       │  User entry point
├─────────────┤
│  Services   │  Business logic
├─────────────┤
│   Models    │  Data models
├─────────────┤
│  Clients    │  External dependencies
└─────────────┘

Dependency: CLI → Services → Models → Clients
Violation: Models → Services (reverse dependency) ❌
```

## Changes

**New file:**
- `src/vibe3/utils/actor_utils.py` - Extracted `normalize_actor()` function with placeholder logic and alias mapping

**Modified:**
- `src/vibe3/models/pr.py` - Import from utils instead of services
- `src/vibe3/ui/flow_ui_primitives.py` - Import from utils instead of services
- `src/vibe3/services/signature_service.py` - Delegates to utils for backward compatibility

## Architecture After Fix

```
models/pr.py → utils/actor_utils.py ✅
ui/flow_ui_primitives.py → utils/actor_utils.py ✅
services/signature_service.py → utils/actor_utils.py ✅ (delegation)
```

All layers now properly depend on utils, maintaining correct dependency direction.

## Verification

All pre-commit checks passed:
- ✅ Black (formatting)
- ✅ Ruff (linting)
- ✅ MyPy (type checking)
- ✅ ShellCheck (bash scripts)
- ✅ Custom lint

Test results from audit:
- ✅ All tests pass (6/6)
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Backward compatibility maintained

## Test Plan

- [x] Run existing test suite
- [x] Verify no imports from services in models layer
- [x] Verify backward compatibility via SignatureService delegation
- [x] Check actor normalization works correctly in PR body rendering
- [ ] CI checks pass after PR creation
- [ ] Manual review of architecture changes

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)