### PR TITLE
docs: align stale references to v3/command-standard (batch 2)

### DIFF
--- a/docs/standards/agent-debugging-standard.md
+++ b/docs/standards/agent-debugging-standard.md
@@ -2,7 +2,7 @@
 
 > **文档定位**：Vibe3 agent 编排调试的统一入口。涵盖日志规范、链路调试方法、观测手段和项目理解。
 > **适用范围**：所有使用 `vibe3 serve`、`vibe3 run`、`vibe3 plan`、`vibe3 review`、heartbeat、orchestra、manager 的 agent 编排调试。
-> **权威性**：本标准是 agent 调试流程与日志规范的权威依据。业务语义以 `skills/`、`supervisor/`、`.agent/policies/` 为准；编排状态语义与 authoritative ref 定义以 [vibe3-state-sync-standard.md](vibe3-state-sync-standard.md) 为准；运行时架构以 [vibe3-orchestra-runtime-standard.md](vibe3-orchestra-runtime-standard.md) 为准。
+> **权威性**：本标准是 agent 调试流程与日志规范的权威依据。业务语义以 `skills/`、`supervisor/`、`.agent/policies/` 为准；编排状态语义与 authoritative ref 定义以 [v3/command-standard.md](v3/command-standard.md) 为准；运行时架构以 [vibe3-orchestra-runtime-standard.md](vibe3-orchestra-runtime-standard.md) 为准。
 > **实践入口**：快速上手请参考 [vibe3-serve-debugging-guide.md](vibe3-serve-debugging-guide.md)。
 
 ---

--- a/docs/standards/flow-context-cache-standard.md
+++ b/docs/standards/flow-context-cache-standard.md
@@ -368,7 +368,7 @@ WHERE branch = ? AND expires_at > datetime('now');
 ## 9. 参考
 
 - [glossary.md](glossary.md) — 术语定义
-- [vibe3-state-sync-standard.md](vibe3-state-sync-standard.md) — 状态同步标准
+- [v3/command-standard.md](v3/command-standard.md) — 状态同步标准
 - [agent-debugging-standard.md](agent-debugging-standard.md) — 调试方法
 
 ## 10. 变更历史

--- a/docs/standards/vibe3-event-driven-standard.md
+++ b/docs/standards/vibe3-event-driven-standard.md
@@ -547,7 +547,7 @@ LabelService().transition(
 
 - **[vibe3-worktree-ownership-standard.md](vibe3-worktree-ownership-standard.md)**: 定义执行层级与 worktree 语义，本文件补充事件语义。
 - **[vibe3-orchestra-runtime-standard.md](vibe3-orchestra-runtime-standard.md)**: 定义 driver/tick/async child 架构，事件发布时机参考该文件。
-- **[vibe3-state-sync-standard.md](vibe3-state-sync-standard.md)**: 定义 flow 状态机，事件触发条件参考该文件。
+- **[v3/command-standard.md](v3/command-standard.md)**: 定义 flow 状态机，事件触发条件参考该文件。
 - **[agent-debugging-standard.md](agent-debugging-standard.md)**: 调试手册，事件日志规范以本文件为准。
 
 ### 11.2 术语真源

--- a/docs/standards/vibe3-orchestra-runtime-standard.md
+++ b/docs/standards/vibe3-orchestra-runtime-standard.md
@@ -23,7 +23,7 @@
 
 本标准不定义：
 
-- `state/*` 业务含义细节（见 `docs/standards/vibe3-state-sync-standard.md`）
+- `state/*` 业务含义细节（见 `docs/standards/v3/command-standard.md`）
 - handoff 正文格式
 - skill / supervisor 具体 prompt 文案
 - 日志读取与调试方法（见 `docs/standards/agent-debugging-standard.md`）

--- a/docs/standards/vibe3-worktree-ownership-standard.md
+++ b/docs/standards/vibe3-worktree-ownership-standard.md
@@ -157,6 +157,6 @@ find . -name ".git" -type f | grep -v "^./.git$" | head -20
 ## 六、与其他标准的关系
 
 - **[vibe3-orchestra-runtime-standard.md](vibe3-orchestra-runtime-standard.md)**：定义 driver/tick/async child 架构，本文件补充其 worktree 语义。
-- **[vibe3-state-sync-standard.md](vibe3-state-sync-standard.md)**：定义 flow 状态机，worktree 生命周期与 flow 状态绑定。
+- **[v3/command-standard.md](v3/command-standard.md)**：定义 flow 状态机，worktree 生命周期与 flow 状态绑定。
 - **[agent-debugging-standard.md](agent-debugging-standard.md)**：调试手册，§5.3 apply 步骤以本文件语义为准。
 - **[agent-workflow-standard.md](agent-workflow-standard.md)**：Agent 工作流规范，`cwd` 参数传递细节参考本文件。


### PR DESCRIPTION
## Summary
- Updated 5 standard docs to reference v3/command-standard.md instead of deprecated vibe3-state-sync-standard.md
- Files updated: agent-debugging-standard.md, vibe3-worktree-ownership-standard.md, vibe3-event-driven-standard.md, vibe3-orchestra-runtime-standard.md, flow-context-cache-standard.md
- No semantic changes, only reference updates to point to current authoritative source

## Test plan
- [x] Verified all 5 files contain stale references to deprecated file
- [x] Confirmed vibe3-state-sync-standard.md is deprecated and points to v3/command-standard.md
- [x] Updated all references to use current authoritative source
- [x] All pre-push checks passed (compile, type check, smoke tests, LOC checks)

Fixes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)