### PR TITLE
fix: improve PR lookup error handling and update tests

### DIFF
--- a/src/vibe3/clients/github_issue_admin_ops.py
+++ b/src/vibe3/clients/github_issue_admin_ops.py
@@ -275,8 +275,14 @@ class IssueAdminMixin:
                 cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
             )
             if result.returncode != 0:
-                logger.bind(external="github", error=result.stderr).error(
-                    "Failed to list PRs for issue lookup"
+                logger.bind(
+                    external="github",
+                    issue_number=issue_number,
+                    repo=repo,
+                    returncode=result.returncode,
+                    stderr=result.stderr.strip() if result.stderr else None,
+                ).warning(
+                    "Failed to list PRs for issue lookup (non-blocking, returning None)"
                 )
                 return None
             prs = json.loads(result.stdout)

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -24,7 +24,7 @@ from vibe3.execution.role_contracts import MANAGER_GATE_CONFIG
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
-from vibe3.prompts.template_loader import DEFAULT_PROMPTS_PATH
+from vibe3.prompts.template_loader import _resolve_prompts_path
 from vibe3.roles.definitions import IssueRoleSyncSpec, TriggerableRoleDefinition
 from vibe3.services.issue_failure_service import fail_manager_issue
 
@@ -239,7 +239,8 @@ def build_manager_sync_request(
     variant_key = "retry.resume" if session_id else "first.bootstrap"
 
     # Load prompts.yaml for static sections
-    with open(DEFAULT_PROMPTS_PATH) as f:
+    prompts_path = _resolve_prompts_path()
+    with open(prompts_path) as f:
         prompts_data = yaml.safe_load(f)
     manager_sections = prompts_data.get("manager", {})
 

--- a/tests/vibe3/roles/test_manager.py
+++ b/tests/vibe3/roles/test_manager.py
@@ -307,7 +307,9 @@ manager:
 
         # Patch paths
         monkeypatch.setattr(manifest, "DEFAULT_PROMPT_RECIPES_PATH", recipes_path)
-        monkeypatch.setattr("vibe3.roles.manager.DEFAULT_PROMPTS_PATH", prompts_path)
+        monkeypatch.setattr(
+            "vibe3.roles.manager._resolve_prompts_path", lambda: prompts_path
+        )
 
         config = OrchestraConfig(assignee_dispatch=AssigneeDispatchConfig())
 
@@ -364,7 +366,9 @@ manager:
         )
 
         monkeypatch.setattr(manifest, "DEFAULT_PROMPT_RECIPES_PATH", recipes_path)
-        monkeypatch.setattr("vibe3.roles.manager.DEFAULT_PROMPTS_PATH", prompts_path)
+        monkeypatch.setattr(
+            "vibe3.roles.manager._resolve_prompts_path", lambda: prompts_path
+        )
 
         config = OrchestraConfig(assignee_dispatch=AssigneeDispatchConfig())
 


### PR DESCRIPTION
## Summary
- Downgrade ERROR to WARNING for non-blocking PR lookup failures
- Add context (issue_number, repo, returncode, stderr) to error logs  
- Update tests to mock `_resolve_prompts_path` instead of removed constant
- Fix test failures introduced in 329c0249

## Problem

**Issue 1: Misleading error logs**
- `get_pr_for_issue()` logged ERROR for non-blocking GitHub API failures
- Missing context made debugging difficult
- ERROR level inappropriate for graceful degradation behavior

**Issue 2: Test failures blocking push**
- Tests still referenced `DEFAULT_PROMPTS_PATH` constant
- Previous commit (329c0249) removed constant, introduced `_resolve_prompts_path` 
- Pre-push hook blocked push due to `AttributeError` in tests

## Solution

1. **Error handling improvement** (src/vibe3/clients/github_issue_admin_ops.py)
   - Downgrade `ERROR` to `WARNING` (reflects non-blocking nature)
   - Add structured context: `issue_number`, `repo`, `returncode`, `stderr`
   - Clarify message: "(non-blocking, returning None)"

2. **Test fix** (tests/vibe3/roles/test_manager.py)
   - Mock `_resolve_prompts_path()` function instead of removed constant
   - Use lambda wrapper: `lambda: prompts_path`
   - Both test methods updated consistently

## Impact
- Better observability for debugging intermittent API failures
- Correct log level for graceful degradation pattern
- Tests now pass, unblocks push workflow
- No behavior change (still returns `None` on failure)

## Test plan
- [x] Manual test with nonexistent repo: returns None without crash
- [x] Type check passes (`mypy`)
- [x] All tests pass (`pytest tests/vibe3/roles/test_manager.py`)
- [x] Pre-push checks pass (all 97 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)