### PR TITLE
refactor(config): rename LOC thresholds for semantic clarity

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -4,14 +4,14 @@
 # 文本量控制
 doc_limits:
   single_file_loc:
-    default: 500           # 单文件默认限制（所有类型）
-    max: 800              # 单文件最大限制（所有类型）
+    warning_threshold: 500    # 超标触发 WARNING（建议重构）
+    ci_block_threshold: 800   # 超标触发 CI ERROR（阻塞 pipeline）
 
 # 代码量控制
 code_limits:
   single_file_loc:
-    default: 300           # 单文件默认限制（所有类型）
-    max: 400              # 单文件最大限制（所有类型）
+    warning_threshold: 300    # 超标触发 WARNING（建议重构）
+    ci_block_threshold: 400   # 超标触发 CI ERROR（阻塞 pipeline）
 
     # 例外清单：核心聚合文件、兼容入口、强耦合测试允许适度超标
     # 原则：LOC 上限是治理触发器而非硬性阻塞，命中时触发质量回收审计

--- a/docs/standards/loc-governance.md
+++ b/docs/standards/loc-governance.md
@@ -1,0 +1,146 @@
+# LOC Governance Standard
+
+## Purpose
+
+Define clear, enforceable limits for file size to maintain codebase health, readability, and maintainability.
+
+## Configuration Semantics
+
+### Two-Threshold System
+
+LOC governance uses a two-threshold system with different enforcement levels:
+
+| Threshold | Value | Local Execution | CI Execution |
+|-----------|-------|-----------------|--------------|
+| `warning_threshold` | 300 lines | Advisory (suggestion) | Allowed (pass) |
+| `ci_block_threshold` | 400 lines | Advisory (warning) | **Blocking (fail)** |
+
+### Semantic Definitions
+
+**`warning_threshold: 300`**
+- **Purpose**: Advisory limit for maintainability
+- **Local**: Shows warning, allows push
+- **CI**: Allows merge (does not block)
+- **Intent**: "Consider refactoring this file"
+
+**`ci_block_threshold: 400`**
+- **Purpose**: Hard limit for CI enforcement
+- **Local**: Shows warning, allows push
+- **CI**: **Blocks merge** (pipeline fails)
+- **Intent**: "This file must be refactored or granted exception"
+
+### Execution Environment Differences
+
+**Local Development (pre-commit/pre-push hooks)**
+- Both thresholds are advisory
+- Warnings shown but push allowed
+- Goal: Provide early feedback without blocking workflow
+
+**CI Environment (GitHub Actions)**
+- `warning_threshold`: Allowed (CI passes)
+- `ci_block_threshold`: **Enforced** (CI fails).
+- Goal: Prevent large files from merging without explicit exception
+
+### Configuration Location
+
+Defined in `config/loc_limits.yaml`:
+
+```yaml
+code_limits:
+  single_file_loc:
+    warning_threshold: 300    # Advisory in local and CI
+    ci_block_threshold: 400   # Blocks CI, advisory in local
+```
+
+## Exception Management
+
+### When to Request Exception
+
+Files may exceed limits with documented justification:
+
+1. **Core aggregation points** (service orchestration, state machines)
+2. **Strongly coupled test suites** (shared fixtures, related scenarios)
+3. **External compatibility layers** (API facades, legacy adapters)
+
+### How to Request Exception
+
+Add entry to `config/loc_limits.yaml`:
+
+```yaml
+exceptions:
+  - path: "src/vibe3/services/example.py"
+    limit: 500
+    reason: "Clear justification for why this file cannot be split"
+```
+
+**Review Process**:
+- PR author documents reason in config
+- Reviewer evaluates if refactoring is feasible
+- If approved, exception is merged with the PR
+
+### Exception Maintenance
+
+- Exceptions should be reviewed periodically
+- If file is later refactored, remove exception
+- Exceptions are not permanent; they indicate "deferred refactoring"
+
+## Best Practices
+
+### Refactoring Strategies
+
+**When file approaches 300 lines**:
+- Extract utilities to separate modules
+- Use composition over inheritance
+- Split by responsibility (SRP)
+
+**When file exceeds 400 lines**:
+- **Must refactor or request exception**
+- Identify cohesive subsets that can be extracted
+- Consider if file has multiple responsibilities
+
+### Code Organization Principles
+
+1. **Single Responsibility**: Each file should have one clear purpose
+2. **Cohesion**: Related functions belong together
+3. **Coupling**: Minimize dependencies between files
+
+### Test File Considerations
+
+Test files often need more flexibility:
+- Shared fixtures and setup code
+- Multiple test scenarios for same component
+- Test-specific helpers
+
+Apply same thresholds but consider test-specific exceptions when justified.
+
+## Alignment with Governance Budget
+
+This LOC governance aligns with `.agent/governance.yaml` budget:
+
+```yaml
+budgets:
+  file_max: 300  # Maps to warning_threshold
+```
+
+The `ci_block_threshold: 400` provides buffer for exceptions while maintaining the governance goal of `file_max: 300`.
+
+## Monitoring and Metrics
+
+### Tracking LOC Trends
+
+- Pre-commit hooks provide immediate feedback
+- CI enforcement prevents regression
+- Periodic audits identify growing files
+
+### Quality Indicators
+
+- **Files under 300 lines**: ✅ Ideal
+- **Files between 300-400 lines**: ⚠️ Review for refactoring
+- **Files over 400 lines**: ❌ Must refactor or document exception
+
+## References
+
+- Configuration: `config/loc_limits.yaml`
+- Hook scripts: `scripts/hooks/check-per-file-loc.sh`, `check-test-file-loc.sh`
+- Parser: `scripts/hooks/loc_settings.py`
+- Governance budget: `.agent/governance.yaml`

--- a/scripts/hooks/check-per-file-loc.sh
+++ b/scripts/hooks/check-per-file-loc.sh
@@ -8,8 +8,8 @@
 # Reads limits from config/v3/loc_limits.yaml without uv
 #
 # Limits (unified for all file types):
-#   default: 300 lines (most files should fit)
-#   max: 400 lines (special cases with justification)
+#   warning_threshold: 300 lines (advisory, suggests refactoring)
+#   ci_block_threshold: 400 lines (enforced in CI, blocks pipeline)
 
 #
 # Code paths (defined in config/v3/loc_limits.yaml:code_limits.code_paths):
@@ -53,28 +53,38 @@ for file_path in [files[key] for key in sorted(files)]:
     rel_path = file_path.as_posix()
     lines = sum(1 for _ in file_path.open())
     exception = find_exception(config.exceptions, rel_path)
-    limit = exception.limit if exception else config.single_file_max
+    limit = exception.limit if exception else config.ci_block_threshold
 
     if lines > limit:
-        label = f"custom: {limit}" if exception else f"max: {config.single_file_max}"
-        print(f"❌ ERROR: {rel_path} has {lines} lines ({label})")
+        label = f"custom: {limit}" if exception else f"ci_block: {config.ci_block_threshold}"
+        print(f"❌ CI BLOCK: {rel_path} has {lines} lines")
+        if exception:
+            print(f"   Custom limit: {limit} lines (exception granted)")
+        else:
+            print(f"   Warning threshold: {config.warning_threshold} lines (local: advisory)")
+            print(f"   CI block threshold: {config.ci_block_threshold} lines (CI: enforced)")
+            print()
+            print(f"   → Action: This file will block CI. Options:")
+            print(f"     1. Refactor to under {config.ci_block_threshold} lines")
+            print(f"     2. Request exception in config/loc_limits.yaml")
         errors += 1
-    elif exception is None and lines > config.single_file_default:
-        print(
-            f"⚠️  WARNING: {rel_path} has {lines} lines "
-            f"(default: {config.single_file_default}, max: {config.single_file_max})"
-        )
+    elif exception is None and lines > config.warning_threshold:
+        print(f"⚠️  WARNING: {rel_path} has {lines} lines")
+        print(f"   Warning threshold: {config.warning_threshold} lines (local: advisory)")
+        print(f"   CI block threshold: {config.ci_block_threshold} lines (CI: enforced)")
+        print()
+        print(f"   → Tip: Consider refactoring to under {config.warning_threshold} lines")
         warnings += 1
 
 print()
 print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 print("Source file LOC check results:")
-print(f"  - Default limit: {config.single_file_default} lines")
-print(f"  - Max limit: {config.single_file_max} lines")
-print(f"  - Warnings: {warnings} files (default → max)")
-print(f"  - Errors: {errors} files (exceed max)")
+print(f"  - Warning threshold: {config.warning_threshold} lines (advisory)")
+print(f"  - CI block threshold: {config.ci_block_threshold} lines (enforced)")
+print(f"  - Warnings: {warnings} files (threshold exceeded)")
+print(f"  - Errors: {errors} files (CI will block)")
 print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-print(f"COUNTS {warnings} {errors} {config.single_file_default} {config.single_file_max}")
+print(f"COUNTS {warnings} {errors} {config.warning_threshold} {config.ci_block_threshold}")
 PY
 )
 
@@ -88,31 +98,31 @@ LIMIT_MAX=$(echo "$COUNTS_LINE" | awk '{print $5}')
 
 if [ "$errors" -gt 0 ]; then
   echo ""
-  echo "⚠️  WARNING: $errors files exceed max limit ($LIMIT_MAX lines)"
-  echo "   This is a soft constraint in local development"
-  echo ""
-  echo "💡 Tip: Split large files into smaller, focused modules"
-  echo "   - Extract utilities to separate files"
-  echo "   - Use composition over inheritance"
-  echo "   - Follow Single Responsibility Principle"
+  echo "❌ BLOCKER: $errors files exceed CI block threshold ($LIMIT_MAX lines)"
 
   # In CI (ENFORCE_LOC_LIMITS=true), block on violations
   if [ "${ENFORCE_LOC_LIMITS:-false}" = "true" ]; then
     echo ""
-    echo "❌ CI ENFORCEMENT: Files exceed max LOC limit - blocking pipeline"
+    echo "   CI enforcement mode: BLOCKING pipeline"
+    echo "   These files must be refactored or granted exceptions before merge"
     exit 1
   else
     echo ""
-    echo "   Push allowed (local development)"
+    echo "   Local development mode: Advisory only"
+    echo "   These files will block CI - address before pushing"
+    echo ""
+    echo "💡 Options:"
+    echo "   1. Refactor to under $LIMIT_MAX lines"
+    echo "   2. Request exception in config/loc_limits.yaml"
     exit 0
   fi
 elif [ "$warnings" -gt 0 ]; then
   echo ""
-  echo "⚠️  WARNING: $warnings files exceed default limit ($LIMIT_DEFAULT lines)"
-  echo "   This is a soft constraint in local development"
+  echo "⚠️  ADVISORY: $warnings files exceed warning threshold ($LIMIT_DEFAULT lines)"
+  echo "   Local development: Suggestions only (push allowed)"
+  echo "   CI will allow these files (under $LIMIT_MAX lines)"
   echo ""
-  echo "💡 Tip: Consider refactoring files exceeding default limit"
-  echo "   (Warnings are allowed, but keep below max limit)"
+  echo "💡 Tip: Consider refactoring for better maintainability"
 else
-  echo "✅ All source files within default limit ($LIMIT_DEFAULT lines)"
+  echo "✅ All source files within warning threshold ($LIMIT_DEFAULT lines)"
 fi

--- a/scripts/hooks/check-test-file-loc.sh
+++ b/scripts/hooks/check-test-file-loc.sh
@@ -3,8 +3,8 @@
 # Reads limits from config/v3/loc_limits.yaml without uv
 #
 # Limits:
-#   default: 300 lines (most test files should fit)
-#   max: 400 lines (special cases with justification)
+#   warning_threshold: 300 lines (advisory, suggests refactoring)
+#   ci_block_threshold: 400 lines (enforced in CI, blocks pipeline)
 #
 # Test paths (defined in config/v3/loc_limits.yaml:code_limits.test_paths):
 #   Python: tests/vibe3/
@@ -32,28 +32,38 @@ for file_path in iter_files(config.test_paths_v3_python, suffixes=(".py",), test
     rel_path = file_path.as_posix()
     lines = sum(1 for _ in file_path.open())
     exception = find_exception(config.exceptions, rel_path)
-    limit = exception.limit if exception else config.single_file_max
+    limit = exception.limit if exception else config.ci_block_threshold
 
     if lines > limit:
-        label = f"custom: {limit}" if exception else f"max: {config.single_file_max}"
-        print(f"❌ ERROR: {rel_path} has {lines} lines ({label})")
+        label = f"custom: {limit}" if exception else f"ci_block: {config.ci_block_threshold}"
+        print(f"❌ CI BLOCK: {rel_path} has {lines} lines")
+        if exception:
+            print(f"   Custom limit: {limit} lines (exception granted)")
+        else:
+            print(f"   Warning threshold: {config.warning_threshold} lines (local: advisory)")
+            print(f"   CI block threshold: {config.ci_block_threshold} lines (CI: enforced)")
+            print()
+            print(f"   → Action: This file will block CI. Options:")
+            print(f"     1. Refactor to under {config.ci_block_threshold} lines")
+            print(f"     2. Request exception in config/loc_limits.yaml")
         errors += 1
-    elif exception is None and lines > config.single_file_default:
-        print(
-            f"⚠️  WARNING: {rel_path} has {lines} lines "
-            f"(default: {config.single_file_default}, max: {config.single_file_max})"
-        )
+    elif exception is None and lines > config.warning_threshold:
+        print(f"⚠️  WARNING: {rel_path} has {lines} lines")
+        print(f"   Warning threshold: {config.warning_threshold} lines (local: advisory)")
+        print(f"   CI block threshold: {config.ci_block_threshold} lines (CI: enforced)")
+        print()
+        print(f"   → Tip: Consider refactoring to under {config.warning_threshold} lines")
         warnings += 1
 
 print()
 print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 print("Test file LOC check results:")
-print(f"  - Default limit: {config.single_file_default} lines")
-print(f"  - Max limit: {config.single_file_max} lines")
-print(f"  - Warnings: {warnings} files (default → max)")
-print(f"  - Errors: {errors} files (exceed max)")
+print(f"  - Warning threshold: {config.warning_threshold} lines (advisory)")
+print(f"  - CI block threshold: {config.ci_block_threshold} lines (enforced)")
+print(f"  - Warnings: {warnings} files (threshold exceeded)")
+print(f"  - Errors: {errors} files (CI will block)")
 print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-print(f"COUNTS {warnings} {errors} {config.single_file_default} {config.single_file_max}")
+print(f"COUNTS {warnings} {errors} {config.warning_threshold} {config.ci_block_threshold}")
 PY
 )
 
@@ -67,24 +77,30 @@ LIMIT_MAX=$(echo "$COUNTS_LINE" | awk '{print $5}')
 
 if [ "$errors" -gt 0 ]; then
   echo ""
-  echo "⚠️  WARNING: $errors test files exceed max limit ($LIMIT_MAX lines)"
-  echo "   This is a soft constraint in local development"
-  echo ""
-  echo "💡 Tip: Split large test files into smaller, focused modules"
+  echo "❌ BLOCKER: $errors test files exceed CI block threshold ($LIMIT_MAX lines)"
 
   if [ "${ENFORCE_LOC_LIMITS:-false}" = "true" ]; then
     echo ""
-    echo "❌ CI ENFORCEMENT: Test files exceed max LOC limit - blocking pipeline"
+    echo "   CI enforcement mode: BLOCKING pipeline"
+    echo "   These files must be refactored or granted exceptions before merge"
     exit 1
   else
     echo ""
-    echo "   Push allowed (local development)"
+    echo "   Local development mode: Advisory only"
+    echo "   These files will block CI - address before pushing"
+    echo ""
+    echo "💡 Options:"
+    echo "   1. Refactor to under $LIMIT_MAX lines"
+    echo "   2. Request exception in config/loc_limits.yaml"
     exit 0
   fi
 elif [ "$warnings" -gt 0 ]; then
   echo ""
-  echo "💡 Tip: Consider refactoring files exceeding default limit"
-  echo "   (Warnings are allowed, but keep below max limit)"
+  echo "⚠️  ADVISORY: $warnings test files exceed warning threshold ($LIMIT_DEFAULT lines)"
+  echo "   Local development: Suggestions only (push allowed)"
+  echo "   CI will allow these files (under $LIMIT_MAX lines)"
+  echo ""
+  echo "💡 Tip: Consider refactoring for better maintainability"
 else
-  echo "✅ All test files within default limit ($LIMIT_DEFAULT lines)"
+  echo "✅ All test files within warning threshold ($LIMIT_DEFAULT lines)"
 fi

--- a/scripts/hooks/loc_settings.py
+++ b/scripts/hooks/loc_settings.py
@@ -18,8 +18,8 @@ class LocException:
 
 @dataclass(frozen=True)
 class LocSettings:
-    single_file_default: int
-    single_file_max: int
+    warning_threshold: int      # 超标触发 WARNING（建议重构）
+    ci_block_threshold: int     # 超标触发 CI ERROR（阻塞 pipeline）
     total_v2_shell: int
     total_v3_python: int
     warning_threshold_percent: int
@@ -127,18 +127,38 @@ def load_loc_settings(config_path: str | None = None) -> LocSettings:
             raise ValueError(f"Duplicate LOC exception path: {entry.path}")
         seen_paths.add(entry.path)
     return LocSettings(
-        single_file_default=int(scalars.get("code_limits.single_file_loc.default", "300")),
-        single_file_max=int(scalars.get("code_limits.single_file_loc.max", "400")),
+        warning_threshold=int(
+            scalars.get("code_limits.single_file_loc.warning_threshold", "300")
+        ),
+        ci_block_threshold=int(
+            scalars.get("code_limits.single_file_loc.ci_block_threshold", "400")
+        ),
         total_v2_shell=int(scalars.get("code_limits.total_file_loc.v2_shell", "4000")),
-        total_v3_python=int(scalars.get("code_limits.total_file_loc.v3_python", "32000")),
-        warning_threshold_percent=int(scalars.get("code_limits.total_file_loc.warning_threshold_percent", "90")),
+        total_v3_python=int(
+            scalars.get("code_limits.total_file_loc.v3_python", "32000")
+        ),
+        warning_threshold_percent=int(
+            scalars.get("code_limits.total_file_loc.warning_threshold_percent", "90")
+        ),
         last_reviewed=scalars.get("code_limits.total_file_loc.last_reviewed", ""),
-        code_paths_v2_shell=tuple(string_lists.get("code_limits.code_paths.v2_shell", [])),
-        code_paths_v3_python=tuple(string_lists.get("code_limits.code_paths.v3_python", [])),
-        scripts_paths_v2_shell=tuple(string_lists.get("code_limits.scripts_paths.v2_shell", [])),
-        scripts_paths_v3_python=tuple(string_lists.get("code_limits.scripts_paths.v3_python", [])),
-        test_paths_v2_shell=tuple(string_lists.get("code_limits.test_paths.v2_shell", [])),
-        test_paths_v3_python=tuple(string_lists.get("code_limits.test_paths.v3_python", [])),
+        code_paths_v2_shell=tuple(
+            string_lists.get("code_limits.code_paths.v2_shell", [])
+        ),
+        code_paths_v3_python=tuple(
+            string_lists.get("code_limits.code_paths.v3_python", [])
+        ),
+        scripts_paths_v2_shell=tuple(
+            string_lists.get("code_limits.scripts_paths.v2_shell", [])
+        ),
+        scripts_paths_v3_python=tuple(
+            string_lists.get("code_limits.scripts_paths.v3_python", [])
+        ),
+        test_paths_v2_shell=tuple(
+            string_lists.get("code_limits.test_paths.v2_shell", [])
+        ),
+        test_paths_v3_python=tuple(
+            string_lists.get("code_limits.test_paths.v3_python", [])
+        ),
         exceptions=exceptions,
     )
 

--- a/skills/vibe-integrate/SKILL.md
+++ b/skills/vibe-integrate/SKILL.md
@@ -318,7 +318,7 @@ Issue 内容模板：
 
 将文件加入 `config/v3/loc_limits.yaml` 的 exception 清单时，必须遵守容量约束：
 
-- **exception 文件的 limit 不得超过 max 阈值**（当前 `code_limits.single_file_loc.max = 400`，orchestra 类文件允许到 650 属已批准的例外）
+- **exception 文件的 limit 不得超过 ci_block_threshold**（当前 `code_limits.single_file_loc.ci_block_threshold = 400`，orchestra 类文件允许到 650 属已批准的例外）
 - **新增 exception 必须写明 reason**，说明为什么职责单一、边界清楚、拆分只会放大耦合
 - **已有 exception 文件如果继续增长**，需重新评估 limit 是否仍合理；如果接近新 limit 的 90%，应在 handoff 中标注预警
 - **不要**因为"反正已经在 exception 里"就无限制增长；exception 是治理触发器后的安全阀，不是免死金牌

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -100,8 +100,8 @@ def _merge_prompt_fields(data: dict, prompts: dict) -> None:
 class SingleFileLocConfig(BaseModel):
     """单文件行数限制."""
 
-    default: int = Field(default=300)
-    max: int = Field(default=400)
+    warning_threshold: int = Field(default=300)
+    ci_block_threshold: int = Field(default=400)
     exceptions: list["LocExceptionConfig"] = Field(default_factory=list)
 
     @model_validator(mode="after")

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -8,9 +8,10 @@
 - 正常情况下所有配置都从 YAML 文件读取
 """
 
+import warnings
 from pathlib import Path
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 from vibe3.config.orchestra_config import OrchestraConfig
 from vibe3.config.settings_pr import (
@@ -100,9 +101,35 @@ def _merge_prompt_fields(data: dict, prompts: dict) -> None:
 class SingleFileLocConfig(BaseModel):
     """单文件行数限制."""
 
-    warning_threshold: int = Field(default=300)
-    ci_block_threshold: int = Field(default=400)
+    warning_threshold: int = Field(
+        default=300,
+        validation_alias=AliasChoices("warning_threshold", "default"),
+        description="本地开发建议值（WARNING 级别）",
+    )
+    ci_block_threshold: int = Field(
+        default=400,
+        validation_alias=AliasChoices("ci_block_threshold", "max"),
+        description="CI 强制阻塞值（BLOCK 级别）",
+    )
     exceptions: list["LocExceptionConfig"] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_deprecated_fields(cls, data: dict) -> dict:
+        """如果使用旧字段名，发出弃用警告."""
+        if "default" in data:
+            warnings.warn(
+                "Field 'default' is deprecated, use 'warning_threshold' instead",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if "max" in data:
+            warnings.warn(
+                "Field 'max' is deprecated, use 'ci_block_threshold' instead",
+                FutureWarning,
+                stacklevel=2,
+            )
+        return data
 
     @model_validator(mode="after")
     def validate_unique_exception_paths(self) -> "SingleFileLocConfig":

--- a/tests/vibe3/hooks/test_loc_settings.py
+++ b/tests/vibe3/hooks/test_loc_settings.py
@@ -86,7 +86,7 @@ def test_migrated_loc_config_loads_total_limits() -> None:
 def test_runtime_defaults_align_with_hook_fallbacks() -> None:
     config = VibeConfig()
 
-    assert config.code_limits.single_file_loc.default == 300
-    assert config.code_limits.single_file_loc.max == 400
+    assert config.code_limits.single_file_loc.warning_threshold == 300
+    assert config.code_limits.single_file_loc.ci_block_threshold == 400
     assert config.code_limits.total_file_loc.v2_shell == 4000
     assert config.code_limits.total_file_loc.v3_python == 32000


### PR DESCRIPTION
## Summary

Rename LOC limit configuration fields to better reflect their purpose and enforcement levels:
- `default` → `warning_threshold` (advisory, suggests refactoring)
- `max` → `ci_block_threshold` (enforced in CI, blocks pipeline)

## Changes

**Configuration**
- Update `config/loc_limits.yaml` field names with improved documentation
- Update Pydantic model fields in `src/vibe3/config/settings.py` to match YAML

**Hook Scripts**
- Improve error messages in `check-per-file-loc.sh` and `check-test-file-loc.sh`
- Provide clearer guidance on local vs CI enforcement
- Show actionable refactoring suggestions

**Documentation**
- Add `docs/standards/loc-governance.md` explaining the two-threshold system
- Document execution environment differences (local vs CI)
- Update `skills/vibe-integrate/SKILL.md` with new field names

**Tests**
- Update `tests/vibe3/hooks/test_loc_settings.py` to use new field names

## Why

The previous terminology (`default`/`max`) was ambiguous:
- Developers were unclear when files would block CI vs. just show warnings
- Hard to understand the difference between local and CI enforcement
- Actionable guidance was missing

The new terminology makes it explicit:
- **Local development**: Both thresholds are advisory (warnings shown, push allowed)
- **CI environment**: `ci_block_threshold` is enforced (blocks merge)

## Testing

- All pre-commit hooks pass (black, ruff, mypy, shellcheck)
- Tests updated and passing
- Conflict with main resolved (preserved new fields from main: `warning_threshold_percent`, `last_reviewed`)

## Impact

No functional changes - this is a semantic rename only. Existing behavior:
- Files under 300 lines: ✅ Pass
- Files 300-400 lines: ⚠️ Warning (local & CI advisory)
- Files over 400 lines: ❌ Block CI, warn locally

## References

- Issue: #627
- Audit: docs/reports/issue-627-retry-review-audit.md