### PR TITLE
docs: align stale documentation semantics batch-2026-05-05

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ This project has **two parallel implementations**:
 ## 📍 Workspace Structure
 
 - **V2 (Shell)**: `bin/`, `lib/`, `config/shell/`
-- **V3 (Python)**: `src/vibe3/` (see [.agent/rules/python-standards.md](.agent/rules/python-standards.md))
+- **V3 (Python)**: `src/vibe3/` (see [.claude/rules/python-standards.md](.claude/rules/python-standards.md))
 - **Skills**: `skills/`（各技能的 SKILL.md 文件）
 - **Workflows, rules, context**: `.agent/`
 - **Shared state truth**: `.git/vibe3/handoff.db`（位于主仓库 git common dir，即最顶层 `.git`）

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -269,8 +269,8 @@ vibe3 inspect commit <sha>                # 改动影响范围
 
 | 文件 | 职责 | 更新频率 |
 |------|------|---------|
-| `task.md` | **[UNTRACKED]** 当前 flow handoff 草稿、阻塞点、短期 TODO（已放入 .gitignore 隔离，通过 `vibe3 handoff` 命令访问，不直接编辑） | 每个动作后 |
-| `memory/` | **[TRACKED]** AI 上下文记忆目录（已迁移至 claude-memory MCP 工具） | 不再主动更新 |
+| `task.md` | **[UNTRACKED]** 当前 flow handoff 草稿、阻塞点、短期 TODO（已放入 .gitignore 隔离，通过 `vibe3 handoff status` 或 `vibe3 handoff show` 命令访问，不直接编辑） | 每个动作后 |
+| `memory/` | **[TRACKED]** AI 上下文记忆目录（包含历史决策与模式参考，日常记忆优先使用 claude-memory MCP 工具） | 仅补充关键模式 |
 
 #### `.claude/rules/` - 编码规则
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 docs/
 ├── README.md                        # 本文件：文档总览
 ├── standards/                       # 标准和规范文档
-│   ├── DOC_ORGANIZATION.md         # 文档组织标准（必读）
+│   ├── doc-organization.md          # 文档组织标准（必读）
 │   ├── cognition-spec-dominion.md  # 宪法大纲：Vibe Guard 流程定义
 │   ├── ...                         # 其他现行标准
 │   └── v3/                          # V3 命令、数据、技能与 handoff 标准


### PR DESCRIPTION
## Summary
Aligned 3 documents to current truth sources per governance issue #689:

1. **AGENTS.md line 46**: Fixed Python standards path reference
   - Changed `.agent/rules/python-standards.md` → `.claude/rules/python-standards.md`
   - Verified `.claude/rules/python-standards.md` exists, `.agent/rules/` directory does not exist

2. **docs/README.md line 13**: Fixed DOC_ORGANIZATION filename case
   - Changed `DOC_ORGANIZATION.md` → `doc-organization.md`
   - Verified actual filename is lowercase `doc-organization.md`

3. **STRUCTURE.md lines 272-273**: Clarified handoff command and memory status
   - Updated handoff access from `vibe3 handoff` → `vibe3 handoff status/show` (matches actual CLI commands)
   - Clarified memory/ contains historical decisions, daily memory uses claude-memory MCP tool
   - Verified memory/ contains 2 historical reference files, handoff CLI shows `status` and `show` commands

## Verification

All other documents mentioned in issue #689 were verified and found to be correct:
- `agent-workflow-standard.md`: All references verified correct (vibe3-event-driven-standard.md exists, v3/handoff-store-standard.md exists, .agent/policies/run.md exists)
- `agent-document-lifecycle-standard.md`: Reference to v3/handoff-store-standard.md verified correct

## Test plan
- [x] Verified all file paths exist before making changes
- [x] Verified handoff CLI command behavior matches documentation
- [x] Checked memory/ directory contents
- [x] All pre-commit hooks passed (ShellCheck, Ruff, Black, MyPy)
- [x] All pre-push checks passed (type check, smoke tests, LOC checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)