### PR TITLE
docs(ui): correct stale comment about actor fields in flow_ui_timeline

### DIFF
--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -278,7 +278,7 @@ def _render_refs(
             if not refs_shown:
                 console.print("[bold]--- Refs ---[/]")
                 refs_shown = True
-            # Use explicit mapping; only plan_ref has a corresponding actor field
+            # Use explicit mapping; all refs except spec_ref have actor fields
             actor_field = REF_TO_ACTOR_FIELD.get(label)
             actor = getattr(state, actor_field, None) if actor_field else None
             actor_str = f"  [dim]{actor}[/]" if actor else ""


### PR DESCRIPTION
## Summary
Update stale inline comment at src/vibe3/ui/flow_ui_timeline.py:281 to accurately reflect current code reality.

## Changes
- **File**: src/vibe3/ui/flow_ui_timeline.py:281
- **Before**: 'only plan_ref has a corresponding actor field'
- **After**: 'all refs except spec_ref have actor fields'
- **Reason**: The REF_TO_ACTOR_FIELD mapping now includes plan_ref, report_ref, and audit_ref

## Verification
- ✅ Ruff linting: PASS
- ✅ Mypy type checking: PASS
- ✅ 11 related tests: PASS
- ✅ Review verdict: PASS (claude/opus)

## Related
- Issue: #590