### PR TITLE
feat(inspect): add YAML output for inspect dead-code

### DIFF
--- a/src/vibe3/commands/inspect.py
+++ b/src/vibe3/commands/inspect.py
@@ -226,6 +226,7 @@ def dead_code(
         str, typer.Argument(help="Root directory to scan (default: src/vibe3)")
     ] = "src/vibe3",
     json_out: _JSON_OPT = False,
+    yaml_out: Annotated[bool, typer.Option("--yaml", help="Output as YAML")] = False,
     min_confidence: Annotated[
         str,
         typer.Option(
@@ -256,6 +257,7 @@ def dead_code(
         vibe3 inspect dead-code
         vibe3 inspect dead-code src/vibe3 --min-confidence=high
         vibe3 inspect dead-code --json
+        vibe3 inspect dead-code --yaml
     """
     if trace:
         enable_trace()
@@ -288,6 +290,12 @@ def dead_code(
 
         if json_out:
             typer.echo(report.model_dump_json(indent=2))
+        elif yaml_out:
+            typer.echo(
+                yaml.dump(
+                    report.model_dump(), default_flow_style=False, allow_unicode=True
+                )
+            )
         else:
             typer.echo("=== Dead Code Report ===")
             typer.echo(f"  Total symbols scanned: {report.total_symbols}")

--- a/tests/vibe3/commands/test_inspect_contract.py
+++ b/tests/vibe3/commands/test_inspect_contract.py
@@ -78,6 +78,7 @@ def test_all_inspect_subcommands_have_yaml_option():
         "base",
         "uncommit",
         "commands",
+        "dead-code",
     ]
 
     # Note: dead-code has a different output model and doesn't need --yaml
@@ -196,6 +197,25 @@ def test_inspect_commands_yaml_produces_valid_yaml():
     assert "command" in data, "YAML should contain command field"
 
 
+def test_inspect_dead_code_yaml_produces_valid_yaml():
+    """Verify inspect dead-code --yaml produces valid parseable YAML."""
+    result = subprocess.run(
+        ["uv", "run", "python", "src/vibe3/cli.py", "inspect", "dead-code", "--yaml"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Parse YAML output
+    data = yaml.safe_load(result.stdout)
+
+    # Verify expected structure
+    assert isinstance(data, dict), "YAML output should be a dict"
+    assert "total_symbols" in data, "YAML should contain total_symbols"
+    assert "dead_code_count" in data, "YAML should contain dead_code_count"
+    assert "findings" in data, "YAML should contain findings list"
+
+
 def test_inspect_json_and_yaml_both_available():
     """Verify that where --json is available, --yaml is also available.
 
@@ -210,6 +230,7 @@ def test_inspect_json_and_yaml_both_available():
         "base",
         "uncommit",
         "commands",
+        "dead-code",
     ]
 
     for cmd in subcommands:


### PR DESCRIPTION
## Summary
Add `--yaml` parameter to `vibe3 inspect dead-code` command to support structured YAML output, following the pattern established in PR #606.

**Changes:**
- Add `--yaml` flag to `inspect dead-code` command
- Output YAML format when flag is set, otherwise default to table format
- Add dead-code test cases to YAML contract tests

**Files Changed:**
- `src/vibe3/commands/inspect.py`: Added YAML output logic
- `tests/vibe3/commands/test_inspect_contract.py`: Added contract tests

## Test Plan
- [x] All contract tests pass (9 tests)
- [x] Type checking clean (mypy)
- [x] Linting passed (ruff, black)
- [x] Pre-push checks passed
- [x] Manual verification of YAML output format

Closes #657