### PR TITLE
feat: vibe3 pr show should fetch CI status and comments as external events

### DIFF
--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -34,6 +34,7 @@ from vibe3.models.trace import TraceOutput
 from vibe3.observability.logger import setup_logging
 from vibe3.observability.trace import trace_context
 from vibe3.services.flow_service import FlowService
+from vibe3.services.handoff_service import HandoffService
 from vibe3.services.pr_service import PRService
 from vibe3.ui.pr_ui import render_pr_details
 
@@ -129,6 +130,73 @@ def _load_pr_analysis_summary(
     return pr_analysis_summary(analysis)
 
 
+def _fetch_and_record_external_events(
+    pr_number: int,
+    branch: str,
+    github_client: Any,
+    handoff_svc: HandoffService,
+) -> None:
+    """Fetch CI status and comments from GitHub, record as external events.
+
+    This is a best-effort operation - failures are logged but not raised.
+
+    Args:
+        pr_number: PR number
+        branch: Branch name
+        github_client: GitHub client with list_pr_comments/list_pr_review_comments
+        handoff_svc: Handoff service for recording events
+    """
+    try:
+        # Fetch CI status (already in PRResponse, but we need to fetch it)
+        # Note: We could pass it from the caller, but re-fetching ensures fresh data
+        pr = github_client.get_pr(pr_number, None)
+        if pr and pr.ci_status:
+            handoff_svc.record_ci_status(
+                branch=branch,
+                pr_number=pr_number,
+                status=pr.ci_status,
+            )
+
+        # Fetch general comments
+        comments = []
+        try:
+            comments = github_client.list_pr_comments(pr_number)
+        except Exception as e:
+            logger.bind(
+                domain="pr",
+                action="fetch_comments",
+                pr_number=pr_number,
+            ).warning(f"Failed to fetch PR comments: {e}")
+
+        # Fetch review comments
+        review_comments = []
+        try:
+            review_comments = github_client.list_pr_review_comments(pr_number)
+        except Exception as e:
+            logger.bind(
+                domain="pr",
+                action="fetch_review_comments",
+                pr_number=pr_number,
+            ).warning(f"Failed to fetch PR review comments: {e}")
+
+        # Record comments
+        if comments or review_comments:
+            handoff_svc.record_pr_comments(
+                branch=branch,
+                pr_number=pr_number,
+                comments=comments,
+                review_comments=review_comments,
+            )
+
+    except Exception as e:
+        logger.bind(
+            domain="pr",
+            action="record_external_events",
+            pr_number=pr_number,
+            branch=branch,
+        ).warning(f"Failed to record external events: {e}")
+
+
 def _build_pr_output_payload(
     pr: "PRResponse",
     analysis_summary: dict[str, Any] | None = None,
@@ -218,6 +286,22 @@ def register_query_commands(app: typer.Typer) -> None:
                     err=True,
                 )
                 raise typer.Exit(1) from None
+
+            # Record external events (best-effort, non-blocking)
+            try:
+                if pr and pr_number:
+                    effective_branch = branch or target.current_branch
+                    if effective_branch:
+                        _fetch_and_record_external_events(
+                            pr_number=pr_number,
+                            branch=effective_branch,
+                            github_client=pr_svc.github_client,
+                            handoff_svc=HandoffService(store=pr_svc.store),
+                        )
+            except Exception as exc:
+                logger.bind(domain="pr", action="record_external_events").warning(
+                    f"Failed to record external events: {exc}"
+                )
 
             analysis_summary = None
             if pr_number:

--- a/src/vibe3/services/external_events.py
+++ b/src/vibe3/services/external_events.py
@@ -1,0 +1,196 @@
+"""External event recording service for handoff system."""
+
+from typing import Any, Callable
+
+from loguru import logger
+
+from vibe3.clients import SQLiteClient
+from vibe3.models.flow import FlowEvent
+from vibe3.services.handoff_storage import HandoffStorage
+
+
+class ExternalEventRecorder:
+    """Records external events (CI status, PR comments) as handoff events."""
+
+    def __init__(
+        self,
+        store: SQLiteClient,
+        storage: HandoffStorage,
+        get_handoff_events_func: Callable[
+            [str, str | None, int | None], list[FlowEvent]
+        ],
+    ) -> None:
+        self.store = store
+        self.storage = storage
+        self._get_handoff_events = get_handoff_events_func
+
+    def get_handoff_events(
+        self,
+        branch: str,
+        event_type_prefix: str | None = None,
+        limit: int | None = None,
+    ) -> list[FlowEvent]:
+        """Query handoff events using injected function."""
+        return self._get_handoff_events(branch, event_type_prefix, limit)
+
+    def record_ci_status(
+        self,
+        branch: str,
+        pr_number: int,
+        status: str,
+        actor: str = "system/github",
+    ) -> bool:
+        """Record CI status as external event.
+
+        Only records if status changed from last recorded status.
+
+        Args:
+            branch: Branch name
+            pr_number: PR number
+            status: CI status string (e.g., "SUCCESS", "FAILURE", "PENDING")
+            actor: Actor string (defaults to "system/github")
+
+        Returns:
+            True if event was recorded, False if skipped (no change)
+        """
+        # Query last recorded CI status for this branch
+        last_events = self.get_handoff_events(
+            branch, event_type_prefix="handoff_ci_status", limit=1
+        )
+
+        # Check if status changed
+        if last_events and last_events[0].refs:
+            last_status = last_events[0].refs.get("status")
+            if last_status == status:
+                logger.bind(
+                    domain="handoff",
+                    action="record_ci_status",
+                    branch=branch,
+                    pr_number=pr_number,
+                    status=status,
+                ).debug("CI status unchanged, skipping recording")
+                return False
+
+        # Record new status
+        detail = f"PR #{pr_number} CI status: {status}"
+        refs = {
+            "pr_number": str(pr_number),
+            "status": status,
+        }
+
+        self.store.add_event(
+            branch,
+            "handoff_ci_status",
+            actor,
+            detail=detail,
+            refs=refs,
+        )
+
+        logger.bind(
+            domain="handoff",
+            action="record_ci_status",
+            branch=branch,
+            pr_number=pr_number,
+            status=status,
+        ).info("Recorded CI status change")
+        return True
+
+    def record_pr_comments(
+        self,
+        branch: str,
+        pr_number: int,
+        comments: list[dict[str, Any]],
+        review_comments: list[dict[str, Any]] | None = None,
+        actor: str = "system/github",
+    ) -> int:
+        """Record PR comments as external events.
+
+        Only records comments not already recorded (dedup by comment ID).
+
+        Args:
+            branch: Branch name
+            pr_number: PR number
+            comments: List of general comments (each has 'id' or 'number' field)
+            review_comments: List of review comments (each has 'id' field)
+            actor: Actor string (defaults to "system/github")
+
+        Returns:
+            Number of new comments recorded
+        """
+        if review_comments is None:
+            review_comments = []
+
+        # Query existing recorded comment IDs
+        existing_events = self.get_handoff_events(
+            branch, event_type_prefix="handoff_pr_comment"
+        )
+        recorded_ids = set()
+        for event in existing_events:
+            if event.refs:
+                comment_id = event.refs.get("comment_id")
+                if comment_id:
+                    recorded_ids.add(str(comment_id))
+
+        # Record new comments
+        recorded_count = 0
+        all_comments = []
+
+        # Process general comments (use 'id' or 'number' field)
+        for comment in comments:
+            comment_id = str(comment.get("id") or comment.get("number"))
+            if comment_id and comment_id not in recorded_ids:
+                all_comments.append(("general", comment_id, comment))
+
+        # Process review comments (use 'id' field)
+        for comment in review_comments:
+            comment_id = str(comment.get("id"))
+            if comment_id and comment_id not in recorded_ids:
+                all_comments.append(("review", comment_id, comment))
+
+        # Record each new comment
+        for comment_type, comment_id, comment_data in all_comments:
+            author = comment_data.get("author", {})
+            author_login = (
+                author.get("login", "unknown")
+                if isinstance(author, dict)
+                else str(author)
+            )
+            body = comment_data.get("body", "")
+            created_at = comment_data.get("createdAt") or comment_data.get(
+                "created_at", ""
+            )
+
+            # Truncate body for event detail (max 200 chars)
+            truncated_body = body[:200] if len(body) > 200 else body
+
+            detail = (
+                f"PR #{pr_number} {comment_type} comment by "
+                f"{author_login}: {truncated_body}"
+            )
+            refs = {
+                "pr_number": str(pr_number),
+                "comment_id": comment_id,
+                "comment_type": comment_type,
+                "author": author_login,
+                "created_at": created_at,
+            }
+
+            self.store.add_event(
+                branch,
+                "handoff_pr_comment",
+                actor,
+                detail=detail,
+                refs=refs,
+            )
+            recorded_count += 1
+
+        if recorded_count > 0:
+            logger.bind(
+                domain="handoff",
+                action="record_pr_comments",
+                branch=branch,
+                pr_number=pr_number,
+                count=recorded_count,
+            ).info(f"Recorded {recorded_count} new PR comments")
+
+        return recorded_count

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
 
@@ -36,6 +37,8 @@ class HandoffService:
         "report_recorded",  # new canonical name
         "run_recorded",  # backward-compat: legacy event type
         "audit_recorded",
+        "handoff_ci_status",
+        "handoff_pr_comment",
     }
     _SUCCESS_HANDOFF_EVENT_TYPES = {
         "handoff_plan",
@@ -44,6 +47,8 @@ class HandoffService:
         "handoff_audit",
         "handoff_indicate",
         "handoff_verdict",
+        "handoff_ci_status",
+        "handoff_pr_comment",
     }
 
     def __init__(
@@ -447,3 +452,165 @@ class HandoffService:
             refs=refs,
         )
         return artifact_path
+
+    def record_ci_status(
+        self,
+        branch: str,
+        pr_number: int,
+        status: str,
+        actor: str = "system/github",
+    ) -> bool:
+        """Record CI status as external event.
+
+        Only records if status changed from last recorded status.
+
+        Args:
+            branch: Branch name
+            pr_number: PR number
+            status: CI status string (e.g., "SUCCESS", "FAILURE", "PENDING")
+            actor: Actor string (defaults to "system/github")
+
+        Returns:
+            True if event was recorded, False if skipped (no change)
+        """
+        # Query last recorded CI status for this branch
+        last_events = self.get_handoff_events(
+            branch, event_type_prefix="handoff_ci_status", limit=1
+        )
+
+        # Check if status changed
+        if last_events and last_events[0].refs:
+            last_status = last_events[0].refs.get("status")
+            if last_status == status:
+                logger.bind(
+                    domain="handoff",
+                    action="record_ci_status",
+                    branch=branch,
+                    pr_number=pr_number,
+                    status=status,
+                ).debug("CI status unchanged, skipping recording")
+                return False
+
+        # Record new status
+        detail = f"PR #{pr_number} CI status: {status}"
+        refs = {
+            "pr_number": str(pr_number),
+            "status": status,
+        }
+
+        self.store.add_event(
+            branch,
+            "handoff_ci_status",
+            actor,
+            detail=detail,
+            refs=refs,
+        )
+
+        logger.bind(
+            domain="handoff",
+            action="record_ci_status",
+            branch=branch,
+            pr_number=pr_number,
+            status=status,
+        ).info("Recorded CI status change")
+        return True
+
+    def record_pr_comments(
+        self,
+        branch: str,
+        pr_number: int,
+        comments: list[dict[str, Any]],
+        review_comments: list[dict[str, Any]] | None = None,
+        actor: str = "system/github",
+    ) -> int:
+        """Record PR comments as external events.
+
+        Only records comments not already recorded (dedup by comment ID).
+
+        Args:
+            branch: Branch name
+            pr_number: PR number
+            comments: List of general comments (each has 'id' or 'number' field)
+            review_comments: List of review comments (each has 'id' field)
+            actor: Actor string (defaults to "system/github")
+
+        Returns:
+            Number of new comments recorded
+        """
+        if review_comments is None:
+            review_comments = []
+
+        # Query existing recorded comment IDs
+        existing_events = self.get_handoff_events(
+            branch, event_type_prefix="handoff_pr_comment"
+        )
+        recorded_ids = set()
+        for event in existing_events:
+            if event.refs:
+                comment_id = event.refs.get("comment_id")
+                if comment_id:
+                    recorded_ids.add(str(comment_id))
+
+        # Record new comments
+        recorded_count = 0
+        all_comments = []
+
+        # Process general comments (use 'id' or 'number' field)
+        for comment in comments:
+            comment_id = str(comment.get("id") or comment.get("number"))
+            if comment_id and comment_id not in recorded_ids:
+                all_comments.append(("general", comment_id, comment))
+
+        # Process review comments (use 'id' field)
+        for comment in review_comments:
+            comment_id = str(comment.get("id"))
+            if comment_id and comment_id not in recorded_ids:
+                all_comments.append(("review", comment_id, comment))
+
+        # Record each new comment
+        for comment_type, comment_id, comment_data in all_comments:
+            author = comment_data.get("author", {})
+            author_login = (
+                author.get("login", "unknown")
+                if isinstance(author, dict)
+                else str(author)
+            )
+            body = comment_data.get("body", "")
+            created_at = comment_data.get("createdAt") or comment_data.get(
+                "created_at", ""
+            )
+
+            # Truncate body for event detail (max 200 chars)
+            truncated_body = body[:200] if len(body) > 200 else body
+
+            detail = (
+                f"PR #{pr_number} {comment_type} comment by "
+                f"{author_login}: {truncated_body}"
+            )
+            refs = {
+                "pr_number": str(pr_number),
+                "comment_id": comment_id,
+                "comment_type": comment_type,
+                "author": author_login,
+                "created_at": created_at,
+            }
+
+            self.store.add_event(
+                branch,
+                "handoff_pr_comment",
+                actor,
+                detail=detail,
+                refs=refs,
+            )
+            recorded_count += 1
+
+        if recorded_count > 0:
+            logger.bind(
+                domain="handoff",
+                action="record_pr_comments",
+                branch=branch,
+                pr_number=pr_number,
+                count=recorded_count,
+            ).info(f"Recorded {recorded_count} new PR comments")
+
+        return recorded_count

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, cast
 
 from loguru import logger
 
@@ -15,7 +15,9 @@ from vibe3.execution.actor_support import (
 from vibe3.models.flow import FlowEvent
 from vibe3.models.verdict import VerdictRecord
 from vibe3.services.artifact_parser import ArtifactParser
+from vibe3.services.external_events import ExternalEventRecorder
 from vibe3.services.handoff_storage import HandoffStorage
+from vibe3.services.handoff_validation import validate_authoritative_ref
 from vibe3.services.signature_service import SignatureService
 from vibe3.utils.path_helpers import (
     _SHARED_HANDOFF_PREFIX,
@@ -59,6 +61,16 @@ class HandoffService:
         self.store = store or SQLiteClient()
         self.git_client = git_client or GitClient()
         self.storage = HandoffStorage(self.git_client)
+        self.external_recorder = ExternalEventRecorder(
+            self.store,
+            self.storage,
+            cast(
+                Callable[[str, str | None, int | None], list[FlowEvent]],
+                lambda branch, event_type_prefix=None, limit=None: self.get_handoff_events(  # noqa: E501
+                    branch, event_type_prefix, limit
+                ),
+            ),
+        )
 
     def get_handoff_events(
         self,
@@ -139,44 +151,6 @@ class HandoffService:
 
         raise UserError("Cannot validate handoff ref without a worktree root")
 
-    @staticmethod
-    def _is_log_like_path(path: Path) -> bool:
-        lowered_parts = [part.lower() for part in path.parts]
-        for idx in range(len(lowered_parts) - 1):
-            if lowered_parts[idx] == "temp" and lowered_parts[idx + 1] == "logs":
-                return True
-        return path.name.endswith(".async.log")
-
-    def _validate_authoritative_ref(
-        self, ref_kind: str, ref_value: str, branch: str
-    ) -> None:
-        if ref_kind.lower() not in self._AUTHORITATIVE_REF_KINDS:
-            return
-
-        worktree_root = self._resolve_branch_worktree_root(branch).resolve()
-        ref_path = Path(ref_value).expanduser()
-        resolved = (
-            ref_path.resolve(strict=False)
-            if ref_path.is_absolute()
-            else (worktree_root / ref_path).resolve(strict=False)
-        )
-
-        if self._is_log_like_path(resolved):
-            raise UserError(
-                f"{ref_kind}_ref cannot point to execution logs under temp/logs: "
-                f"{ref_value}"
-            )
-        git_common = Path(self.git_client.get_git_common_dir()).resolve()
-        if resolved.is_relative_to(git_common):
-            raise UserError(
-                f"{ref_kind}_ref must point to an agent worktree document, "
-                f"not shared handoff store: {ref_value}"
-            )
-        if not resolved.is_relative_to(worktree_root):
-            raise UserError(
-                f"{ref_kind}_ref must stay inside the agent worktree: {ref_value}"
-            )
-
     def _record_ref(
         self,
         ref_kind: str,
@@ -192,7 +166,14 @@ class HandoffService:
         This method only handles active handoff events (handoff_plan/report/audit).
         """
         branch = self.git_client.get_current_branch()
-        self._validate_authoritative_ref(ref_kind, ref_value, branch)
+        validate_authoritative_ref(
+            ref_kind,
+            ref_value,
+            branch,
+            self.git_client,
+            self._AUTHORITATIVE_REF_KINDS,
+            self._resolve_branch_worktree_root,
+        )
         # Inlined _normalize_ref_value
         ref_value = self.storage.normalize_ref_value(ref_value, branch)
         effective_actor = SignatureService.resolve_for_branch(
@@ -473,47 +454,7 @@ class HandoffService:
         Returns:
             True if event was recorded, False if skipped (no change)
         """
-        # Query last recorded CI status for this branch
-        last_events = self.get_handoff_events(
-            branch, event_type_prefix="handoff_ci_status", limit=1
-        )
-
-        # Check if status changed
-        if last_events and last_events[0].refs:
-            last_status = last_events[0].refs.get("status")
-            if last_status == status:
-                logger.bind(
-                    domain="handoff",
-                    action="record_ci_status",
-                    branch=branch,
-                    pr_number=pr_number,
-                    status=status,
-                ).debug("CI status unchanged, skipping recording")
-                return False
-
-        # Record new status
-        detail = f"PR #{pr_number} CI status: {status}"
-        refs = {
-            "pr_number": str(pr_number),
-            "status": status,
-        }
-
-        self.store.add_event(
-            branch,
-            "handoff_ci_status",
-            actor,
-            detail=detail,
-            refs=refs,
-        )
-
-        logger.bind(
-            domain="handoff",
-            action="record_ci_status",
-            branch=branch,
-            pr_number=pr_number,
-            status=status,
-        ).info("Recorded CI status change")
-        return True
+        return self.external_recorder.record_ci_status(branch, pr_number, status, actor)
 
     def record_pr_comments(
         self,
@@ -537,80 +478,6 @@ class HandoffService:
         Returns:
             Number of new comments recorded
         """
-        if review_comments is None:
-            review_comments = []
-
-        # Query existing recorded comment IDs
-        existing_events = self.get_handoff_events(
-            branch, event_type_prefix="handoff_pr_comment"
+        return self.external_recorder.record_pr_comments(
+            branch, pr_number, comments, review_comments, actor
         )
-        recorded_ids = set()
-        for event in existing_events:
-            if event.refs:
-                comment_id = event.refs.get("comment_id")
-                if comment_id:
-                    recorded_ids.add(str(comment_id))
-
-        # Record new comments
-        recorded_count = 0
-        all_comments = []
-
-        # Process general comments (use 'id' or 'number' field)
-        for comment in comments:
-            comment_id = str(comment.get("id") or comment.get("number"))
-            if comment_id and comment_id not in recorded_ids:
-                all_comments.append(("general", comment_id, comment))
-
-        # Process review comments (use 'id' field)
-        for comment in review_comments:
-            comment_id = str(comment.get("id"))
-            if comment_id and comment_id not in recorded_ids:
-                all_comments.append(("review", comment_id, comment))
-
-        # Record each new comment
-        for comment_type, comment_id, comment_data in all_comments:
-            author = comment_data.get("author", {})
-            author_login = (
-                author.get("login", "unknown")
-                if isinstance(author, dict)
-                else str(author)
-            )
-            body = comment_data.get("body", "")
-            created_at = comment_data.get("createdAt") or comment_data.get(
-                "created_at", ""
-            )
-
-            # Truncate body for event detail (max 200 chars)
-            truncated_body = body[:200] if len(body) > 200 else body
-
-            detail = (
-                f"PR #{pr_number} {comment_type} comment by "
-                f"{author_login}: {truncated_body}"
-            )
-            refs = {
-                "pr_number": str(pr_number),
-                "comment_id": comment_id,
-                "comment_type": comment_type,
-                "author": author_login,
-                "created_at": created_at,
-            }
-
-            self.store.add_event(
-                branch,
-                "handoff_pr_comment",
-                actor,
-                detail=detail,
-                refs=refs,
-            )
-            recorded_count += 1
-
-        if recorded_count > 0:
-            logger.bind(
-                domain="handoff",
-                action="record_pr_comments",
-                branch=branch,
-                pr_number=pr_number,
-                count=recorded_count,
-            ).info(f"Recorded {recorded_count} new PR comments")
-
-        return recorded_count

--- a/src/vibe3/services/handoff_validation.py
+++ b/src/vibe3/services/handoff_validation.py
@@ -1,0 +1,57 @@
+"""Validation utilities for handoff service."""
+
+from pathlib import Path
+from typing import Callable
+
+from vibe3.exceptions import UserError
+from vibe3.utils.path_helpers import GitClientProtocol
+
+
+def is_log_like_path(path: Path) -> bool:
+    """Check if path points to execution logs."""
+    lowered_parts = [part.lower() for part in path.parts]
+    for idx in range(len(lowered_parts) - 1):
+        if lowered_parts[idx] == "temp" and lowered_parts[idx + 1] == "logs":
+            return True
+    return path.name.endswith(".async.log")
+
+
+def validate_authoritative_ref(
+    ref_kind: str,
+    ref_value: str,
+    branch: str,
+    git_client: GitClientProtocol,
+    authoritative_kinds: set[str],
+    resolve_branch_worktree_root: Callable[[str], Path],
+) -> None:
+    """Validate that authoritative ref points to valid location.
+
+    Raises:
+        UserError: If ref is invalid
+    """
+    if ref_kind.lower() not in authoritative_kinds:
+        return
+
+    worktree_root = resolve_branch_worktree_root(branch).resolve()
+    ref_path = Path(ref_value).expanduser()
+    resolved = (
+        ref_path.resolve(strict=False)
+        if ref_path.is_absolute()
+        else (worktree_root / ref_path).resolve(strict=False)
+    )
+
+    if is_log_like_path(resolved):
+        raise UserError(
+            f"{ref_kind}_ref cannot point to execution logs under temp/logs: "
+            f"{ref_value}"
+        )
+    git_common = Path(git_client.get_git_common_dir()).resolve()
+    if resolved.is_relative_to(git_common):
+        raise UserError(
+            f"{ref_kind}_ref must point to an agent worktree document, "
+            f"not shared handoff store: {ref_value}"
+        )
+    if not resolved.is_relative_to(worktree_root):
+        raise UserError(
+            f"{ref_kind}_ref must stay inside the agent worktree: {ref_value}"
+        )

--- a/tests/vibe3/commands/test_pr_show_external_events.py
+++ b/tests/vibe3/commands/test_pr_show_external_events.py
@@ -1,0 +1,135 @@
+"""Integration tests for PR show external event recording."""
+
+from unittest.mock import MagicMock
+
+from vibe3.commands.pr_query import _fetch_and_record_external_events
+from vibe3.models.pr import PRResponse
+
+
+def test_fetch_and_record_external_events_happy_path() -> None:
+    """Test successful recording of CI status and comments."""
+    # Setup mocks
+    mock_github = MagicMock()
+    mock_handoff = MagicMock()
+
+    # Mock PR with CI status
+    mock_pr = MagicMock(spec=PRResponse)
+    mock_pr.ci_status = "SUCCESS"
+    mock_github.get_pr.return_value = mock_pr
+
+    # Mock comments
+    mock_github.list_pr_comments.return_value = [
+        {"id": 1, "author": {"login": "user1"}, "body": "Comment 1"}
+    ]
+    mock_github.list_pr_review_comments.return_value = [
+        {"id": 2, "author": {"login": "user2"}, "body": "Review comment"}
+    ]
+
+    # Mock handoff service returns
+    mock_handoff.record_ci_status.return_value = True
+    mock_handoff.record_pr_comments.return_value = 2
+
+    # Execute
+    _fetch_and_record_external_events(
+        pr_number=123,
+        branch="test-branch",
+        github_client=mock_github,
+        handoff_svc=mock_handoff,
+    )
+
+    # Verify calls
+    mock_github.get_pr.assert_called_once_with(123, None)
+    mock_handoff.record_ci_status.assert_called_once_with(
+        branch="test-branch",
+        pr_number=123,
+        status="SUCCESS",
+    )
+    mock_github.list_pr_comments.assert_called_once_with(123)
+    mock_github.list_pr_review_comments.assert_called_once_with(123)
+    mock_handoff.record_pr_comments.assert_called_once_with(
+        branch="test-branch",
+        pr_number=123,
+        comments=[{"id": 1, "author": {"login": "user1"}, "body": "Comment 1"}],
+        review_comments=[
+            {"id": 2, "author": {"login": "user2"}, "body": "Review comment"}
+        ],
+    )
+
+
+def test_fetch_and_record_external_events_graceful_failure() -> None:
+    """Test that failures in fetching/recording are handled gracefully."""
+    # Setup mocks
+    mock_github = MagicMock()
+    mock_handoff = MagicMock()
+
+    # Mock PR fetch failure
+    mock_github.get_pr.side_effect = Exception("API error")
+
+    # Execute - should not raise
+    _fetch_and_record_external_events(
+        pr_number=123,
+        branch="test-branch",
+        github_client=mock_github,
+        handoff_svc=mock_handoff,
+    )
+
+    # Verify partial progress before failure
+    mock_github.get_pr.assert_called_once()
+
+
+def test_fetch_and_record_external_events_comment_fetch_failure() -> None:
+    """Test handling of comment fetch failures."""
+    # Setup mocks
+    mock_github = MagicMock()
+    mock_handoff = MagicMock()
+
+    # Mock PR with CI status
+    mock_pr = MagicMock(spec=PRResponse)
+    mock_pr.ci_status = "PENDING"
+    mock_github.get_pr.return_value = mock_pr
+
+    # Mock comment fetch failure
+    mock_github.list_pr_comments.side_effect = Exception("API error")
+    mock_github.list_pr_review_comments.return_value = []
+
+    # Execute - should not raise
+    _fetch_and_record_external_events(
+        pr_number=123,
+        branch="test-branch",
+        github_client=mock_github,
+        handoff_svc=mock_handoff,
+    )
+
+    # Verify CI status was recorded despite comment failure
+    mock_handoff.record_ci_status.assert_called_once_with(
+        branch="test-branch",
+        pr_number=123,
+        status="PENDING",
+    )
+
+
+def test_fetch_and_record_external_events_no_ci_status() -> None:
+    """Test handling of PR without CI status."""
+    # Setup mocks
+    mock_github = MagicMock()
+    mock_handoff = MagicMock()
+
+    # Mock PR without CI status
+    mock_pr = MagicMock(spec=PRResponse)
+    mock_pr.ci_status = None
+    mock_github.get_pr.return_value = mock_pr
+
+    # Mock empty comments
+    mock_github.list_pr_comments.return_value = []
+    mock_github.list_pr_review_comments.return_value = []
+
+    # Execute
+    _fetch_and_record_external_events(
+        pr_number=123,
+        branch="test-branch",
+        github_client=mock_github,
+        handoff_svc=mock_handoff,
+    )
+
+    # Verify CI status was not recorded (None status)
+    mock_handoff.record_ci_status.assert_not_called()

--- a/tests/vibe3/services/test_handoff_external_events.py
+++ b/tests/vibe3/services/test_handoff_external_events.py
@@ -1,0 +1,214 @@
+"""Tests for HandoffService external event recording."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibe3.services.handoff_service import HandoffService
+
+
+@pytest.fixture
+def handoff_svc() -> HandoffService:
+    """Create HandoffService with mocked dependencies."""
+    store = MagicMock()
+    git_client = MagicMock()
+    git_client.get_current_branch.return_value = "test-branch"
+    return HandoffService(store=store, git_client=git_client)
+
+
+class TestRecordCIStatus:
+    """Tests for record_ci_status method."""
+
+    def test_record_ci_status_no_previous_event(
+        self, handoff_svc: HandoffService
+    ) -> None:
+        """Should record CI status when no previous event exists."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        result = handoff_svc.record_ci_status(
+            branch="test-branch",
+            pr_number=123,
+            status="SUCCESS",
+        )
+
+        assert result is True
+        handoff_svc.store.add_event.assert_called_once()
+        call_args = handoff_svc.store.add_event.call_args
+        assert call_args[0][0] == "test-branch"
+        assert call_args[0][1] == "handoff_ci_status"
+        assert call_args[0][2] == "system/github"
+        assert "SUCCESS" in call_args[1]["detail"]
+        assert call_args[1]["refs"]["status"] == "SUCCESS"
+        assert call_args[1]["refs"]["pr_number"] == "123"
+
+    def test_record_ci_status_changed(self, handoff_svc: HandoffService) -> None:
+        """Should record CI status when status changed."""
+        last_event = MagicMock()
+        last_event.refs = {"status": "PENDING"}
+        handoff_svc.get_handoff_events = MagicMock(return_value=[last_event])
+
+        result = handoff_svc.record_ci_status(
+            branch="test-branch",
+            pr_number=123,
+            status="SUCCESS",
+        )
+
+        assert result is True
+        handoff_svc.store.add_event.assert_called_once()
+
+    def test_record_ci_status_unchanged(self, handoff_svc: HandoffService) -> None:
+        """Should not record CI status when status unchanged."""
+        last_event = MagicMock()
+        last_event.refs = {"status": "SUCCESS"}
+        handoff_svc.get_handoff_events = MagicMock(return_value=[last_event])
+
+        result = handoff_svc.record_ci_status(
+            branch="test-branch",
+            pr_number=123,
+            status="SUCCESS",
+        )
+
+        assert result is False
+        handoff_svc.store.add_event.assert_not_called()
+
+    def test_record_ci_status_custom_actor(self, handoff_svc: HandoffService) -> None:
+        """Should use custom actor when provided."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        handoff_svc.record_ci_status(
+            branch="test-branch",
+            pr_number=123,
+            status="FAILURE",
+            actor="custom/actor",
+        )
+
+        call_args = handoff_svc.store.add_event.call_args
+        assert call_args[0][2] == "custom/actor"
+
+
+class TestRecordPRComments:
+    """Tests for record_pr_comments method."""
+
+    def test_record_pr_comments_new_comments(self, handoff_svc: HandoffService) -> None:
+        """Should record new comments."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        comments = [
+            {"id": 1, "author": {"login": "user1"}, "body": "Comment 1"},
+            {"id": 2, "author": {"login": "user2"}, "body": "Comment 2"},
+        ]
+
+        result = handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=comments,
+        )
+
+        assert result == 2
+        assert handoff_svc.store.add_event.call_count == 2
+
+    def test_record_pr_comments_skip_duplicates(
+        self, handoff_svc: HandoffService
+    ) -> None:
+        """Should skip comments already recorded."""
+        existing_event = MagicMock()
+        existing_event.refs = {"comment_id": "1"}
+        handoff_svc.get_handoff_events = MagicMock(return_value=[existing_event])
+
+        comments = [
+            {"id": 1, "author": {"login": "user1"}, "body": "Already recorded"},
+            {"id": 2, "author": {"login": "user2"}, "body": "New comment"},
+        ]
+
+        result = handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=comments,
+        )
+
+        assert result == 1
+        handoff_svc.store.add_event.assert_called_once()
+        call_args = handoff_svc.store.add_event.call_args
+        assert call_args[1]["refs"]["comment_id"] == "2"
+
+    def test_record_pr_comments_with_review_comments(
+        self, handoff_svc: HandoffService
+    ) -> None:
+        """Should handle both general and review comments."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        comments = [{"id": 1, "author": {"login": "user1"}, "body": "General"}]
+        review_comments = [{"id": 2, "author": {"login": "user2"}, "body": "Review"}]
+
+        result = handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=comments,
+            review_comments=review_comments,
+        )
+
+        assert result == 2
+        assert handoff_svc.store.add_event.call_count == 2
+
+        # Check that both comment types were recorded
+        calls = handoff_svc.store.add_event.call_args_list
+        comment_types = [call[1]["refs"]["comment_type"] for call in calls]
+        assert "general" in comment_types
+        assert "review" in comment_types
+
+    def test_record_pr_comments_empty_lists(self, handoff_svc: HandoffService) -> None:
+        """Should handle empty comment lists."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        result = handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=[],
+            review_comments=[],
+        )
+
+        assert result == 0
+        handoff_svc.store.add_event.assert_not_called()
+
+    def test_record_pr_comments_truncate_long_body(
+        self, handoff_svc: HandoffService
+    ) -> None:
+        """Should truncate comment body to 200 characters."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        long_body = "x" * 300
+        comments = [{"id": 1, "author": {"login": "user1"}, "body": long_body}]
+
+        handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=comments,
+        )
+
+        call_args = handoff_svc.store.add_event.call_args
+        detail = call_args[1]["detail"]
+        assert len(detail) < len(long_body) + 50  # Allow for prefix
+
+    def test_record_pr_comments_handles_missing_fields(
+        self, handoff_svc: HandoffService
+    ) -> None:
+        """Should handle comments with missing fields gracefully."""
+        handoff_svc.get_handoff_events = MagicMock(return_value=[])
+
+        # Comments with various missing fields
+        comments = [
+            {"id": 1},  # Missing author and body
+            {
+                "number": 2,
+                "author": {"login": "user1"},
+            },  # Missing body, uses 'number' field
+        ]
+
+        result = handoff_svc.record_pr_comments(
+            branch="test-branch",
+            pr_number=123,
+            comments=comments,
+        )
+
+        assert result == 2
+        assert handoff_svc.store.add_event.call_count == 2


### PR DESCRIPTION
## Summary
- Extended `vibe3 pr show` to fetch and record CI status and PR comments as external events in the handoff system
- Added `handoff_ci_status` and `handoff_pr_comment` event types to HandoffService
- Implemented deduplication logic for both CI status and comments
- Non-blocking error handling ensures PR display continues even if event recording fails

## Changes
- `src/vibe3/services/handoff_service.py`: Added `record_ci_status()`, `record_pr_comments()`, and event type registration
- `src/vibe3/commands/pr_query.py`: Added `_fetch_and_record_external_events()` helper and integrated into `show()` command
- Test suites: 14 tests covering unit and integration scenarios

## Test Plan
- [x] All 14 tests passing (pytest)
- [x] No type errors (mypy clean)
- [x] No lint errors (ruff clean)
- [x] Deduplication logic verified (CI status change detection, comment ID extraction)
- [x] Non-blocking behavior verified (event recording failures don't block PR display)

Closes #240

---

## Contributors

claude/sonnet-4.6, claude/opus