### PR TITLE
feat(vibe3): add task search subcommand for duplicate detection

### DIFF
--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -270,3 +270,52 @@ class IssuesMixin(IssueAdminMixin):
             )
             return []
         return cast(list[dict[str, Any]], json.loads(result.stdout))
+
+    def search_issues(
+        self,
+        query: str,
+        limit: int = 30,
+        state: str = "open",
+        label: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search GitHub issues using gh issue list --search.
+
+        Args:
+            query: Search query string
+            limit: Maximum number of results
+            state: Issue state filter (open, closed, all)
+            label: Optional label filter
+
+        Returns:
+            List of issue dicts with number, title, state, labels
+        """
+        logger.bind(
+            external="github",
+            operation="search_issues",
+            query=query,
+            limit=limit,
+            state=state,
+            label=label,
+        ).debug("Calling GitHub API: search_issues")
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--search",
+            query,
+            "--limit",
+            str(limit),
+            "--state",
+            state,
+            "--json",
+            "number,title,state,labels",
+        ]
+        if label:
+            cmd.extend(["--label", label])
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            logger.bind(external="github", error=result.stderr).error(
+                "Failed to search issues"
+            )
+            return []
+        return cast(list[dict[str, Any]], json.loads(result.stdout))

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -16,6 +16,7 @@ from vibe3.services.task_resume_usecase import TaskResumeUsecase
 from vibe3.services.task_service import TaskService
 from vibe3.ui.task_ui import (
     render_task_comments,
+    render_task_search,
     render_task_show,
 )
 
@@ -414,3 +415,44 @@ def resume(
                 "\nTip: If all failed issues are resumed, "
                 "the failed gate will automatically unblock."
             )
+
+
+@app.command()
+def search(
+    query: Annotated[
+        str,
+        typer.Argument(help="Search query for issues"),
+    ],
+    state: Annotated[
+        str,
+        typer.Option("--state", help="Issue state: open, closed, all"),
+    ] = "open",
+    label: Annotated[
+        str | None,
+        typer.Option("--label", help="Filter by label"),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", help="Maximum results"),
+    ] = 30,
+    json_output: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """Search existing GitHub issues for potential duplicates.
+
+    Use before creating new tasks to avoid duplicates.
+
+    Examples:
+        vibe3 task search "review"
+        vibe3 task search "vibe3 task" --state all
+        vibe3 task search "bug" --label bug --limit 10
+    """
+    task_svc = TaskService()
+
+    results = task_svc.search_issues(
+        query=query,
+        limit=limit,
+        state=state,
+        label=label,
+    )
+
+    render_task_search(results, query, json_output)

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -403,3 +403,28 @@ class TaskService:
     def show_task(self, branch: str | None = None) -> TaskShowResult:
         """Load task detail from local state."""
         return self._show_service.show_task(branch)
+
+    def search_issues(
+        self,
+        query: str,
+        limit: int = 30,
+        state: str = "open",
+        label: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search GitHub issues for potential duplicates.
+
+        Args:
+            query: Search query string
+            limit: Maximum number of results
+            state: Issue state filter (open, closed, all)
+            label: Optional label filter
+
+        Returns:
+            List of issue dicts with number, title, state, labels
+        """
+        return self.github_client.search_issues(
+            query=query,
+            limit=limit,
+            state=state,
+            label=label,
+        )

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -191,3 +191,50 @@ def render_task_comments(issue: dict[str, object], max_comments: int = 3) -> Non
 
         console.print(body)
         console.print()  # Empty line between comments
+
+
+def render_task_search(
+    results: list[dict[str, object]],
+    query: str,
+    json_output: bool = False,
+) -> None:
+    """Render task search results.
+
+    Args:
+        results: List of issue dicts from search
+        query: The search query string
+        json_output: If True, output as JSON; otherwise formatted table
+    """
+    if json_output:
+        console.print(
+            json.dumps(results, indent=2, default=str),
+            markup=False,
+            highlight=False,
+            soft_wrap=True,
+        )
+        return
+
+    # Human-readable format
+    count = len(results)
+    console.print(f'\n[bold]Found {count} issue(s) matching "{query}":[/]\n')
+
+    if not results:
+        return
+
+    for issue in results:
+        if not isinstance(issue, dict):
+            continue
+
+        number = issue.get("number")
+        title = issue.get("title", "")
+        state = str(issue.get("state", "OPEN")).upper()
+
+        # State color
+        state_color = "green" if state == "OPEN" else "red"
+
+        # Format: #237  [OPEN]   Split review/plan/run agent contracts...
+        console.print(
+            f"  [bold]#{number}[/]  [{state_color}][{state}][/{state_color}]   {title}"
+        )
+
+    console.print()  # Empty line at end


### PR DESCRIPTION
## Summary

Add `vibe3 task search` subcommand to search existing GitHub issues for potential duplicates before creating new tasks.

## Changes

- **GitHub client**: Add `search_issues()` method wrapping `gh issue list --search`
- **Service layer**: Add delegation method in `TaskService`
- **UI layer**: Add `render_task_search()` for formatted output (table/JSON)
- **CLI layer**: Add `search` command with query, state, label, and limit options

## Implementation Details

- Uses `gh issue list --search` under the hood
- Supports `--state` (open/closed/all) and `--label` filters
- Outputs JSON with `--json` flag for programmatic use
- Returns issue number, title, state, and labels
- Follows existing layered architecture (client → service → UI → CLI)

## Testing

All pre-push checks passed:
- ✅ 107 tests (DAG-based incremental test selection)
- ✅ MyPy type checking
- ✅ Ruff linting
- ✅ Black formatting
- ✅ LOC limits

## Usage Examples

```bash
# Search for issues mentioning "review"
vibe3 task search "review"

# Search all issues (open and closed)
vibe3 task search "vibe3 task" --state all

# Search with label filter
vibe3 task search "bug" --label bug --limit 10

# JSON output for scripts
vibe3 task search "feature" --json
```

Closes #215