### PR TITLE
fix(orchestra): recover frozen queue from dead session deadlock

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -321,6 +321,25 @@ class GlobalDispatchCoordinator:
 
             current_state = issue.state.value
             if current_state == entry.waiting_state:
+                # State unchanged. Check whether the agent session that would
+                # advance it is still alive.  If no session exists the label can
+                # never change ─ promote the entry for re-dispatch so the queue
+                # can eventually drain and re-collect.
+                if self._registry is not None:
+                    active = self._registry.get_live_sessions_for_issue(
+                        issue_number=entry.issue_number,
+                        roles=["manager", "planner", "executor", "reviewer"],
+                    )
+                    if not active:
+                        entry.waiting_state = None
+                        promoted.append(entry)
+                        append_orchestra_event(
+                            "dispatcher",
+                            f"GlobalDispatchCoordinator: requeued "
+                            f"#{entry.issue_number} "
+                            f"(no active session, state={current_state})",
+                        )
+                        continue
                 retained.append(entry)
                 continue
 


### PR DESCRIPTION
## Summary

- Fix frozen queue deadlock when agent sessions die after dispatch
- In `_promote_progressed_entries`, check for active sessions when state hasn't changed
- If no active session exists, promote entry for re-dispatch so queue can drain

## Problem

When an agent session dies after dispatch, the issue entry remains in the frozen queue with `waiting_state` set. Since the session is dead, the GitHub label never changes, causing:
- Entry permanently stuck in queue
- Queue never drains
- Fresh collection never triggers (Rule #1 requires empty queue)

## Solution

Added session liveness check in `_promote_progressed_entries`:
- When `current_state == waiting_state` (state unchanged)
- If `registry` is available, check for live sessions
- If no active sessions → reset `waiting_state=None` and promote for re-dispatch

## Test Plan

- [ ] Manual: Run orchestra serve, observe queue draining after session death
- [ ] Verify: Logs show "requeued #N (no active session, state=X)" events
- [ ] Verify: Queue eventually empties and fresh collection triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)