### PR TITLE
feat: add periodic governance scan mode (separate from server mode)

### DIFF
--- a/docs/v3/orchestra/runtime-modes.md
+++ b/docs/v3/orchestra/runtime-modes.md
@@ -1,0 +1,286 @@
+# Orchestra Runtime Modes
+
+Orchestra supports two runtime modes for different deployment scenarios.
+
+## Overview
+
+| Mode | Command | Use Case |
+|------|---------|----------|
+| **Always-on Server** | `vibe3 serve start` | Continuous webhook receiver + heartbeat polling |
+| **Periodic Scan** | `vibe3 scan` | Standalone governance/supervisor checks |
+
+Both modes share the same observation logic (OrchestrationFacade) but have different deployment assumptions.
+
+## Always-on Server Mode
+
+**Command**: `vibe3 serve start`
+
+### Characteristics
+
+- Long-running daemon process
+- HTTP webhook receiver (FastAPI on port 8080 by default)
+- Periodic heartbeat polling (default: 60s interval)
+- Event-driven architecture
+- FailedGate integration for error recovery
+
+### When to Use
+
+- Production deployments
+- Real-time GitHub webhook integration
+- Continuous monitoring of issue state changes
+- Environments requiring immediate response to webhook events
+
+### Architecture
+
+```
+HeartbeatServer (event loop)
+  ├── HTTP Server (FastAPI)
+  │   └── POST /webhook/github
+  └── Polling Loop (heartbeat tick)
+      └── OrchestrationFacade
+          ├── Governance scan (interval-gated)
+          ├── Supervisor scan (interval-gated)
+          └── Issue label dispatch polling
+```
+
+### Service Lifecycle
+
+- PID file management for daemon control
+- Session registry cleanup on startup/shutdown
+- FailedGate preflight check before starting
+- Graceful shutdown via SIGTERM
+
+### Example
+
+```bash
+# Start server with defaults from config/settings.yaml
+vibe3 serve start
+
+# Debug mode (60s heartbeat, current branch as base)
+vibe3 serve start --debug
+
+# Custom interval and port
+vibe3 serve start --interval 30 --port 9000
+
+# Check server status
+vibe3 serve status
+
+# Stop server
+vibe3 serve stop
+```
+
+## Periodic Scan Mode
+
+**Command**: `vibe3 scan [governance|supervisor|all]`
+
+### Characteristics
+
+- Run once and exit
+- No HTTP server
+- No heartbeat event loop
+- Direct event publishing (bypasses interval gating)
+- Suitable for cron/scheduled execution
+
+### When to Use
+
+- CI/CD pipeline integration
+- GitHub Actions scheduled workflows
+- Manual governance checks
+- Environments without webhook accessibility
+- Testing and debugging specific scan behaviors
+
+### Architecture
+
+```
+Scan Command
+  └── OrchestrationFacade (direct)
+      ├── Governance scan (no interval gating)
+      └── Supervisor scan (no interval gating)
+```
+
+### Subcommands
+
+#### `vibe3 scan governance [--tick N]`
+
+Runs governance scan once:
+- Scans all open issues for governance rule violations
+- Publishes `GovernanceScanStarted` event
+- Triggers governance agent dispatch via event handler
+- Optional `--tick` to override tick count
+
+#### `vibe3 scan supervisor`
+
+Runs supervisor scan once:
+- Scans for issues with `supervisor` + `state/handoff` labels
+- Publishes `SupervisorIssueIdentified` events
+- Triggers supervisor handoff dispatch via event handler
+
+#### `vibe3 scan all [--tick N]`
+
+Runs both governance and supervisor scans in sequence.
+
+### Example
+
+```bash
+# Run governance scan
+vibe3 scan governance
+
+# Run supervisor scan
+vibe3 scan supervisor
+
+# Run both scans
+vibe3 scan all
+
+# Dry-run mode (show what would be done)
+vibe3 scan governance --dry-run
+
+# Override tick count for governance scan
+vibe3 scan governance --tick 42
+```
+
+## Shared Components
+
+Both modes share the same core components:
+
+### OrchestrationFacade
+
+Unified entry point for runtime observations:
+- Publishes domain events (observation layer)
+- Does not execute dispatch directly
+- Same observation logic for both modes
+
+### Domain Event Handlers
+
+Event handlers subscribe to domain events:
+- `handle_governance_scan_started` - L1 governance chain
+- `handle_supervisor_issue_identified` - L2 supervisor chain
+- Dispatch execution happens in handlers, not facade
+
+### FailedGate
+
+Error recovery mechanism shared by both modes:
+- Blocks dispatch when errors exceed threshold
+- SQLite-backed state (shared across modes)
+- Manual resume required via `vibe3 serve resume`
+
+### CapacityService
+
+Tracks active execution sessions:
+- Prevents over-provisioning
+- Same capacity limits for both modes
+- Session state persisted in SQLite
+
+## Behavioral Differences
+
+| Aspect | Server Mode | Scan Mode |
+|--------|-------------|-----------|
+| **Interval gating** | Active (tick modulo check) | Bypassed (explicit request) |
+| **Min time between scans** | Enforced | Bypassed |
+| **FailedGate check** | Before each tick | Before dispatch |
+| **Webhook handling** | Active | Not applicable |
+| **PID management** | Required | Not applicable |
+| **Session cleanup** | Startup/shutdown | Manual |
+
+## Deployment Recommendations
+
+### Always-on Server
+
+**Production (systemd)**:
+```ini
+[Unit]
+Description=Vibe3 Orchestra Server
+After=network.target
+
+[Service]
+Type=simple
+User=vibe
+WorkingDirectory=/opt/vibe3
+ExecStart=/usr/local/bin/vibe3 serve start --no-async
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Development (tmux)**:
+```bash
+vibe3 serve start  # Default: async tmux session
+vibe3 serve start --no-async  # Foreground (blocking)
+```
+
+### Periodic Scan
+
+**Cron (every 5 minutes)**:
+```cron
+*/5 * * * * cd /opt/vibe3 && vibe3 scan all >> /var/log/vibe3/scan.log 2>&1
+```
+
+**GitHub Actions (scheduled workflow)**:
+```yaml
+name: Orchestra Governance Scan
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # Every 5 minutes
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install vibe3
+        run: pip install -e .
+      - name: Run governance scan
+        run: vibe3 scan governance
+```
+
+**Manual debugging**:
+```bash
+# Test governance scan without execution
+vibe3 scan governance --dry-run
+
+# Run with verbose logging
+vibe3 scan all -vv
+```
+
+## Risk Mitigation
+
+### Duplicate Execution
+
+If both modes run simultaneously:
+- **Session registry check** prevents duplicate governance runs
+- Same SQLite session state prevents concurrent dispatch
+- CapacityService enforces max_concurrent_flows limit
+
+### FailedGate State Sharing
+
+- Both modes use same SQLite store for FailedGate
+- Scan command respects FailedGate state
+- Manual resume required: `vibe3 serve resume --reason "<reason>"`
+
+### Service Initialization
+
+- Both modes use same service factories
+- SQLiteClient, CapacityService, FailedGate initialized identically
+- Event handlers registered before publishing events
+
+## Configuration
+
+Both modes share the same configuration in `config/settings.yaml`:
+
+```yaml
+orchestra:
+  enabled: true
+  repo: "owner/repo"
+  port: 8080
+  polling_interval: 60
+  max_concurrent_flows: 5
+
+  governance:
+    interval_ticks: 1  # Scan every tick (server mode)
+    enabled: true
+
+  supervisor_handoff:
+    interval_ticks: 1  # Scan every tick (server mode)
+    enabled: true
+```
+
+**Note**: `interval_ticks` only applies to server mode. Scan mode bypasses interval gating.

--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -24,6 +24,7 @@ from vibe3.commands import (
     pr,
     review,
     run,
+    scan,
     snapshot,
     status,
     task,
@@ -62,6 +63,7 @@ app.add_typer(inspect.app, name="inspect")
 app.add_typer(review.app, name="review")
 app.add_typer(handoff.app, name="handoff")
 app.add_typer(check.app, name="check")
+app.add_typer(scan.app, name="scan")
 app.add_typer(snapshot.app, name="snapshot")
 app.add_typer(serve.app, name="serve")
 app.add_typer(internal.app, name="internal")

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -1,0 +1,249 @@
+"""Scan command: standalone governance/supervisor scans without HeartbeatServer."""
+
+import asyncio
+from typing import Annotated
+
+import typer
+from loguru import logger
+
+from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.observability import setup_logging
+
+app = typer.Typer(
+    help="Run governance and supervisor scans without starting the server",
+    no_args_is_help=True,
+)
+
+
+def _run_governance_scan(tick_count: int | None = None) -> None:
+    """Execute governance scan once.
+
+    Args:
+        tick_count: Override tick count (bypasses interval gating)
+    """
+    from vibe3.agents.backends.codeagent import CodeagentBackend
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.domain.handlers import register_event_handlers
+    from vibe3.domain.orchestration_facade import OrchestrationFacade
+    from vibe3.execution.capacity_service import CapacityService
+    from vibe3.orchestra.failed_gate import FailedGate
+
+    # Register event handlers before publishing events
+    register_event_handlers()
+
+    # Load config
+    config = load_orchestra_config()
+
+    # Initialize services (following _build_server_with_launch_cwd pattern)
+    shared_store = SQLiteClient()
+    shared_backend = CodeagentBackend()
+    failed_gate = FailedGate(store=shared_store)
+    shared_capacity = CapacityService(config, shared_store, shared_backend)
+
+    # Check FailedGate before dispatching
+    gate_result = failed_gate.check()
+    if gate_result.blocked:
+        logger.bind(domain="orchestra").error(
+            f"Scan blocked by failed gate: {gate_result.reason}"
+        )
+        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
+        return
+
+    # Create facade with minimal services for governance scan
+    facade = OrchestrationFacade(
+        tick_count=tick_count if tick_count is not None else 0,
+        config=config,
+        dispatch_services=None,  # Not needed for governance scan
+        capacity=shared_capacity,
+        failed_gate=failed_gate,
+    )
+
+    # Trigger governance scan
+    # on_heartbeat_tick publishes GovernanceScanStarted event
+    # which triggers handle_governance_scan_started
+    facade.on_heartbeat_tick()
+
+    logger.bind(domain="orchestra").info("Governance scan completed")
+
+
+async def _run_supervisor_scan_async() -> None:
+    """Execute supervisor scan once (async implementation)."""
+    from vibe3.agents.backends.codeagent import CodeagentBackend
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.domain.handlers import register_event_handlers
+    from vibe3.domain.orchestration_facade import OrchestrationFacade
+    from vibe3.execution.capacity_service import CapacityService
+    from vibe3.orchestra.failed_gate import FailedGate
+
+    # Register event handlers before publishing events
+    register_event_handlers()
+
+    # Load config
+    config = load_orchestra_config()
+
+    # Initialize services
+    shared_store = SQLiteClient()
+    shared_backend = CodeagentBackend()
+    failed_gate = FailedGate(store=shared_store)
+    shared_capacity = CapacityService(config, shared_store, shared_backend)
+
+    # Check FailedGate before dispatching
+    gate_result = failed_gate.check()
+    if gate_result.blocked:
+        logger.bind(domain="orchestra").error(
+            f"Scan blocked by failed gate: {gate_result.reason}"
+        )
+        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
+        return
+
+    # Create facade
+    facade = OrchestrationFacade(
+        tick_count=0,
+        config=config,
+        dispatch_services=None,
+        capacity=shared_capacity,
+        failed_gate=failed_gate,
+    )
+
+    # Trigger supervisor scan
+    # on_supervisor_scan publishes SupervisorIssueIdentified events
+    await facade.on_supervisor_scan()
+
+    logger.bind(domain="orchestra").info("Supervisor scan completed")
+
+
+@app.command()
+def governance(
+    tick: Annotated[
+        int | None,
+        typer.Option("--tick", "-t", help="Override tick count for governance scan"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would be done without executing"),
+    ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option("-v", "--verbose", count=True, help="Increase verbosity"),
+    ] = 0,
+) -> None:
+    """Run governance scan once.
+
+    Scans all open issues and triggers governance dispatch for issues
+    matching governance rules. Runs once and exits.
+    """
+    setup_logging(verbose=verbose)
+
+    if dry_run:
+        typer.echo("DRY RUN: Would run governance scan")
+        if tick is not None:
+            typer.echo(f"  - Using tick count: {tick}")
+        return
+
+    _run_governance_scan(tick_count=tick)
+    typer.echo("Governance scan completed")
+
+
+@app.command()
+def supervisor(
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would be done without executing"),
+    ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option("-v", "--verbose", count=True, help="Increase verbosity"),
+    ] = 0,
+) -> None:
+    """Run supervisor scan once.
+
+    Scans for issues with supervisor + state/handoff labels and triggers
+    supervisor handoff dispatch. Runs once and exits.
+    """
+    setup_logging(verbose=verbose)
+
+    if dry_run:
+        typer.echo("DRY RUN: Would run supervisor scan")
+        return
+
+    asyncio.run(_run_supervisor_scan_async())
+    typer.echo("Supervisor scan completed")
+
+
+async def _run_combined_scan_async(tick_count: int | None = None) -> None:
+    """Execute both governance and supervisor scans in sequence."""
+    from vibe3.agents.backends.codeagent import CodeagentBackend
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.domain.handlers import register_event_handlers
+    from vibe3.domain.orchestration_facade import OrchestrationFacade
+    from vibe3.execution.capacity_service import CapacityService
+    from vibe3.orchestra.failed_gate import FailedGate
+
+    # Register event handlers before publishing events
+    register_event_handlers()
+
+    # Load config
+    config = load_orchestra_config()
+
+    # Initialize services
+    shared_store = SQLiteClient()
+    shared_backend = CodeagentBackend()
+    failed_gate = FailedGate(store=shared_store)
+    shared_capacity = CapacityService(config, shared_store, shared_backend)
+
+    # Check FailedGate before dispatching
+    gate_result = failed_gate.check()
+    if gate_result.blocked:
+        logger.bind(domain="orchestra").error(
+            f"Scan blocked by failed gate: {gate_result.reason}"
+        )
+        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
+        return
+
+    # Create facade
+    facade = OrchestrationFacade(
+        tick_count=tick_count if tick_count is not None else 0,
+        config=config,
+        dispatch_services=None,
+        capacity=shared_capacity,
+        failed_gate=failed_gate,
+    )
+
+    # Run governance scan first
+    facade.on_heartbeat_tick()
+    logger.bind(domain="orchestra").info("Governance scan completed")
+
+    # Then run supervisor scan
+    await facade.on_supervisor_scan()
+    logger.bind(domain="orchestra").info("Supervisor scan completed")
+
+
+@app.command()
+def all(
+    tick: Annotated[
+        int | None,
+        typer.Option("--tick", "-t", help="Override tick count for governance scan"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would be done without executing"),
+    ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option("-v", "--verbose", count=True, help="Increase verbosity"),
+    ] = 0,
+) -> None:
+    """Run both governance and supervisor scans once.
+
+    Equivalent to running 'scan governance' and 'scan supervisor' in sequence.
+    """
+    setup_logging(verbose=verbose)
+
+    if dry_run:
+        typer.echo("DRY RUN: Would run both governance and supervisor scans")
+        if tick is not None:
+            typer.echo(f"  - Using tick count: {tick}")
+        return
+
+    asyncio.run(_run_combined_scan_async(tick_count=tick))
+    typer.echo("Combined scan completed")

--- a/src/vibe3/runtime/README.md
+++ b/src/vibe3/runtime/README.md
@@ -2,6 +2,15 @@
 
 事件驱动运行时基础设施，提供 service protocol、心跳轮询和子进程执行能力。
 
+## 运行时模式
+
+Orchestra 支持两种运行时模式：
+
+1. **Always-on Server Mode** (`vibe3 serve start`): 持续运行的守护进程，支持 webhook 接收和心跳轮询
+2. **Periodic Scan Mode** (`vibe3 scan`): 单次执行的治理/监督扫描，适合 cron 或 CI/CD 集成
+
+详见 [Runtime Modes 文档](../../../docs/v3/orchestra/runtime-modes.md)
+
 ## 职责
 
 - Service protocol（GitHubEvent + ServiceBase）

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -1,0 +1,320 @@
+"""Tests for scan CLI command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from vibe3.cli import app
+
+runner = CliRunner()
+
+
+class TestScanCommand:
+    """Tests for scan CLI command group."""
+
+    def test_scan_help(self):
+        """Test scan command shows help."""
+        result = runner.invoke(app, ["scan", "--help"])
+        assert result.exit_code == 0
+        assert "Run governance and supervisor scans" in result.output
+        assert "governance" in result.output
+        assert "supervisor" in result.output
+        assert "all" in result.output
+
+    def test_scan_governance_help(self):
+        """Test scan governance subcommand help."""
+        result = runner.invoke(app, ["scan", "governance", "--help"])
+        assert result.exit_code == 0
+        assert "Run governance scan once" in result.output
+        assert "--tick" in result.output
+        assert "--dry-run" in result.output
+
+    def test_scan_supervisor_help(self):
+        """Test scan supervisor subcommand help."""
+        result = runner.invoke(app, ["scan", "supervisor", "--help"])
+        assert result.exit_code == 0
+        assert "Run supervisor scan once" in result.output
+        assert "--dry-run" in result.output
+
+    def test_scan_all_help(self):
+        """Test scan all subcommand help."""
+        result = runner.invoke(app, ["scan", "all", "--help"])
+        assert result.exit_code == 0
+        assert "Run both governance and supervisor scans once" in result.output
+        assert "--tick" in result.output
+        assert "--dry-run" in result.output
+
+
+class TestGovernanceScan:
+    """Tests for scan governance subcommand."""
+
+    def test_governance_dry_run(self):
+        """Test governance scan with --dry-run flag."""
+        result = runner.invoke(app, ["scan", "governance", "--dry-run"])
+        assert result.exit_code == 0
+        assert "DRY RUN: Would run governance scan" in result.output
+
+    def test_governance_dry_run_with_tick(self):
+        """Test governance scan dry-run with custom tick count."""
+        result = runner.invoke(app, ["scan", "governance", "--dry-run", "--tick", "42"])
+        assert result.exit_code == 0
+        assert "DRY RUN: Would run governance scan" in result.output
+        assert "Using tick count: 42" in result.output
+
+    @patch("vibe3.commands.scan._run_governance_scan")
+    def test_governance_execution(self, mock_run):
+        """Test governance scan execution."""
+        result = runner.invoke(app, ["scan", "governance"])
+        assert result.exit_code == 0
+        assert "Governance scan completed" in result.output
+        mock_run.assert_called_once_with(tick_count=None)
+
+    @patch("vibe3.commands.scan._run_governance_scan")
+    def test_governance_execution_with_tick(self, mock_run):
+        """Test governance scan execution with custom tick."""
+        result = runner.invoke(app, ["scan", "governance", "--tick", "100"])
+        assert result.exit_code == 0
+        assert "Governance scan completed" in result.output
+        mock_run.assert_called_once_with(tick_count=100)
+
+
+class TestSupervisorScan:
+    """Tests for scan supervisor subcommand."""
+
+    def test_supervisor_dry_run(self):
+        """Test supervisor scan with --dry-run flag."""
+        result = runner.invoke(app, ["scan", "supervisor", "--dry-run"])
+        assert result.exit_code == 0
+        assert "DRY RUN: Would run supervisor scan" in result.output
+
+    @patch("vibe3.commands.scan._run_supervisor_scan_async")
+    def test_supervisor_execution(self, mock_run):
+        """Test supervisor scan execution."""
+        # Mock async function needs to return a coroutine
+        mock_run.return_value = None
+        result = runner.invoke(app, ["scan", "supervisor"])
+        assert result.exit_code == 0
+        assert "Supervisor scan completed" in result.output
+
+
+class TestCombinedScan:
+    """Tests for scan all subcommand."""
+
+    def test_all_dry_run(self):
+        """Test combined scan with --dry-run flag."""
+        result = runner.invoke(app, ["scan", "all", "--dry-run"])
+        assert result.exit_code == 0
+        assert (
+            "DRY RUN: Would run both governance and supervisor scans" in result.output
+        )
+
+    def test_all_dry_run_with_tick(self):
+        """Test combined scan dry-run with custom tick count."""
+        result = runner.invoke(app, ["scan", "all", "--dry-run", "--tick", "50"])
+        assert result.exit_code == 0
+        assert (
+            "DRY RUN: Would run both governance and supervisor scans" in result.output
+        )
+        assert "Using tick count: 50" in result.output
+
+    @patch("vibe3.commands.scan._run_combined_scan_async")
+    def test_all_execution(self, mock_run):
+        """Test combined scan execution."""
+        mock_run.return_value = None
+        result = runner.invoke(app, ["scan", "all"])
+        assert result.exit_code == 0
+        assert "Combined scan completed" in result.output
+
+    @patch("vibe3.commands.scan._run_combined_scan_async")
+    def test_all_execution_with_tick(self, mock_run):
+        """Test combined scan execution with custom tick."""
+        mock_run.return_value = None
+        result = runner.invoke(app, ["scan", "all", "--tick", "75"])
+        assert result.exit_code == 0
+        assert "Combined scan completed" in result.output
+
+
+class TestScanIntegration:
+    """Integration tests for scan command with services."""
+
+    def test_governance_scan_registers_handlers(self):
+        """Test that governance scan registers event handlers."""
+        with (
+            patch("vibe3.domain.handlers.register_event_handlers") as mock_handlers,
+            patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade,
+            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
+            patch("vibe3.execution.capacity_service.CapacityService"),
+            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+        ):
+
+            # Mock FailedGate to return open gate
+            mock_gate_instance = MagicMock()
+            mock_gate_result = MagicMock()
+            mock_gate_result.blocked = False
+            mock_gate_instance.check.return_value = mock_gate_result
+            mock_failed_gate.return_value = mock_gate_instance
+
+            mock_facade_instance = MagicMock()
+            mock_facade.return_value = mock_facade_instance
+
+            from vibe3.commands.scan import _run_governance_scan
+
+            _run_governance_scan(tick_count=10)
+
+            # Verify handlers were registered before facade methods called
+            mock_handlers.assert_called_once()
+            mock_facade.assert_called_once()
+            mock_facade_instance.on_heartbeat_tick.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_supervisor_scan_registers_handlers(self):
+        """Test that supervisor scan registers event handlers."""
+        with (
+            patch("vibe3.domain.handlers.register_event_handlers") as mock_handlers,
+            patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade,
+            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
+            patch("vibe3.execution.capacity_service.CapacityService"),
+            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+        ):
+
+            # Mock FailedGate to return open gate
+            mock_gate_instance = MagicMock()
+            mock_gate_result = MagicMock()
+            mock_gate_result.blocked = False
+            mock_gate_instance.check.return_value = mock_gate_result
+            mock_failed_gate.return_value = mock_gate_instance
+
+            mock_facade_instance = MagicMock()
+
+            # Make on_supervisor_scan an async mock
+            async def async_mock():
+                pass
+
+            mock_facade_instance.on_supervisor_scan = async_mock
+            mock_facade.return_value = mock_facade_instance
+
+            from vibe3.commands.scan import _run_supervisor_scan_async
+
+            await _run_supervisor_scan_async()
+
+            # Verify handlers were registered
+            mock_handlers.assert_called_once()
+            mock_facade.assert_called_once()
+
+
+class TestFailedGateBlocking:
+    """Tests for FailedGate blocking in scan commands."""
+
+    def test_governance_scan_blocked_by_failed_gate(self):
+        """Test that governance scan respects FailedGate."""
+        with (
+            patch("vibe3.domain.handlers.register_event_handlers"),
+            patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade,
+            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
+            patch("vibe3.execution.capacity_service.CapacityService"),
+            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+        ):
+
+            # Mock FailedGate to return blocked state
+            mock_gate_instance = MagicMock()
+            mock_gate_result = MagicMock()
+            mock_gate_result.blocked = True
+            mock_gate_result.reason = "API error threshold: 2 recent errors"
+            mock_gate_instance.check.return_value = mock_gate_result
+            mock_failed_gate.return_value = mock_gate_instance
+
+            mock_facade_instance = MagicMock()
+            mock_facade.return_value = mock_facade_instance
+
+            from vibe3.commands.scan import _run_governance_scan
+
+            _run_governance_scan(tick_count=10)
+
+            # Verify FailedGate was checked
+            mock_gate_instance.check.assert_called_once()
+
+            # Verify facade was NOT called (blocked by gate)
+            mock_facade_instance.on_heartbeat_tick.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_supervisor_scan_blocked_by_failed_gate(self):
+        """Test that supervisor scan respects FailedGate."""
+        with (
+            patch("vibe3.domain.handlers.register_event_handlers"),
+            patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade,
+            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
+            patch("vibe3.execution.capacity_service.CapacityService"),
+            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+        ):
+
+            # Mock FailedGate to return blocked state
+            mock_gate_instance = MagicMock()
+            mock_gate_result = MagicMock()
+            mock_gate_result.blocked = True
+            mock_gate_result.reason = "Model configuration errors: E_MODEL_INVALID"
+            mock_gate_instance.check.return_value = mock_gate_result
+            mock_failed_gate.return_value = mock_gate_instance
+
+            mock_facade_instance = MagicMock()
+            mock_facade_instance.on_supervisor_scan = MagicMock(return_value=None)
+            mock_facade.return_value = mock_facade_instance
+
+            from vibe3.commands.scan import _run_supervisor_scan_async
+
+            await _run_supervisor_scan_async()
+
+            # Verify FailedGate was checked
+            mock_gate_instance.check.assert_called_once()
+
+            # Verify facade was NOT called (blocked by gate)
+            mock_facade_instance.on_supervisor_scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_combined_scan_blocked_by_failed_gate(self):
+        """Test that combined scan respects FailedGate."""
+        with (
+            patch("vibe3.domain.handlers.register_event_handlers"),
+            patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade,
+            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
+            patch("vibe3.execution.capacity_service.CapacityService"),
+            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+        ):
+
+            # Mock FailedGate to return blocked state
+            mock_gate_instance = MagicMock()
+            mock_gate_result = MagicMock()
+            mock_gate_result.blocked = True
+            mock_gate_result.reason = "System in failed state"
+            mock_gate_instance.check.return_value = mock_gate_result
+            mock_failed_gate.return_value = mock_gate_instance
+
+            mock_facade_instance = MagicMock()
+            mock_facade_instance.on_supervisor_scan = MagicMock(return_value=None)
+            mock_facade.return_value = mock_facade_instance
+
+            from vibe3.commands.scan import _run_combined_scan_async
+
+            await _run_combined_scan_async(tick_count=20)
+
+            # Verify FailedGate was checked
+            mock_gate_instance.check.assert_called_once()
+
+            # Verify neither facade method was called (blocked by gate)
+            mock_facade_instance.on_heartbeat_tick.assert_not_called()
+            mock_facade_instance.on_supervisor_scan.assert_not_called()

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -1,5 +1,6 @@
 """Tests for scan CLI command."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,12 @@ from typer.testing import CliRunner
 from vibe3.cli import app
 
 runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI escape sequences from text."""
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    return ansi_escape.sub("", text)
 
 
 class TestScanCommand:
@@ -26,24 +33,27 @@ class TestScanCommand:
         """Test scan governance subcommand help."""
         result = runner.invoke(app, ["scan", "governance", "--help"])
         assert result.exit_code == 0
-        assert "Run governance scan once" in result.output
-        assert "--tick" in result.output
-        assert "--dry-run" in result.output
+        output = _strip_ansi(result.output)
+        assert "Run governance scan once" in output
+        assert "--tick" in output
+        assert "--dry-run" in output
 
     def test_scan_supervisor_help(self):
         """Test scan supervisor subcommand help."""
         result = runner.invoke(app, ["scan", "supervisor", "--help"])
         assert result.exit_code == 0
-        assert "Run supervisor scan once" in result.output
-        assert "--dry-run" in result.output
+        output = _strip_ansi(result.output)
+        assert "Run supervisor scan once" in output
+        assert "--dry-run" in output
 
     def test_scan_all_help(self):
         """Test scan all subcommand help."""
         result = runner.invoke(app, ["scan", "all", "--help"])
         assert result.exit_code == 0
-        assert "Run both governance and supervisor scans once" in result.output
-        assert "--tick" in result.output
-        assert "--dry-run" in result.output
+        output = _strip_ansi(result.output)
+        assert "Run both governance and supervisor scans once" in output
+        assert "--tick" in output
+        assert "--dry-run" in output
 
 
 class TestGovernanceScan:


### PR DESCRIPTION
## Summary

Implements periodic governance/supervisor scan mode as separate from always-on server mode, addressing issue #419.

### Key Changes
- New `vibe scan" command with three modes: governance, supervisor, or combined
- FailedGate protection before dispatch (prevents cascading failures)
- Documentation clarifies runtime mode separation

### Test Coverage
- 19/19 tests passing
- 3 FailedGate blocking tests verify scan respects system failure state
- All scan functions tested for handler registration and dispatch

### Quality Checks
- Type checking: mypy clean
- Linting: ruff clean
- Architecture: matches server mode pattern

## References
- Issue: #419
- Audit: docs/reports/issue-419-audit-report-fix.md (PASS verdict)