### PR TITLE
docs: align 5 standards/docs to glossary terminology (repo issue → GitHub issue)

### DIFF
--- a/docs/standards/issue-standard.md
+++ b/docs/standards/issue-standard.md
@@ -218,7 +218,7 @@ dependencies:
 ### ❌ 错误说法
 
 - "创建一个 task issue"
-- "task issue 和 repo issue 是两种类型"
+- "task issue 和 GitHub issue 是两种类型"
 - "vibe-task 标签是真源"
 
 ---

--- a/docs/standards/v3/handoff-governance-standard.md
+++ b/docs/standards/v3/handoff-governance-standard.md
@@ -130,7 +130,7 @@ related_docs:
 - handoff 更正
 - follow-up 链接
 
-禁止把 merge 后出现的新需求、新目标或新开发范围继续写回旧 plan；这些内容必须进入新的 `repo issue`，并按需要重新进入 `roadmap item` 与后续 execution record。
+禁止把 merge 后出现的新需求、新目标或新开发范围继续写回旧 plan；这些内容必须进入新的 `GitHub issue`，并按需要重新进入 `roadmap item` 与后续 execution record。
 
 ## 7. Root-Doc Requirement
 

--- a/docs/standards/v3/handoff-store-standard.md
+++ b/docs/standards/v3/handoff-store-standard.md
@@ -168,7 +168,7 @@ CREATE TABLE flow_state (
 
 ### 4.2 `flow_issue_links`
 
-这张表只记录 flow 和 repo issue 的多对多关系。
+这张表只记录 flow 和 GitHub issue 的多对多关系。
 
 ```sql
 CREATE TABLE flow_issue_links (

--- a/docs/v3/handoff/04-handoff-and-cutover.md
+++ b/docs/v3/handoff/04-handoff-and-cutover.md
@@ -24,7 +24,7 @@ related_docs:
 
 本阶段固定以下口径：
 
-- `repo issue -> pr` 是唯一标准交付链
+- `GitHub issue -> pr` 是唯一标准交付链
 - `git` 与 GitHub 现场负责业务事实
 - SQLite handoff store 只负责 flow 责任链与最小索引
 - 共享目录下的 `current.md` 负责结构化 handoff 中间态，不负责主链事实
@@ -316,7 +316,7 @@ handoff command 不负责：
 
 ### 11.1 Concept Acceptance
 
-- [x] `repo issue -> pr` 主链和本地 handoff store 的职责边界写清
+- [x] `GitHub issue -> pr` 主链和本地 handoff store 的职责边界写清
 - [x] SQLite 只存责任链与引用、不存正文的约束写清
 - [x] 共享 `current.md` 的中间态角色写清
 - [x] `.agent/context/task.md` 的降级角色写清

--- a/docs/v3/infrastructure/01-data-standard.md
+++ b/docs/v3/infrastructure/01-data-standard.md
@@ -27,7 +27,7 @@ related_docs:
 ```
 GitHub 层（唯一真源 - gh CLI 直接访问）
 ├── GitHub Project Items (task, feature, bug) - 规划层真源
-├── GitHub Issues (repo issue) - 来源层真源
+├── GitHub Issues - 来源层真源
 ├── GitHub PRs (pr) - 交付层真源
 └── Git Branches (flow 身份锚点)
 


### PR DESCRIPTION
## Summary

Aligns deprecated "repo issue" terminology to formal "GitHub issue" term per glossary.md §3.1 in 5 documents:

- **docs/standards/issue-standard.md**: "task issue 和 repo issue" → "task issue 和 GitHub issue"
- **docs/standards/v3/handoff-store-standard.md**: "flow 和 repo issue" → "flow 和 GitHub issue"
- **docs/standards/v3/handoff-governance-standard.md**: "新的 repo issue" → "新的 GitHub issue"
- **docs/v3/handoff/04-handoff-and-cutover.md**: "repo issue -> pr" → "GitHub issue -> pr" (2 occurrences)
- **docs/v3/infrastructure/01-data-standard.md**: removed deprecated parenthetical "(repo issue)"

## Why

- "repo issue" was explicitly deprecated in glossary.md §3.1
- These are standards and infrastructure docs that should reflect current terminology
- issue-standard.md defines issue semantics — using deprecated terms undermines its authority
- handoff-store-standard.md and handoff-governance-standard.md are critical V3 standards
- 04-handoff-and-cutover.md describes the primary delivery chain
- 01-data-standard.md is a data model reference

## Forbidden Actions

✅ Scope limited to the 5 listed documents
✅ No main code changes
✅ No doc restructuring or workflow logic changes
✅ No new features
✅ Preserved "broader repo issue pool" (valid formal term per glossary §3.3.4)

## Test Plan

- [x] All grep searches confirm no remaining "repo issue" occurrences in the 5 files
- [x] Pre-push checks passed (lint, type check, smoke tests)
- [x] Terminology now consistent with glossary.md

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)