### PR TITLE
Clean up dead code and deprecated CLI options (Phase 1)

### DIFF
--- a/src/vibe3/commands/handoff_render.py
+++ b/src/vibe3/commands/handoff_render.py
@@ -13,10 +13,6 @@ from vibe3.utils.path_helpers import (
     sanitize_event_detail_paths,
 )
 
-# Preview limit for update messages
-UPDATE_LOG_MESSAGE_PREVIEW_LIMIT = 80
-
-
 _to_handoff_cmd = ref_to_handoff_cmd
 
 
@@ -113,17 +109,3 @@ def _render_handoff_events(
                 display_ref = resolve_ref_path(ref, worktree_root)
                 console.print(f"  [dim]- {_to_handoff_cmd(display_ref, branch)}[/]")
         console.print()
-
-
-def _preview_update_message(message: str, truncate: bool = True) -> str:
-    """Preview update message with truncation if needed."""
-    if not truncate or len(message) <= UPDATE_LOG_MESSAGE_PREVIEW_LIMIT:
-        return message
-
-    # Truncate to limit, preserving word boundaries
-    truncated = message[:UPDATE_LOG_MESSAGE_PREVIEW_LIMIT]
-    # Find last space to avoid cutting words mid-way
-    last_space = truncated.rfind(" ")
-    if last_space > 0:
-        truncated = truncated[:last_space]
-    return truncated + "..."

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -117,13 +117,6 @@ def resume(
         list[int] | None,
         typer.Argument(help="Issue numbers to resume"),
     ] = None,
-    failed: Annotated[
-        bool,
-        typer.Option(
-            "--failed",
-            help="[DEPRECATED] Use --blocked instead. Resume all blocked issues",
-        ),
-    ] = False,
     blocked: Annotated[
         bool, typer.Option("--blocked", help="Resume all blocked issues")
     ] = False,
@@ -162,11 +155,10 @@ def resume(
     json_output: Annotated[bool, typer.Option("--json")] = False,
     trace: Annotated[bool, typer.Option("--trace")] = False,
 ) -> None:
-    """Resume failed or blocked issues to ready.
+    """Resume blocked issues to ready.
 
-    Use --failed to resume all failed issues, --blocked to resume all
-    blocked issues, or --all to reset every auto-created task/issue-*
-    scene back to ready. Or specify issue numbers directly.
+    Use --blocked to resume all blocked issues, --all to reset every
+    auto-created task/issue-* scene back to ready, or specify issue numbers directly.
 
     **Label-only mode (no worktree deletion)**:
     Use --label [STATE] to clear blocked_reason and restore
@@ -207,25 +199,25 @@ def resume(
     register_event_handlers()
 
     # Validate arguments
-    selected_modes = [failed, blocked, all_tasks]
+    selected_modes = [blocked, all_tasks]
     has_flag = any(selected_modes)
     if not has_flag and not issue_numbers:
         typer.echo(
-            "Error: Must specify --failed, --blocked, --all, or provide issue numbers",
+            "Error: Must specify --blocked, --all, or provide issue numbers",
             err=True,
         )
         raise typer.Exit(1)
 
     if sum(1 for flag in selected_modes if flag) > 1:
         typer.echo(
-            "Error: Cannot specify more than one of --failed, --blocked, and --all",
+            "Error: Cannot specify more than one of --blocked and --all",
             err=True,
         )
         raise typer.Exit(1)
 
     if has_flag and issue_numbers:
         typer.echo(
-            "Error: Cannot combine issue numbers with --failed, --blocked, or --all",
+            "Error: Cannot combine issue numbers with --blocked or --all",
             err=True,
         )
         raise typer.Exit(1)
@@ -280,7 +272,7 @@ def resume(
     if candidate_mode != "all_task":
         stale_flows = flow_service.list_flows(status="stale")
 
-    # Handle --failed/--blocked filtering by state label
+    # Handle --blocked filtering by state label
     if has_flag and candidate_mode == "resumable":
         # Fetch all orchestrated issues (not just stale)
         all_issues = usecase.status_service.fetch_orchestrated_issues(
@@ -288,13 +280,6 @@ def resume(
             queued_set=set(),
             stale_flows=stale_flows,
         )
-
-        if failed:
-            typer.echo(
-                "⚠  --failed is deprecated and will be removed in a future version. "
-                "Use --blocked instead.",
-                err=True,
-            )
 
         # Filter by state label (FAILED unified to BLOCKED)
         target_state = IssueState.BLOCKED
@@ -355,8 +340,6 @@ def resume(
     if not yes and has_flag and not result.get("candidates"):
         if all_tasks:
             typer.echo("No auto-created task scenes found.")
-        elif failed:
-            typer.echo("No failed issues found.")
         else:
             typer.echo("No blocked issues found.")
         return
@@ -370,8 +353,6 @@ def resume(
                 candidate_count = len(result.get("candidates", []))
                 if all_tasks:
                     typer.echo(f"Found {candidate_count} auto-created task scene(s)")
-                elif failed:
-                    typer.echo(f"Found {candidate_count} failed issue(s)")
                 else:
                     typer.echo(f"Found {candidate_count} blocked issue(s)")
                 typer.echo("\n[dry-run mode] Would resume the following issues:")

--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -190,7 +190,7 @@ def _render_actors(state: FlowStatusResponse) -> None:
 
 
 def _render_reasons(state: FlowStatusResponse) -> None:
-    """Show blocked reason if present (failed_reason deprecated)."""
+    """Show blocked reason if present."""
     if state.blocked_reason:
         console.print()
         console.print(f"  [red bold]blocked_reason:[/] [red]{state.blocked_reason}[/]")


### PR DESCRIPTION
## Summary

Phase 1 of dead code cleanup for issue #620. This PR removes unused code and deprecated CLI options that were identified as safe to remove.

**Changes:**
- Remove unused `_preview_update_message` function
- Remove unused constant `UPDATE_LOG_MESSAGE_PREVIEW_LIMIT`
- Remove deprecated `--failed` CLI option
- Update related docstrings

**Stats:** 3 files changed, -46/+9 lines (net -37 LOC)

## Verification

- ✅ All 37 related tests pass
- ✅ Type checking: Success in 274 source files
- ✅ Lint checks: All pass
- ✅ No functional regression

## Acceptance Criteria

- **Code correctness**: All changes verified and tested
- **Python LOC target**: < 45,000 lines
  - Note: This target was already achieved on main branch through other refactoring work (current main: 40,428 LOC)
  - This PR contributes additional code cleanup (-37 LOC), though it's not the primary reason for meeting the target

## Related Issues

Closes #620

**Follow-up**: Issue #732 created for skill documentation cleanup

## Notes

- Branch was rebased onto latest main before creating PR
- Pre-push checks passed with warning about LOC approaching limit (47,580 / 50,000)
- No conflicts during rebase