### PR TITLE
docs: align stale terminology with glossary standards

### DIFF
--- a/.agent/workflows/vibe:new-feature.md
+++ b/.agent/workflows/vibe:new-feature.md
@@ -19,8 +19,8 @@ tags: [workflow, vibe, planning, orchestration]
 
 1. 回复用户：`我会先把当前目标解释为 feature 视角的规划入口，再转到统一的 vibe:new 路径。`
 2. 先确认用户当前关心的是：
-   - `repo issue` intake
-   - `roadmap item(type=feature)` 规划
+   - GitHub issue intake
+   - feature 规划与排期
    - feature 下的 task 拆分与 plan 绑定
 3. 然后统一委托 [`vibe:new`](./vibe:new.md)：
    - 由 `vibe:new` 负责后续的 roadmap / plan / task / flow 编排
@@ -30,6 +30,6 @@ tags: [workflow, vibe, planning, orchestration]
 ## Boundary
 
 - `vibe:new-feature` 是 agent workflow，不是 GitHub workflow，也不是 GitHub Project workflow。
-- 它不重新定义 `repo issue`、`roadmap item`、`task`、`flow`。
+- 它不重新定义 `GitHub issue`、`task`、`flow`。
 - 它不直接承载 task binding、blocker 分类、物理 worktree 决策或 planning gates。
 - 若需要新的逻辑现场，遵循 `vibe:new` 与 `CLAUDE.md` 的规则：默认在当前目录使用 `vibe3 flow update`，未经人类授权不得新建物理 worktree。

--- a/.agent/workflows/vibe:new-flow.md
+++ b/.agent/workflows/vibe:new-flow.md
@@ -10,8 +10,8 @@ tags: [workflow, vibe, planning, orchestration]
 ## 定位
 
 - `vibe:new-flow` 是一个 `standalone orchestration workflow`。
-- 它不需要同名 skill；它只负责把用户带到“新建逻辑 flow”这一步。
-- 它不承担 `repo issue`、`roadmap item` 或 feature 定义职责。
+- 它不需要同名 skill；它只负责把用户带到”新建逻辑 flow”这一步。
+- 它不承担 `GitHub issue` 或 feature 定义职责。
 
 ## Steps
 

--- a/docs/references/skill-loop-memo.md
+++ b/docs/references/skill-loop-memo.md
@@ -35,7 +35,9 @@ related_docs:
 
 ## 主链路
 
-`GitHub issue -> roadmap item -> vibe-new -> vibe-start -> spec execution -> PR -> review/integrate -> done`
+`GitHub issue -> vibe-new -> vibe-start -> spec execution -> PR -> review/integrate -> done`
+
+> Note: `roadmap item` 是历史兼容/规划参考语义（见 glossary.md §3.2）。当前治理直接管理 assignee issue，不经过 roadmap item 中间层转换。
 
 对应常用 skill：
 
@@ -45,9 +47,9 @@ related_docs:
    - 记忆句：它是“发 issue / 整理 issue”的入口，不是“拿 issue 开做”。
 
 2. `vibe-roadmap`
-   - 做什么：管理 roadmap item、版本窗口、triage、决定“下一个 roadmap 做什么”。
+   - 做什么：管理版本规划、triage、决定”下一个要推进什么”。
    - 不做什么：不创建 issue，不修 runtime。
-   - 记忆句：它是 roadmap 的大脑。
+   - 记忆句：它是规划的大脑。
 
 3. `vibe-new`
    - 做什么：旧 flow 到新 flow 的转换器；决定主 issue，判断是否带着未提交改动进入新 flow，还是清空现场后再进入。


### PR DESCRIPTION
## Summary
Aligned 3 documents with glossary.md terminology standards as requested in #694.

### Changes Made

**docs/references/skill-loop-memo.md**
- Removed deprecated 'roadmap item' from main flow diagram
- Added clarifying note about historical status (glossary §3.2)
- Updated vibe-roadmap description to remove deprecated terminology

**.agent/workflows/vibe:new-feature.md**
- Replaced 'repo issue' → 'GitHub issue' (glossary §3.1)
- Removed deprecated 'roadmap item' references

**.agent/workflows/vibe:new-flow.md**
- Replaced 'repo issue' → 'GitHub issue' (glossary §3.1)
- Removed deprecated 'roadmap item' references

### Verification

- ✅ flow-dependency.md commands verified to align with command-standard.md
- ✅ openspec-guide.md is external tool reference, no changes needed
- ✅ All terminology changes align with glossary.md standards

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)