### PR TITLE
fix(path_helpers): display relative paths for cross-machine handoff artifacts

### DIFF
--- a/src/vibe3/utils/path_helpers.py
+++ b/src/vibe3/utils/path_helpers.py
@@ -163,6 +163,13 @@ def _resolve_absolute_path(
     except (OSError, ValueError):
         pass
 
+    # Priority 3: Pattern-based extraction for cross-machine handoff paths
+    path_str = str(ref_path)
+    if _SHARED_HANDOFF_PREFIX in path_str:
+        # Extract relative path starting from vibe3/handoff/
+        idx = path_str.find(_SHARED_HANDOFF_PREFIX)
+        return path_str[idx:]
+
     return str(ref_path)
 
 

--- a/tests/vibe3/utils/test_path_helpers.py
+++ b/tests/vibe3/utils/test_path_helpers.py
@@ -7,6 +7,7 @@ from vibe3.utils.path_helpers import (
     is_shared_handoff_ref,
     ref_to_handoff_cmd,
     resolve_handoff_target,
+    resolve_ref_path,
     sanitize_event_detail_paths,
     to_display_target,
 )
@@ -223,3 +224,24 @@ def test_resolve_handoff_target_branch_no_worktree_raises(tmp_path: Path) -> Non
         resolve_handoff_target(
             "docs/report.md", branch="task/issue-99", git_client=client
         )
+
+
+# --- resolve_ref_path ---
+
+
+def test_resolve_ref_path_cross_machine_handoff_path(tmp_path: Path) -> None:
+    """Handoff paths from other machines should be converted to relative."""
+    # Path from different machine (not current git_common)
+    cross_machine_path = (
+        "/Users/other/src/repo/.git/vibe3/handoff/task-123/run-2026-03-27.md"
+    )
+    result = resolve_ref_path(cross_machine_path, worktree_root=str(tmp_path))
+    assert result == "vibe3/handoff/task-123/run-2026-03-27.md"
+
+
+def test_resolve_ref_path_non_handoff_absolute_path(tmp_path: Path) -> None:
+    """Non-handoff absolute paths should stay absolute."""
+    non_handoff_path = "/Users/other/src/repo/docs/report.md"
+    result = resolve_ref_path(non_handoff_path, worktree_root=str(tmp_path))
+    # Should return as absolute since it doesn't match any pattern
+    assert result == non_handoff_path


### PR DESCRIPTION
Add pattern-based fallback to resolve_ref_path() to recognize handoff
artifact paths containing vibe3/handoff/ pattern, regardless of current
system's git common dir. This ensures handoff show and flow show commands
display relative paths instead of absolute paths for cross-machine artifacts.

## Changes
- Add Priority 3 pattern extraction in _resolve_absolute_path()
- Extract vibe3/handoff/... from absolute paths when git common dir check fails
- Add comprehensive unit tests for cross-machine and non-handoff paths

## Quality Verification
- ✓ All tests pass (25/25)
- ✓ No type errors (mypy: Success)
- ✓ No lint errors (ruff: All checks passed)
- ✓ Impact scope: LOW risk
- ✓ Baseline changes: minimal (29 lines added, no structural changes)

Fixes #277