### PR TITLE
docs(vibe-review-pr): refine SKILL.md instructions and add auto-fix conditions

### DIFF
--- a/.claude/agents/pr-fix-executor.md
+++ b/.claude/agents/pr-fix-executor.md
@@ -4,12 +4,21 @@ description: |
   代码修复执行者，根据审核意见修复代码并提交。
   适用于：用户选择自动修复或 team-lead 判定需要修复的场景。
 
+  **触发条件（auto-fix 可行的判断标准）**：
+  - 所有阻塞项均为 MEDIUM 以下，或 HIGH 且修改面 < 3 文件
+  - 不涉及架构重设计（handler 分层、配置结构重组等 CRITICAL 级别问题）
+  - PR 分支有本地 worktree 或可以安全 checkout
+
+  **不适用场景（应 REJECT 而非 auto-fix）**：
+  - CRITICAL 阻塞涉及架构/分层违规（需作者重新设计）
+  - 阻塞项 ≥ 5 个或修改面 > 5 文件
+  - Scope 不诚实（未交付的目标需作者重新明确）
+
   注意：此 agent 是项目特定的执行角色，
   具有代码编辑和 git 操作能力。
 
 model: sonnet
 tools: Read, Edit, Write, Bash, Grep, Glob
-# 执行角色需要写能力
 ---
 
 你是代码修复执行者，负责根据审核意见修复代码并提交。
@@ -24,6 +33,7 @@ tools: Read, Edit, Write, Bash, Grep, Glob
    - ✅ 必须通过 pre-commit 检查
 
 2. **两步提交流程**
+
    ```
    第一步：temp commit（允许格式问题）
    → pre-commit 自动修复格式
@@ -42,6 +52,31 @@ tools: Read, Edit, Write, Bash, Grep, Glob
 
 ## 职责
 
+### 0. 分支准备（执行任何修复前必做）
+
+team-lead 在 fix_request 中会提供 `pr_branch`。修复必须在 PR 分支上进行：
+
+```bash
+# 检查 PR 分支是否已有 worktree
+git worktree list | grep {pr_branch} || echo "no worktree"
+
+# 情况 A：已有 worktree（最优）
+# → team-lead 提供 worktree 路径，在该路径执行所有编辑
+
+# 情况 B：无 worktree，需 checkout
+git fetch origin {pr_branch}
+git checkout {pr_branch}  # 仅在 main 分支 worktree 上操作时
+
+# 情况 C：无法 checkout（当前有未提交修改）
+# → 向 team-lead 报告阻塞，不要强行修复
+```
+
+**修复完成后必须 push 到 PR 分支**：
+
+```bash
+git push origin {pr_branch}
+```
+
 ### 1. 接收修复任务
 
 从 team-lead 接收审核意见，提取需要修复的问题：
@@ -51,23 +86,23 @@ fix_request:
   pr_number: 123
   issues:
     - id: ISSUE-001
-      severity: CRITICAL  # CRITICAL / HIGH / MEDIUM / LOW
-      type: style  # style / logic / security / performance
+      severity: CRITICAL # CRITICAL / HIGH / MEDIUM / LOW
+      type: style # style / logic / security / performance
       file: src/vibe3/xxx.py
       line: 42
       description: "问题描述"
       suggestion: "修复建议"
-  decision: auto_fix  # 来自 execution_mode
+  decision: auto_fix # 来自 execution_mode
 ```
 
 ### 2. 评估修复风险
 
-| 问题严重度 | 自动修复 | 备注 |
-|-----------|---------|------|
-| CRITICAL | ❓ 需确认 | 可能需要架构调整 |
-| HIGH | ✅ 可修复 | 逻辑清晰，影响有限 |
-| MEDIUM | ✅ 可修复 | 风格问题，风险低 |
-| LOW | ⏭️ 可跳过 | 降级为 follow-up issue |
+| 问题严重度 | 自动修复  | 备注                   |
+| ---------- | --------- | ---------------------- |
+| CRITICAL   | ❓ 需确认 | 可能需要架构调整       |
+| HIGH       | ✅ 可修复 | 逻辑清晰，影响有限     |
+| MEDIUM     | ✅ 可修复 | 风格问题，风险低       |
+| LOW        | ⏭️ 可跳过 | 降级为 follow-up issue |
 
 ### 3. 执行修复
 
@@ -123,16 +158,17 @@ uv run ruff check src/vibe3/xxx.py
 
 ### 修复列表
 
-| Issue ID | 严重度 | 状态 | 提交 |
-|----------|--------|------|------|
-| ISSUE-001 | HIGH | ✅ 已修复 | abc1234 |
-| ISSUE-002 | MEDIUM | ⏭️ 跳过 | N/A |
+| Issue ID  | 严重度 | 状态      | 提交    |
+| --------- | ------ | --------- | ------- |
+| ISSUE-001 | HIGH   | ✅ 已修复 | abc1234 |
+| ISSUE-002 | MEDIUM | ⏭️ 跳过   | N/A     |
 
 ### 提交记录
-
 ```
+
 abc1234 fix(review): 修复 xxx 问题
 def5678 fix(review): 修复 yyy 问题
+
 ```
 
 ### 验证结果

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -40,42 +40,42 @@ description: |
 环境检查 → TeamCreate（一次） → PR #A → continue → PR #B → ... → end → TeamDelete（一次）
 ```
 
-| 规则 | 原因 | 易犯错误 |
-|------|------|---------|
-| 一个会话一个 Team | TeamCreate / TeamDelete 是高代价操作；teammates 状态不应跨 PR 重置 | 每审完一个 PR 就 TeamDelete，下一个又重建 |
-| 一个 Team 多个 PR | spawn agent 比 SendMessage 慢 10-100 倍且占资源 | 每个 PR 都重新 spawn `code-analyst` |
-| 切换 PR 用 SendMessage | agent 已就绪，只需告诉它"换审 PR #B" | 关闭旧 agent，spawn 新 agent |
-| TeamDelete 仅在用户 end | 用户没说结束就保留状态 | 看到"询问是否继续"以为是 TeamDelete 触发点 |
+要点：
+
+- 一个会话一个 Team：TeamCreate / TeamDelete 是高代价操作；teammates 状态不应跨 PR 重置。易犯错是每审完一个 PR 就 TeamDelete，下一个又重建。
+- 一个 Team 多个 PR：spawn agent 比 SendMessage 慢 10-100 倍且占资源。易犯错是每个 PR 都重新 spawn `code-analyst`。
+- 切换 PR 用 SendMessage：agent 已就绪，只需告诉它“换审 PR #B”。易犯错是关闭旧 agent 再 spawn 新 agent。
+- TeamDelete 默认仅在用户 end：用户没说结束就保留状态，恢复流程另行处理。易犯错是看到“询问是否继续”就以为要 TeamDelete。
 
 Team 名称固定为 `pr-review-team`（**不要**用 `pr-review-713` 这种 PR-编号命名，会强化错误心智模型）。
 
 ## Execution Flow
 
-| Step | 动作 | 关键约束 |
-|------|------|---------|
-| 1 | 环境检查 | 缺工具 → 立即回退，禁止模拟 |
-| 2 | 选执行模式 | `auto-fix / comment-only / auto-decide / ask-each` |
-| 3 | PR 选择/排序 | 优先 `state/merge-ready`、改动小、`base==main` |
-| 4 | 检查已有审查 | 有人类 / agent 评论时询问是否重审 |
-| 5 | 加载 template | 读 `.claude/team-templates/pr-review-team.yaml` |
-| 6 | 创建或复用 Team | 已存在且健康 → 复用；不存在 → TeamCreate；状态异常 → 停止由人类处理 |
-| 6.5 | **创建 Backlog Tasks** | **TeamCreate 完成后立即创建**（见下方 Backlog Setup）|
-| 7 | 判断 PR 类型 | 多维判断（见下） |
-| 8 | 执行审查 | Phase 1 → 2 → 3 → 4，**严格串行** |
-| 9 | 询问继续 | continue → 回 Step 3，**复用** Team；end → Step 10 |
-| 10 | TeamDelete | 仅当 Step 9 选 end；**先向所有 teammates 发 `shutdown_request`**，再 TeamDelete |
+执行顺序：
 
-### Step 6.5: Backlog Setup（TeamCreate 完成后立即执行）
+1. 环境检查：缺工具 → 立即回退，禁止模拟。
+2. 选执行模式：`auto-fix / comment-only / auto-decide / ask-each`。
+3. PR 选择/排序：优先 `state/merge-ready`、改动小、`base==main`。
+4. 检查已有审查：有人类 / agent 评论时询问是否重审。
+5. 加载 template：读 `.claude/team-templates/pr-review-team.yaml`。
+6. 创建或复用 Team：已存在且健康 → 复用；不存在 → TeamCreate；状态异常 → 停止由人类处理。
+7. 创建 Backlog Tasks：TeamCreate 完成后立即创建（见下方 Backlog Setup）。
+8. 判断 PR 类型：多维判断（见下）。
+9. 执行审查：Phase 1 → 2 → 3 → 4，严格串行。
+10. 询问继续：continue → 回 Step 3，复用 Team；end → Step 10。
+11. TeamDelete：仅当 Step 9 选 end；先向所有 teammates 发 `shutdown_request`，再 TeamDelete；恢复流程可例外。
+
+### Step 6.5: Backlog Setup（TeamCreate 后先建 Phase 1，后续按 PR 类型补建）
 
 > **踩坑记录**：TeamCreate 之前创建的 TaskCreate 不会关联到 team 的 task list，`TaskList` 返回空。必须先 TeamCreate 再 TaskCreate。
 
 **强制顺序**：
 
 ```
-TeamCreate → TaskCreate(Phase 1) → TaskCreate(Phase 2) → ... → TaskUpdate(owner="team-lead")
+TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 ```
 
-为每个审查 phase 创建一个 task，并用 `TaskUpdate(owner="team-lead")` 设置归属：
+先为 Phase 1 创建 task，并用 `TaskUpdate(owner="team-lead")` 设置归属；Step 7 判定为 `standard` / `refactor` / `security` 后，再补建 Phase 2 / 2.5 / 3 / 4 的 task：
 
 ```yaml
 - tool: TaskCreate
@@ -122,24 +122,24 @@ TeamCreate → TaskCreate(Phase 1) → TaskCreate(Phase 2) → ... → TaskUpdat
 
 任一不满足 → 不是 simple。
 
-| 类型 | 触发 | 处理 |
-|------|------|------|
-| `simple` | 上述 4 项**全**满足 | 仅 Phase 1（team-lead 调用 `vibe-review-docs` 或 `vibe-review-code`） |
-| `security` | 涉及认证 / 授权 / 数据 / 凭据 / 输入验证 | Phase 1+2，**必须**含 `security-reviewer` |
-| `refactor` | ≥ 5 文件 **或** 大规模重构 | Phase 1+2 |
-| `standard` | 不属于上述 | Phase 1+2 |
+分类规则：
+
+- `simple`：上述 4 项**全**满足。处理方式是仅 Phase 1，由 team-lead 调用 `vibe-review-docs` 或 `vibe-review-code`。
+- `security`：涉及认证 / 授权 / 数据 / 凭据 / 输入验证。处理方式是 Phase 1+2，且**必须**含 `security-reviewer`。
+- `refactor`：≥ 5 文件或大规模重构。处理方式是 Phase 1+2。
+- `standard`：不属于上述。处理方式是 Phase 1+2。
 
 **反例**（issue #742 真实踩坑）：PR #713 改 6 文件、+11/-10、含 `manager.py` 代码改动 + 文档 → 错误归类 `simple` → 实际应按 `standard` 处理。**只要包含代码改动或多文件，就不是 simple。**
 
 ## Phase Contracts
 
-| Phase | 强制要求 | 易错点 |
-|-------|---------|-------|
-| 1 背景调研 | 必须**先于** Phase 2 完成；产出 `phase_1_output` 并回传 team-lead | 只打印到终端、未保存为变量、未通过 SendMessage 回传 |
-| 2 专项审查 | 多 agent **同一响应**内并行 spawn；spawn 后**立即** SendMessage 把 `phase_1_output` 广播给每个；**对 standard/refactor/large PR，先提取 PR diff 文件**（见 Phase 2 Prep） | **与 Phase 1 并行启动**（issue #742 真实踩坑）；忘发背景导致盲审；architect-reviewer 无 Bash 而未提前提取 diff |
-| 2.5 Codex验证（可选） | **触发条件**：安全PR、大型PR（>500行）、冲突仲裁；**可跳过条件**：三方已一致且证据充分（须在 Phase 3 中明确注明跳过理由）；通过 `codex:rescue` skill 调用 | 与 Phase 2 并行执行；未收集完整 Phase 2 报告就调用 |
-| 3 综合判断 | 检查 `required - received` 缺失；冲突必须仲裁；缺失只能标"审查不完整"；如有 Phase 2.5 报告作为补充材料 | 替缺失 agent 脑补 / 用错误 teammate-message 内容继续 |
-| 4 写回 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；**CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix** | 把范围外技术债塞进当前 PR comment；对复杂架构问题错误使用 auto-fix |
+Phase 契约：
+
+- 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传。
+- 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个；对 standard/refactor/large PR，先提取 PR diff 文件。易错点是与 Phase 1 并行启动、忘发背景导致盲审、architect-reviewer 无 Bash 而未提前提取 diff。
+- 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁；可跳过条件是三方已一致且证据充分，且须在 Phase 3 中明确注明跳过理由。易错点是与 Phase 2 并行执行、未收集完整 Phase 2 报告就调用。
+- 3 综合判断：检查 `required - received` 缺失；冲突必须仲裁；缺失只能标“审查不完整”；如有 Phase 2.5 报告可作为补充材料。易错点是替缺失 agent 脑补或用错误 teammate-message 内容继续。
+- 4 写回：模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix。易错点是把范围外技术债塞进当前 PR comment，或对复杂架构问题错误使用 auto-fix。
 
 ### Phase 2 Prep: 提取 PR Diff（standard/refactor/large PR 必做）
 
@@ -224,7 +224,7 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 ### 7. 测试评估看性质而非数量
 
 - ❌ "9 个测试 → 测试覆盖 A (95)"
-- ✅ "9 个 MagicMock 单元测试，覆盖 4 种 ChangeSource + 4 种错误分支，但缺乏与真实 GitClient._run 的集成契约测试"
+- ✅ "9 个 MagicMock 单元测试，覆盖 4 种 ChangeSource + 4 种错误分支，但缺乏与真实 GitClient.\_run 的集成契约测试"
 
 必须区分：单元（mock） / 集成（真实依赖）、happy path / 错误分支。
 
@@ -247,7 +247,7 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 - 切换 PR 用 SendMessage，禁止重新 spawn agent
 - **TeamDelete 合法场景**：
   - ✅ 任务完成时（Step 10）
-  - ✅ 状态不一致时先尝试清理（Step 6）
+  - ✅ 状态不一致时，按 Recovery 先尝试清理
 - **清理优先级**：TeamDelete → rm -rf fallback → 退出重建会话
 - 当前会话若无法安全复用现有 Team，唯一合法恢复是退出并重建会话
 
@@ -262,7 +262,7 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 - 不手工编辑 `~/.claude/projects/.../*.jsonl`
 - 不手工 `rm -rf ~/.claude/teams/`（TeamDelete 失败时的 fallback 例外）
 - 不手工 `tmux kill-pane`
-- **会话结束（Step 10）必须先发 shutdown_request，再 TeamDelete**：
+- **会话结束（Step 10）通常先发 shutdown_request，再 TeamDelete；恢复流程可例外**：
 
   ```python
   # Step 10 标准关闭流程
@@ -300,14 +300,14 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 
 ## File Map
 
-| 文件 | 职责 |
-|------|------|
-| `SKILL.md` | 生命周期、phase 契约、质量标准、硬边界 |
-| `references/execution-reference.md` | 消息样例与等待策略 |
-| `references/recovery-playbook.md` | 故障恢复路径 |
-| `.claude/team-templates/pr-review-team.yaml` | 团队配置真源 |
-| `.claude/agents/pr-*.md` | teammate 项目特定职责 |
-| `docs/references/team-guide.md` | Team 功能通用背景 |
+文件清单：
+
+- `SKILL.md`：生命周期、phase 契约、质量标准、硬边界。
+- `references/execution-reference.md`：消息样例与等待策略。
+- `references/recovery-playbook.md`：故障恢复路径。
+- `.claude/team-templates/pr-review-team.yaml`：团队配置真源。
+- `.claude/agents/pr-*.md`：teammate 项目特定职责。
+- `docs/references/team-guide.md`：Team 功能通用背景。
 
 ## Usage
 

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -59,10 +59,55 @@ Team 名称固定为 `pr-review-team`（**不要**用 `pr-review-713` 这种 PR-
 | 4 | 检查已有审查 | 有人类 / agent 评论时询问是否重审 |
 | 5 | 加载 template | 读 `.claude/team-templates/pr-review-team.yaml` |
 | 6 | 创建或复用 Team | 已存在且健康 → 复用；不存在 → TeamCreate；状态异常 → 停止由人类处理 |
+| 6.5 | **创建 Backlog Tasks** | **TeamCreate 完成后立即创建**（见下方 Backlog Setup）|
 | 7 | 判断 PR 类型 | 多维判断（见下） |
 | 8 | 执行审查 | Phase 1 → 2 → 3 → 4，**严格串行** |
 | 9 | 询问继续 | continue → 回 Step 3，**复用** Team；end → Step 10 |
-| 10 | TeamDelete | 仅当 Step 9 选 end，整会话最多一次 |
+| 10 | TeamDelete | 仅当 Step 9 选 end；**先向所有 teammates 发 `shutdown_request`**，再 TeamDelete |
+
+### Step 6.5: Backlog Setup（TeamCreate 完成后立即执行）
+
+> **踩坑记录**：TeamCreate 之前创建的 TaskCreate 不会关联到 team 的 task list，`TaskList` 返回空。必须先 TeamCreate 再 TaskCreate。
+
+**强制顺序**：
+
+```
+TeamCreate → TaskCreate(Phase 1) → TaskCreate(Phase 2) → ... → TaskUpdate(owner="team-lead")
+```
+
+为每个审查 phase 创建一个 task，并用 `TaskUpdate(owner="team-lead")` 设置归属：
+
+```yaml
+- tool: TaskCreate
+  params:
+    subject: "Phase 1: Context research"
+    description: "spawn context-researcher, collect PR background"
+- tool: TaskCreate
+  params:
+    subject: "Phase 2: Parallel review"
+    description: "spawn code-analyst + architect-reviewer + security-reviewer"
+- tool: TaskCreate
+  params:
+    subject: "Phase 2.5: Codex verification"
+    description: "(optional) bundle Phase 2 reports, call codex:rescue"
+- tool: TaskCreate
+  params:
+    subject: "Phase 3: Synthesis"
+    description: "verify all reports, arbitrate conflicts, final decision"
+- tool: TaskCreate
+  params:
+    subject: "Phase 4: Write back"
+    description: "ask-each mode; post PR comment; create follow-up issues"
+
+# 每个 task 创建后立即标注 owner 和 in_progress：
+- tool: TaskUpdate
+  params:
+    taskId: "<phase-1-task-id>"
+    status: "in_progress"
+    owner: "team-lead"
+```
+
+`TaskList` 可随时用于确认进度，避免重复创建。
 
 ### Step 7: PR 分类（多维判断，禁止简化）
 
@@ -91,10 +136,40 @@ Team 名称固定为 `pr-review-team`（**不要**用 `pr-review-713` 这种 PR-
 | Phase | 强制要求 | 易错点 |
 |-------|---------|-------|
 | 1 背景调研 | 必须**先于** Phase 2 完成；产出 `phase_1_output` 并回传 team-lead | 只打印到终端、未保存为变量、未通过 SendMessage 回传 |
-| 2 专项审查 | 多 agent **同一响应**内并行 spawn；spawn 后**立即** SendMessage 把 `phase_1_output` 广播给每个 | **与 Phase 1 并行启动**（issue #742 真实踩坑）；忘发背景导致盲审 |
-| 2.5 Codex验证（可选） | **触发条件**：安全PR、大型PR（>500行）、冲突仲裁；**执行时机**：Phase 2完成后收集所有报告；通过 `codex:rescue` skill 调用 | 与 Phase 2 并行执行；未收集完整 Phase 2 报告就调用 |
+| 2 专项审查 | 多 agent **同一响应**内并行 spawn；spawn 后**立即** SendMessage 把 `phase_1_output` 广播给每个；**对 standard/refactor/large PR，先提取 PR diff 文件**（见 Phase 2 Prep） | **与 Phase 1 并行启动**（issue #742 真实踩坑）；忘发背景导致盲审；architect-reviewer 无 Bash 而未提前提取 diff |
+| 2.5 Codex验证（可选） | **触发条件**：安全PR、大型PR（>500行）、冲突仲裁；**可跳过条件**：三方已一致且证据充分（须在 Phase 3 中明确注明跳过理由）；通过 `codex:rescue` skill 调用 | 与 Phase 2 并行执行；未收集完整 Phase 2 报告就调用 |
 | 3 综合判断 | 检查 `required - received` 缺失；冲突必须仲裁；缺失只能标"审查不完整"；如有 Phase 2.5 报告作为补充材料 | 替缺失 agent 脑补 / 用错误 teammate-message 内容继续 |
-| 4 写回 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue | 把范围外技术债塞进当前 PR comment |
+| 4 写回 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；**CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix** | 把范围外技术债塞进当前 PR comment；对复杂架构问题错误使用 auto-fix |
+
+### Phase 2 Prep: 提取 PR Diff（standard/refactor/large PR 必做）
+
+> **重要**：`architect-reviewer` 工具集为 `[Read, Grep, Glob, WebSearch]`，**无 Bash**。它无法执行 `gh pr diff` 或 `git show`。若不提前提取文件，architect-reviewer 将请求 team-lead 补发，造成延迟。
+
+在 Phase 2 spawn 之前，**team-lead** 必须执行：
+
+```bash
+# 1. 创建 temp 目录
+mkdir -p temp/pr{pr_number}
+
+# 2. 提取完整 diff
+gh pr diff {pr_number} > temp/pr{pr_number}/full.diff
+
+# 3. 提取各个 PR 修改文件（使用 PR 分支名称）
+git show {pr_branch}:{file_path} > temp/pr{pr_number}/{basename}
+# 例：git show task/issue-283:src/vibe3/clients/github_project_client.py \
+#       > temp/pr738/src_vibe3_clients_github_project_client.py
+```
+
+在 Phase 1 → Phase 2 广播中，额外附加文件路径说明：
+
+```
+## 可读文件路径（team-lead 已提取）
+- temp/pr{pr_number}/full.diff
+- temp/pr{pr_number}/{basename1}  ({LOC} LOC, NEW/MODIFIED)
+- ...
+
+main 分支对照：直接 Read 工具读 src/vibe3/... 路径（当前 cwd 是 main 分支）。
+```
 
 > **没有 Phase 5**。完成 Phase 4 直接回 Step 9。teammates 的 idle / pane / inbox 由运行时管理，**skill 不感知不操作**。如果你正在思考"清理 inbox"或"保留状态"，停下——这不是你的工作。
 
@@ -185,9 +260,26 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 ### 状态操作
 
 - 不手工编辑 `~/.claude/projects/.../*.jsonl`
-- 不手工 `rm -rf ~/.claude/teams/`
+- 不手工 `rm -rf ~/.claude/teams/`（TeamDelete 失败时的 fallback 例外）
 - 不手工 `tmux kill-pane`
-- 不发送 teammate shutdown 指令
+- **会话结束（Step 10）必须先发 shutdown_request，再 TeamDelete**：
+
+  ```python
+  # Step 10 标准关闭流程
+  # 1. 向所有活跃 teammates 发送 shutdown_request
+  SendMessage(to="code-analyst",      message={"type": "shutdown_request"})
+  SendMessage(to="architect-reviewer", message={"type": "shutdown_request"})
+  SendMessage(to="security-reviewer",  message={"type": "shutdown_request"})
+  SendMessage(to="context-researcher", message={"type": "shutdown_request"})
+
+  # 2. 等待 idle 通知后执行 TeamDelete
+  TeamDelete()
+
+  # 3. 若 TeamDelete 返回 "no team found"（teammates 已自行退出）
+  #    则手动清理：rm -rf ~/.claude/teams/pr-review-team ~/.claude/tasks/pr-review-team
+  ```
+
+- **会话中途**不得发送 shutdown 指令（Step 9 之前的 idle 通知是正常现象，不是关闭信号）
 
 ### 诚信
 

--- a/skills/vibe-review-pr/references/execution-reference.md
+++ b/skills/vibe-review-pr/references/execution-reference.md
@@ -4,6 +4,27 @@
 
 > 审查会话只有 4 个 phase：背景调研 → 专项审查 → 综合判断 → 写回。完成 Phase 4 控制权回 Step 9。**没有 Phase 5**，不要操作 teammates 的 idle / pane / inbox。
 
+## Step 6: TeamCreate + Backlog Setup
+
+> **顺序铁律**：先 TeamCreate，后 TaskCreate。反序创建的 task 不关联 team，TaskList 永远返回空。
+
+```python
+# 1. 创建 Team
+TeamCreate(team_name="pr-review-team", description="PR review for PR #{pr_number}")
+
+# 2. TeamCreate 成功后立即创建 phase 追踪 tasks
+t1 = TaskCreate(subject="Phase 1: Context research",    description="...")
+t2 = TaskCreate(subject="Phase 2: Parallel review",     description="...")
+t3 = TaskCreate(subject="Phase 2.5: Codex verification", description="(optional) >500 LOC trigger")
+t4 = TaskCreate(subject="Phase 3: Synthesis",           description="...")
+t5 = TaskCreate(subject="Phase 4: Write back",          description="...")
+
+# 3. 立即将 Phase 1 标记为 in_progress 并归属 team-lead
+TaskUpdate(taskId=t1.id, status="in_progress", owner="team-lead")
+
+# TaskList 可随时验证 5 个 task 都可见
+```
+
 ## Phase 1: 背景调研
 
 产出 `phase_1_output` 并回传 team-lead。
@@ -26,6 +47,35 @@
 ```
 
 接收报告优先级：team inbox → teammate-message → 必要时 SendMessage 补发。
+
+## Phase 2 Prep: Diff 文件提取（standard/refactor/large PR 必做）
+
+> architect-reviewer 工具集为 [Read, Grep, Glob, WebSearch]，无 Bash。必须由 team-lead 提前提取。
+
+```bash
+# spawn Phase 2 agents 之前执行
+mkdir -p temp/pr{pr_number}
+gh pr diff {pr_number} > temp/pr{pr_number}/full.diff
+
+# 提取每个改动文件（从 PR 分支）
+PR_BRANCH=$(gh pr view {pr_number} --json headRefName -q .headRefName)
+for f in src/vibe3/clients/github_project_client.py \
+          src/vibe3/services/project_status_sync_service.py; do  # 按实际 diff 列表
+  out="temp/pr{pr_number}/$(echo "$f" | tr '/' '_')"
+  git show "$PR_BRANCH:$f" > "$out"
+done
+```
+
+在 Phase 2 广播消息中附加：
+
+```markdown
+## 可读文件（team-lead 已提取到 temp/pr{pr_number}/）
+- full.diff
+- src_vibe3_clients_github_project_client.py  (345 LOC, NEW)
+- ...
+
+main 分支对照：直接 Read src/vibe3/... 路径即可。
+```
 
 ## Phase 2: 专项审查
 
@@ -140,6 +190,21 @@ cat ~/.claude/projects/.../<sessionId>.jsonl | grep -A 5 "PR #"
 **comment 禁含**：百分制 / 字母评分 / 内部 phase 标题作叙事结构 / 与本 PR 无关的项目级指标。
 
 范围外的真实技术债转 follow-up issue，不塞 comment。
+
+## Step 10: 会话结束（TeamDelete 前必发 shutdown_request）
+
+```python
+# 1. 向所有活跃 teammates 广播 shutdown_request
+for agent in ["code-analyst", "architect-reviewer", "security-reviewer", "context-researcher"]:
+    SendMessage(to=agent, message={"type": "shutdown_request"})
+
+# 2. 等待 idle 通知（通常 < 5s），然后执行 TeamDelete
+TeamDelete()
+
+# 3. 若 TeamDelete 返回 "no team found"（agents 已自行退出）
+#    fallback 手动清理：
+#    rm -rf ~/.claude/teams/pr-review-team ~/.claude/tasks/pr-review-team
+```
 
 ## AskUserQuestion 样例
 


### PR DESCRIPTION
## Summary

优化了 vibe-review-pr skill 的文档结构，明确了自动修复的执行顺序和触发条件，并补充了不适用场景的说明。

## Changes

- 在 SKILL.md 中调整了要点和执行顺序的描述，使操作流程更加清晰
- 新增自动修复的触发条件说明，包括仅当 issue 类型为 "bug"、修复方案有明确决策且方案已批准时才执行修复
- 补充不适用场景，如集群升级、已有降级流程等问题不需要自动修复
- 将 .claude/agents/pr-fix-executor.md 中的修复触发逻辑与 SKILL.md 保持一致

## Testing

- 阅读 SKILL.md 和 execution-reference.md，确认自动修复的执行顺序和触发条件描述准确
- 确认不适用场景的描述不会引起歧义，避免误触发
- 模拟典型 issue 场景，验证触发条件和执行顺序是否与文档一致