### PR TITLE
fix(review): clarify PR review workflow prompts

### DIFF
--- a/.claude/agents/pr-architect-reviewer.md
+++ b/.claude/agents/pr-architect-reviewer.md
@@ -26,13 +26,14 @@ extends: architect  # 继承全局 architect 的基础能力
 
 ```yaml
 context_bundle:
-  pr_info: "gh pr view <number> --json headRefName,title,body"
+  pr_info: "gh pr view <number> --json headRefName,title,body,comments"
   pr_branch: "PR 开发分支名"
   handoff_status: "handoff status 输出；不可用时标注 handoff not available"
-  issue_comments: "从分支名推断 issue 编号后读取的 issue comments；无编号时标注 unavailable"
+  issue_comments: "仅 task/issue-* 或 dev/issue-* 分支自动读取；人机合作分支标注不适用"
+  pr_comments: "PR review history and human collaboration context"
 ```
 
-如果 `handoff_status` 不可用，使用 `issue_comments` 和 `pr_info` 作为 fallback 上下文。不要读取 `.git/vibe3` 共享文件。
+如果 `handoff_status` 不可用，自动 flow 分支使用 `issue_comments` 和 `pr_info` 作为 fallback；人机合作分支使用 `pr_info`、`pr_comments` 和人类 review 意见作为真源。不要读取 `.git/vibe3` 共享文件。
 
 阅读关键架构文档：
 - `SOUL.md` — 项目宪法和核心原则
@@ -64,6 +65,65 @@ src/vibe3/
 - PR 可能基于过时的架构假设
 - 可能有更简单的替代方案
 - 可能引入不必要的复杂性
+- 可能错误地在底层包装已有能力
+
+### 底层能力扩充必要性检查（关键）
+
+核心问题：PR 是否在 Shell 能力层（`vibe3` 命令）包装了已有能力？
+
+必须回答：
+1. 这个能力是否已经被 `git` / `gh` / 其他 CLI 覆盖？
+2. 这个能力是否更适合在 Skill 层实现？
+3. 增加底层命令是否会带来长期维护负担？
+
+检查步骤：
+1. 阅读 `docs/standards/v3/command-standard.md` 禁止条款
+2. 检查 PR 是否包装了 `git` / `gh` 已有能力
+3. 评估 `skills/` 目录是否已有类似能力或更合适的编排位置
+
+### 反面范例：PR #614
+
+PR #614 新增 `vibe3 task search <query>` 命令，本质上包装了 `gh issue list --search`。
+
+| 检查项 | 结果 | 说明 |
+|--------|------|------|
+| 是否包装 gh 已有能力 | 是 | 包装了 `gh issue list --search` |
+| Skill 层是否已有相近能力 | 是 | `skills/vibe-issue/SKILL.md` 已有查重/语义判断流程 |
+| 是否增加维护负担 | 是 | 底层命令扩张会让 Shell 层承担语义工作流职责 |
+
+正确做法：
+- 直接使用 `gh issue list --search`
+- 或增强 `skills/vibe-issue/SKILL.md` 的查重和语义分析
+
+错误做法：
+- 在 Shell 层新增 `vibe3 task search`
+- 用 `vibe3` 重新包装 `gh` 已覆盖的常规查询能力
+- 把应该留在 Skill 层的语义判断下沉到底层命令
+
+能力分层原则：
+
+```text
+Tier 3: Policies / Rules
+  - 质量标准、治理原则、边界约束
+
+Tier 2: Skills / Workflows
+  - 理解上下文、调度、编排
+  - 语义分析、相似度判断、决策建议
+  - 调用多个 shell 命令组合成复杂流程
+
+Tier 1: Shell Commands / git / gh
+  - 原子操作、确定性状态修改
+  - 只提供可验证的输入输出
+  - 不做业务判断或语义分析
+```
+
+| 能力类型 | 应该放在 | 原因 |
+|----------|----------|------|
+| 纯数据查询/聚合 | 直接用 `gh` / `git` 或 Shell 层 | 无业务判断，可验证输出 |
+| 语义分析/相似度判断 | Skill 层 | 涉及业务决策 |
+| 编排多个命令 | Skill 层 | 组合逻辑属于工作流 |
+| 用户交互/确认 | Skill 层 | 交互属于工作流 |
+| 状态修改 + 回滚 | Shell 层 | 需要原子操作 |
 
 ## 审查流程
 
@@ -91,11 +151,15 @@ src/vibe3/
 - 是否有更简单的实现方式？
 - 是否有现有组件可以复用？
 - 是否有行业标准方案？
+- 这个能力是否已被 `git` / `gh` / 其他 CLI 覆盖？
+- 是否应该放在 Skill 层而非 Shell 层？
 
 **替代方案搜索**：
 - Glob 搜索项目内类似实现
 - WebSearch 搜索行业最佳实践
 - 检查是否有废弃的路径
+- 阅读 `docs/standards/v3/command-standard.md` 禁止条款
+- 检查 `skills/` 目录是否已有类似功能
 
 ### 4. 价值评估
 

--- a/.claude/agents/pr-context-researcher.md
+++ b/.claude/agents/pr-context-researcher.md
@@ -9,9 +9,9 @@ description: |
   增加了 PR 特定的时效性检查和依赖关系分析。
 
 model: haiku
-tools: Read, Grep, Glob, WebFetch
+tools: Read, Grep, Glob, WebFetch, Bash
 extends: Explore  # 继承全局 Explore 的基础能力
-# 安全限制：此 agent 无 Bash 工具，只做信息收集
+# Bash 仅用于只读 GitHub/context 命令，不执行写操作或本地状态修改
 ---
 
 你是 PR 背景调研员，负责在代码审查前收集必要的项目上下文。
@@ -20,19 +20,36 @@ extends: Explore  # 继承全局 Explore 的基础能力
 
 ### 1. 审查前状态检查
 
-**重要**：审查分支和开发分支不同，需要从 PR 获取开发分支上下文。
+**重要**：审查分支和开发分支不同，需要从被审查 PR 的分支获取上下文，而不是当前工作区分支。
 
-你没有 Bash 工具，不直接执行 `gh` 或 `uv run`。Team-lead 必须先收集并传入 context bundle：
+你可以直接执行只读 `gh` 命令获取 PR / issue context，也可以读取 team-lead 传入的 context bundle：
+
+```bash
+PR_BRANCH=$(gh pr view <number> --json headRefName -q .headRefName)
+
+# 仅自动 flow 分支可推断 issue：task/issue-123 或 dev/issue-123。
+# 人机合作分支（如 codex/pr-123-*）不自动推断 issue，优先使用 PR body/comments。
+if echo "$PR_BRANCH" | grep -qE '^(task|dev)/issue-[0-9]+'; then
+  ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+  gh issue view "$ISSUE_NUM" --comments
+else
+  echo "issue comments unavailable for non-flow branch: $PR_BRANCH"
+  gh pr view <number> --comments
+fi
+```
+
+### Context Bundle 结构
 
 ```yaml
 context_bundle:
-  pr_info: "gh pr view <number> --json headRefName,title,body"
-  pr_branch: "PR 开发分支名"
-  handoff_status: "handoff status 输出；不可用时标注 handoff not available"
-  issue_comments: "从分支名推断 issue 编号后读取的 issue comments；无编号时标注 unavailable"
+  pr_info: "gh pr view <number> --json headRefName,title,body,comments"
+  pr_branch: "PR 开发分支名（从 gh pr view 获取）"
+  handoff_status: "handoff status 输出；远程审查时可能不可用"
+  issue_comments: "仅 task/issue-* 或 dev/issue-* 分支自动读取"
+  pr_comments: "PR review history and human collaboration context"
 ```
 
-如果 `handoff_status` 不可用，使用 `issue_comments` 和 `pr_info` 作为 fallback 上下文。不要读取 `.git/vibe3` 共享文件。
+如果 `handoff_status` 不可用，自动 flow 分支使用 `issue_comments` 和 `pr_info` 作为 fallback；人机合作分支使用 `pr_info`、`pr_comments` 和人类 review 意见作为真源。不要读取 `.git/vibe3` 共享文件。
 
 ### 2. 项目结构理解
 
@@ -88,7 +105,7 @@ context_bundle:
 | AGENTS.md | 已读/未读 | 项目根目录 |
 | glossary.md | 已读/未读 | docs/standards/ |
 | PR description | 已读/未读 | GitHub |
-| issue comments | 已读/未读 | 从分支名推断 issue 编号 |
+| issue comments | 已读/未读/不适用 | 仅自动 flow 分支从分支名推断 issue |
 
 **注意**：审查分支 ≠ 开发分支，handoff 仅在本地可用，fallback 从 issue comments 获取上下文。
 

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -32,18 +32,22 @@ preflight_checks:
       - 复用：SendMessage 唤醒现有 teammates
       - 不复用：cleanup_phase 清理后重新 spawn
 
-# Team-lead 负责收集 shell 上下文，并把结果传给无 Bash 权限的 teammates
+# Team-lead 负责收集 shell 上下文，并把结果传给 teammates
 context_bundle:
   executor: team-lead
   commands:
-    pr_info: "gh pr view <number> --json headRefName,title,body"
+    pr_info: "gh pr view <number> --json headRefName,title,body,comments"
     pr_branch: "gh pr view <number> --json headRefName -q .headRefName"
     handoff_status: "uv run python src/vibe3/cli.py handoff status <pr-branch> 2>/dev/null || echo 'handoff not available'"
     issue_comments: |
-      ISSUE_NUM=$(echo "<pr-branch>" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-      if [ -n "$ISSUE_NUM" ]; then
+      PR_BRANCH="<pr-branch>"
+      if echo "$PR_BRANCH" | grep -qE '^(task|dev)/issue-[0-9]+'; then
+        ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
         gh issue view "$ISSUE_NUM" --comments
+      else
+        echo "issue comments unavailable for non-flow branch: $PR_BRANCH"
       fi
+    pr_comments: "gh pr view <number> --comments"
   provided_to:
     - context-researcher
     - architect-reviewer
@@ -157,21 +161,46 @@ workflow:
     agents: []
     actions:
       - write_review_comment  # 写入 PR 评论（必须）
-      - check_fixable_issues  # 检查是否有可修复问题
+      - create_follow_up_issues  # 为范围外发现创建 issue（需去重并标注来源）
     conditions:
       APPROVE:
         - 写评论，说明建议
         - 无需修改代码
+        - 如有范围外发现，可创建 follow-up issue
       NEEDS_INFO:
         - 写评论，请求更多信息
         - 等待作者响应
+        - 如有范围外发现，可创建 follow-up issue
       REJECT:
         - 写评论，说明拒绝理由
-        - 如有小问题可修复：提交修复代码到 PR 分支
+        - 不直接修改 PR 分支；需要修复时交给后续执行流程
       has_fixable_issues:
         - 写评论，列出问题
-        - 创建修复分支或直接提交到 PR 分支
-        - 示例：`git checkout task/issue-xxx && git commit --amend`
+        - 不提交、amend、push 或修改 PR 分支
+        - 需要代码变更时，交给 vibe-commit / executor 或等待用户明确授权
+
+  # Follow-up Issue 创建规则
+  follow_up_issue_policy:
+    trigger: when_out_of_scope_findings_exist
+    requirements:
+      - 先搜索现有 issue，避免重复
+      - issue body 必须标注来源 PR、审查角色、问题范围和建议优先级
+      - 不把需要当前 PR 修复的阻塞问题转成 follow-up issue
+    template:
+      title: "[follow-up] <简短描述>"
+      body: |
+        ## 来源
+        PR #<number> 审查中发现
+
+        ## 问题描述
+        [具体描述]
+
+        ## 建议处理方式
+        [可选]
+
+        ## 优先级建议
+        - [ ] 高 / 中 / 低
+    labels: ["type/follow-up", "scope/<component>"]
 
   phase_5:
     name: 清理与复用准备

--- a/skills/vibe-review-code/SKILL.md
+++ b/skills/vibe-review-code/SKILL.md
@@ -73,6 +73,16 @@ uv run python src/vibe3/cli.py task show
 
 If these commands fail because the branch has no bound flow, continue reviewing the requested diff and state the limitation.
 
+For remote PR review, distinguish automatic flow branches from human-collaboration
+branches:
+
+- `task/issue-123` and `dev/issue-123`: infer the issue number and read issue
+  comments as the remote handoff / decision history.
+- other branch names such as `codex/pr-123-*`: do not infer an issue number from
+  the branch name. Treat PR body, PR comments, and human review comments as the
+  primary remote context, and explicitly state that issue comments are
+  unavailable for a non-flow branch.
+
 ### 3. Run Impact Analysis
 
 Before assigning severity, collect impact evidence with `inspect`:

--- a/skills/vibe-review-code/SKILL.md
+++ b/skills/vibe-review-code/SKILL.md
@@ -64,7 +64,11 @@ For opened PRs, GitHub PR metadata and PR diff are the source of truth for what 
 
 ### 2. Gather Project Context
 
-Use the shared state commands only as context, not as proof that code is correct:
+**关键区分**：本地开发 vs 远程审查
+
+#### 本地开发（当前 worktree = PR 开发分支）
+
+使用共享状态命令获取上下文：
 
 ```bash
 uv run python src/vibe3/cli.py handoff status $(git branch --show-current)
@@ -73,15 +77,38 @@ uv run python src/vibe3/cli.py task show
 
 If these commands fail because the branch has no bound flow, continue reviewing the requested diff and state the limitation.
 
-For remote PR review, distinguish automatic flow branches from human-collaboration
-branches:
+#### 远程审查（当前 worktree ≠ PR 开发分支）
+
+远程审查时，GitHub comments 是跨机器、跨 agent 的共享现场。不要把本地 handoff 当作唯一真源。
+
+**自动 flow 分支**：
 
 - `task/issue-123` and `dev/issue-123`: infer the issue number and read issue
   comments as the remote handoff / decision history.
-- other branch names such as `codex/pr-123-*`: do not infer an issue number from
-  the branch name. Treat PR body, PR comments, and human review comments as the
-  primary remote context, and explicitly state that issue comments are
-  unavailable for a non-flow branch.
+
+```bash
+PR_BRANCH=$(gh pr view <number> --json headRefName -q .headRefName)
+if echo "$PR_BRANCH" | grep -qE '^(task|dev)/issue-[0-9]+'; then
+  ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+  gh issue view "$ISSUE_NUM" --comments
+fi
+gh pr view <number> --comments
+```
+
+**人机合作分支**：
+
+- Branch names such as `codex/pr-123-*` do not imply an issue number.
+- Do not infer an issue number from these branch names.
+- Treat PR body, PR comments, and human review comments as the primary remote
+  context.
+- Explicitly state that issue comments are unavailable for a non-flow branch.
+
+**远程审查上下文优先级**：
+
+1. **PR comments** — 审查历史、人类意见和团队共享现场
+2. **Issue comments** — 仅自动 flow 分支的 agent 决策过程
+3. **PR description** — 改动摘要
+4. **Local handoff** — 仅本地开发分支可用，不作为远程审查前提
 
 ### 3. Run Impact Analysis
 

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -42,11 +42,14 @@ env | grep -i "CLAUDE.*TEAM" || echo "未设置"
 "Team 功能需要在 tmux session 内运行。
  请运行: tmux new-session -s vibe-review
  然后重新启动 Claude Code。
- 
+
  当前回退到单 agent 审查模式..."
- 
+
 -> 使用 vibe-review-code
 ```
+
+不要启动非 tmux team 模式。Team workflow 依赖 tmux panes、SendMessage 和
+team cleanup 状态；环境不满足时，直接转入 `vibe-review-code` 单 agent 审查。
 
 ---
 
@@ -89,6 +92,18 @@ gh pr view <number> --json title,labels,additions
 
 **Phase 1（必须先完成）**：
 ```
+PR_BRANCH=$(gh pr view <number> --json headRefName -q .headRefName)
+
+# 仅自动 flow 分支可推断 issue：task/issue-123 或 dev/issue-123。
+# 人机合作分支（如 codex/pr-123-*）不自动推断 issue，优先使用 PR body/comments。
+if echo "$PR_BRANCH" | grep -qE '^(task|dev)/issue-[0-9]+'; then
+  ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+  gh issue view "$ISSUE_NUM" --comments
+else
+  echo "issue comments unavailable for non-flow branch: $PR_BRANCH"
+  gh pr view <number> --comments
+fi
+
 Agent(context-researcher, model=haiku, prompt="收集 PR 背景...")
 v 等待 teammate-message
 ```
@@ -115,7 +130,8 @@ if security_related:
 ```
 team-lead 执行：
 - write_review_comment -> gh pr comment
-- check_fixable_issues -> 如需修复，提交代码
+- create_follow_up_issues -> 为范围外发现创建 issue（需要去重、标注来源和优先级）
+- 不直接提交、amend、push 或修改 PR 分支；需要代码修复时，写明建议并交给后续执行流程
 ```
 
 **Phase 5（清理与复用准备）**：

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -11,8 +11,9 @@ description: |
 
 **本 Skill 只负责**：
 1. 环境检查
-2. 加载 Team Template
-3. 启动审查团队
+2. PR 队列排序与选择
+3. 加载 Team Template
+4. 启动审查团队
 
 **所有配置和流程定义在**：`.claude/team-templates/pr-review-team.yaml`
 
@@ -53,7 +54,41 @@ team cleanup 状态；环境不满足时，直接转入 `vibe-review-code` 单 a
 
 ---
 
-## Step 2: 加载 Team Template
+## Step 2: PR 队列排序与选择
+
+当用户没有指定 PR 编号时，先检查当前 repo 的所有未合并 PR，排序后建议审查顺序。
+
+```bash
+gh pr list --state open --json number,title,labels,additions,deletions,baseRefName,headRefName,updatedAt
+```
+
+### PR 排序规则
+
+优先级从高到低：
+
+1. **merge-ready 状态**：标签含 `state/merge-ready`
+2. **最小改动优先**：`additions + deletions` 行数最小
+3. **无依赖优先**：`baseRefName == main` 优先于依赖其他 PR 分支
+4. **范围重叠处理**：
+   - 复杂 PR（改动更多文件）先审查
+   - 简单 PR（改动较少文件）后审查
+   - 同一文件的多个改动：先审查改动量大的
+
+### PR 依赖关系检测
+
+```bash
+gh pr view <number> --json baseRefName,headRefName
+```
+
+依赖判断：
+- `baseRefName == main`：无依赖，优先审查
+- `baseRefName == task/issue-xxx` 或其他 PR 分支：可能依赖另一个 PR，需先审查依赖来源
+
+如果用户已经明确指定 PR 编号，直接审查该 PR，不重新路由到其他 PR。
+
+---
+
+## Step 3: 加载 Team Template
 
 **读取配置文件**：`.claude/team-templates/pr-review-team.yaml`
 
@@ -71,7 +106,7 @@ cat .claude/team-templates/pr-review-team.yaml
 
 ---
 
-## Step 3: 判断 PR 类型
+## Step 4: 判断 PR 类型
 
 根据 Template 中的 `pr_classification` 规则：
 
@@ -88,7 +123,7 @@ gh pr view <number> --json title,labels,additions
 
 ---
 
-## Step 4: 按流程启动 Agent
+## Step 5: 按流程启动 Agent
 
 **Phase 1（必须先完成）**：
 ```


### PR DESCRIPTION
## Summary

Clean follow-up for the PR review workflow prompts after closing #631.

- Keep tmux/team mode as the only team workflow path; fall back to vibe-review-code when unavailable
- Preserve PR comments and follow-up issues as remote handoff, with dedupe/source requirements
- Forbid default review-phase commit/amend/push changes to PR branches
- Clarify issue-comment inference only applies to automatic flow branches: task/issue-* and dev/issue-*

## Scope

Prompt/template only. No Python or shell implementation changes.

## Verification

- git diff --check
- YAML parse for .claude/team-templates/pr-review-team.yaml
- rg check for direct commit/push/amend instructions
- pre-commit/pre-push hooks passed during commit/push

Related: closed #631 because it mixed already-merged #622 content and conflicted.

[review] Created by Codex as a clean follow-up after human review guidance.