### PR TITLE
docs(vibe-review-pr): improve multi-agent PR review workflow documentation

### DIFF
--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -22,6 +22,8 @@ description: |
 
 任一缺失 → 立即停止，按文件范围回退到单 agent 审查。
 
+> **tmux 机制说明**：`TMUX` 已设置是前置条件，因为 `Agent(team_name=...)` 会由 Claude Code 运行时**自动**在当前 tmux session 中创建新 pane 来运行 teammate。team-lead **不需要**手动执行 tmux 命令管理 pane——pane 的创建、复用、销毁全部由运行时处理。team-lead 只通过 `SendMessage` 和接收 teammate-message 与 teammates 通信。
+
 ## Must Read
 
 启动前读取：
@@ -137,7 +139,7 @@ Phase 契约：
 
 - 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传。
 - 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个；对 standard/refactor/large PR，先提取 PR diff 文件。易错点是与 Phase 1 并行启动、忘发背景导致盲审、architect-reviewer 无 Bash 而未提前提取 diff。
-- 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁；可跳过条件是三方已一致且证据充分，且须在 Phase 3 中明确注明跳过理由。易错点是与 Phase 2 并行执行、未收集完整 Phase 2 报告就调用。
+- 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁。**⚠️ 升级规则：若 Phase 2 报告不完整（有 agent 超时/限流/未回报），且 PR 满足触发条件（large_pr / security），Phase 2.5 从「可选」升级为「强制」——用 Codex 独立复查补偿缺失报告，不能直接跳到 Phase 3。** 可跳过条件（仅当 Phase 2 三方报告**全部到齐**时）：三方结论一致且证据充分，须在 Phase 3 明确注明跳过理由。易错点是与 Phase 2 并行执行、Phase 2 不完整却以"跳过"理由绕过 Codex。
 - 3 综合判断：检查 `required - received` 缺失；冲突必须仲裁；缺失只能标“审查不完整”；如有 Phase 2.5 报告可作为补充材料。易错点是替缺失 agent 脑补或用错误 teammate-message 内容继续。
 - 4 写回：模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix。易错点是把范围外技术债塞进当前 PR comment，或对复杂架构问题错误使用 auto-fix。
 

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -137,7 +137,7 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 
 Phase 契约：
 
-- 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传。
+- 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。**team-lead 等待期间只允许执行 context_bundle 中定义的 shell 基础命令（gh pr view、CI 状态等）并将结果传给 context-researcher，禁止自行做深度代码分析（读 diff、读源码、分析架构）——这是 context-researcher 的专属职责。** 易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传；以及 team-lead 在等待期间"顺手"自己做分析，导致 Phase 1 产出变成 team-lead 的个人研究而非 context-researcher 的独立调研。
 - 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个；对 standard/refactor/large PR，先提取 PR diff 文件。易错点是与 Phase 1 并行启动、忘发背景导致盲审、architect-reviewer 无 Bash 而未提前提取 diff。
 - 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁。**⚠️ 升级规则：若 Phase 2 报告不完整（有 agent 超时/限流/未回报），且 PR 满足触发条件（large_pr / security），Phase 2.5 从「可选」升级为「强制」——用 Codex 独立复查补偿缺失报告，不能直接跳到 Phase 3。** 可跳过条件（仅当 Phase 2 三方报告**全部到齐**时）：三方结论一致且证据充分，须在 Phase 3 明确注明跳过理由。易错点是与 Phase 2 并行执行、Phase 2 不完整却以"跳过"理由绕过 Codex。
 - 3 综合判断：检查 `required - received` 缺失；冲突必须仲裁；缺失只能标“审查不完整”；如有 Phase 2.5 报告可作为补充材料。易错点是替缺失 agent 脑补或用错误 teammate-message 内容继续。


### PR DESCRIPTION
## Summary

- 添加 tmux 机制说明，明确 pane 自动管理，team-lead 无需手动操作
- 明确 Phase 2.5 升级规则：当 Phase 2 不完整且 PR 满足触发条件时，Codex 验证从可选升级为强制
- 禁止 team-lead 在 Phase 1 等待期间进行深度代码分析，确保 context-researcher 的独立调研职责

## Changes

这两个 commit 改进了 `vibe-review-pr` skill 的文档，解决了多 agent PR 审查流程中的三个关键问题：

1. **tmux pane 管理**：明确说明 `Agent(team_name=...)` 会自动创建和管理 pane，team-lead 只需通过 `SendMessage` 通信
2. **Phase 2.5 强制验证**：添加升级规则，防止 Phase 2 报告不完整时错误跳过 Codex 验证
3. **Phase 1 角色边界**：明确禁止 team-lead 在等待期间"顺手"做 context-researcher 的工作，保证多 agent 设计的有效性

## Context

基于 PR #759 的多 agent 审查实践发现的问题：

- Phase 1 文档只描述了 context-researcher 的输出要求，未明确 team-lead 的行为边界
- team-lead 容易在等待期间自行做深度分析，导致 Phase 1 产出变成 team-lead 个人研究
- tmux pane 管理机制需要明确说明，避免 team-lead 手动管理
- Phase 2 不完整时的验证流程需要更严格的规则

🤖 Generated with [Claude Code](https://claude.com/claude-code)