### PR TITLE
fix(docs): remove obsolete --async flags from release-handoff.md

### DIFF
--- a/docs/v3/orchestra/release-handoff.md
+++ b/docs/v3/orchestra/release-handoff.md
@@ -35,7 +35,7 @@
 3. 本地启动检查
 - 启动：
 ```bash
-uv run python src/vibe3/cli.py serve start --async -v --port 8080
+uv run python src/vibe3/cli.py serve start -v --port 8080
 ```
 - 状态：
 ```bash
@@ -47,7 +47,7 @@ curl -sS http://127.0.0.1:8080/status
 ### 3.1 干跑（建议先做）
 
 ```bash
-uv run python src/vibe3/cli.py serve start --async -v --dry-run --port 8080
+uv run python src/vibe3/cli.py serve start -v --dry-run --port 8080
 ```
 
 创建并指派 issue 给 `vibe-manager-agent`，预期日志包含：


### PR DESCRIPTION
## Summary

- Remove obsolete `--async` flags from two `serve start` commands in release-handoff.md (lines 38 and 50)
- Async is now the default behavior; the flag is no longer needed
- Verified via `serve start --help` that `--async` is not a valid option

## Context

Issue #609 identified that the release handoff documentation contained outdated CLI syntax. The `--async` flag was removed in a previous refactoring when async execution became the default behavior.

## Test plan

- [x] Verified `uv run python src/vibe3/cli.py serve start --help` shows `--no-async` (confirming async is default)
- [x] Checked file for any remaining `--async` instances (none found)
- [x] Confirmed command syntax is correct without the flag

Fixes #609