### PR TITLE
docs: align 5 external tool reference docs to current V3 scope

### DIFF
--- a/docs/references/codex-serena-intetration.md
+++ b/docs/references/codex-serena-intetration.md
@@ -1,4 +1,13 @@
 
+---
+title: Codex + Serena PR Review 集成架构
+status: historical-reference
+scope: external-tool-chain
+note: 本文档描述外部工具链 Codex + Serena 的 PR review 集成架构，非当前项目主流程。当前项目 PR review 实际方式通过 vibe3 CLI，详见 CLAUDE.md §Agent 工作流 和 docs/standards/v3/skill-standard.md。
+---
+
+# Codex + Serena PR Review 集成架构
+
 目标架构
 
 你要的完整版本是这条链：

--- a/docs/references/everything-claude-code-installation-guide.md
+++ b/docs/references/everything-claude-code-installation-guide.md
@@ -3,7 +3,9 @@ title: Everything Claude Code (ECC) 安装与使用指南
 author: Claude Sonnet 4.6
 created_at: 2026-03-17
 category: guide
-status: active
+status: historical-reference
+scope: external-plugin-ecosystem
+note: 本文档描述外部插件生态 Everything Claude Code (ECC)，非当前项目核心依赖。当前项目自有技能系统见 skills/ 目录，外部依赖说明见 AGENTS.md §External Dependencies。
 version: 1.0
 related_docs:
   - docs/v3/ROADMAP.md

--- a/docs/references/harness-vs-omo.md
+++ b/docs/references/harness-vs-omo.md
@@ -1,3 +1,11 @@
+---
+title: harness vs omo 技能对比
+status: historical-reference
+scope: external-framework-comparison
+note: 本文档对比外部框架 harness 和 omo，两者均非当前 Vibe 3.0 核心编排系统。当前项目工作流见 CLAUDE.md §Agent 工作流 和 docs/v3/README.md §实施阶段。
+generated: 2026-03-18
+---
+
 # harness vs omo 技能对比
 
 生成时间: 2026-03-18

--- a/docs/references/metaclaw-harness.md
+++ b/docs/references/metaclaw-harness.md
@@ -1,4 +1,11 @@
-MetaClaw-Harness 集成规范 (v1.0)
+---
+title: MetaClaw-Harness 集成规范
+status: historical-reference
+scope: external-integration-example
+note: 本文档描述外部系统 MetaClaw-Harness 的集成规范，非当前 Vibe 3.0 核心组件。当前项目核心系统见 CLAUDE.md §项目组成 和 docs/v3/README.md §核心理念。
+---
+
+# MetaClaw-Harness 集成规范 (v1.0)
 1. 系统角色定义
 The Brain (Cloud API): 处理复杂逻辑与规划（如 GPT-4o）。
 The Cerebellum (Local MLX + LoRA): 处理风格化输出、工具调用格式、私有代码偏好。

--- a/docs/references/openspec-guide.md
+++ b/docs/references/openspec-guide.md
@@ -1,3 +1,10 @@
+---
+title: OpenSpec Workflow Guide
+status: historical-reference
+scope: external-workflow-tool
+note: 本文档描述外部工作流工具 OpenSpec，使用 /opsx:* 命令，非当前 Vibe 3.0 主命令体系。当前项目能力层与编排层边界见 docs/standards/v3/skill-standard.md，技能入口见 skills/ 目录。
+---
+
 # OpenSpec Workflow Guide: From Concept to Code
 
 Welcome to **OpenSpec**, an artifact-driven development workflow designed to make software changes structured, thoughtful, and documented by default.


### PR DESCRIPTION
## Summary
- Added frontmatter markers to 5 reference documents (metaclaw-harness.md, harness-vs-omo.md, everything-claude-code-installation-guide.md, codex-serena-intetration.md, openspec-guide.md)
- Marked all as `historical-reference` with explicit scope annotations (external-integration-example, external-framework-comparison, external-plugin-ecosystem, external-tool-chain, external-workflow-tool)
- Aligned references to current Vibe 3.0 authoritative sources (CLAUDE.md §项目组成, AGENTS.md §External Dependencies, docs/v3/README.md §核心理念, docs/standards/v3/skill-standard.md §能力层与编排层边界)
- Preserved existing document content structure; only adjusted positioning and added clarifying notes

## Why
These documents describe external frameworks (MetaClaw, Harness, Omo, ECC, Codex-Serena, OpenSpec) that are not part of the current Vibe 3.0 core implementation. The alignment prevents confusion about what is project core vs external tool references, ensuring developers and AI agents have clear guidance on which systems are part of Vibe 3.0 and which are external/historical references.

## Test plan
- [x] Verified all 5 documents have correct frontmatter with status, scope, and note fields
- [x] Verified references to authoritative sources are correct and accessible
- [x] Confirmed no structural changes to document content
- [x] Pre-commit hooks passed (no code changes, documentation only)

Closes #724

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)