### PR TITLE
docs: align 3 V3 standards to glossary terminology

### DIFF
--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -423,7 +423,7 @@ Manager 提交 PR
   └─ issue label: state/review
   ↓ 人工审查
 PR merged
-  ├─ flow.flow_status: merged
+  ├─ flow.flow_status: done
   └─ issue.state: closed
   ↓ vibe check --clean-branch
 清理物理资源

--- a/docs/standards/v3/github-remote-call-standard.md
+++ b/docs/standards/v3/github-remote-call-standard.md
@@ -22,7 +22,7 @@ related_docs:
 
 本文档定义 Vibe 3.0 与 GitHub 远端交互时的最小调用标准。
 
-目标不是覆盖所有 GitHub API，而是锁定执行器最容易猜错的几件事：
+目标不是覆盖所有 GitHub API，而是锁定执行代理最容易猜错的几件事：
 
 - 什么时候用 `gh issue` / `gh pr`
 - 什么时候用 `gh api graphql`
@@ -37,7 +37,7 @@ Vibe 3.0 的远端调用固定遵循：
 - **优先 GitHub 一等命令**
 - **ProjectV2 和复杂字段更新才进入 GraphQL**
 
-禁止执行器直接自行发明：
+禁止执行代理直接自行发明：
 
 - 未记录在标准中的 GraphQL 对象写入路径
 - 随意 `curl` GitHub API 替代 `gh`
@@ -122,7 +122,7 @@ gh api graphql -f query='...'
 
 ### 4.1 Allowed GraphQL Reads
 
-允许执行器通过 GraphQL 读取：
+允许执行代理通过 GraphQL 读取：
 
 - ProjectV2 items
 - ProjectV2 fieldValues
@@ -131,14 +131,14 @@ gh api graphql -f query='...'
 
 ### 4.2 Allowed GraphQL Writes
 
-允许执行器通过 GraphQL 写入：
+允许执行代理通过 GraphQL 写入：
 
 - `updateProjectV2ItemFieldValue`
 - issue dependency 相关 mutation
 
 ### 4.3 Prohibited GraphQL Assumptions
 
-执行器不得假设：
+执行代理不得假设：
 
 - 所有 Project 字段都能通过 `updateProjectV2ItemFieldValue` 更新
 - Assignees / Labels / Milestone / Repository 也能按普通 field value 一样写
@@ -150,7 +150,7 @@ gh api graphql -f query='...'
 
 ## 5. Project Field Rules
 
-V3 当前只要求执行器明确区分两类字段：
+V3 当前只要求执行代理明确区分两类字段：
 
 ### 5.1 Official GitHub Fields
 

--- a/docs/standards/vibe3-architecture-convergence-standard.md
+++ b/docs/standards/vibe3-architecture-convergence-standard.md
@@ -170,7 +170,7 @@ Vibe3 最终应收敛为六层。
 
 这是当前最需要显式收敛出来的一层。
 
-`execution` 不是新的业务层，而是 domain 的执行器。
+`execution` 不是新的业务层，而是 domain 的执行代理。
 
 ### 5.5 Environment
 


### PR DESCRIPTION
## Summary

Aligns deprecated terminology in 3 V3 standard documents to glossary.md standards:
- **github-remote-call-standard.md**: Replace "执行器" with "执行代理" (6 instances) per glossary §5.3
- **flow-lifecycle-standard.md**: Replace deprecated "merged" flow status with "done" in lifecycle diagram per glossary §3.4.1  
- **vibe3-architecture-convergence-standard.md**: Replace "执行器" with "执行代理" in architectural context per glossary §5.3

## Changes

**docs/standards/v3/github-remote-call-standard.md**:
- Lines 25, 40, 125, 134, 141, 153: "执行器" → "执行代理"

**docs/standards/flow-lifecycle-standard.md**:
- Line 426: `flow.flow_status: merged` → `flow.flow_status: done` in lifecycle diagram

**docs/standards/vibe3-architecture-convergence-standard.md**:
- Line 173: "execution 是 domain 的执行器" → "execution 是 domain 的执行代理"

## Why

These V3 standards (created in 2026) should reflect latest terminology from glossary.md. Using deprecated terms creates confusion about proper project semantics:
- "执行器" is marked as historical alias; "执行代理" is the formal term
- "merged" is a historical flow status that should be unified to "done"

## Related

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)