### PR TITLE
refactor(error): decouple ErrorTrackingService singleton from db_path (#550)

### DIFF
--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -37,15 +37,58 @@ class ErrorTrackingService:
     # Threshold count in time window
     THRESHOLD_COUNT = 2
 
-    # Global singleton instance
+    # Global singleton instance (backward compatibility)
     _instance: ErrorTrackingService | None = None
 
+    # Per-db-path registry for multi-instance support
+    _registry: dict[str, ErrorTrackingService] = {}
+
+    # Default instance for backward compatibility
+    _default_instance: ErrorTrackingService | None = None
+
     @classmethod
-    def get_instance(cls) -> ErrorTrackingService:
-        """Get global singleton instance."""
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
+    def get_instance(cls, store: SQLiteClient | None = None) -> ErrorTrackingService:
+        """Get error tracking instance.
+
+        Args:
+            store: Optional SQLiteClient for persistence. If None, returns/creates
+                   the default instance for backward compatibility.
+
+        Returns:
+            ErrorTrackingService instance keyed by store.db_path if store provided,
+            otherwise the default instance.
+        """
+        if store is None:
+            # Backward compatibility: check _instance first (tests may set it directly)
+            if cls._instance is not None:
+                return cls._instance
+            # If no _instance, create default instance
+            if cls._default_instance is None:
+                cls._default_instance = cls()
+                cls._instance = cls._default_instance  # Keep _instance in sync
+            return cls._default_instance
+        else:
+            # Per-db-path instance
+            db_path = store.db_path
+            if db_path not in cls._registry:
+                cls._registry[db_path] = cls(store=store)
+            return cls._registry[db_path]
+
+    @classmethod
+    def clear_instance(cls, db_path: str | None = None) -> None:
+        """Clear instance(s) for testing.
+
+        Args:
+            db_path: If provided, clear only the instance for that db_path.
+                     If None, clear only the default instance.
+        """
+        if db_path is None:
+            # Clear default instance
+            cls._default_instance = None
+            cls._instance = None  # Keep _instance in sync
+        else:
+            # Clear specific db_path instance
+            cls._registry.pop(db_path, None)
 
     def __init__(self, store: SQLiteClient | None = None) -> None:
         """Initialize error tracking service.

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -16,7 +16,7 @@ def reset_error_tracking() -> Iterator[None]:
     yield
     from vibe3.exceptions.error_tracking import ErrorTrackingService
 
-    ErrorTrackingService._instance = None
+    ErrorTrackingService.clear_instance()
 
 
 @pytest.fixture
@@ -144,3 +144,132 @@ def test_failed_gate_increment_blocked_ticks(temp_store: SQLiteClient) -> None:
     # Check status
     status = gate.get_status()
     assert status.blocked_ticks == 2
+
+
+def test_per_db_path_instance_isolation(tmp_path: Path) -> None:
+    """Different db_path instances should be isolated."""
+    from vibe3.exceptions.error_tracking import ErrorTrackingService
+
+    # Create two separate databases
+    db_path1 = tmp_path / "test1.db"
+    db_path2 = tmp_path / "test2.db"
+
+    for db_path in [db_path1, db_path2]:
+        conn = sqlite3.connect(db_path)
+        from vibe3.clients.sqlite_schema import init_schema
+
+        init_schema(conn)
+        conn.close()
+
+    store1 = SQLiteClient(db_path=str(db_path1))
+    store2 = SQLiteClient(db_path=str(db_path2))
+
+    # Get instances keyed by db_path
+    instance1 = ErrorTrackingService.get_instance(store=store1)
+    instance2 = ErrorTrackingService.get_instance(store=store2)
+
+    # Should be different instances
+    assert instance1 is not instance2
+    assert instance1.db_path != instance2.db_path
+
+    # Record error in instance1
+    instance1.record_error("E_MODEL_TEST", "Test error in db1")
+
+    # instance2 should not see the error (different database)
+    assert instance1.has_model_config_error()
+    assert not instance2.has_model_config_error()
+
+    # Clear instance1's registry entry (not the error data)
+    ErrorTrackingService.clear_instance(db_path=str(db_path1))
+
+    # Get a new instance for store1
+    instance1_new = ErrorTrackingService.get_instance(store=store1)
+
+    # New instance still sees the error data (same database)
+    # This is expected - clear_instance() only clears the in-memory instance, not the DB
+    assert instance1_new.has_model_config_error()
+
+    # instance2 still unaffected
+    assert not instance2.has_model_config_error()
+
+
+def test_clear_instance_specific_db_path(tmp_path: Path) -> None:
+    """clear_instance(db_path) should only clear that instance."""
+    from vibe3.exceptions.error_tracking import ErrorTrackingService
+
+    # Create two separate databases
+    db_path1 = tmp_path / "test1.db"
+    db_path2 = tmp_path / "test2.db"
+
+    for db_path in [db_path1, db_path2]:
+        conn = sqlite3.connect(db_path)
+        from vibe3.clients.sqlite_schema import init_schema
+
+        init_schema(conn)
+        conn.close()
+
+    store1 = SQLiteClient(db_path=str(db_path1))
+    store2 = SQLiteClient(db_path=str(db_path2))
+
+    # Create instances
+    instance1 = ErrorTrackingService.get_instance(store=store1)
+    instance2 = ErrorTrackingService.get_instance(store=store2)
+
+    # Record errors in both
+    instance1.record_error("E_API_TEST1", "Error 1")
+    instance2.record_error("E_API_TEST2", "Error 2")
+
+    # Clear instance1's registry entry (not the error data)
+    ErrorTrackingService.clear_instance(db_path=str(db_path1))
+
+    # Get new instances
+    instance1_new = ErrorTrackingService.get_instance(store=store1)
+    instance2_new = ErrorTrackingService.get_instance(store=store2)
+
+    # Both still see their error data (same databases)
+    # clear_instance() only clears in-memory instance, not DB
+    assert instance1_new.get_api_error_count() == 1
+    assert instance2_new.get_api_error_count() == 1
+
+    # But instance2 is still the same object (not cleared)
+    assert instance2_new is instance2
+
+
+def test_get_instance_with_and_without_store(tmp_path: Path) -> None:
+    """get_instance() without store should return default instance."""
+    from vibe3.exceptions.error_tracking import ErrorTrackingService
+
+    # Clear any existing state
+    ErrorTrackingService.clear_instance()
+
+    # Get default instance
+    default_instance = ErrorTrackingService.get_instance()
+    assert default_instance is not None
+
+    # Get default instance again - should be same object
+    default_instance2 = ErrorTrackingService.get_instance()
+    assert default_instance is default_instance2
+
+    # Create a separate db_path instance
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    from vibe3.clients.sqlite_schema import init_schema
+
+    init_schema(conn)
+    conn.close()
+
+    store = SQLiteClient(db_path=str(db_path))
+    custom_instance = ErrorTrackingService.get_instance(store=store)
+
+    # Should be different from default instance
+    assert custom_instance is not default_instance
+    assert custom_instance.db_path != default_instance.db_path
+
+    # Clear default instance
+    ErrorTrackingService.clear_instance()
+    default_instance3 = ErrorTrackingService.get_instance()
+    assert default_instance3 is not default_instance
+
+    # Custom instance should still be accessible
+    custom_instance2 = ErrorTrackingService.get_instance(store=store)
+    assert custom_instance2 is custom_instance


### PR DESCRIPTION
## Summary
Refactor ErrorTrackingService from global singleton to per-db-path registry pattern, enabling better isolation in multi-worktree scenarios.

## Changes
- Added `_registry` dict for per-db-path instance management
- Added `_default_instance` for backward-compatible default instance  
- Modified `get_instance(store=None)` to accept optional store parameter
- Added `clear_instance(db_path=None)` class method for test cleanup
- Updated test fixture to use `clear_instance()` instead of direct `_instance` manipulation
- Added 3 new tests for instance isolation and clear_instance behavior

## Test Results
- ✅ 9/9 tests pass (including 3 new isolation tests)
- ✅ mypy: PASS
- ✅ ruff: PASS
- ✅ All existing call sites verified backward compatible

## Backward Compatibility
All 5 existing production call sites work without modification:
1. `vibe3/commands/orchestrate.py` - `ErrorTrackingService.get_instance()`
2. `vibe3/runtime/manager_service.py` - `ErrorTrackingService.get_instance()`  
3. `vibe3/runtime/execution_service.py` - `ErrorTrackingService.get_instance()`
4. `vibe3/runtime/execution_service.py` - `ErrorTrackingService.get_instance()`
5. `tests/vibe3/orchestra/test_failed_gate.py` - fixture with clear_instance

## References
- Issue: #550
- Plan: docs/plans/issue-550-implementation-plan.md
- Report: docs/reports/issue-550-execution-report.md
- Audit: docs/reports/issue-550-audit-report.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)