### PR TITLE
fix(dispatcher): 清空空队列触发重新收集

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -77,6 +77,15 @@ class GlobalDispatchCoordinator:
 
         self._promote_progressed_entries()
 
+        # Check if queue was emptied by _promote_progressed_entries
+        # (e.g., all issues became blocked/done)
+        if not self._frozen_queue:
+            append_orchestra_event(
+                "dispatcher",
+                "GlobalDispatchCoordinator: queue emptied by state changes",
+            )
+            return
+
         import subprocess
 
         try:
@@ -325,6 +334,10 @@ class GlobalDispatchCoordinator:
         # Update frozen queue: promoted + retained (removed entries discarded)
         if promoted or retained:
             self._frozen_queue = promoted + retained
+        else:
+            # All entries removed (e.g., all issues became blocked)
+            # Clear frozen queue to trigger fresh collection on next tick
+            self._frozen_queue = None
 
     def _load_issue(self, issue_number: int) -> IssueInfo | None:
         """Load the current issue snapshot for an already-frozen issue."""


### PR DESCRIPTION
## Summary

修复 dispatcher frozen-queue 死锁 bug：当所有队列条目被移除后，`_promote_progressed_entries` 未清空 `_frozen_queue`，导致后续 tick 无法重新收集队列。

**问题场景**：
- Tick #26: Issue #671 因 `blocked` 状态被移除，队列变空
- Tick #27+: `_frozen_queue` 仍保留旧值，`coordinate()` 误判队列非空
- 结果：跳过队列重新收集，后续 handoff issues 无法派发

**修复内容**：
1. `_promote_progressed_entries()`: 当 `promoted` 和 `retained` 都为空时，设置 `_frozen_queue = None`
2. `coordinate()`: 在 `_promote_progressed_entries()` 后添加检查，队列被清空后提前返回

**测试**：
- ✅ `test_terminal_state_removes_issue_from_queue` 通过
- ✅ 所有 dispatcher 测试通过 (15/15)

## Test plan

- [x] 单元测试通过：`uv run pytest tests/vibe3/orchestra/test_global_dispatch_coordinator.py -v`
- [x] 修复前日志分析：tick #26 后无队列收集日志
- [x] 修复后逻辑验证：队列清空后触发重新收集
- [ ] CI 通过
- [ ] 生产环境验证：下一个 tick 应重新收集 handoff issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)