### PR TITLE
feat(clients): add public GitClient.get_numstat() API

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -79,7 +79,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check if review already requested
         id: check-review
@@ -147,7 +147,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check if review already requested
         id: check-review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -21,7 +21,7 @@ jobs:
 
       # Setup Python environment for v3
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
 

--- a/.github/workflows/issue-state-sync.yml
+++ b/.github/workflows/issue-state-sync.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-aliases.yml
+++ b/.github/workflows/test-aliases.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install zsh (Ubuntu)
         if: runner.os == 'Linux'

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -36,6 +36,9 @@ from vibe3.clients.git_status_ops import (
     get_diff as _get_diff,
 )
 from vibe3.clients.git_status_ops import (
+    get_numstat as _get_numstat,
+)
+from vibe3.clients.git_status_ops import (
     get_untracked_files as _get_untracked_files,
 )
 from vibe3.clients.git_status_ops import (
@@ -212,6 +215,10 @@ class GitClient:
     def get_diff(self, source: ChangeSource) -> str:
         """统一接口：获取 diff 内容."""
         return _get_diff(self._run, source, self._github_client, self._pr_diff_cache)
+
+    def get_numstat(self, source: ChangeSource) -> str:
+        """Get git diff --numstat output for a change source."""
+        return _get_numstat(self._run, source, self._github_client, self.get_merge_base)
 
     def get_untracked_files(self) -> list[str]:
         """Return untracked files in the worktree."""

--- a/src/vibe3/clients/git_status_ops.py
+++ b/src/vibe3/clients/git_status_ops.py
@@ -176,3 +176,71 @@ def has_uncommitted_changes(run: Callable[[list[str]], str]) -> bool:
         return bool(status)
     except GitError:
         return False
+
+
+def get_numstat(
+    run: Callable[[list[str]], str],
+    source: ChangeSource,
+    github_client: "GitHubClient | None" = None,
+    get_merge_base: Callable[[str, str], str] | None = None,
+) -> str:
+    """Unified interface: get git diff --numstat output.
+
+    Args:
+        run: Git command runner function
+        source: Change source (PR/Commit/Branch/Uncommitted)
+        github_client: Optional GitHubClient for PR ref resolution
+        get_merge_base: Optional merge-base resolver callable
+
+    Returns:
+        numstat output string (tab-separated: added deleted filepath)
+
+    Raises:
+        GitError: git command execution failed
+        ValueError: missing required dependencies (e.g., github_client for PR source)
+    """
+    log = logger.bind(domain="git", action="get_numstat", source_type=source.type)
+    log.info("Getting numstat")
+
+    if source.type == ChangeSourceType.UNCOMMITTED:
+        output = run(["diff", "--numstat", "HEAD"])
+    elif source.type == ChangeSourceType.COMMIT:
+        if not isinstance(source, CommitSource):
+            raise SystemError(
+                f"Type mismatch: expected CommitSource, got {type(source).__name__}"
+            )
+        output = run(["diff", "--numstat", f"{source.sha}^", source.sha])
+    elif source.type == ChangeSourceType.BRANCH:
+        if not isinstance(source, BranchSource):
+            raise SystemError(
+                f"Type mismatch: expected BranchSource, got {type(source).__name__}"
+            )
+        if not get_merge_base:
+            raise ValueError("get_merge_base callable required for BranchSource")
+        merge_base = get_merge_base(source.branch, source.base)
+        output = run(["diff", "--numstat", f"{merge_base}...{source.branch}"])
+    elif source.type == ChangeSourceType.PR:
+        if not isinstance(source, PRSource):
+            raise SystemError(
+                f"Type mismatch: expected PRSource, got {type(source).__name__}"
+            )
+        if not github_client:
+            raise GitError(
+                "get_numstat",
+                "PR source requires GitHubClient injection",
+            )
+        if not get_merge_base:
+            raise ValueError("get_merge_base callable required for PRSource")
+        pr_info = github_client.get_pr(source.pr_number)
+        if not pr_info:
+            raise GitError(
+                "get_numstat",
+                f"PR #{source.pr_number} not found",
+            )
+        merge_base = get_merge_base(pr_info.head_branch, pr_info.base_branch)
+        output = run(["diff", "--numstat", f"{merge_base}...{pr_info.head_branch}"])
+    else:
+        raise GitError("get_numstat", f"Unknown source type: {source.type}")
+
+    log.bind(output_len=len(output)).success("Got numstat")
+    return output

--- a/src/vibe3/services/loc_service.py
+++ b/src/vibe3/services/loc_service.py
@@ -129,62 +129,8 @@ class LocService:
         )
 
     def _get_numstat(self, source: ChangeSource) -> str:
-        """Get git diff numstat output for a source.
-
-        Args:
-            source: ChangeSource (PRSource or BranchSource)
-
-        Returns:
-            Raw numstat output from git
-        """
-        if isinstance(source, PRSource):
-            # For PR, use the PR diff
-            # Note: We need to use gh pr diff to get the PR diff directly
-            # git diff --numstat doesn't work directly for PRs
-            import json
-            import subprocess
-
-            try:
-                # gh pr diff --name-only only gives filenames
-                # We need to use git diff with the PR merge base
-                # Get the PR head and base refs
-                pr_info = subprocess.run(
-                    [
-                        "gh",
-                        "pr",
-                        "view",
-                        str(source.pr_number),
-                        "--json",
-                        "baseRefName,headRefName",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                pr_data = json.loads(pr_info.stdout)
-                base_ref = pr_data["baseRefName"]
-                head_ref = pr_data["headRefName"]
-
-                # Use git diff --numstat with merge-base
-                base_commit = self.git_client.get_merge_base(head_ref, base_ref)
-                return self.git_client._run(
-                    ["diff", "--numstat", f"{base_commit}...{head_ref}"]
-                )
-            except Exception as e:
-                logger.bind(pr_number=source.pr_number).error(
-                    f"Failed to get PR numstat: {e}"
-                )
-                raise
-
-        elif isinstance(source, BranchSource):
-            # For branch, use git diff --numstat with merge-base
-            base_commit = self.git_client.get_merge_base(source.branch, source.base)
-            return self.git_client._run(
-                ["diff", "--numstat", f"{base_commit}...{source.branch}"]
-            )
-
-        else:
-            raise ValueError(f"Unsupported source type: {type(source)}")
+        """Get git diff --numstat output for a source."""
+        return self.git_client.get_numstat(source)
 
     def _is_core_code_file(self, filepath: str) -> bool:
         """Check if a file is in core code paths and not a test file.

--- a/tests/vibe3/clients/test_git_status_ops.py
+++ b/tests/vibe3/clients/test_git_status_ops.py
@@ -1,0 +1,109 @@
+"""Tests for git status ops functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibe3.clients.git_status_ops import get_numstat
+from vibe3.exceptions import GitError
+from vibe3.models.change_source import (
+    BranchSource,
+    CommitSource,
+    PRSource,
+    UncommittedSource,
+)
+
+
+class TestGetNumstat:
+    """Test get_numstat function."""
+
+    def test_uncommitted_source_uses_head(self) -> None:
+        """Test uncommitted source uses 'git diff --numstat HEAD'."""
+        run = MagicMock(return_value="10\t5\tsrc/test.py")
+        source = UncommittedSource()
+
+        result = get_numstat(run, source)
+
+        run.assert_called_once_with(["diff", "--numstat", "HEAD"])
+        assert result == "10\t5\tsrc/test.py"
+
+    def test_commit_source_uses_sha_range(self) -> None:
+        """Test commit source uses 'git diff --numstat sha^ sha'."""
+        run = MagicMock(return_value="15\t8\tsrc/main.py")
+        source = CommitSource(sha="abc123")
+
+        result = get_numstat(run, source)
+
+        run.assert_called_once_with(["diff", "--numstat", "abc123^", "abc123"])
+        assert result == "15\t8\tsrc/main.py"
+
+    def test_branch_source_uses_merge_base(self) -> None:
+        """Test branch source uses merge-base correctly."""
+        run = MagicMock(return_value="20\t10\tsrc/feature.py")
+        get_merge_base = MagicMock(return_value="base456")
+        source = BranchSource(branch="feature", base="main")
+
+        result = get_numstat(run, source, get_merge_base=get_merge_base)
+
+        get_merge_base.assert_called_once_with("feature", "main")
+        run.assert_called_once_with(["diff", "--numstat", "base456...feature"])
+        assert result == "20\t10\tsrc/feature.py"
+
+    def test_branch_source_raises_without_merge_base_callable(self) -> None:
+        """Test branch source raises error when get_merge_base not provided."""
+        run = MagicMock()
+        source = BranchSource(branch="feature", base="main")
+
+        with pytest.raises(ValueError, match="get_merge_base callable required"):
+            get_numstat(run, source)
+
+    def test_pr_source_uses_github_client(self) -> None:
+        """Test PR source uses github_client.get_pr for ref resolution."""
+        run = MagicMock(return_value="30\t15\tsrc/pr_file.py")
+        github_client = MagicMock()
+        pr_info = MagicMock()
+        pr_info.head_branch = "pr-branch"
+        pr_info.base_branch = "main"
+        github_client.get_pr.return_value = pr_info
+        get_merge_base = MagicMock(return_value="merge789")
+        source = PRSource(pr_number=42)
+
+        result = get_numstat(
+            run, source, github_client=github_client, get_merge_base=get_merge_base
+        )
+
+        github_client.get_pr.assert_called_once_with(42)
+        get_merge_base.assert_called_once_with("pr-branch", "main")
+        run.assert_called_once_with(["diff", "--numstat", "merge789...pr-branch"])
+        assert result == "30\t15\tsrc/pr_file.py"
+
+    def test_pr_source_raises_without_github_client(self) -> None:
+        """Test PR source raises error when github_client not provided."""
+        run = MagicMock()
+        get_merge_base = MagicMock()
+        source = PRSource(pr_number=42)
+
+        with pytest.raises(GitError, match="PR source requires GitHubClient"):
+            get_numstat(run, source, get_merge_base=get_merge_base)
+
+    def test_pr_source_raises_without_merge_base_callable(self) -> None:
+        """Test PR source raises error when get_merge_base not provided."""
+        run = MagicMock()
+        github_client = MagicMock()
+        source = PRSource(pr_number=42)
+
+        with pytest.raises(ValueError, match="get_merge_base callable required"):
+            get_numstat(run, source, github_client=github_client)
+
+    def test_pr_source_raises_when_pr_not_found(self) -> None:
+        """Test PR source raises error when get_pr returns None."""
+        run = MagicMock()
+        github_client = MagicMock()
+        github_client.get_pr.return_value = None
+        get_merge_base = MagicMock()
+        source = PRSource(pr_number=999)
+
+        with pytest.raises(GitError, match="PR #999 not found"):
+            get_numstat(
+                run, source, github_client=github_client, get_merge_base=get_merge_base
+            )

--- a/tests/vibe3/services/test_loc_service.py
+++ b/tests/vibe3/services/test_loc_service.py
@@ -86,8 +86,7 @@ class TestLocService:
         """Test that branch diff works."""
         service = LocService()
         service.git_client = MagicMock()
-        service.git_client.get_merge_base.return_value = "abc123"
-        service.git_client._run.return_value = "15\t8\tsrc/vibe3/new_file.py"
+        service.git_client.get_numstat.return_value = "15\t8\tsrc/vibe3/new_file.py"
 
         stats = service.get_branch_loc_stats("feature-branch", "main")
 
@@ -138,3 +137,16 @@ invalid line here
         with patch.object(service, "_get_numstat", side_effect=Exception("Git error")):
             with pytest.raises(Exception, match="Git error"):
                 service.get_pr_loc_stats(300)
+
+    def test_get_numstat_delegates_to_git_client(self) -> None:
+        """Test that _get_numstat uses public GitClient.get_numstat()."""
+        from vibe3.models.change_source import PRSource
+
+        service = LocService()
+        service.git_client = MagicMock()
+        service.git_client.get_numstat.return_value = "10\t5\tsrc/vibe3/test.py"
+
+        result = service._get_numstat(PRSource(pr_number=1))
+
+        service.git_client.get_numstat.assert_called_once()
+        assert result == "10\t5\tsrc/vibe3/test.py"


### PR DESCRIPTION
## Summary

Add public `get_numstat()` method to `GitClient` with full `ChangeSource` type support.

## Key Changes

- **GitClient**: Add public `get_numstat()` method
- **LocService**: Refactor `_get_numstat()` to use public API (eliminate subprocess duplication)
- **Tests**: 9 new tests covering all `ChangeSource` types
- **Workflows**: Update 5 GitHub Actions to Node.js 24

## Verification Results

- ✅ Tests: 17/17 PASS
- ✅ Type check (mypy): 0 errors
- ✅ Lint (ruff): 0 violations
- ✅ LOC ceiling: PRService at 394/400 (maintained)

## Technical Details

### ChangeSource Support

The new `get_numstat()` method handles all four source types:

1. **UNCOMMITTED**: `git diff --numstat HEAD` (working tree changes)
2. **COMMIT**: `git diff --numstat sha^ sha` (single commit)
3. **BRANCH**: Uses merge-base + three-dot diff
4. **PR**: Resolves PR via GitHub API + merge-base diff

### Error Handling

Complete error handling for:
- Unknown source types
- Missing `github_client` dependency
- Missing `get_merge_base` callable
- PR not found

## Impact

This refactoring eliminates subprocess duplication in `LocService` while preserving exact behavior. No breaking changes.

Closes #671