### PR TITLE
refactor: remove redundant __str__ from MissingTaskIssueError (#565)

### DIFF
--- a/src/vibe3/services/task_binding_guard.py
+++ b/src/vibe3/services/task_binding_guard.py
@@ -8,9 +8,6 @@ from vibe3.exceptions import UserError
 class MissingTaskIssueError(UserError):
     """Raised when current flow has no bound task issue."""
 
-    def __str__(self) -> str:
-        return self.message
-
 
 def has_task_issue(flow_status: Any | None) -> bool:
     """Return True when flow status includes a task_issue_number."""


### PR DESCRIPTION
## Summary
- Removed redundant `__str__` method from `MissingTaskIssueError`
- Python's default Exception behavior already provides identical functionality
- Pure behavior-preserving cleanup with zero risk

## Changes
- `src/vibe3/services/task_binding_guard.py`: 3 lines deleted (removed `__str__` method)

## Verification
- ✓ Type check: mypy Success (274 files)
- ✓ Lint: ruff clean
- ✓ Tests: 1488 passed
- ✓ Manual verification: `str(exception)` correctly returns message

## Risk Assessment
**ZERO RISK** - Behavior-preserving refactor. Python's `Exception.__str__` returns `self.args[0]` by default, which is set to `message` by `VibeError.__init__`.

Closes #565

---

## Contributors

claude/sonnet-4.6