### PR TITLE
refactor(commands): extract business logic to services and roles

### DIFF
--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -1,48 +1,23 @@
 """Handoff read commands - status and artifact display."""
 
 import json
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 from loguru import logger
 
-from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.clients.git_client import GitClient
-from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.commands.command_options import FormatOption, VerboseOption
 from vibe3.commands.common import trace_scope
 from vibe3.commands.handoff_render import (
     _render_handoff_events,
 )
-from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.exceptions import SystemError, UserError
 from vibe3.services.flow_service import FlowService
-from vibe3.services.handoff_service import HandoffService
-from vibe3.services.verdict_service import VerdictService
+from vibe3.services.handoff_status_service import HandoffStatusService
 from vibe3.ui.console import console
 from vibe3.ui.handoff_ui import render_handoff_detail
 from vibe3.utils.issue_branch_resolver import resolve_issue_branch_input
-
-
-def _get_live_sessions_for_branch(
-    store: SQLiteClient, branch: str
-) -> list[dict[str, Any]]:
-    """Return truly live runtime sessions from the registry for a given branch.
-
-    This function confirms tmux liveness for each session, unlike
-    store.list_live_runtime_sessions which only checks status.
-
-    Args:
-        store: SQLiteClient instance for database access.
-        branch: The branch to filter sessions by.
-
-    Returns:
-        List of session dicts that are truly live.
-    """
-    backend = CodeagentBackend()
-    registry = SessionRegistryService(store=store, backend=backend)
-    return registry.get_truly_live_sessions_for_branch(branch)
-
 
 _HANDOFF_SHOW_HELP = """\
 Usage: vibe3 handoff show <target> [--branch <branch>]
@@ -144,31 +119,31 @@ def status(
             "Showing handoff details"
         )
 
-        service = FlowService()
-        handoff_service = HandoffService(store=service.store)
+        flow_service = FlowService()
         if branch:
             try:
-                target_branch = resolve_issue_branch_input(branch, service) or branch
+                target_branch = (
+                    resolve_issue_branch_input(branch, flow_service) or branch
+                )
             except (UserError, SystemError) as error:
                 typer.echo(f"Error: {error}", err=True)
                 raise typer.Exit(1) from error
         else:
-            target_branch = service.get_current_branch()
+            target_branch = flow_service.get_current_branch()
 
-        state = service.get_flow_state(target_branch)
-        if not state:
-            logger.error(f"Flow not found: {target_branch}")
-            raise typer.Exit(1)
-
+        # Aggregate handoff status from service
+        status_service = HandoffStatusService(flow_service=flow_service)
         limit = None if show_all else 5
-        handoff_events = handoff_service.get_success_handoff_events(
-            target_branch, limit=limit
-        )
+        try:
+            result = status_service.get_handoff_status(target_branch, limit=limit)
+        except ValueError as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(1) from error
 
         if format == "json":
             output = {
-                "state": state.model_dump(),
-                "events": [e.model_dump() for e in handoff_events],
+                "state": result.state.model_dump(),
+                "events": [e.model_dump() for e in result.events],
             }
             typer.echo(json.dumps(output, indent=2, default=str))
             return
@@ -177,53 +152,39 @@ def status(
             import yaml
 
             output = {
-                "state": state.model_dump(),
-                "events": [e.model_dump() for e in handoff_events],
+                "state": result.state.model_dump(),
+                "events": [e.model_dump() for e in result.events],
             }
             typer.echo(yaml.dump(output, default_flow_style=False, allow_unicode=True))
             return
 
         # Table format (default)
-        # Fetch live registry sessions (preferred over deprecated FlowState fields)
-        live_sessions = _get_live_sessions_for_branch(service.store, target_branch)
-
-        # Resolve worktree root for the target branch, not the current
-        # command execution context
-        worktree_path = service.git_client.find_worktree_path_for_branch(target_branch)
-        if worktree_path:
-            worktree_root = str(worktree_path)
-        else:
-            # Fallback: if branch has no dedicated worktree, use current
-            worktree_root = service.git_client.get_worktree_root()
-
-        console.print(f"\n[bold cyan]flow[/]: {state.flow_slug}")
+        console.print(f"\n[bold cyan]flow[/]: {result.flow_slug}")
 
         # Show worktree path for context (where files actually live)
-        if worktree_path:
-            console.print(f"[dim]worktree: {worktree_root}[/]")
+        if result.worktree_root:
+            console.print(f"[dim]worktree: {result.worktree_root}[/]")
         console.print()
 
         # Show latest verdict at the top
-        verdict_service = VerdictService(store=service.store)
-        latest_verdict = verdict_service.get_latest_verdict(target_branch)
-        if latest_verdict:
+        if result.latest_verdict:
             console.print("[bold]## Latest Verdict[/]")
-            console.print(f"  [cyan]verdict:[/] {latest_verdict.verdict}")
-            console.print(f"  [cyan]actor:[/] {latest_verdict.actor}")
-            console.print(f"  [cyan]role:[/] {latest_verdict.role}")
+            console.print(f"  [cyan]verdict:[/] {result.latest_verdict.verdict}")
+            console.print(f"  [cyan]actor:[/] {result.latest_verdict.actor}")
+            console.print(f"  [cyan]role:[/] {result.latest_verdict.role}")
             console.print(
-                f"  [cyan]timestamp:[/] {latest_verdict.timestamp.isoformat()}"
+                f"  [cyan]timestamp:[/] {result.latest_verdict.timestamp.isoformat()}"
             )
-            if latest_verdict.reason:
-                console.print(f"  [cyan]reason:[/] {latest_verdict.reason}")
-            if latest_verdict.issues:
-                console.print(f"  [cyan]issues:[/] {latest_verdict.issues}")
+            if result.latest_verdict.reason:
+                console.print(f"  [cyan]reason:[/] {result.latest_verdict.reason}")
+            if result.latest_verdict.issues:
+                console.print(f"  [cyan]issues:[/] {result.latest_verdict.issues}")
             console.print()
 
         # Show resume hints from registry only (registry is source of truth)
-        if live_sessions:
+        if result.live_sessions:
             hints_shown = False
-            for sess in live_sessions:
+            for sess in result.live_sessions:
                 backend_session_id = sess.get("backend_session_id")
                 if backend_session_id:
                     if not hints_shown:
@@ -238,8 +199,8 @@ def status(
         console.print("[bold]--- Successful Handoff Events ---[/]")
         console.print()
         _render_handoff_events(
-            handoff_events,
-            worktree_root=worktree_root,
+            result.events,
+            worktree_root=result.worktree_root,
             branch=target_branch,
             verbose=verbose,
         )

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -23,6 +23,7 @@ from vibe3.roles.review import (
     build_base_review_request,
     execute_manual_review_async,
     execute_manual_review_sync,
+    validate_review_prerequisites,
 )
 from vibe3.services.flow_service import FlowService
 from vibe3.utils.branch_arg import resolve_branch_arg
@@ -63,25 +64,11 @@ def _review_branch_impl(
         enable_trace()
 
     flow_service = FlowService()
-    flow = flow_service.get_flow_status(branch)
-
-    if not flow:
-        typer.echo(
-            f"Error: No flow for branch '{branch}'.\n"
-            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
-            err=True,
-        )
-        raise typer.Exit(1)
-
-    issue_number = flow.task_issue_number
-
-    if not issue_number:
-        typer.echo(
-            f"Error: No issue linked to flow '{branch}'.\n"
-            "Run 'vibe flow bind <issue>' first.",
-            err=True,
-        )
-        raise typer.Exit(1)
+    try:
+        flow, issue_number = validate_review_prerequisites(flow_service, branch)
+    except UserError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1) from error
 
     if no_async:
         run_issue_role_sync(

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -16,11 +16,13 @@ from vibe3.commands.command_options import (
     _TRACE_OPT,
 )
 from vibe3.config.settings import VibeConfig
+from vibe3.exceptions import UserError
 from vibe3.roles.run import (
     ensure_plan_file_exists,
     execute_manual_run,
     find_skill_file,
     resolve_run_mode,
+    validate_run_prerequisites,
 )
 from vibe3.services.flow_service import FlowService
 from vibe3.utils.branch_arg import resolve_branch_arg
@@ -88,19 +90,11 @@ def run_command(
     target_branch = resolve_branch_arg(branch)
 
     flow_service = FlowService()
-    flow = flow_service.get_flow_status(target_branch)
-
-    if not flow:
-        typer.echo(
-            f"Error: No flow for branch '{target_branch}'.\n"
-            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first.",
-            err=True,
-        )
-        raise typer.Exit(1)
-
-    issue_number = (
-        str(flow.task_issue_number) if flow and flow.task_issue_number else None
-    )
+    try:
+        flow, issue_number = validate_run_prerequisites(flow_service, target_branch)
+    except UserError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1) from error
 
     if publish and skill:
         typer.echo("Error: --publish and --skill are mutually exclusive.", err=True)
@@ -123,7 +117,7 @@ def run_command(
         execute_manual_run(
             config=config,
             branch=target_branch,
-            issue_number=int(issue_number) if issue_number else None,
+            issue_number=issue_number,
             instructions=instructions,
             plan_file=None,
             skill=skill,
@@ -175,7 +169,7 @@ def run_command(
     execute_manual_run(
         config=config,
         branch=target_branch,
-        issue_number=int(issue_number) if issue_number else None,
+        issue_number=issue_number,
         instructions=instructions,
         plan_file=plan_file,
         skill=None,

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -43,6 +43,44 @@ from vibe3.roles.review_helpers import (
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_failure_service import fail_reviewer_issue
 
+
+def validate_review_prerequisites(
+    flow_service: FlowService,
+    branch: str,
+) -> tuple[Any, int]:
+    """Validate flow exists and has linked issue.
+
+    Args:
+        flow_service: FlowService instance for flow operations
+        branch: Target branch name
+
+    Returns:
+        Tuple of (flow status, issue number)
+
+    Raises:
+        UserError: If no flow exists or no linked issue
+    """
+    from vibe3.exceptions import UserError
+
+    flow = flow_service.get_flow_status(branch)
+
+    if not flow:
+        raise UserError(
+            f"No flow for branch '{branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first."
+        )
+
+    issue_number = flow.task_issue_number
+
+    if not issue_number:
+        raise UserError(
+            f"No issue linked to flow '{branch}'.\n"
+            "Run 'vibe3 flow bind <issue>' first."
+        )
+
+    return flow, issue_number
+
+
 REVIEWER_ROLE = TriggerableRoleDefinition(
     name="reviewer",
     registry_role="reviewer",

--- a/src/vibe3/roles/run.py
+++ b/src/vibe3/roles/run.py
@@ -17,6 +17,7 @@ from vibe3.agents.run_prompt import (
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.settings import VibeConfig
+from vibe3.exceptions import UserError
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
 from vibe3.execution.contracts import ExecutionRequest
@@ -36,7 +37,39 @@ from vibe3.execution.session_service import load_session_id
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.roles.definitions import TriggerableRoleDefinition
+from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_failure_service import fail_executor_issue
+
+
+def validate_run_prerequisites(
+    flow_service: FlowService,
+    target_branch: str,
+) -> tuple[Any, int | None]:
+    """Validate flow exists and return flow status with issue number.
+
+    Args:
+        flow_service: FlowService instance for flow operations
+        target_branch: Target branch name
+
+    Returns:
+        Tuple of (flow status, issue number)
+
+    Raises:
+        UserError: If no flow exists for branch
+    """
+    from vibe3.models.flow import FlowStatusResponse
+
+    flow: FlowStatusResponse | None = flow_service.get_flow_status(target_branch)
+
+    if not flow:
+        raise UserError(
+            f"No flow for branch '{target_branch}'.\n"
+            "Run 'vibe3 flow update' or 'vibe3 flow bind <issue> --role task' first."
+        )
+
+    issue_number: int | None = flow.task_issue_number
+    return flow, issue_number
+
 
 EXECUTOR_ROLE = TriggerableRoleDefinition(
     name="executor",

--- a/src/vibe3/services/handoff_status_service.py
+++ b/src/vibe3/services/handoff_status_service.py
@@ -1,0 +1,146 @@
+"""Handoff status aggregation service."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from vibe3.clients.git_client import GitClient
+from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.models.flow import FlowEvent, FlowState
+from vibe3.models.verdict import VerdictRecord
+from vibe3.services.flow_service import FlowService
+from vibe3.services.handoff_service import HandoffService
+from vibe3.services.verdict_service import VerdictService
+
+
+@dataclass
+class HandoffStatusResult:
+    """Aggregated handoff status from multiple sources.
+
+    Attributes:
+        flow_slug: Flow identifier
+        worktree_root: Worktree path for the branch
+        state: Flow state from database
+        events: List of successful handoff events
+        latest_verdict: Latest verdict record if available
+        live_sessions: List of truly live runtime sessions
+    """
+
+    flow_slug: str
+    worktree_root: str | None
+    state: FlowState
+    events: list[FlowEvent]
+    latest_verdict: VerdictRecord | None
+    live_sessions: list[dict[str, Any]]
+
+
+class HandoffStatusService:
+    """Service for aggregating handoff status from multiple sources.
+
+    This service encapsulates the status aggregation logic that was previously
+    scattered across command layer (handoff_read.py), bringing together:
+    - Flow state retrieval
+    - Handoff events
+    - Verdict lookup
+    - Live session registry query
+    - Worktree path resolution
+    """
+
+    store: SQLiteClient
+    git_client: GitClient
+    flow_service: FlowService
+    handoff_service: HandoffService
+    verdict_service: VerdictService
+    session_registry: SessionRegistryService | None
+
+    def __init__(
+        self,
+        store: SQLiteClient | None = None,
+        git_client: GitClient | None = None,
+        flow_service: FlowService | None = None,
+    ) -> None:
+        """Initialize handoff status service.
+
+        Args:
+            store: SQLiteClient instance for database access
+            git_client: GitClient instance for git operations
+            flow_service: FlowService instance for flow operations
+        """
+        self.store = store or SQLiteClient()
+        self.git_client = git_client or GitClient()
+        self.flow_service = flow_service or FlowService(
+            store=self.store, git_client=self.git_client
+        )
+        self.handoff_service = HandoffService(store=self.store)
+        self.verdict_service = VerdictService(store=self.store)
+
+        # Session registry requires backend; we'll instantiate on-demand
+        # to avoid coupling to CodeagentBackend at construction time
+        self.session_registry = None
+
+    def get_handoff_status(
+        self, branch: str, limit: int | None = 5
+    ) -> HandoffStatusResult:
+        """Aggregate handoff status from multiple sources.
+
+        Args:
+            branch: Target branch name
+            limit: Maximum number of handoff events to retrieve (None = all)
+
+        Returns:
+            Aggregated handoff status result
+
+        Raises:
+            ValueError: If no flow exists for branch
+        """
+        state = self.flow_service.get_flow_state(branch)
+        if not state:
+            raise ValueError(f"No flow for branch '{branch}'")
+
+        # Fetch handoff events
+        events = self.handoff_service.get_success_handoff_events(branch, limit=limit)
+
+        # Fetch latest verdict
+        latest_verdict = self.verdict_service.get_latest_verdict(branch)
+
+        # Fetch live sessions from registry
+        live_sessions = self._get_live_sessions_for_branch(branch)
+
+        # Resolve worktree path for the target branch
+        worktree_path = self.git_client.find_worktree_path_for_branch(branch)
+        if worktree_path:
+            worktree_root = str(worktree_path)
+        else:
+            # Fallback: if branch has no dedicated worktree, use current
+            worktree_root = self.git_client.get_worktree_root()
+
+        return HandoffStatusResult(
+            flow_slug=state.flow_slug,
+            worktree_root=worktree_root,
+            state=state,
+            events=events,
+            latest_verdict=latest_verdict,
+            live_sessions=live_sessions,
+        )
+
+    def _get_live_sessions_for_branch(self, branch: str) -> list[dict[str, Any]]:
+        """Return truly live runtime sessions from the registry for a branch.
+
+        This method instantiates SessionRegistryService with CodeagentBackend
+        on-demand to confirm tmux liveness for each session.
+
+        Args:
+            branch: Branch name to filter sessions by
+
+        Returns:
+            List of session dicts that are truly live
+        """
+        from vibe3.agents.backends.codeagent import CodeagentBackend
+
+        if self.session_registry is None:
+            backend = CodeagentBackend()
+            self.session_registry = SessionRegistryService(
+                store=self.store, backend=backend
+            )
+
+        return self.session_registry.get_truly_live_sessions_for_branch(branch)

--- a/tests/vibe3/commands/test_handoff_commands_advanced.py
+++ b/tests/vibe3/commands/test_handoff_commands_advanced.py
@@ -29,36 +29,27 @@ class TestHandoffAdvancedCommands:
             == "vibe3 handoff show --branch task/issue-123 docs/plans/test-plan.md"
         )
 
-    @patch("vibe3.commands.handoff_read.VerdictService")
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_renders_current_md_via_handoff_show(
         self,
         mock_flow_service_cls,
-        mock_handoff_service_cls,
-        mock_verdict_service_cls,
+        mock_status_service_cls,
         tmp_path,
     ):
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "task/issue-467"
-        mock_flow_service.get_git_common_dir.return_value = "/tmp/repo/.git"
-        mock_flow_service.git_client.find_worktree_path_for_branch.return_value = (
-            "/tmp/repo/.worktrees/task/issue-467"
-        )
-        mock_flow_service.git_client.get_worktree_root.return_value = (
-            "/tmp/repo/.worktrees/wt-claude-v3"
-        )
-        mock_flow_service.store = MagicMock()
-        mock_flow_service.get_flow_state.return_value = MagicMock(flow_slug="issue-467")
         mock_flow_service_cls.return_value = mock_flow_service
 
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_handoff_events.return_value = []
-        mock_handoff_service_cls.return_value = mock_handoff_service
-
-        mock_verdict_service = MagicMock()
-        mock_verdict_service.get_latest_verdict.return_value = None
-        mock_verdict_service_cls.return_value = mock_verdict_service
+        mock_status_service = MagicMock()
+        mock_status_result = MagicMock()
+        mock_status_result.flow_slug = "issue-467"
+        mock_status_result.worktree_root = "/tmp/repo/.worktrees/task/issue-467"
+        mock_status_result.events = []
+        mock_status_result.latest_verdict = None
+        mock_status_result.live_sessions = []
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_status_service_cls.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status", "task/issue-467"])
 

--- a/tests/vibe3/commands/test_handoff_commands_basic.py
+++ b/tests/vibe3/commands/test_handoff_commands_basic.py
@@ -35,36 +35,42 @@ class TestHandoffBasicCommands:
             force=expected_force
         )
 
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_command(
-        self, mock_flow_service_class, mock_handoff_service_class
+        self, mock_flow_service_class, mock_status_service_class
     ):
         """Test handoff status command shows agent chain and events."""
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
-        mock_flow_service.get_flow_state.return_value = FlowState(
+        mock_flow_service_class.return_value = mock_flow_service
+
+        mock_status_service = MagicMock()
+        mock_status_result = MagicMock()
+        mock_status_result.flow_slug = "feature-test"
+        mock_status_result.worktree_root = "/path/to/worktree"
+        mock_status_result.state = FlowState(
             branch="feature/test",
             flow_slug="feature-test",
             flow_status="active",
         )
-        mock_flow_service.get_git_common_dir.return_value = "/path/to/.git"
-        mock_flow_service_class.return_value = mock_flow_service
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_success_handoff_events.return_value = []
-        mock_handoff_service_class.return_value = mock_handoff_service
+        mock_status_result.events = []
+        mock_status_result.latest_verdict = None
+        mock_status_result.live_sessions = []
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_status_service_class.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status"])
 
         assert result.exit_code == 0
         assert "Handoff" in result.output
-        mock_flow_service.get_flow_state.assert_called_once()
-        mock_handoff_service.get_success_handoff_events.assert_called_once()
+        mock_flow_service.get_current_branch.assert_called_once()
+        mock_status_service.get_handoff_status.assert_called_once()
 
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_numeric_issue_resolves_branch(
-        self, mock_flow_service_class, mock_handoff_service_class
+        self, mock_flow_service_class, mock_status_service_class
     ):
         """handoff status 436 should resolve to task/dev issue branch."""
         mock_flow_service = MagicMock()
@@ -73,17 +79,28 @@ class TestHandoffBasicCommands:
             if branch == "task/issue-436"
             else None
         )
-        mock_flow_service.get_git_common_dir.return_value = "/path/to/.git"
         mock_flow_service_class.return_value = mock_flow_service
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_success_handoff_events.return_value = []
-        mock_handoff_service_class.return_value = mock_handoff_service
+
+        mock_status_service = MagicMock()
+        mock_status_result = MagicMock()
+        mock_status_result.flow_slug = "issue-436"
+        mock_status_result.worktree_root = "/path/to/worktree"
+        mock_status_result.state = FlowState(
+            branch="task/issue-436",
+            flow_slug="issue-436",
+            flow_status="active",
+        )
+        mock_status_result.events = []
+        mock_status_result.latest_verdict = None
+        mock_status_result.live_sessions = []
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_status_service_class.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status", "436"])
 
         assert result.exit_code == 0
         mock_flow_service.get_flow_state.assert_any_call("task/issue-436")
-        mock_handoff_service.get_success_handoff_events.assert_called_once_with(
+        mock_status_service.get_handoff_status.assert_called_once_with(
             "task/issue-436", limit=5
         )
 
@@ -192,24 +209,33 @@ class TestHandoffBasicCommands:
         assert result.exit_code != 0
         assert "not a file" in result.output.lower()
 
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_format_json(
-        self, mock_flow_service_class, mock_handoff_service_class
+        self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --format json outputs JSON."""
+        from vibe3.services.handoff_status_service import HandoffStatusResult
+
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
-        mock_flow_service.get_flow_state.return_value = FlowState(
-            branch="feature/test",
-            flow_slug="feature-test",
-            flow_status="active",
-        )
-        mock_flow_service.get_git_common_dir.return_value = "/path/to/.git"
         mock_flow_service_class.return_value = mock_flow_service
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_success_handoff_events.return_value = []
-        mock_handoff_service_class.return_value = mock_handoff_service
+
+        mock_status_service = MagicMock()
+        mock_status_result = HandoffStatusResult(
+            flow_slug="feature-test",
+            worktree_root=None,
+            state=FlowState(
+                branch="feature/test",
+                flow_slug="feature-test",
+                flow_status="active",
+            ),
+            events=[],
+            latest_verdict=None,
+            live_sessions=[],
+        )
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_handoff_status_service_class.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status", "--format", "json"])
 
@@ -221,24 +247,33 @@ class TestHandoffBasicCommands:
         assert "events" in output
         assert output["state"]["branch"] == "feature/test"
 
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_format_yaml(
-        self, mock_flow_service_class, mock_handoff_service_class
+        self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --format yaml outputs YAML."""
+        from vibe3.services.handoff_status_service import HandoffStatusResult
+
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
-        mock_flow_service.get_flow_state.return_value = FlowState(
-            branch="feature/test",
-            flow_slug="feature-test",
-            flow_status="active",
-        )
-        mock_flow_service.get_git_common_dir.return_value = "/path/to/.git"
         mock_flow_service_class.return_value = mock_flow_service
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_success_handoff_events.return_value = []
-        mock_handoff_service_class.return_value = mock_handoff_service
+
+        mock_status_service = MagicMock()
+        mock_status_result = HandoffStatusResult(
+            flow_slug="feature-test",
+            worktree_root=None,
+            state=FlowState(
+                branch="feature/test",
+                flow_slug="feature-test",
+                flow_status="active",
+            ),
+            events=[],
+            latest_verdict=None,
+            live_sessions=[],
+        )
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_handoff_status_service_class.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status", "--format", "yaml"])
 
@@ -247,24 +282,33 @@ class TestHandoffBasicCommands:
         assert "events:" in result.output
         assert "branch: feature/test" in result.output
 
-    @patch("vibe3.commands.handoff_read.HandoffService")
+    @patch("vibe3.commands.handoff_read.HandoffStatusService")
     @patch("vibe3.commands.handoff_read.FlowService")
     def test_handoff_status_deprecated_json_flag(
-        self, mock_flow_service_class, mock_handoff_service_class
+        self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --json shows deprecation warning."""
+        from vibe3.services.handoff_status_service import HandoffStatusResult
+
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
-        mock_flow_service.get_flow_state.return_value = FlowState(
-            branch="feature/test",
-            flow_slug="feature-test",
-            flow_status="active",
-        )
-        mock_flow_service.get_git_common_dir.return_value = "/path/to/.git"
         mock_flow_service_class.return_value = mock_flow_service
-        mock_handoff_service = MagicMock()
-        mock_handoff_service.get_success_handoff_events.return_value = []
-        mock_handoff_service_class.return_value = mock_handoff_service
+
+        mock_status_service = MagicMock()
+        mock_status_result = HandoffStatusResult(
+            flow_slug="feature-test",
+            worktree_root=None,
+            state=FlowState(
+                branch="feature/test",
+                flow_slug="feature-test",
+                flow_status="active",
+            ),
+            events=[],
+            latest_verdict=None,
+            live_sessions=[],
+        )
+        mock_status_service.get_handoff_status.return_value = mock_status_result
+        mock_handoff_status_service_class.return_value = mock_status_service
 
         result = runner.invoke(app, ["handoff", "status", "--json"])
 


### PR DESCRIPTION
## Summary
- Extracted business logic from `handoff_read.py`, `run.py`, and `review.py` commands into services and roles following PR #345 pattern
- Created `HandoffStatusService` to encapsulate handoff status aggregation logic
- Added validation functions in `roles/run.py` and `roles/review.py` for better separation of concerns
- Preserved all CLI output contracts and error messages for backward compatibility

## Changes
| File | Change | Lines |
|------|--------|-------|
| `src/vibe3/services/handoff_status_service.py` | NEW: HandoffStatusService + HandoffStatusResult | +146 |
| `src/vibe3/commands/handoff_read.py` | Simplified status() to delegate aggregation | -39 |
| `src/vibe3/roles/run.py` | NEW: validate_run_prerequisites() | +33 |
| `src/vibe3/commands/run.py` | Uses role validation, removes inline checks | -6 |
| `src/vibe3/roles/review.py` | NEW: validate_review_prerequisites() | +38 |
| `src/vibe3/commands/review.py` | Uses role validation, removes inline checks | -13 |
| `tests/.../test_handoff_commands_*.py` | Updated mocks for HandoffStatusService | ~50 |

## Verification
- ✅ All tests pass (56/56 incremental tests)
- ✅ Mypy clean (284 source files)
- ✅ Ruff clean
- ✅ CLI output contracts preserved (JSON/YAML formats, UI rendering)

## Related
- Closes #349
- Follows pattern from PR #345 (flow/check refactoring)
- Part of tech-debt initiative for thin command layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)