### PR TITLE
feat(flow): mark waiting-review on pr ready and allow flow create in that state

### DIFF
--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -21,6 +21,7 @@ class SQLiteFlowStateRepo:
         "audit_ref",
         "indicate_ref",
         "pr_ref",  # PR URL as proof of PR creation
+        "pr_ready_marked_at",  # Timestamp when PR was marked ready
         "planner_actor",
         "executor_actor",
         "reviewer_actor",

--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -38,7 +38,8 @@ _CREATE_FLOW_STATE = """
         reviewer_status TEXT,
         execution_pid INTEGER,
         execution_started_at TEXT,
-        execution_completed_at TEXT
+        execution_completed_at TEXT,
+        pr_ready_marked_at TEXT
     )
 """
 
@@ -262,6 +263,13 @@ def init_schema(conn: sqlite3.Connection) -> None:
         cursor.execute("ALTER TABLE flow_state ADD COLUMN indicate_ref TEXT")
         logger.bind(external="sqlite", operation="migration").info(
             "Added indicate_ref column to flow_state"
+        )
+
+    # Migration: add pr_ready_marked_at column for waiting-review state tracking
+    if "pr_ready_marked_at" not in existing:
+        cursor.execute("ALTER TABLE flow_state ADD COLUMN pr_ready_marked_at TEXT")
+        logger.bind(external="sqlite", operation="migration").info(
+            "Added pr_ready_marked_at column to flow_state"
         )
 
     # Migration: migrate existing blocked_by data to new fields

--- a/src/vibe3/execution/flow_dispatch.py
+++ b/src/vibe3/execution/flow_dispatch.py
@@ -68,7 +68,15 @@ class FlowManager:
             ).warning(f"Flow branch '{branch}' missing in git — rejecting as stale")
             return False
 
-        return str(flow.get("flow_status") or "active") not in {
+        # A flow is "reusable" if not terminal AND not waiting for PR review
+        flow_status = str(flow.get("flow_status") or "active")
+        pr_ready_marked_at = flow.get("pr_ready_marked_at")
+
+        # If waiting for review, don't reuse - create new flow for different issue
+        if pr_ready_marked_at is not None and flow_status == "active":
+            return False
+
+        return flow_status not in {
             "done",
             "aborted",
             "stale",

--- a/src/vibe3/models/flow.py
+++ b/src/vibe3/models/flow.py
@@ -62,6 +62,7 @@ class FlowState(BaseModel):
     report_ref: str | None = None
     audit_ref: str | None = None
     pr_ref: str | None = None  # PR URL as proof of PR creation
+    pr_ready_marked_at: str | None = None  # Timestamp when PR was marked ready
     planner_actor: str | None = None
     executor_actor: str | None = None
     reviewer_actor: str | None = None
@@ -232,6 +233,7 @@ class FlowStatusResponse(BaseModel):
     pr_number: int | None = None
     pr_ref: str | None = None  # PR URL as proof of PR creation
     pr_ready_for_review: bool = False
+    pr_ready_marked_at: str | None = None  # Timestamp when PR was marked ready
     spec_ref: str | None = None
     plan_ref: str | None = None
     report_ref: str | None = None
@@ -321,6 +323,7 @@ class FlowStatusResponse(BaseModel):
                 if pr_ready is not None
                 else bool(data.get("pr_ready_for_review"))
             ),
+            pr_ready_marked_at=data.get("pr_ready_marked_at"),
             spec_ref=data.get("spec_ref"),
             plan_ref=data.get("plan_ref"),
             report_ref=data.get("report_ref"),

--- a/src/vibe3/services/flow_service.py
+++ b/src/vibe3/services/flow_service.py
@@ -1,8 +1,11 @@
 """Flow service implementation."""
 
+from typing import Any
+
 from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.config.settings import VibeConfig
+from vibe3.models.flow import FlowState
 from vibe3.services.flow_block_mixin import FlowLifecycleMixin
 from vibe3.services.flow_transition import FlowTransitionMixin
 from vibe3.utils.git_path_client import GitPathProtocol
@@ -49,3 +52,24 @@ class FlowService(FlowLifecycleMixin, FlowTransitionMixin):
             Current branch name
         """
         return self.git_client.get_current_branch()
+
+    def is_flow_waiting_review(self, flow_state: FlowState | dict[str, Any]) -> bool:
+        """Check if flow is waiting for PR review.
+
+        A flow is "waiting review" if:
+        - pr_ready_marked_at is set (PR was marked ready)
+        - flow_status is 'active' (not done/stale/aborted)
+
+        Args:
+            flow_state: Flow state dict or FlowState model
+
+        Returns:
+            True if flow is waiting for review
+        """
+        if isinstance(flow_state, FlowState):
+            marked_at = flow_state.pr_ready_marked_at
+            status = flow_state.flow_status
+        else:
+            marked_at = flow_state.get("pr_ready_marked_at")
+            status = flow_state.get("flow_status", "active")
+        return marked_at is not None and status == "active"

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -209,7 +209,15 @@ class PRService:
         is_already_ready: bool = False,
     ) -> None:
         """Finalize PR ready state: sync, briefing, and AI reviews."""
+        from datetime import datetime
+
         self._sync_pr_flow_state(pr_for_sync, actor=actor)
+
+        # Mark flow as waiting for review
+        self.store.update_flow_state(
+            pr_for_sync.head_branch,
+            pr_ready_marked_at=datetime.now().isoformat(),
+        )
 
         try:
             self.briefing_service.publish_briefing(

--- a/tests/vibe3/execution/test_flow_dispatch_waiting_review.py
+++ b/tests/vibe3/execution/test_flow_dispatch_waiting_review.py
@@ -1,0 +1,163 @@
+"""Tests for flow dispatch with waiting-review flows.
+
+Tests the scenario where:
+1. Flow F1 exists on worktree W with PR marked ready (pr_ready_marked_at set)
+2. New flow F2 for different issue should be allowed to create on W
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vibe3.execution.flow_dispatch import FlowManager
+from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models.orchestration import IssueInfo, IssueState
+
+
+@pytest.fixture
+def mock_store():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_git():
+    git = MagicMock()
+    git.branch_exists.return_value = True
+    git.find_worktree_path_for_branch.return_value = None
+    git.create_branch_ref.return_value = None
+    return git
+
+
+@pytest.fixture
+def mock_github():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock()
+    registry.count_live_worker_sessions.return_value = 0
+    return registry
+
+
+@pytest.fixture
+def flow_manager(mock_store, mock_git, mock_github, mock_registry):
+    config = OrchestraConfig(repo="test/repo", max_concurrent_flows=5)
+    return FlowManager(
+        config,
+        store=mock_store,
+        git=mock_git,
+        github=mock_github,
+        registry=mock_registry,
+    )
+
+
+class TestWaitingReviewFlowNotReusable:
+    """Test _is_reusable_auto_flow with waiting-review flows."""
+
+    def test_waiting_review_flow_not_reusable(self, flow_manager, mock_store, mock_git):
+        """Flow with pr_ready_marked_at should not be reusable."""
+        mock_git.branch_exists.return_value = True
+
+        # Flow with PR ready marker
+        waiting_flow = {
+            "branch": "task/issue-123",
+            "flow_status": "active",
+            "pr_ready_marked_at": "2026-05-02T10:00:00",
+        }
+
+        is_reusable = flow_manager._is_reusable_auto_flow(
+            waiting_flow, issue_number=123
+        )
+
+        # Should return False (not reusable) - allows new flow creation
+        assert is_reusable is False
+
+    def test_active_flow_without_marker_is_reusable(
+        self, flow_manager, mock_store, mock_git
+    ):
+        """Active flow without PR ready marker should be reusable."""
+        mock_git.branch_exists.return_value = True
+
+        # Active flow without marker
+        active_flow = {
+            "branch": "task/issue-456",
+            "flow_status": "active",
+        }
+
+        is_reusable = flow_manager._is_reusable_auto_flow(active_flow, issue_number=456)
+
+        # Should return True (reusable) - blocks new flow creation
+        assert is_reusable is True
+
+    def test_done_flow_not_reusable(self, flow_manager, mock_store, mock_git):
+        """Done flow should not be reusable."""
+        mock_git.branch_exists.return_value = True
+
+        done_flow = {
+            "branch": "task/issue-789",
+            "flow_status": "done",
+            "pr_ready_marked_at": "2026-05-02T10:00:00",
+        }
+
+        is_reusable = flow_manager._is_reusable_auto_flow(done_flow, issue_number=789)
+
+        assert is_reusable is False
+
+
+class TestCreateFlowAllowsWaitingReview:
+    """Test create_flow_for_issue allows new flow when existing is waiting review."""
+
+    def test_new_flow_allowed_when_waiting_review_exists(
+        self, flow_manager, mock_store, mock_git, mock_registry
+    ):
+        """New flow creation for different issue should succeed when existing
+        flow is waiting review."""
+        # NEW issue #888 (different from existing flow for #999)
+        new_issue = IssueInfo(
+            number=888,
+            title="New task",
+            state=IssueState.READY,
+            labels=["state/ready"],
+        )
+
+        # Existing flow for issue #999 with PR ready marker (waiting review)
+        existing_flow = {
+            "branch": "task/issue-999",
+            "flow_slug": "issue-999",
+            "flow_status": "active",
+            "pr_ready_marked_at": "2026-05-02T10:00:00",
+        }
+
+        # Mock returns NO flows for the new issue #888
+        mock_store.get_flows_by_issue.return_value = []
+
+        # Mock returns the waiting-review flow when checking available
+        # worktrees. This simulates: worktree has a waiting-review flow,
+        # can be reused for new issue.
+        mock_store.get_all_flows.return_value = [existing_flow]
+
+        mock_git.branch_exists.return_value = False
+        mock_git.find_worktree_path_for_branch.return_value = None
+
+        # Mock capacity check
+        mock_registry.count_live_worker_sessions.return_value = 0
+
+        # Mock create_flow - should be called for the NEW issue #888
+        with patch.object(flow_manager.flow_service, "create_flow") as mock_create:
+            mock_create.return_value = MagicMock(
+                branch="task/issue-888",
+                flow_slug="issue-888",
+                model_dump=lambda: {
+                    "branch": "task/issue-888",
+                    "flow_slug": "issue-888",
+                },
+            )
+
+            # Should create new flow for issue #888
+            result = flow_manager.create_flow_for_issue(new_issue)
+
+            # Result should be the newly created flow
+            assert result is not None
+            # create_flow should have been called for the new issue
+            mock_create.assert_called_once()

--- a/tests/vibe3/services/test_flow_service.py
+++ b/tests/vibe3/services/test_flow_service.py
@@ -136,3 +136,57 @@ class TestFlowServiceAbort:
         assert mock_store.add_event.called
         event_call = mock_store.add_event.call_args
         assert event_call[0][1] == "flow_reactivated"
+
+
+class TestFlowServiceWaitingReview:
+    """Tests for is_flow_waiting_review helper."""
+
+    def test_waiting_review_detects_marked_flow(self, mock_store, mock_git):
+        """Test is_flow_waiting_review returns True for flow with marker."""
+        service = FlowService(store=mock_store, git_client=mock_git)
+
+        flow_dict = {
+            "branch": "task/issue-123",
+            "flow_status": "active",
+            "pr_ready_marked_at": "2026-05-02T10:00:00",
+        }
+
+        assert service.is_flow_waiting_review(flow_dict) is True
+
+    def test_waiting_review_false_without_marker(self, mock_store, mock_git):
+        """Test is_flow_waiting_review returns False without marker."""
+        service = FlowService(store=mock_store, git_client=mock_git)
+
+        flow_dict = {
+            "branch": "task/issue-123",
+            "flow_status": "active",
+        }
+
+        assert service.is_flow_waiting_review(flow_dict) is False
+
+    def test_waiting_review_false_for_non_active_status(self, mock_store, mock_git):
+        """Test is_flow_waiting_review returns False for non-active flow."""
+        service = FlowService(store=mock_store, git_client=mock_git)
+
+        flow_dict = {
+            "branch": "task/issue-123",
+            "flow_status": "done",
+            "pr_ready_marked_at": "2026-05-02T10:00:00",
+        }
+
+        assert service.is_flow_waiting_review(flow_dict) is False
+
+    def test_waiting_review_works_with_flow_state_model(self, mock_store, mock_git):
+        """Test is_flow_waiting_review works with FlowState model instance."""
+        from vibe3.models.flow import FlowState
+
+        service = FlowService(store=mock_store, git_client=mock_git)
+
+        flow_state = FlowState(
+            branch="task/issue-123",
+            flow_slug="issue-123",
+            flow_status="active",
+            pr_ready_marked_at="2026-05-02T10:00:00",
+        )
+
+        assert service.is_flow_waiting_review(flow_state) is True

--- a/tests/vibe3/services/test_pr_service.py
+++ b/tests/vibe3/services/test_pr_service.py
@@ -361,3 +361,43 @@ def test_mark_ready_handles_loc_comment_failure(
     # Verify PR was still marked ready despite LOC error
     gh_instance.mark_ready.assert_called_once_with(123)
     assert result.draft is False
+
+
+def test_mark_ready_writes_pr_ready_marked_at(
+    pr_service: PRService, no_conflict_git: MagicMock
+) -> None:
+    """Test mark_ready writes pr_ready_marked_at timestamp."""
+    gh_instance = pr_service.github_client
+    mock_pr = PRResponse(
+        number=123,
+        title="Test PR",
+        body="Test body",
+        state=PRState.OPEN,
+        head_branch="feature-branch",
+        base_branch="main",
+        url="https://github.com/org/repo/pull/123",
+        draft=True,
+    )
+
+    gh_instance.check_auth.return_value = True
+    gh_instance.get_pr.return_value = mock_pr
+    gh_instance.mark_ready.return_value = mock_pr.model_copy(update={"draft": False})
+    mock_store = MagicMock()
+    mock_store.get_issue_links.return_value = []
+
+    with patch.object(pr_service, "git_client", no_conflict_git):
+        with patch.object(pr_service, "store", mock_store):
+            pr = pr_service.mark_ready(123)
+
+            assert pr.number == 123
+            # Verify update_flow_state was called with pr_ready_marked_at
+            calls = mock_store.update_flow_state.call_args_list
+            # Find the call that includes pr_ready_marked_at
+            found_marker = False
+            for call in calls:
+                kwargs = call.kwargs
+                if "pr_ready_marked_at" in kwargs:
+                    found_marker = True
+                    assert kwargs["pr_ready_marked_at"] is not None
+                    break
+            assert found_marker, "pr_ready_marked_at should be written to flow state"


### PR DESCRIPTION
## Summary

Add `pr_ready_marked_at` timestamp field to mark flows as "waiting for review" after `pr ready` is called. Update flow creation logic to allow new flows on the same worktree when the existing flow is waiting for review.

## Changes

- Add `pr_ready_marked_at` field to `FlowState` and `FlowStatusResponse` models
- Add field to `VALID_FLOW_STATE_FIELDS` for SQLite storage
- Add schema migration for `pr_ready_marked_at` column
- Update `pr_service` to write timestamp after `pr ready`
- Add `is_flow_waiting_review()` helper in `flow_service`
- Update `_is_reusable_auto_flow()` to check marker and allow new flow creation
- Add comprehensive tests for waiting-review flow behavior

## Test plan

- [x] All integration tests pass (25 tests)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Pre-push checks pass (173 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)