### PR TITLE
feat(reports): add report cleanup mechanism with configurable retention

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,6 +11,23 @@ flow:
     - "master"
     - "develop"
 
+# Reports cleanup configuration
+# Controls retention policy for .agent/reports/ directory
+reports:
+  retention:
+    # Maximum number of reports to keep per type
+    max_count: 10
+    # Maximum age in days (reports older than this are deleted)
+    max_age_days: 30
+    # Report types with specific retention (optional)
+    types:
+      pre-push-review:
+        max_count: 5
+      skills-state:
+        max_count: 3
+      coverage:
+        max_count: 3
+
 # GitHub Projects v2 配置（Task Bridge 真源）
 # project_number 和 owner 是 task bridge 的远端真源配置
 # owner_type: "user" 表示个人账号，"org" 表示组织

--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -22,6 +22,7 @@ from vibe3.commands import (
     internal,
     plan,
     pr,
+    reports,
     review,
     run,
     snapshot,
@@ -63,6 +64,7 @@ app.add_typer(review.app, name="review")
 app.add_typer(handoff.app, name="handoff")
 app.add_typer(check.app, name="check")
 app.add_typer(snapshot.app, name="snapshot")
+app.add_typer(reports.app, name="reports")
 app.add_typer(serve.app, name="serve")
 app.add_typer(internal.app, name="internal")
 

--- a/src/vibe3/commands/reports.py
+++ b/src/vibe3/commands/reports.py
@@ -1,0 +1,277 @@
+"""Reports command implementation - manage .agent/reports/ cleanup."""
+
+import json
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vibe3.services.report_cleanup_service import ReportCleanupService
+
+app = typer.Typer(
+    help="Manage reports cleanup and retention",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+console = Console()
+
+
+@app.command("list")
+def list_reports(
+    report_type: Annotated[
+        str | None,
+        typer.Option("--type", "-t", help="Filter by report type"),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output in JSON format"),
+    ] = False,
+) -> None:
+    """List all reports with sizes and ages.
+
+    Examples:
+        vibe3 reports list
+        vibe3 reports list --type pre-push-review
+        vibe3 reports list --json
+    """
+    service = ReportCleanupService()
+
+    if report_type:
+        # List specific type
+        reports = service.list_reports(report_type)
+        if not reports:
+            if json_output:
+                print(json.dumps([]))
+            else:
+                console.print(
+                    f"[yellow]No reports found for type: " f"{report_type}[/yellow]"
+                )
+            return
+
+        if json_output:
+            data = [
+                {
+                    "path": str(r.path),
+                    "size_bytes": r.size_bytes,
+                    "size_kb": round(r.size_kb, 2),
+                    "mtime": r.mtime,
+                    "age_days": round(r.age_days, 2),
+                }
+                for r in reports
+            ]
+            print(json.dumps(data, indent=2))
+        else:
+            table = Table(title=f"Reports: {report_type}")
+            table.add_column("File", style="cyan")
+            table.add_column("Size", justify="right", style="green")
+            table.add_column("Age", justify="right", style="yellow")
+
+            for report in reports:
+                table.add_row(
+                    report.path.name,
+                    f"{report.size_kb:.1f} KB",
+                    report.age_display,
+                )
+
+            console.print(table)
+    else:
+        # List all types
+        all_reports: list[dict[str, Any]] = []
+        for type_def in service.get_report_types():
+            reports = service.list_reports(type_def.name)
+            for rpt in reports:
+                all_reports.append(
+                    {
+                        "type": type_def.name,
+                        "path": str(rpt.path),
+                        "size_bytes": rpt.size_bytes,
+                        "size_kb": round(rpt.size_kb, 2),
+                        "mtime": rpt.mtime,
+                        "age_days": round(rpt.age_days, 2),
+                    }
+                )
+
+        if json_output:
+            print(json.dumps(all_reports, indent=2))
+        else:
+            table = Table(title="All Reports")
+            table.add_column("Type", style="cyan")
+            table.add_column("File", style="cyan")
+            table.add_column("Size", justify="right", style="green")
+            table.add_column("Age", justify="right", style="yellow")
+
+            for report_dict in all_reports:
+                table.add_row(
+                    report_dict["type"],
+                    Path(report_dict["path"]).name,
+                    f"{report_dict['size_kb']:.1f} KB",
+                    f"{report_dict['age_days']:.1f}d",
+                )
+
+            console.print(table)
+
+
+@app.command("clean")
+def clean_reports(
+    report_type: Annotated[
+        str | None,
+        typer.Option("--type", "-t", help="Clean specific report type only"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Preview deletions without executing (default: True)",
+        ),
+    ] = True,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Actually delete files (required for non-dry-run)",
+        ),
+    ] = False,
+    max_count: Annotated[
+        int | None,
+        typer.Option("--max-count", help="Override max_count for retention"),
+    ] = None,
+    max_age_days: Annotated[
+        int | None,
+        typer.Option("--max-age-days", help="Override max_age_days for retention"),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output in JSON format"),
+    ] = False,
+) -> None:
+    """Clean old reports based on retention policy.
+
+    By default, runs in dry-run mode to preview deletions.
+    Use --force to actually delete files.
+
+    Examples:
+        vibe3 reports clean                    # Dry-run all types
+        vibe3 reports clean --force            # Actually clean all types
+        vibe3 reports clean --type coverage    # Dry-run specific type
+        vibe3 reports clean --type coverage --force  # Clean specific type
+        vibe3 reports clean --max-count 5      # Override retention count
+    """
+    # Safety check: require --force for actual deletion
+    if not dry_run and not force:
+        console.print(
+            "[red]Error: Must use --force to actually delete files. "
+            "Default is dry-run mode.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    # If --force is set, disable dry_run
+    if force:
+        dry_run = False
+
+    service = ReportCleanupService()
+
+    if report_type:
+        # Clean specific type
+        result = service.clean_reports(
+            report_type,
+            dry_run=dry_run,
+            max_count=max_count,
+            max_age_days=max_age_days,
+        )
+
+        if json_output:
+            print(json.dumps(result, indent=2))
+        else:
+            mode = "Would delete" if dry_run else "Deleted"
+            console.print(
+                f"\n[cyan]{mode} {result['deleted']} reports[/cyan] "
+                f"(kept {result['kept']}, freed {result['freed_bytes'] / 1024:.1f} KB)"
+            )
+
+            if dry_run and result["files_deleted"]:
+                console.print("\n[yellow]Files to be deleted:[/yellow]")
+                for file_path in result["files_deleted"]:
+                    console.print(f"  {file_path}")
+    else:
+        # Clean all types
+        results = service.clean_all(dry_run=dry_run)
+
+        if json_output:
+            print(json.dumps(results, indent=2))
+        else:
+            mode = "Would delete" if dry_run else "Deleted"
+            total_deleted = sum(r["deleted"] for r in results.values())
+            total_freed = sum(r["freed_bytes"] for r in results.values())
+
+            console.print(
+                f"\n[cyan]{mode} {total_deleted} reports total[/cyan] "
+                f"(freed {total_freed / 1024:.1f} KB)"
+            )
+
+            table = Table(title="Cleanup Summary")
+            table.add_column("Type", style="cyan")
+            table.add_column("Kept", justify="right", style="green")
+            table.add_column("Deleted", justify="right", style="red")
+            table.add_column("Freed (KB)", justify="right", style="yellow")
+
+            for type_name, result in results.items():
+                table.add_row(
+                    type_name,
+                    str(result["kept"]),
+                    str(result["deleted"]),
+                    f"{result['freed_bytes'] / 1024:.1f}",
+                )
+
+            console.print(table)
+
+
+@app.command("status")
+def status(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output in JSON format"),
+    ] = False,
+) -> None:
+    """Show disk usage summary for reports directory.
+
+    Examples:
+        vibe3 reports status
+        vibe3 reports status --json
+    """
+    service = ReportCleanupService()
+    usage = service.get_disk_usage()
+
+    if json_output:
+        print(json.dumps(usage, indent=2))
+    else:
+        console.print("\n[bold]Reports Directory Summary[/bold]")
+        console.print(f"  Location: {service.REPORTS_DIR}")
+        console.print(f"  Total size: {usage['total_bytes'] / 1024:.1f} KB")
+        console.print(f"  Total files: {usage['total_files']}")
+        console.print(f"  Total directories: {usage['total_dirs']}")
+
+        # Show per-type breakdown
+        console.print("\n[bold]Reports by Type:[/bold]")
+        table = Table()
+        table.add_column("Type", style="cyan")
+        table.add_column("Count", justify="right", style="green")
+        table.add_column("Total Size", justify="right", style="yellow")
+
+        for type_def in service.get_report_types():
+            reports = service.list_reports(type_def.name)
+            if reports:
+                total_size = sum(r.size_bytes for r in reports)
+                table.add_row(
+                    type_def.name,
+                    str(len(reports)),
+                    f"{total_size / 1024:.1f} KB",
+                )
+
+        console.print(table)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -226,11 +226,39 @@ class QualityConfig(BaseModel):
     test_coverage: TestCoverageConfig = Field(default_factory=TestCoverageConfig)
 
 
+class ReportsRetentionTypeConfig(BaseModel):
+    """Report retention configuration for a specific report type."""
+
+    max_count: int | None = Field(
+        default=None, ge=1, description="Maximum reports to keep"
+    )
+    max_age_days: int | None = Field(
+        default=None, ge=1, description="Maximum age in days"
+    )
+
+
+class ReportsRetentionConfig(BaseModel):
+    """Reports retention policy configuration."""
+
+    max_count: int = Field(default=10, ge=1, description="Default max reports per type")
+    max_age_days: int = Field(default=30, ge=1, description="Default max age in days")
+    types: dict[str, ReportsRetentionTypeConfig] = Field(
+        default_factory=dict, description="Type-specific retention overrides"
+    )
+
+
+class ReportsConfig(BaseModel):
+    """Reports management configuration."""
+
+    retention: ReportsRetentionConfig = Field(default_factory=ReportsRetentionConfig)
+
+
 class VibeConfig(BaseModel):
     """Root configuration model."""
 
     agent_prompt: AgentPromptConfig = Field(default_factory=AgentPromptConfig)
     flow: FlowConfig = Field(default_factory=FlowConfig)
+    reports: ReportsConfig = Field(default_factory=ReportsConfig)
     doc_limits: DocLimitsConfig = Field(default_factory=DocLimitsConfig)
     code_limits: CodeLimitsConfig = Field(default_factory=CodeLimitsConfig)
     review_scope: ReviewScopeConfig = Field(default_factory=ReviewScopeConfig)

--- a/src/vibe3/services/report_cleanup_service.py
+++ b/src/vibe3/services/report_cleanup_service.py
@@ -9,55 +9,19 @@ This service provides cleanup of old reports based on configurable retention pol
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from vibe3.services.report_cleanup_types import (
+    CleanupResult,
+    ReportInfo,
+    ReportTypeDefinition,
+)
+
 if TYPE_CHECKING:
     from vibe3.config.settings import ReportsRetentionTypeConfig, VibeConfig
-
-
-class CleanupResult(TypedDict):
-    """Result of cleanup operation."""
-
-    kept: int
-    deleted: int
-    freed_bytes: int
-    files_deleted: list[str]
-
-
-@dataclass
-class ReportInfo:
-    """Information about a report file."""
-
-    path: Path
-    size_bytes: int
-    mtime: float  # Unix timestamp
-    age_days: float
-
-    @property
-    def size_kb(self) -> float:
-        """Size in kilobytes."""
-        return self.size_bytes / 1024
-
-    @property
-    def age_display(self) -> str:
-        """Human-readable age."""
-        if self.age_days < 1:
-            hours = self.age_days * 24
-            return f"{hours:.1f}h"
-        return f"{self.age_days:.1f}d"
-
-
-@dataclass
-class ReportTypeDefinition:
-    """Definition of a report type with its file pattern."""
-
-    name: str
-    pattern: str  # Glob pattern
-    is_subdirectory: bool  # Whether reports are in subdirectories
 
 
 class ReportCleanupService:

--- a/src/vibe3/services/report_cleanup_service.py
+++ b/src/vibe3/services/report_cleanup_service.py
@@ -1,0 +1,414 @@
+"""Report cleanup service - manages retention policy for .agent/reports/ directory.
+
+This service provides cleanup of old reports based on configurable retention policy:
+- Max count per report type
+- Max age in days
+- Type-specific retention overrides
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.config.settings import ReportsRetentionTypeConfig, VibeConfig
+
+
+class CleanupResult(TypedDict):
+    """Result of cleanup operation."""
+
+    kept: int
+    deleted: int
+    freed_bytes: int
+    files_deleted: list[str]
+
+
+@dataclass
+class ReportInfo:
+    """Information about a report file."""
+
+    path: Path
+    size_bytes: int
+    mtime: float  # Unix timestamp
+    age_days: float
+
+    @property
+    def size_kb(self) -> float:
+        """Size in kilobytes."""
+        return self.size_bytes / 1024
+
+    @property
+    def age_display(self) -> str:
+        """Human-readable age."""
+        if self.age_days < 1:
+            hours = self.age_days * 24
+            return f"{hours:.1f}h"
+        return f"{self.age_days:.1f}d"
+
+
+@dataclass
+class ReportTypeDefinition:
+    """Definition of a report type with its file pattern."""
+
+    name: str
+    pattern: str  # Glob pattern
+    is_subdirectory: bool  # Whether reports are in subdirectories
+
+
+class ReportCleanupService:
+    """Service for cleaning up old reports based on retention policy.
+
+    The service manages cleanup of various report types in .agent/reports/:
+    - pre-push-review-*.md
+    - serena-impact.json
+    - skills-state-*.json
+    - skills-analysis-*.md
+    - rules-report.md
+    - coverage.json (in subdirectories)
+    - audit-result.md
+
+    Retention policy is configurable via config/settings.yaml:
+    - max_count: Maximum reports to keep per type (default: 10)
+    - max_age_days: Maximum age in days (default: 30)
+    - types: Type-specific retention overrides
+    """
+
+    REPORTS_DIR = Path(".agent/reports")
+
+    # Define report types with their patterns
+    REPORT_TYPES: list[ReportTypeDefinition] = [
+        ReportTypeDefinition(
+            name="pre-push-review",
+            pattern="pre-push-review-*.md",
+            is_subdirectory=False,
+        ),
+        ReportTypeDefinition(
+            name="serena-impact", pattern="serena-impact.json", is_subdirectory=False
+        ),
+        ReportTypeDefinition(
+            name="skills-state", pattern="skills-state-*.json", is_subdirectory=False
+        ),
+        ReportTypeDefinition(
+            name="skills-analysis",
+            pattern="skills-analysis-*.md",
+            is_subdirectory=False,
+        ),
+        ReportTypeDefinition(
+            name="rules-report", pattern="rules-report.md", is_subdirectory=False
+        ),
+        ReportTypeDefinition(
+            name="coverage", pattern="coverage.json", is_subdirectory=True
+        ),
+        ReportTypeDefinition(
+            name="audit-result", pattern="audit-result.md", is_subdirectory=False
+        ),
+    ]
+
+    def __init__(self, config: VibeConfig | None = None) -> None:
+        """Initialize report cleanup service.
+
+        Args:
+            config: Optional VibeConfig instance. If None, loads via get_config().
+        """
+        if config is None:
+            from vibe3.config.loader import get_config
+
+            config = get_config()
+
+        self.config = config
+        self.reports_dir = self.REPORTS_DIR
+
+    def get_report_types(self) -> list[ReportTypeDefinition]:
+        """Return list of report type definitions.
+
+        Returns:
+            List of ReportTypeDefinition objects.
+        """
+        return self.REPORT_TYPES
+
+    def list_reports(self, report_type: str) -> list[ReportInfo]:
+        """List all reports of a given type with metadata.
+
+        Args:
+            report_type: Name of report type (e.g., "pre-push-review").
+
+        Returns:
+            List of ReportInfo objects for matching reports.
+        """
+        type_def = self._get_type_definition(report_type)
+        if not type_def:
+            logger.bind(
+                domain="cleanup",
+                action="list_reports",
+                report_type=report_type,
+            ).warning("Unknown report type")
+            return []
+
+        reports: list[ReportInfo] = []
+        current_time = time.time()
+
+        if not self.reports_dir.exists():
+            logger.bind(
+                domain="cleanup",
+                action="list_reports",
+                report_type=report_type,
+            ).debug("Reports directory does not exist")
+            return []
+
+        if type_def.is_subdirectory:
+            # For subdirectory reports, search in all subdirectories
+            for subdir in self.reports_dir.iterdir():
+                if subdir.is_dir():
+                    for report_file in subdir.glob(type_def.pattern):
+                        info = self._get_report_info(report_file, current_time)
+                        if info:
+                            reports.append(info)
+        else:
+            # For flat reports, search directly in reports directory
+            if self.reports_dir.exists():
+                for report_file in self.reports_dir.glob(type_def.pattern):
+                    info = self._get_report_info(report_file, current_time)
+                    if info:
+                        reports.append(info)
+
+        # Sort by mtime (newest first)
+        reports.sort(key=lambda r: r.mtime, reverse=True)
+
+        logger.bind(
+            domain="cleanup",
+            action="list_reports",
+            report_type=report_type,
+            count=len(reports),
+        ).debug("Found reports")
+
+        return reports
+
+    def clean_reports(
+        self,
+        report_type: str,
+        dry_run: bool = True,
+        max_count: int | None = None,
+        max_age_days: int | None = None,
+    ) -> CleanupResult:
+        """Clean old reports for a specific type.
+
+        Args:
+            report_type: Name of report type.
+            dry_run: If True, only preview deletions without executing.
+            max_count: Override config max_count for this type.
+            max_age_days: Override config max_age_days for this type.
+
+        Returns:
+            Dict with:
+                - kept: Number of reports kept
+                - deleted: Number of reports deleted
+                - freed_bytes: Total bytes freed
+                - files_deleted: List of deleted file paths (for dry_run preview)
+        """
+        # Get retention policy (prefer args over config)
+        retention = self._get_retention_policy(report_type)
+        effective_max_count = (
+            max_count if max_count is not None else retention.max_count or 10
+        )
+        effective_max_age = (
+            max_age_days if max_age_days is not None else retention.max_age_days or 30
+        )
+
+        reports = self.list_reports(report_type)
+
+        # Determine which reports to keep and delete
+        to_keep: list[ReportInfo] = []
+        to_delete: list[ReportInfo] = []
+
+        for report in reports:
+            # Keep if within max_count
+            if len(to_keep) < effective_max_count:
+                # Also check age
+                if report.age_days <= effective_max_age:
+                    to_keep.append(report)
+                else:
+                    to_delete.append(report)
+            else:
+                # Exceeds max_count, delete
+                to_delete.append(report)
+
+        # Delete reports (or preview)
+        deleted_count = 0
+        freed_bytes = 0
+        files_deleted: list[str] = []
+
+        for report in to_delete:
+            if not dry_run:
+                try:
+                    report.path.unlink()
+                    deleted_count += 1
+                    freed_bytes += report.size_bytes
+                    logger.bind(
+                        domain="cleanup",
+                        action="clean_reports",
+                        report_type=report_type,
+                        file=str(report.path),
+                    ).debug("Deleted report")
+                except Exception as exc:
+                    logger.bind(
+                        domain="cleanup",
+                        action="clean_reports",
+                        report_type=report_type,
+                        file=str(report.path),
+                    ).warning(f"Failed to delete: {exc}")
+            else:
+                files_deleted.append(str(report.path))
+
+        if not dry_run:
+            logger.bind(
+                domain="cleanup",
+                action="clean_reports",
+                report_type=report_type,
+                kept=len(to_keep),
+                deleted=deleted_count,
+                freed_bytes=freed_bytes,
+            ).info("Cleaned reports")
+
+        return {
+            "kept": len(to_keep),
+            "deleted": deleted_count if not dry_run else len(to_delete),
+            "freed_bytes": (
+                freed_bytes if not dry_run else sum(r.size_bytes for r in to_delete)
+            ),
+            "files_deleted": files_deleted,
+        }
+
+    def clean_all(self, dry_run: bool = True) -> dict[str, CleanupResult]:
+        """Clean all report types.
+
+        Args:
+            dry_run: If True, only preview deletions without executing.
+
+        Returns:
+            Dict mapping report type to cleanup results.
+        """
+        results: dict[str, CleanupResult] = {}
+
+        for type_def in self.REPORT_TYPES:
+            results[type_def.name] = self.clean_reports(type_def.name, dry_run=dry_run)
+
+        logger.bind(
+            domain="cleanup",
+            action="clean_all",
+            dry_run=dry_run,
+        ).info("Cleaned all report types")
+
+        return results
+
+    def get_disk_usage(self) -> dict[str, int]:
+        """Get disk usage summary for reports directory.
+
+        Returns:
+            Dict with:
+                - total_bytes: Total size in bytes
+                - total_files: Total number of files
+                - total_dirs: Total number of subdirectories
+        """
+        if not self.reports_dir.exists():
+            return {"total_bytes": 0, "total_files": 0, "total_dirs": 0}
+
+        total_bytes = 0
+        total_files = 0
+        total_dirs = 0
+
+        for item in self.reports_dir.rglob("*"):
+            if item.is_file():
+                try:
+                    total_bytes += item.stat().st_size
+                    total_files += 1
+                except Exception:
+                    pass
+            elif item.is_dir():
+                total_dirs += 1
+
+        return {
+            "total_bytes": total_bytes,
+            "total_files": total_files,
+            "total_dirs": total_dirs,
+        }
+
+    def _get_type_definition(self, report_type: str) -> ReportTypeDefinition | None:
+        """Get type definition by name.
+
+        Args:
+            report_type: Name of report type.
+
+        Returns:
+            ReportTypeDefinition or None if not found.
+        """
+        for type_def in self.REPORT_TYPES:
+            if type_def.name == report_type:
+                return type_def
+        return None
+
+    def _get_retention_policy(self, report_type: str) -> "ReportsRetentionTypeConfig":
+        """Get effective retention policy for a report type.
+
+        Args:
+            report_type: Name of report type.
+
+        Returns:
+            ReportsRetentionTypeConfig with effective values.
+        """
+        from vibe3.config.settings import ReportsRetentionTypeConfig
+
+        # Check for type-specific override
+        if report_type in self.config.reports.retention.types:
+            type_config = self.config.reports.retention.types[report_type]
+            # Use type-specific values, fall back to defaults
+            return ReportsRetentionTypeConfig(
+                max_count=(
+                    type_config.max_count or self.config.reports.retention.max_count
+                ),
+                max_age_days=(
+                    type_config.max_age_days
+                    or self.config.reports.retention.max_age_days
+                ),
+            )
+
+        # Use default values
+        return ReportsRetentionTypeConfig(
+            max_count=self.config.reports.retention.max_count,
+            max_age_days=self.config.reports.retention.max_age_days,
+        )
+
+    def _get_report_info(
+        self, report_file: Path, current_time: float
+    ) -> ReportInfo | None:
+        """Get ReportInfo for a file.
+
+        Args:
+            report_file: Path to report file.
+            current_time: Current Unix timestamp.
+
+        Returns:
+            ReportInfo or None if file cannot be accessed.
+        """
+        try:
+            stat = report_file.stat()
+            age_seconds = current_time - stat.st_mtime
+            age_days = age_seconds / (24 * 3600)
+
+            return ReportInfo(
+                path=report_file,
+                size_bytes=stat.st_size,
+                mtime=stat.st_mtime,
+                age_days=age_days,
+            )
+        except Exception as exc:
+            logger.bind(
+                domain="cleanup",
+                action="get_report_info",
+                file=str(report_file),
+            ).warning(f"Failed to get file info: {exc}")
+            return None

--- a/src/vibe3/services/report_cleanup_types.py
+++ b/src/vibe3/services/report_cleanup_types.py
@@ -1,0 +1,48 @@
+"""Type definitions for report cleanup service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypedDict
+
+
+class CleanupResult(TypedDict):
+    """Result of cleanup operation."""
+
+    kept: int
+    deleted: int
+    freed_bytes: int
+    files_deleted: list[str]
+
+
+@dataclass
+class ReportInfo:
+    """Information about a report file."""
+
+    path: Path
+    size_bytes: int
+    mtime: float  # Unix timestamp
+    age_days: float
+
+    @property
+    def size_kb(self) -> float:
+        """Size in kilobytes."""
+        return self.size_bytes / 1024
+
+    @property
+    def age_display(self) -> str:
+        """Human-readable age."""
+        if self.age_days < 1:
+            hours = self.age_days * 24
+            return f"{hours:.1f}h"
+        return f"{self.age_days:.1f}d"
+
+
+@dataclass
+class ReportTypeDefinition:
+    """Definition of a report type with its file pattern."""
+
+    name: str
+    pattern: str  # Glob pattern
+    is_subdirectory: bool  # Whether reports are in subdirectories

--- a/tests/vibe3/commands/test_reports.py
+++ b/tests/vibe3/commands/test_reports.py
@@ -1,0 +1,293 @@
+"""Tests for reports CLI commands."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from vibe3.commands.reports import app
+from vibe3.services.report_cleanup_service import (
+    ReportCleanupService,
+    ReportInfo,
+)
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    """Create CLI runner."""
+    return CliRunner()
+
+
+@pytest.fixture()
+def mock_service() -> MagicMock:
+    """Create mock ReportCleanupService."""
+    return MagicMock(spec=ReportCleanupService)
+
+
+@pytest.fixture()
+def sample_reports() -> list[ReportInfo]:
+    """Create sample report info for testing."""
+    return [
+        ReportInfo(
+            path=Path(".agent/reports/pre-push-review-20240101.md"),
+            size_bytes=1024,
+            mtime=1704067200.0,
+            age_days=30.0,
+        ),
+        ReportInfo(
+            path=Path(".agent/reports/pre-push-review-20240102.md"),
+            size_bytes=2048,
+            mtime=1704153600.0,
+            age_days=29.0,
+        ),
+    ]
+
+
+# --- list command ---
+
+
+def test_list_all_reports(
+    cli_runner: CliRunner, mock_service: MagicMock, sample_reports: list[ReportInfo]
+) -> None:
+    """vibe3 reports list shows all reports."""
+    from vibe3.services.report_cleanup_service import ReportTypeDefinition
+
+    mock_service.get_report_types.return_value = [
+        ReportTypeDefinition(
+            name="pre-push-review", pattern="*.md", is_subdirectory=False
+        ),
+    ]
+    mock_service.list_reports.return_value = sample_reports
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "pre-push-review" in result.output
+
+
+def test_list_specific_type(
+    cli_runner: CliRunner, mock_service: MagicMock, sample_reports: list[ReportInfo]
+) -> None:
+    """vibe3 reports list --type shows specific type only."""
+    mock_service.list_reports.return_value = sample_reports
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["list", "--type", "pre-push-review"])
+
+    assert result.exit_code == 0
+    mock_service.list_reports.assert_called_once_with("pre-push-review")
+
+
+def test_list_json_output(
+    cli_runner: CliRunner, mock_service: MagicMock, sample_reports: list[ReportInfo]
+) -> None:
+    """vibe3 reports list --json outputs JSON format."""
+    mock_service.get_report_types.return_value = []
+    mock_service.list_reports.return_value = []
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    # Should output JSON array
+    assert "[" in result.output or result.output.strip() == "[]"
+
+
+def test_list_empty_reports(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports list handles empty results gracefully."""
+    mock_service.list_reports.return_value = []
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["list", "--type", "pre-push-review"])
+
+    assert result.exit_code == 0
+    assert "No reports found" in result.output
+
+
+# --- clean command ---
+
+
+def test_clean_dry_run_default(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports clean defaults to dry-run mode."""
+    mock_service.clean_all.return_value = {
+        "pre-push-review": {
+            "kept": 5,
+            "deleted": 2,
+            "freed_bytes": 2048,
+            "files_deleted": [],
+        },
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["clean"])
+
+    assert result.exit_code == 0
+    # Should call clean_all with dry_run=True
+    mock_service.clean_all.assert_called_once_with(dry_run=True)
+    assert "Would delete" in result.output
+
+
+def test_clean_default_is_dry_run(cli_runner: CliRunner) -> None:
+    """vibe3 reports clean defaults to dry-run mode (preview only)."""
+    # Without --force, command runs in dry-run mode by default
+    # This is the safety behavior: preview without deleting
+    with patch("vibe3.commands.reports.ReportCleanupService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service_class.return_value = mock_service
+        mock_service.clean_all.return_value = {
+            "pre-push-review": {
+                "kept": 5,
+                "deleted": 2,
+                "freed_bytes": 2048,
+                "files_deleted": [],
+            },
+        }
+
+        result = cli_runner.invoke(app, ["clean"])
+
+        assert result.exit_code == 0
+        # Should call clean_all with dry_run=True
+        mock_service.clean_all.assert_called_once_with(dry_run=True)
+        assert "Would delete" in result.output
+
+
+def test_clean_with_force(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports clean --force actually deletes."""
+    mock_service.clean_all.return_value = {
+        "pre-push-review": {
+            "kept": 5,
+            "deleted": 2,
+            "freed_bytes": 2048,
+            "files_deleted": [],
+        },
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["clean", "--force"])
+
+    assert result.exit_code == 0
+    # Should call clean_all with dry_run=False
+    mock_service.clean_all.assert_called_once_with(dry_run=False)
+    assert "Deleted" in result.output
+
+
+def test_clean_specific_type(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports clean --type cleans specific type only."""
+    mock_service.clean_reports.return_value = {
+        "kept": 5,
+        "deleted": 2,
+        "freed_bytes": 2048,
+        "files_deleted": ["file1.md", "file2.md"],
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(
+            app, ["clean", "--type", "pre-push-review", "--force"]
+        )
+
+    assert result.exit_code == 0
+    mock_service.clean_reports.assert_called_once_with(
+        "pre-push-review", dry_run=False, max_count=None, max_age_days=None
+    )
+
+
+def test_clean_with_override_max_count(
+    cli_runner: CliRunner, mock_service: MagicMock
+) -> None:
+    """vibe3 reports clean --max-count overrides retention."""
+    mock_service.clean_reports.return_value = {
+        "kept": 2,
+        "deleted": 3,
+        "freed_bytes": 3072,
+        "files_deleted": [],
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(
+            app,
+            ["clean", "--type", "pre-push-review", "--max-count", "2", "--force"],
+        )
+
+    assert result.exit_code == 0
+    mock_service.clean_reports.assert_called_once_with(
+        "pre-push-review", dry_run=False, max_count=2, max_age_days=None
+    )
+
+
+def test_clean_json_output(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports clean --json outputs JSON format."""
+    mock_service.clean_all.return_value = {
+        "pre-push-review": {
+            "kept": 5,
+            "deleted": 2,
+            "freed_bytes": 2048,
+            "files_deleted": [],
+        },
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["clean", "--json"])
+
+    assert result.exit_code == 0
+    assert "{" in result.output
+
+
+# --- status command ---
+
+
+def test_status(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports status shows disk usage."""
+    mock_service.get_disk_usage.return_value = {
+        "total_bytes": 10240,
+        "total_files": 5,
+        "total_dirs": 2,
+    }
+    mock_service.get_report_types.return_value = []
+    mock_service.list_reports.return_value = []
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Reports Directory Summary" in result.output
+    assert "10.0 KB" in result.output
+
+
+def test_status_json(cli_runner: CliRunner, mock_service: MagicMock) -> None:
+    """vibe3 reports status --json outputs JSON format."""
+    mock_service.get_disk_usage.return_value = {
+        "total_bytes": 10240,
+        "total_files": 5,
+        "total_dirs": 2,
+    }
+
+    with patch(
+        "vibe3.commands.reports.ReportCleanupService", return_value=mock_service
+    ):
+        result = cli_runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    assert "total_bytes" in result.output
+    assert "10240" in result.output

--- a/tests/vibe3/services/test_report_cleanup_service.py
+++ b/tests/vibe3/services/test_report_cleanup_service.py
@@ -1,0 +1,296 @@
+"""Tests for ReportCleanupService."""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vibe3.config.settings import (
+    ReportsConfig,
+    ReportsRetentionConfig,
+    ReportsRetentionTypeConfig,
+    VibeConfig,
+)
+from vibe3.services.report_cleanup_service import (
+    ReportCleanupService,
+    ReportInfo,
+)
+
+
+@pytest.fixture()
+def reports_dir(tmp_path: Path) -> Path:
+    """Create temporary reports directory."""
+    reports = tmp_path / ".agent" / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    return reports
+
+
+@pytest.fixture()
+def config() -> VibeConfig:
+    """Create test config with retention policy."""
+    return VibeConfig(
+        reports=ReportsConfig(
+            retention=ReportsRetentionConfig(
+                max_count=10,
+                max_age_days=30,
+                types={
+                    "pre-push-review": ReportsRetentionTypeConfig(max_count=5),
+                    "skills-state": ReportsRetentionTypeConfig(max_count=3),
+                    "coverage": ReportsRetentionTypeConfig(max_count=3),
+                },
+            )
+        )
+    )
+
+
+@pytest.fixture()
+def service(reports_dir: Path, config: VibeConfig) -> ReportCleanupService:
+    """Create service with test config."""
+    service = ReportCleanupService(config=config)
+    service.reports_dir = reports_dir
+    return service
+
+
+def test_get_report_types(service: ReportCleanupService) -> None:
+    """get_report_types returns all defined types."""
+    types = service.get_report_types()
+    assert len(types) == 7
+    type_names = [t.name for t in types]
+    assert "pre-push-review" in type_names
+    assert "coverage" in type_names
+    assert "audit-result" in type_names
+
+
+def test_list_reports_empty_directory(service: ReportCleanupService) -> None:
+    """list_reports returns empty list when no reports exist."""
+    reports = service.list_reports("pre-push-review")
+    assert reports == []
+
+
+def test_list_reports_flat_reports(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """list_reports finds reports in flat directory."""
+    # Create test reports
+    report1 = reports_dir / "pre-push-review-20240101.md"
+    report2 = reports_dir / "pre-push-review-20240102.md"
+    report1.write_text("report 1")
+    report2.write_text("report 2")
+
+    reports = service.list_reports("pre-push-review")
+    assert len(reports) == 2
+    assert all(isinstance(r, ReportInfo) for r in reports)
+    # Should be sorted by mtime (newest first)
+    assert reports[0].path.name == "pre-push-review-20240102.md"
+
+
+def test_list_reports_subdirectory_reports(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """list_reports finds reports in subdirectories."""
+    # Create coverage reports in flow subdirectories
+    flow1_dir = reports_dir / "task-issue-123"
+    flow1_dir.mkdir()
+    coverage1 = flow1_dir / "coverage.json"
+    coverage1.write_text('{"coverage": 80}')
+
+    flow2_dir = reports_dir / "task-issue-456"
+    flow2_dir.mkdir()
+    coverage2 = flow2_dir / "coverage.json"
+    coverage2.write_text('{"coverage": 85}')
+
+    reports = service.list_reports("coverage")
+    assert len(reports) == 2
+    assert all(r.path.name == "coverage.json" for r in reports)
+
+
+def test_clean_reports_dry_run(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """clean_reports in dry_run mode previews without deleting."""
+    # Create 7 reports (exceeds max_count=5)
+    for i in range(7):
+        report = reports_dir / f"pre-push-review-2024010{i}.md"
+        report.write_text(f"report {i}")
+        # Small delay to ensure different mtimes
+        time.sleep(0.01)
+
+    result = service.clean_reports("pre-push-review", dry_run=True)
+
+    # Should preview deletion
+    assert result["kept"] == 5
+    assert result["deleted"] == 2
+    assert len(result["files_deleted"]) == 2
+    # But files should still exist
+    assert len(list(reports_dir.glob("pre-push-review-*.md"))) == 7
+
+
+def test_clean_reports_actual_delete(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """clean_reports with dry_run=False deletes files."""
+    # Create 7 reports (exceeds max_count=5)
+    for i in range(7):
+        report = reports_dir / f"pre-push-review-2024010{i}.md"
+        report.write_text(f"report {i}")
+        time.sleep(0.01)
+
+    result = service.clean_reports("pre-push-review", dry_run=False)
+
+    # Should actually delete
+    assert result["kept"] == 5
+    assert result["deleted"] == 2
+    assert result["freed_bytes"] > 0
+    # Files should be deleted
+    assert len(list(reports_dir.glob("pre-push-review-*.md"))) == 5
+
+
+def test_clean_reports_age_based(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """clean_reports deletes reports older than max_age_days."""
+    # Create old report
+    old_report = reports_dir / "pre-push-review-old.md"
+    old_report.write_text("old report")
+    # Set mtime to 60 days ago
+    old_time = time.time() - (60 * 24 * 3600)
+    import os
+
+    os.utime(old_report, (old_time, old_time))
+
+    # Create new report
+    new_report = reports_dir / "pre-push-review-new.md"
+    new_report.write_text("new report")
+
+    result = service.clean_reports("pre-push-review", dry_run=False)
+
+    # Old report should be deleted (exceeds max_age_days=30)
+    assert not old_report.exists()
+    # New report should be kept
+    assert new_report.exists()
+    assert result["deleted"] >= 1
+
+
+def test_clean_reports_override_max_count(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """clean_reports respects override max_count."""
+    # Create 5 reports
+    for i in range(5):
+        report = reports_dir / f"pre-push-review-2024010{i}.md"
+        report.write_text(f"report {i}")
+        time.sleep(0.01)
+
+    # Override max_count to 2
+    result = service.clean_reports("pre-push-review", dry_run=False, max_count=2)
+
+    assert result["kept"] == 2
+    assert result["deleted"] == 3
+
+
+def test_clean_all(service: ReportCleanupService, reports_dir: Path) -> None:
+    """clean_all cleans all report types."""
+    # Create reports of different types
+    pre_push = reports_dir / "pre-push-review-20240101.md"
+    pre_push.write_text("pre-push review")
+
+    skills_state = reports_dir / "skills-state-run1.json"
+    skills_state.write_text('{"state": "running"}')
+
+    audit = reports_dir / "audit-result.md"
+    audit.write_text("audit result")
+
+    results = service.clean_all(dry_run=False)
+
+    # Should return results for each type
+    assert isinstance(results, dict)
+    assert "pre-push-review" in results
+    assert "skills-state" in results
+    assert "audit-result" in results
+
+
+def test_get_disk_usage_empty(service: ReportCleanupService) -> None:
+    """get_disk_usage returns zeros for empty directory."""
+    usage = service.get_disk_usage()
+    assert usage["total_bytes"] == 0
+    assert usage["total_files"] == 0
+    assert usage["total_dirs"] == 0
+
+
+def test_get_disk_usage_with_files(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """get_disk_usage counts files and directories correctly."""
+    # Create some files
+    report1 = reports_dir / "pre-push-review-20240101.md"
+    report1.write_text("x" * 1000)
+
+    flow_dir = reports_dir / "task-issue-123"
+    flow_dir.mkdir()
+    coverage = flow_dir / "coverage.json"
+    coverage.write_text('{"coverage": 80}')
+
+    usage = service.get_disk_usage()
+    assert usage["total_bytes"] > 0
+    assert usage["total_files"] == 2
+    assert (
+        usage["total_dirs"] >= 1
+    )  # flow_dir (reports_dir is counted separately by rglob)
+
+
+def test_retention_policy_type_specific(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """Type-specific retention policy overrides defaults."""
+    # Create 7 pre-push-review reports (max_count=5 for this type)
+    for i in range(7):
+        report = reports_dir / f"pre-push-review-2024010{i}.md"
+        report.write_text(f"report {i}")
+        time.sleep(0.01)
+
+    result = service.clean_reports("pre-push-review", dry_run=False)
+
+    # Should keep only 5 (type-specific override)
+    assert result["kept"] == 5
+    assert result["deleted"] == 2
+
+
+def test_report_info_properties() -> None:
+    """ReportInfo properties compute correct values."""
+    info = ReportInfo(
+        path=Path("/tmp/test.md"),
+        size_bytes=2048,
+        mtime=time.time(),
+        age_days=0.5,
+    )
+
+    assert info.size_kb == 2.0
+    assert info.age_display == "12.0h"
+
+
+def test_list_reports_handles_missing_directory(
+    config: VibeConfig,
+) -> None:
+    """list_reports returns empty list when directory doesn't exist."""
+    service = ReportCleanupService(config=config)
+    service.reports_dir = Path("/nonexistent")
+
+    reports = service.list_reports("pre-push-review")
+    assert reports == []
+
+
+def test_clean_reports_handles_error(
+    service: ReportCleanupService, reports_dir: Path
+) -> None:
+    """clean_reports handles file deletion errors gracefully."""
+    # Create a report
+    report = reports_dir / "pre-push-review-20240101.md"
+    report.write_text("test")
+
+    # Mock unlink to raise exception
+    with patch.object(Path, "unlink", side_effect=PermissionError("No access")):
+        result = service.clean_reports("pre-push-review", dry_run=False)
+
+    # Should not crash, but deletion should fail
+    assert result["deleted"] == 0


### PR DESCRIPTION
## Summary

Implemented a report cleanup mechanism for `.agent/reports/` directory with configurable retention policy to prevent historical report accumulation.

### Changes

- **Service Layer**: Added `ReportCleanupService` with retention logic (max_count, max_age_days)
- **CLI Commands**: New `vibe3 reports list/clean/status` commands
- **Configuration**: Configurable retention policy in `config/settings.yaml`
- **Tests**: Comprehensive unit tests (27 tests, all passing)

### Key Features

- Configurable retention policy (max_count, max_age_days)
- Type-specific retention overrides
- Safety-first design (default dry-run mode, requires --force for actual deletion)
- Cross-platform compatibility (pathlib.Path throughout)

### Test Plan

- [x] Unit tests: 27 tests pass
- [x] Type checks: mypy success
- [x] Lint: ruff all checks passed
- [x] Manual verification:
  - `vibe3 reports status` shows disk usage summary
  - `vibe3 reports list` displays all reports with metadata
  - `vibe3 reports clean --dry-run` previews deletions safely
  - `vibe3 reports clean --force` required for actual deletion

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)