### PR TITLE
feat(review): enforce findings-first principle and improve PASS explanations

### DIFF
--- a/.agent/policies/review.md
+++ b/.agent/policies/review.md
@@ -16,6 +16,21 @@
 - 不把个人偏好包装成缺陷。
 - 不因风格差异给出高严重性结论。
 
+## Findings First Principle
+
+**核心原则**：先给 findings，再给 verdict。没有 finding 就不要编造。
+
+输出优先级：
+1. Blocking issue（必须修复）
+2. Non-blocking but noteworthy risk（应关注）
+3. No finding（明确说明为何无发现）
+
+**禁止**：
+- 输出冗长的 praise 或 description 段落
+- 与当前 diff 无关的泛化架构点评
+- 把风格偏好包装成高严重性结论
+- PASS 时生成冗长表扬而非简洁理由
+
 ## 审查前强制检查清单
 
 开始 review 前，**必须完成**以下检查：
@@ -173,7 +188,13 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 ### PASS
 
 - 未发现会影响正确性、回归、安全性或项目边界的明显问题
-- 即使有建议，也只是次要改进
+- **必须简洁说明为何没有发现 blocking / major issue**（1-2句话）
+- 即使有建议，也只是次要改进，用 notes 形式给出
+- 不要生成 praise 段落
+
+示例：
+✓ "PASS: 变更范围有限，仅新增辅助函数，未触及公开API或关键路径，测试覆盖充分。"
+✗ "PASS: 代码质量优秀，结构清晰，命名规范，注释完整..."（冗长表扬）
 
 ### MAJOR
 
@@ -199,6 +220,18 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 
 ## 输出要求
 
+**强制结构**：
+1. VERDICT 行（首行）
+2. Findings 列表（如有）
+3. PASS/MAJOR/BLOCK 理由说明（简洁）
+4. Notes（可选，仅限次要建议）
+
+**禁止**：
+- 先写 lengthy summary 再给 findings
+- 输出 “Strength” / “Positive” 段落
+- 与当前 diff 无关的泛化点评
+
+**基本要求**：
 - 先给 findings，再给 verdict。
 - 只写可操作问题。
 - 问题描述必须指出为什么这是问题，而不只是说”建议更好”。

--- a/config/prompts.yaml
+++ b/config/prompts.yaml
@@ -536,19 +536,27 @@ review:
   # Target recipe section name: review.output_format
   # Unlike plan/run output shape guidance, this is a hard behavioral contract.
   output_format: |
+    **FINDINGS FIRST — No praise, no generic commentary.**
+
     The first line must be exactly:
     VERDICT: PASS | MAJOR | BLOCK
 
-    Each finding should follow this format:
-    path/to/file.py:42 [MAJOR] concise issue description
+    If findings exist, list them concisely:
+    path/to/file.py:42 [BLOCK] <specific issue with code evidence>
+    path/to/file.py:100 [MAJOR] <specific issue with code evidence>
 
-    The final line must repeat the same `VERDICT:`:
-    VERDICT: PASS | MAJOR | BLOCK
+    Then provide a brief rationale (1-2 sentences):
+    - PASS: "Why no blocking/major issue was found for this diff"
+    - MAJOR: "Summary of what should be addressed before merge"
+    - BLOCK: "Summary of critical issues that must be fixed"
 
-    Where:
-    - PASS: No significant issues found
-    - MAJOR: Issues found that should be addressed before merge
-    - BLOCK: Critical issues that must be fixed before merge
+    The final line must repeat the same VERDICT.
+
+    **DO NOT**:
+    - Write lengthy summary before findings
+    - Include "Strength" / "Positive" / "Praise" paragraphs
+    - Give generic architecture commentary unrelated to the diff
+    - Use template-style phrases like "code quality is good"
 
   # Static: reviewer exit contract plus default review guidance.
   # Target recipe section name: review.exit_contract

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -135,14 +135,21 @@ def build_review_task_section(task_text: str | None) -> str:
     if task_text:
         return f"## Review Task\n{task_text}"
 
-    # Default task guidance
+    # Default: findings-first task guidance
     return """## Review Task
 
+**Prioritize**: correctness → regression risk → API breaks → missing tests
+
+**Focus on**:
 - Run `git diff <base>...HEAD` to see file changes
 - Review only changed code, not the entire codebase
 - Use AST analysis to understand function-level impact
-- Prioritize: correctness, regression risk, API breaks
-- Focus on actionable, specific findings"""
+- Give findings first, then verdict with brief rationale
+
+**Skip**:
+- Generic architecture commentary unrelated to this diff
+- Praise/description paragraphs
+- Style suggestions unless they affect correctness"""
 
 
 def build_output_contract_section(output_format: str | None) -> str:
@@ -159,19 +166,29 @@ def build_output_contract_section(output_format: str | None) -> str:
     if output_format:
         return f"## Output format requirements\n{output_format}"
 
-    # Default output format
+    # Default: findings-first output format
     return """## Output format requirements
 
-Each finding should follow this format:
-path/to/file.py:42 [MAJOR] concise issue description
+**FINDINGS FIRST — No praise, no generic commentary.**
 
-The final line must be:
+The first line must be exactly:
 VERDICT: PASS | MAJOR | BLOCK
 
-Where:
-- PASS: No significant issues found
-- MAJOR: Issues found that should be addressed before merge
-- BLOCK: Critical issues that must be fixed before merge"""
+If findings exist, list them concisely:
+path/to/file.py:42 [BLOCK] <specific issue with code evidence>
+path/to/file.py:100 [MAJOR] <specific issue with code evidence>
+
+Then provide a brief rationale (1-2 sentences):
+- PASS: "Why no blocking/major issue was found for this diff"
+- MAJOR: "Summary of what should be addressed before merge"
+- BLOCK: "Summary of critical issues that must be fixed"
+
+The final line must repeat the same VERDICT.
+
+**DO NOT**:
+- Write lengthy summary before findings
+- Include "Strength" / "Positive" / "Praise" paragraphs
+- Give generic architecture commentary unrelated to the diff"""
 
 
 def _review_variant(mode: ReviewPromptMode, context_mode: PromptContextMode) -> str:


### PR DESCRIPTION
## Summary
- Add Findings First Principle to review policy, requiring all findings to be listed before any conclusion
- Require explicit reasoning for PASS verdicts with evidence citations
- Eliminate generic praise/commentary (e.g., "well-structured", "solid implementation") from review output
- Improve signal-to-noise ratio by focusing on actionable findings

## Changes
- `.agent/policies/review.md`: Added Findings First Principle, PASS explanation requirement with examples
- `config/prompts.yaml`: Updated review prompt configuration to enforce new principles
- `src/vibe3/agents/review_prompt.py`: Implemented prompt generation logic with findings-first structure

## Test Plan
- ✓ 32 tests passed across 3 test files (unit + integration)
- ✓ Type check passed (mypy)
- ✓ Lint check passed (ruff)
- ✓ All acceptance criteria verified with evidence

Closes #214