### PR TITLE
docs: align stale references to v3/command-standard.md (batch 2)

### DIFF
--- a/docs/standards/flow-context-cache-standard.md
+++ b/docs/standards/flow-context-cache-standard.md
@@ -368,7 +368,7 @@ WHERE branch = ? AND expires_at > datetime('now');
 ## 9. 参考
 
 - [glossary.md](glossary.md) — 术语定义
-- [v3/command-standard.md](v3/command-standard.md) — 状态同步标准
+- [v3/command-standard.md](v3/command-standard.md) — 命令与状态同步标准
 - [agent-debugging-standard.md](agent-debugging-standard.md) — 调试方法
 
 ## 10. 变更历史

--- a/docs/standards/github-labels-reference.md
+++ b/docs/standards/github-labels-reference.md
@@ -236,5 +236,5 @@ gh issue list --milestone "Phase 1: 基础设施"
 
 - [github-labels-standard.md](github-labels-standard.md) - 标签语义和真源标准
 - [roadmap-label-management.md](roadmap-label-management.md) - 如何使用标签管理 roadmap
-- [vibe3-state-sync-standard.md](vibe3-state-sync-standard.md) - 状态同步标准
+- [v3/command-standard.md](v3/command-standard.md) - 命令与状态同步标准
 - [issue-standard.md](issue-standard.md) - Issue 标准

--- a/docs/standards/vibe3-architecture-convergence-standard.md
+++ b/docs/standards/vibe3-architecture-convergence-standard.md
@@ -283,7 +283,7 @@ Vibe3 最终应收敛为六层。
 
 - 事件语义与处理规则：见 [vibe3-event-driven-standard.md](vibe3-event-driven-standard.md)
 - runtime driver / tick / async child：见 [vibe3-orchestra-runtime-standard.md](vibe3-orchestra-runtime-standard.md)
-- 状态机与 authoritative refs：见 [vibe3-state-sync-standard.md](vibe3-state-sync-standard.md)
+- 状态机与 authoritative refs：见 [v3/command-standard.md](v3/command-standard.md)
 - worktree ownership：见 [vibe3-worktree-ownership-standard.md](vibe3-worktree-ownership-standard.md)
 
 本文件负责回答“整体最后该长成什么样”，上述文件负责回答各分层内部的细节语义。

--- a/docs/standards/vibe3-execution-paths-standard.md
+++ b/docs/standards/vibe3-execution-paths-standard.md
@@ -13,7 +13,7 @@ last_updated: 2026-04-19
 related_docs:
   - docs/standards/vibe3-noop-gate-boundary-standard.md
   - docs/standards/vibe3-orchestra-runtime-standard.md
-  - docs/standards/vibe3-state-sync-standard.md
+  - docs/standards/v3/command-standard.md
   - src/vibe3/execution/issue_role_sync_runner.py
   - src/vibe3/execution/codeagent_runner.py
 ---

--- a/docs/standards/vibe3-serve-debugging-guide.md
+++ b/docs/standards/vibe3-serve-debugging-guide.md
@@ -13,7 +13,7 @@ related_docs:
   - docs/standards/agent-debugging-standard.md
   - docs/standards/vibe3-orchestra-runtime-standard.md
   - docs/standards/vibe3-noop-gate-boundary-standard.md
-  - docs/standards/vibe3-state-sync-standard.md
+  - docs/standards/v3/command-standard.md
 ---
 
 # Vibe3 Serve 调试指南
@@ -41,7 +41,7 @@ related_docs:
    - blocked 作为调试信号的正确理解
    - gate/block/fail 的区别与处理
 
-4. **[vibe3-state-sync-standard.md](./vibe3-state-sync-standard.md)**：状态同步与真源定义
+4. **[v3/command-standard.md](./v3/command-standard.md)**：命令与状态同步标准
    - authoritative ref 的定义
    - 状态一致性检查方法
 


### PR DESCRIPTION
## Summary

Aligned 5 stale document references from deprecated `vibe3-state-sync-standard.md` to the current `v3/command-standard.md`:

- `docs/standards/flow-context-cache-standard.md` (reference section)
- `docs/standards/github-labels-reference.md` (reference section)
- `docs/standards/vibe3-architecture-convergence-standard.md` (related standards section)
- `docs/standards/vibe3-execution-paths-standard.md` (frontmatter related_docs)
- `docs/standards/vibe3-serve-debugging-guide.md` (frontmatter + debugging guide section)

This is a semantic alignment task identified by supervisor governance scan. The deprecated file `vibe3-state-sync-standard.md` has been officially replaced by `v3/command-standard.md`.

## Scope Boundaries

- ✅ Update reference links only (no content changes)
- ✅ Minimal semantic alignment
- ❌ No main code modifications
- ❌ No structural rewrites

## Test plan

- [x] Manual verification: all 5 documents now reference the correct current standard
- [x] Link paths validated (relative paths resolved correctly)
- [x] No breaking changes to document structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)