### PR TITLE
fix: add type annotations to domain event bus API

### DIFF
--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -8,6 +8,8 @@ This module provides domain events for all execution layers:
 Reference: docs/standards/vibe3-worktree-ownership-standard.md §二
 """
 
+from typing import TYPE_CHECKING, Callable
+
 from vibe3.domain.events import (
     # Base
     DomainEvent,
@@ -27,6 +29,9 @@ from vibe3.domain.events import (
     SupervisorPromptRendered,
 )
 
+if TYPE_CHECKING:
+    from vibe3.domain.publisher import EventPublisher
+
 
 def register_event_handlers() -> None:
     """Register domain event handlers lazily to avoid import cycles."""
@@ -37,21 +42,21 @@ def register_event_handlers() -> None:
     _register_event_handlers()
 
 
-def get_publisher():  # type: ignore[no-untyped-def]
+def get_publisher() -> "EventPublisher":
     """Return the global domain event publisher lazily."""
     from vibe3.domain.publisher import get_publisher as _get_publisher
 
     return _get_publisher()
 
 
-def publish(event):  # type: ignore[no-untyped-def]
+def publish(event: DomainEvent) -> None:
     """Publish a domain event lazily."""
     from vibe3.domain.publisher import publish as _publish
 
     return _publish(event)
 
 
-def subscribe(event_type, handler):  # type: ignore[no-untyped-def]
+def subscribe(event_type: str, handler: "Callable[[DomainEvent], None]") -> None:
     """Subscribe a handler lazily."""
     from vibe3.domain.publisher import subscribe as _subscribe
 

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -236,7 +236,7 @@ class OrchestrationFacade(ServiceBase):
             to_state=to_state,
         ).info("Emitting IssueStateChanged event")
 
-        publish(event)  # type: ignore[no-untyped-call]
+        publish(event)
 
     def on_heartbeat_tick(self) -> None:
         """Heartbeat polling -> 发布 GovernanceScanStarted 事件.
@@ -280,7 +280,7 @@ class OrchestrationFacade(ServiceBase):
             domain="orchestration_facade",
             tick_count=self._tick_count,
         ).info("Emitting GovernanceScanStarted event")
-        publish(event)  # type: ignore[no-untyped-call]
+        publish(event)
 
     def on_governance_decision(
         self,
@@ -348,4 +348,4 @@ class OrchestrationFacade(ServiceBase):
                 issue_number=event.issue_number,
                 supervisor_file=event.supervisor_file,
             ).info("Supervisor candidate found, publishing SupervisorIssueIdentified")
-            publish(event)  # type: ignore[no-untyped-call]
+            publish(event)


### PR DESCRIPTION
## Summary
- Added type annotations to domain event bus API functions (get_publisher, publish, subscribe)
- Removed all `# type: ignore` comments from event bus functions and call sites
- Used TYPE_CHECKING block to prevent circular imports

## Test plan
- ✅ mypy passes on src/vibe3/ (283 files)
- ✅ mypy --strict passes on changed files
- ✅ Domain event tests pass (57/57)
- ✅ No remaining `type: ignore` comments on event bus calls

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)