### PR TITLE
docs: align 3 docs to glossary GitHub issue terminology

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -64,7 +64,7 @@
 | :--- | :--- | :--- |
 | **[/vibe-task](workflows/vibe:task.md)** | task 总览与 registry 审计 | 委托 `vibe-task` skill 处理跨 worktree 总览与 roadmap-task 修复。 |
 | **[/vibe-check](workflows/vibe:check.md)** | runtime 检查与修复 | 委托 `vibe-check` skill 处理 `task <-> flow` / runtime 问题。 |
-| **[/vibe-issue](workflows/vibe:issue.md)** | issue intake | 委托 `vibe-issue` skill 处理 repo issue 创建、查重与补全。 |
+| **[/vibe-issue](workflows/vibe:issue.md)** | issue intake | 委托 `vibe-issue` skill 处理 GitHub issue 创建、查重与补全。 |
 | **[/vibe-save](workflows/vibe:save.md)** | 会话保存 | 委托 `vibe-save` skill 写回本地 handoff。 |
 
 ---

--- a/docs/v3/execution_plan/phase_2_execution_plan.md
+++ b/docs/v3/execution_plan/phase_2_execution_plan.md
@@ -129,7 +129,7 @@ bin/vibe3 check
 **实现步骤**:
 
 1. **实现 task linkage layer (Python)**
-   - 职责: 宬现 task issue / repo issue 关联与责任链引用的最小索引
+   - 职责: 实现task issue / GitHub issue 关联与责任链引用的最小索引
    - 警告: 不复制 GitHub issue 全量数据，真源仍是 GitHub issue / Project
    - 落地方式: 对 SQLite 的 `flow_issue_links` 做写入和查询，由 Python `store.py` 负责
 
@@ -172,7 +172,7 @@ bin/vibe3 task link task-456 --repo-issue 789
 **目标**: 实现 flow 和 task 的绑定关系
 
 **范围**:
-- `flow bind --issue` - 绑定 repo issue
+- `flow bind --issue` - 绑定 GitHub issue
 - `flow bind task` - 绑定 task issue
 
 **实现步骤**:

--- a/docs/v3/handoff/02-flow-task-foundation.md
+++ b/docs/v3/handoff/02-flow-task-foundation.md
@@ -108,7 +108,7 @@ This handoff focuses on flow/task foundation, with PR lifecycle kept separate.
 
 **职责拆分**:
 
-- `task`：吸收 `repo issue`，做 execution record、分合、依赖、主闭环 issue 绑定
+- `task`：吸收 `GitHub issue`，做 execution record、分合、依赖、主闭环 issue 绑定
 - `flow`：把 task 带入 branch 现场，表达当前交付切片
 - `pr`：承载当前交付产物，只保留 `create` / `ready` / `show`
 - `review`：负责审查动作，不承担 PR 状态切换
@@ -116,7 +116,7 @@ This handoff focuses on flow/task foundation, with PR lifecycle kept separate.
 
 **主链**:
 
-`repo issue -> task issue -> flow new/bind -> pr create -> pr ready -> review pr -> integrate -> flow done -> close repo issue`
+`GitHub issue -> task issue -> flow new/bind -> pr create -> pr ready -> review pr -> integrate -> flow done -> close GitHub issue`
 
 **补充约束**:
 


### PR DESCRIPTION
## Summary
- Replace deprecated "repo issue" terminology with "GitHub issue" per glossary.md §3.1
- Align 3 documentation files to current terminology standards

## Changes
- `.agent/README.md`: Updated workflow table entry for vibe-issue
- `docs/v3/execution_plan/phase_2_execution_plan.md`: Updated task linkage layer description and flow bind command
- `docs/v3/handoff/02-flow-task-foundation.md`: Updated responsibility split and main chain flow

## Verification
- All occurrences of "repo issue" replaced with "GitHub issue" in target files
- No scope expansion beyond the 3 specified files
- All pre-push checks passed

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)