### PR TITLE
优化 PR 审查 workflow：Architect 自主性 + Task Lifecycle

### DIFF
--- a/.claude/agents/pr-architect-reviewer.md
+++ b/.claude/agents/pr-architect-reviewer.md
@@ -9,9 +9,8 @@ description: |
   增加了 PR 特定的价值评估和时效性检查。
 
 model: opus
-tools: Read, Grep, Glob, WebSearch, SendMessage
+tools: Read, Grep, Glob, WebSearch, Bash, SendMessage
 extends: architect  # 继承全局 architect 的基础能力
-# 安全限制：此 agent 无 Bash 工具，仅做架构评估
 ---
 
 你是架构审查专家，负责评估 PR 对项目架构的影响。
@@ -22,7 +21,7 @@ extends: architect  # 继承全局 architect 的基础能力
 
 **重要**：审查分支和开发分支不同，需要从 PR 获取开发分支上下文。
 
-你没有 Bash 工具，不直接执行 `gh` 或 `uv run`。Team-lead 必须先收集并传入 context bundle：
+Team-lead 应先提供基础 context bundle；你可以直接使用 Bash 获取所需 diff、提交历史和目标文件内容。
 
 ```yaml
 context_bundle:
@@ -34,6 +33,7 @@ context_bundle:
 ```
 
 如果 `handoff_status` 不可用，自动 flow 分支使用 `issue_comments` 和 `pr_info` 作为 fallback；人机合作分支使用 `pr_info`、`pr_comments` 和人类 review 意见作为真源。不要读取 `.git/vibe3` 共享文件。
+你可以直接使用 Bash 获取所需 diff、提交历史和目标文件内容。
 
 阅读关键架构文档：
 - `SOUL.md` — 项目宪法和核心原则
@@ -274,18 +274,13 @@ Tier 3 (Policies) <-> Tier 2 (Skills) <-> Tier 1 (Shell)
 
 ## 工作协议（强制）
 
-### 1. 必须等待背景信息
+### 1. 先确认背景到达方式
 
-**在开始工作前**，必须先收到 team-lead 通过 SendMessage 发送的 Phase 1 背景报告。
+初次 spawn 审查当前 PR 时，背景已在初始 prompt 中提供；无需等待额外 SendMessage。
 
-**等待机制**：
-- 你被 spawn 后进入等待状态
-- Team-lead 会发送包含 PR 信息和 Phase 1 背景的消息
-- 收到背景后才能开始架构评估
-
-**如果未收到背景**：
-- 不要自行开始工作
-- 使用 SendMessage 向 team-lead 请求背景
+**复用场景**：
+- 切换到下一轮 PR 时，team-lead 会通过 SendMessage 下发新的背景
+- 如需补充额外上下文，可请求 team-lead 补发
 
 ### 2. 必须发送结果给 team-lead
 

--- a/.claude/agents/pr-code-analyst.md
+++ b/.claude/agents/pr-code-analyst.md
@@ -213,18 +213,13 @@ uv run python src/vibe3/cli.py snapshot diff --quiet
 
 ## 工作协议（强制）
 
-### 1. 必须等待背景信息
+### 1. 先确认背景到达方式
 
-**在开始工作前**，必须先收到 team-lead 通过 SendMessage 发送的 Phase 1 背景报告。
+初次 spawn 审查当前 PR 时，背景已在初始 prompt 中提供；无需等待额外 SendMessage。
 
-**等待机制**：
-- 你被 spawn 后进入等待状态
-- Team-lead 会发送包含 PR 信息和 Phase 1 背景的消息
-- 收到背景后才能开始分析
-
-**如果未收到背景**：
-- 不要自行开始工作
-- 使用 SendMessage 向 team-lead 请求背景
+**复用场景**：
+- 切换到下一轮 PR 时，team-lead 会通过 SendMessage 下发新的背景
+- 如需补充额外上下文，可请求 team-lead 补发
 
 ### 2. 必须发送结果给 team-lead
 

--- a/.claude/agents/pr-security-reviewer.md
+++ b/.claude/agents/pr-security-reviewer.md
@@ -218,18 +218,13 @@ uv run python src/vibe3/cli.py snapshot diff --quiet
 
 ## 工作协议（强制）
 
-### 1. 必须等待背景信息
+### 1. 先确认背景到达方式
 
-**在开始工作前**，必须先收到 team-lead 通过 SendMessage 发送的 Phase 1 背景报告。
+初次 spawn 审查当前 PR 时，背景已在初始 prompt 中提供；无需等待额外 SendMessage。
 
-**等待机制**：
-- 你被 spawn 后进入等待状态
-- Team-lead 会发送包含 PR 信息和 Phase 1 背景的消息
-- 收到背景后才能开始安全评估
-
-**如果未收到背景**：
-- 不要自行开始工作
-- 使用 SendMessage 向 team-lead 请求背景
+**复用场景**：
+- 切换到下一轮 PR 时，team-lead 会通过 SendMessage 下发新的背景
+- 如需补充额外上下文，可请求 team-lead 补发
 
 ### 2. 必须发送结果给 team-lead
 

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -191,7 +191,7 @@ agents:
     model: opus
     description: 架构审查专家，评估 PR 对项目架构的影响
     spawn_config:
-      tools: [Read, Grep, Glob, WebSearch]
+      tools: [Read, Grep, Glob, WebSearch, Bash]
       run_in_background: true  # Phase 2 可并行
     output_format:
       required_fields: [结论, 置信度, 关键发现]
@@ -319,6 +319,13 @@ workflow:
 
             ## PR #{pr_number} 背景报告
             {phase_1_output}
+
+            ## 获取 diff 指引
+            你可以使用 Bash 工具获取所需的 diff 数据：
+            - 完整 diff: `gh pr diff {pr_number}`
+            - 特定文件: `git show {pr_branch}:{file_path}`
+            - 提交历史: `git log --oneline {base_branch}..{pr_branch}`
+            - 改动统计: `git diff --stat {base_branch}...{pr_branch}`
 
             请基于以上背景评估架构影响。
           run_in_background: true

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -7,7 +7,7 @@
 # 3. 使用 Agent tool spawn teammate:
 #    Agent(team_name="pr-review-team", name="<agent-name>",
 #          subagent_type="<subagent_type>", model="<model>", prompt="<prompt>")
-# 4. 使用 SendMessage 在 teammates 间传递 context bundle
+# 4. fresh spawn 背景优先写入 prompt；复用 teammates 或补充上下文时再用 SendMessage
 # 5. Phase 4 由 team-lead 执行（当前 session），不需要 spawn
 
 name: pr-review-team
@@ -274,10 +274,10 @@ workflow:
       - step: save_phase_1_output
         action: |
           【关键步骤】将背景报告内容保存为 phase_1_output 变量
-          这是 Phase 2 SendMessage 的必要输入
+          这是 Phase 2 fresh spawn prompt / reuse SendMessage 的共同输入
           如果不保存，Phase 2 将无法获取背景信息
       - step: prepare_phase_2_context
-        action: 将背景报告通过 SendMessage 传给 Phase 2 agents
+        action: 保存背景，供 fresh spawn prompt 或复用 teammate 的 SendMessage 使用
 
   phase_2:
     name: 专项审查
@@ -285,16 +285,15 @@ workflow:
     parallel: true
     requires_phase_1_output: true
     message_passing: SendMessage
-    # 【关键】必须通过 SendMessage 将 Phase 1 背景传递给 Phase 2 agents
-    # 否则 Phase 2 将处于"盲审"状态，两阶段设计失去意义
+    # 【关键】fresh spawn 直接在 prompt 中携带 Phase 1 背景
+    # SendMessage 仅用于复用 teammate 或补发额外上下文，避免盲审
     # 执行指令
     execution:
       - step: spawn_code_analyst
         tool: Agent
         params:
           # 注意：parallel spawn 需要在单次响应中发起多个 Agent 调用
-          # 【修复】在 spawn prompt 中嵌入完整背景，避免 agent idle
-          # 实际执行发现：spawn 后 SendMessage 可能延迟，导致 agent 立即 idle
+          # 【修复】fresh spawn 时在 prompt 中直接内嵌背景，避免等待额外消息
           team_name: pr-review-team
           name: code-analyst
           subagent_type: pr-code-analyst
@@ -345,8 +344,8 @@ workflow:
             请基于以上背景评估安全性。
           run_in_background: true
 
-      # 【说明】不再需要 SendMessage，背景已在 spawn prompt 中传递
-      # 如果需要补充额外信息，可使用 SendMessage，但非必需
+      # 【说明】fresh spawn 的背景已在 prompt 中传递
+      # 如果需要补充额外信息或复用已有 teammate，可再使用 SendMessage
       - step: wait_for_phase_2_results
         action: |
           等待所有 Phase 2 agents 返回结果。
@@ -384,21 +383,23 @@ workflow:
         action: |
           判断是否触发Codex验证（两阶段判断）：
 
-          **第一阶段：PR 类型判断**
+          **第一阶段：PR 风险判断**
           满足以下任一条件：
           1. PR类型为 `security`
-          2. 改动行数 > 500 或影响关键架构
-
+          2. 改动行数 > 500 或影响关键架构（inspect base风险高）
+          3. Phase 3 出现需要第三方裁决的冲突
           **第二阶段：Phase 2 完整性判断**
           required_agents = [code-analyst, architect-reviewer, security-reviewer]
           检查是否有 agent 超时/未返回结果
 
           **最终触发条件**：
-          - 第一阶段 AND 第二阶段 都满足 → 执行 Phase 2.5
-          - 仅第一阶段满足 → 跳过 Phase 2.5，直接进入 Phase 3
-          - 仅第二阶段满足 → 跳过 Phase 2.5（非 security PR 不强制 Codex）
+          - 第一阶段满足且 Phase 2 完整 → Phase 2.5 保持可选
+          - 第一阶段满足且 Phase 2 不完整 → Phase 2.5 升级为强制
+          - 第一阶段不满足 → 跳过 Phase 2.5，直接进入 Phase 3
 
-          **注意**：SKILL.md 中的升级规则（"Phase 2 报告不完整且 security PR"）即此两阶段判断。
+          **注意**：
+          - "可选"保留给 security / large / conflict_arbitration 的独立复核场景
+          - "升级为强制"只适用于第一阶段已命中的高风险 PR
 
       - step: collect_phase_2_reports
         action: |
@@ -443,7 +444,7 @@ workflow:
           验证所有 Phase 2 agents 已返回报告：
 
           required_agents = ["code-analyst", "architect-reviewer", "security-reviewer"]
-          received_agents = [从 idle notifications 获取]
+          received_agents = [从 task-notification(status=completed) 获取]
 
           missing = set(required_agents) - set(received_agents)
           if missing:
@@ -452,7 +453,7 @@ workflow:
             # 重要：不要假设缺失的 agent 同意其他结论
 
       - step: collect_all_reports
-        action: 从 idle notifications 获取各 agent 报告
+        action: 从 task-notification（status=completed）收集各 agent 报告
       - step: detect_conflicts
         action: 对比各报告，找出差异点
       - step: arbitrate

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -293,13 +293,19 @@ workflow:
         tool: Agent
         params:
           # 注意：parallel spawn 需要在单次响应中发起多个 Agent 调用
-          # 【重要】prompt 中不要写 {phase_1_output} 占位符
-          # 实际背景通过 SendMessage 发送，而非在 spawn prompt 中
+          # 【修复】在 spawn prompt 中嵌入完整背景，避免 agent idle
+          # 实际执行发现：spawn 后 SendMessage 可能延迟，导致 agent 立即 idle
           team_name: pr-review-team
           name: code-analyst
           subagent_type: pr-code-analyst
           model: haiku
-          prompt: "分析 PR #{pr_number} 的代码质量。等待接收背景信息后开始分析。"
+          prompt: |
+            分析 PR #{pr_number} 的代码质量。
+
+            ## PR #{pr_number} 背景报告
+            {phase_1_output}
+
+            请基于以上背景分析代码质量。
           run_in_background: true
       - step: spawn_architect_reviewer
         tool: Agent
@@ -308,7 +314,13 @@ workflow:
           name: architect-reviewer
           subagent_type: pr-architect-reviewer
           model: sonnet
-          prompt: "评估 PR #{pr_number} 的架构影响。等待接收背景信息后开始评估。"
+          prompt: |
+            评估 PR #{pr_number} 的架构影响。
+
+            ## PR #{pr_number} 背景报告
+            {phase_1_output}
+
+            请基于以上背景评估架构影响。
           run_in_background: true
       - step: spawn_security_reviewer
         tool: Agent
@@ -317,35 +329,17 @@ workflow:
           name: security-reviewer
           subagent_type: pr-security-reviewer
           model: sonnet
-          prompt: "评估 PR #{pr_number} 的安全性。等待接收背景信息后开始评估。"
+          prompt: |
+            评估 PR #{pr_number} 的安全性。
+
+            ## PR #{pr_number} 背景报告
+            {phase_1_output}
+
+            请基于以上背景评估安全性。
           run_in_background: true
 
-      # 【关键步骤】使用 SendMessage 发送 Phase 1 背景给各 agent
-      # 这是规定动作，不可跳过！如果不发送，Phase 2 agents 无法获得背景信息
-      - step: send_context_to_phase_2
-        tool: SendMessage
-        params:
-          to: code-analyst
-          message: |
-            ## PR #{pr_number} 背景报告
-            {phase_1_output}
-            请基于以上背景分析代码质量。
-      - step: send_context_to_phase_2
-        tool: SendMessage
-        params:
-          to: architect-reviewer
-          message: |
-            ## PR #{pr_number} 背景报告
-            {phase_1_output}
-            请基于以上背景评估架构影响。
-      - step: send_context_to_phase_2
-        tool: SendMessage
-        params:
-          to: security-reviewer
-          message: |
-            ## PR #{pr_number} 背景报告
-            {phase_1_output}
-            请基于以上背景评估安全性。
+      # 【说明】不再需要 SendMessage，背景已在 spawn prompt 中传递
+      # 如果需要补充额外信息，可使用 SendMessage，但非必需
       - step: wait_for_phase_2_results
         action: |
           等待所有 Phase 2 agents 返回结果。
@@ -355,7 +349,15 @@ workflow:
           - architect-reviewer
           - security-reviewer
 
-          超时：5 分钟
+          **等待策略**：
+          1. 收到 idle 通知 → 不操作，继续等待（idle 是正常状态，不代表完成）
+          2. 收到 task-notification（status=completed）→ 读取结果
+          3. 超时（5 分钟）→ 标注"审查不完整"，进入 Phase 3
+
+          **重要**：
+          - idle 通知是 agent 的正常状态（等待输入），不代表"未开始"或"失败"
+          - 实际审查结果通过 task-notification 返回
+          - 不要在收到 idle 后立即 SendMessage 提示 agent 执行任务
 
           如果超时仍有 agent 未返回：
           - 记录 WARNING
@@ -373,12 +375,23 @@ workflow:
     execution:
       - step: check_trigger_conditions
         action: |
-          判断是否触发Codex验证：
-          1. PR类型为 `security`
-          2. 改动行数 > 500 或影响关键架构（inspect base风险高）
+          判断是否触发Codex验证（两阶段判断）：
 
-          满足任一条件 → 执行Phase 2.5
-          不满足 → 跳过，直接进入Phase 3
+          **第一阶段：PR 类型判断**
+          满足以下任一条件：
+          1. PR类型为 `security`
+          2. 改动行数 > 500 或影响关键架构
+
+          **第二阶段：Phase 2 完整性判断**
+          required_agents = [code-analyst, architect-reviewer, security-reviewer]
+          检查是否有 agent 超时/未返回结果
+
+          **最终触发条件**：
+          - 第一阶段 AND 第二阶段 都满足 → 执行 Phase 2.5
+          - 仅第一阶段满足 → 跳过 Phase 2.5，直接进入 Phase 3
+          - 仅第二阶段满足 → 跳过 Phase 2.5（非 security PR 不强制 Codex）
+
+          **注意**：SKILL.md 中的升级规则（"Phase 2 报告不完整且 security PR"）即此两阶段判断。
 
       - step: collect_phase_2_reports
         action: |

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -154,13 +154,13 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 
 ## Phase Contracts
 
-Phase 契约：
-
-- 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。**team-lead 等待期间只允许执行 context_bundle 中定义的 shell 基础命令（gh pr view、CI 状态等）并将结果传给 context-researcher，禁止自行做深度代码分析（读 diff、读源码、分析架构）——这是 context-researcher 的专属职责。** 易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传；以及 team-lead 在等待期间"顺手"自己做分析，导致 Phase 1 产出变成 team-lead 的个人研究而非 context-researcher 的独立调研。
-- 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个。易错点是与 Phase 1 并行启动、忘发背景导致盲审。
-- 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁。**⚠️ 升级规则：若 Phase 2 报告不完整（有 agent 超时/限流/未回报），且 PR 满足触发条件（large_pr / security），Phase 2.5 从「可选」升级为「强制」——用 Codex 独立复查补偿缺失报告，不能直接跳到 Phase 3。** 可跳过条件（仅当 Phase 2 三方报告**全部到齐**时）：三方结论一致且证据充分，须在 Phase 3 明确注明跳过理由。易错点是与 Phase 2 并行执行、Phase 2 不完整却以"跳过"理由绕过 Codex。
-- 3 综合判断：检查 `required - received` 缺失；冲突必须仲裁；缺失只能标“审查不完整”；如有 Phase 2.5 报告可作为补充材料。易错点是替缺失 agent 脑补或用错误 teammate-message 内容继续。
-- 4 写回：模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix。易错点是把范围外技术债塞进当前 PR comment，或对复杂架构问题错误使用 auto-fix。
+| Phase | 强制要求 | 易错点 |
+|-------|---------|-------|
+| 1 背景调研 | 必须**先于** Phase 2 完成；产出 `phase_1_output` 并回传 team-lead | 只打印到终端、未保存为变量、未通过 SendMessage 回传 |
+| 2 专项审查 | 多 agent **同一响应**内并行 spawn；fresh spawn 时在 prompt 中直接内嵌 `phase_1_output`；复用 teammate 或补发上下文时才用 SendMessage | **与 Phase 1 并行启动**（issue #742 真实踩坑）；fresh spawn 仍要求额外 SendMessage 才开始，或让复用语义和首轮语义混在一起 |
+| 2.5 Codex验证（可选） | **触发条件**：安全PR、大型PR（>500行）、冲突仲裁；**执行时机**：Phase 2完成后收集所有报告；通过 `codex:rescue` skill 调用；第一阶段满足且 Phase 2 完整 → Phase 2.5 保持可选；第一阶段满足且 Phase 2 不完整 → Phase 2.5 升级为强制 | 与 Phase 2 并行执行；未收集完整 Phase 2 报告就调用；把”可选触发”误写成”只有不完整才触发” |
+| 3 综合判断 | 检查 `required - received` 缺失；冲突必须仲裁；缺失只能标”审查不完整”；如有 Phase 2.5 报告作为补充材料 | 替缺失 agent 脑补 / 用错误 teammate-message 内容继续 |
+| 4 写回 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue | 把范围外技术债塞进当前 PR comment |
 
 > **没有 Phase 5**。完成 Phase 4 直接回 Step 9。teammates 的 idle / pane / inbox 由运行时管理，**skill 不感知不操作**。如果你正在思考"清理 inbox"或"保留状态"，停下——这不是你的工作。
 
@@ -245,7 +245,8 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 ### Phase 流程
 
 - Phase 1 / Phase 2 严格**串行**，禁止并行 spawn
-- Phase 2 spawn 后必须 SendMessage 发 `phase_1_output`，禁止盲审
+- fresh spawn 时在 prompt 中直接内嵌 `phase_1_output`；不要求额外 SendMessage 才开始
+- 切换到下一 PR、复用 teammate 或补发额外上下文时，才使用 SendMessage
 - 仅 `refactor / security / standard` 走双阶段；`simple` 只做 Phase 1
 
 ### 状态操作

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -111,6 +111,25 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 
 `TaskList` 可随时用于确认进度，避免重复创建。
 
+### Step 6.6: Task Lifecycle（跨 PR 管理）
+
+> **踩坑记录**：跨 PR 审查时，旧 PR 的 task 会累积在 task list 中，造成视觉混乱和状态不一致。
+
+**每个 PR 开始审查前**：
+
+1. 检查 `TaskList`，如有上一轮 PR 的未完成 task，标记为 `completed`（附带说明：上一 PR 遗留）
+2. 如有上一轮 PR 已完成但未标记的 task，标记为 `completed`
+3. 为当前 PR 创建 Phase 1 task（按 Step 6.5）
+
+**每个 Phase 执行时**：
+
+- 开始 Phase → `TaskUpdate(status="in_progress")`
+- 完成 Phase → `TaskUpdate(status="completed")`
+
+**会话结束时**（Step 10）：
+
+- 所有 task 由 TeamDelete 自动清理，无需手动删除
+
 ### Step 7: PR 分类（多维判断，禁止简化）
 
 > **常见错误**：看到"文档改动"就归类 `simple`。这是错的。
@@ -138,40 +157,10 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 Phase 契约：
 
 - 1 背景调研：必须先于 Phase 2 完成；产出 `phase_1_output` 并回传 team-lead。**team-lead 等待期间只允许执行 context_bundle 中定义的 shell 基础命令（gh pr view、CI 状态等）并将结果传给 context-researcher，禁止自行做深度代码分析（读 diff、读源码、分析架构）——这是 context-researcher 的专属职责。** 易错点是只打印到终端、未保存为变量、未通过 SendMessage 回传；以及 team-lead 在等待期间"顺手"自己做分析，导致 Phase 1 产出变成 team-lead 的个人研究而非 context-researcher 的独立调研。
-- 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个；对 standard/refactor/large PR，先提取 PR diff 文件。易错点是与 Phase 1 并行启动、忘发背景导致盲审、architect-reviewer 无 Bash 而未提前提取 diff。
+- 2 专项审查：多 agent 在同一响应内并行 spawn；spawn 后立即 SendMessage，把 `phase_1_output` 广播给每个。易错点是与 Phase 1 并行启动、忘发背景导致盲审。
 - 2.5 Codex验证（可选）：触发条件是安全PR、大型PR（>500行）、冲突仲裁。**⚠️ 升级规则：若 Phase 2 报告不完整（有 agent 超时/限流/未回报），且 PR 满足触发条件（large_pr / security），Phase 2.5 从「可选」升级为「强制」——用 Codex 独立复查补偿缺失报告，不能直接跳到 Phase 3。** 可跳过条件（仅当 Phase 2 三方报告**全部到齐**时）：三方结论一致且证据充分，须在 Phase 3 明确注明跳过理由。易错点是与 Phase 2 并行执行、Phase 2 不完整却以"跳过"理由绕过 Codex。
 - 3 综合判断：检查 `required - received` 缺失；冲突必须仲裁；缺失只能标“审查不完整”；如有 Phase 2.5 报告可作为补充材料。易错点是替缺失 agent 脑补或用错误 teammate-message 内容继续。
 - 4 写回：模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue；CRITICAL 阻塞 ≥ 2 个或涉及架构重设计时应建议 REJECT 而非 auto-fix。易错点是把范围外技术债塞进当前 PR comment，或对复杂架构问题错误使用 auto-fix。
-
-### Phase 2 Prep: 提取 PR Diff（standard/refactor/large PR 必做）
-
-> **重要**：`architect-reviewer` 工具集为 `[Read, Grep, Glob, WebSearch]`，**无 Bash**。它无法执行 `gh pr diff` 或 `git show`。若不提前提取文件，architect-reviewer 将请求 team-lead 补发，造成延迟。
-
-在 Phase 2 spawn 之前，**team-lead** 必须执行：
-
-```bash
-# 1. 创建 temp 目录
-mkdir -p temp/pr{pr_number}
-
-# 2. 提取完整 diff
-gh pr diff {pr_number} > temp/pr{pr_number}/full.diff
-
-# 3. 提取各个 PR 修改文件（使用 PR 分支名称）
-git show {pr_branch}:{file_path} > temp/pr{pr_number}/{basename}
-# 例：git show task/issue-283:src/vibe3/clients/github_project_client.py \
-#       > temp/pr738/src_vibe3_clients_github_project_client.py
-```
-
-在 Phase 1 → Phase 2 广播中，额外附加文件路径说明：
-
-```
-## 可读文件路径（team-lead 已提取）
-- temp/pr{pr_number}/full.diff
-- temp/pr{pr_number}/{basename1}  ({LOC} LOC, NEW/MODIFIED)
-- ...
-
-main 分支对照：直接 Read 工具读 src/vibe3/... 路径（当前 cwd 是 main 分支）。
-```
 
 > **没有 Phase 5**。完成 Phase 4 直接回 Step 9。teammates 的 idle / pane / inbox 由运行时管理，**skill 不感知不操作**。如果你正在思考"清理 inbox"或"保留状态"，停下——这不是你的工作。
 

--- a/skills/vibe-review-pr/references/execution-reference.md
+++ b/skills/vibe-review-pr/references/execution-reference.md
@@ -81,6 +81,8 @@ main 分支对照：直接 Read src/vibe3/... 路径即可。
 
 仅适用 `refactor / security / standard`。**Phase 1 必须先完成**，禁止并行启动。
 
+fresh spawn 的 Phase 2 agent 直接从初始 prompt 读取 `phase_1_output` 并开始审查。
+
 同一响应内并行 spawn：
 
 ```yaml
@@ -90,7 +92,13 @@ main 分支对照：直接 Read src/vibe3/... 路径即可。
     name: code-analyst
     subagent_type: pr-code-analyst
     model: haiku
-    prompt: "分析 PR #{pr_number} 的代码质量。等待背景信息后开始。"
+    prompt: |
+      分析 PR #{pr_number} 的代码质量。
+
+      ## PR #{pr_number} 背景报告
+      {phase_1_output}
+
+      请基于以上背景开始审查。
     run_in_background: true
 
 - tool: Agent
@@ -99,7 +107,13 @@ main 分支对照：直接 Read src/vibe3/... 路径即可。
     name: architect-reviewer
     subagent_type: pr-architect-reviewer
     model: sonnet
-    prompt: "评估 PR #{pr_number} 的架构影响。等待背景信息后开始。"
+    prompt: |
+      评估 PR #{pr_number} 的架构影响。
+
+      ## PR #{pr_number} 背景报告
+      {phase_1_output}
+
+      你可以使用 Bash 工具补充读取 diff / git show / git log 数据。
     run_in_background: true
 
 - tool: Agent
@@ -108,23 +122,30 @@ main 分支对照：直接 Read src/vibe3/... 路径即可。
     name: security-reviewer
     subagent_type: pr-security-reviewer
     model: sonnet
-    prompt: "评估 PR #{pr_number} 的安全性。等待背景信息后开始。"
+    prompt: |
+      评估 PR #{pr_number} 的安全性。
+
+      ## PR #{pr_number} 背景报告
+      {phase_1_output}
     run_in_background: true
 ```
 
-立即广播背景：
+fresh spawn 不需要额外 SendMessage。只有两类场景继续使用 SendMessage：
+
+- 复用上一轮已经存在的 teammate
+- Phase 2 过程中需要补发额外上下文
 
 ```yaml
 - tool: SendMessage
   params:
-    to: "code-analyst"  # 对每个 Phase 2 agent 都执行
+    to: "code-analyst"
     message: |
-      ## PR #{pr_number} 背景报告
-      {phase_1_output}
-      请基于以上背景开始审查。
+      ## 切换到 PR #{next_pr_number}
+      {phase_1_output_of_next_pr}
+      请基于以上背景分析新的 PR。
 ```
 
-等待策略：等所有 Phase 2 agents idle；默认 5 分钟超时；超时只能标"部分审查未完成"。
+等待策略：idle 只表示空闲/等待态，最终结果以 `task-notification(status=completed)` 为准；默认 5 分钟超时；超时只能标"部分审查未完成"。
 
 ### 多 PR 复用模式（第二个及之后的 PR）
 

--- a/skills/vibe-review-pr/references/execution-reference.md
+++ b/skills/vibe-review-pr/references/execution-reference.md
@@ -48,35 +48,6 @@ TaskUpdate(taskId=t1.id, status="in_progress", owner="team-lead")
 
 接收报告优先级：team inbox → teammate-message → 必要时 SendMessage 补发。
 
-## Phase 2 Prep: Diff 文件提取（standard/refactor/large PR 必做）
-
-> architect-reviewer 工具集为 [Read, Grep, Glob, WebSearch]，无 Bash。必须由 team-lead 提前提取。
-
-```bash
-# spawn Phase 2 agents 之前执行
-mkdir -p temp/pr{pr_number}
-gh pr diff {pr_number} > temp/pr{pr_number}/full.diff
-
-# 提取每个改动文件（从 PR 分支）
-PR_BRANCH=$(gh pr view {pr_number} --json headRefName -q .headRefName)
-for f in src/vibe3/clients/github_project_client.py \
-          src/vibe3/services/project_status_sync_service.py; do  # 按实际 diff 列表
-  out="temp/pr{pr_number}/$(echo "$f" | tr '/' '_')"
-  git show "$PR_BRANCH:$f" > "$out"
-done
-```
-
-在 Phase 2 广播消息中附加：
-
-```markdown
-## 可读文件（team-lead 已提取到 temp/pr{pr_number}/）
-- full.diff
-- src_vibe3_clients_github_project_client.py  (345 LOC, NEW)
-- ...
-
-main 分支对照：直接 Read src/vibe3/... 路径即可。
-```
-
 ## Phase 2: 专项审查
 
 仅适用 `refactor / security / standard`。**Phase 1 必须先完成**，禁止并行启动。

--- a/tests/vibe2/skills/test_vibe_review_pr_skill.bats
+++ b/tests/vibe2/skills/test_vibe_review_pr_skill.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+setup() {
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+}
+
+@test "vibe-review-pr fresh Phase 2 flow uses spawn prompt context instead of mandatory follow-up SendMessage" {
+  run grep -F "fresh spawn 时在 prompt 中直接内嵌 \`phase_1_output\`；不要求额外 SendMessage 才开始" \
+    "$REPO_ROOT/skills/vibe-review-pr/SKILL.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "fresh spawn 的 Phase 2 agent 直接从初始 prompt 读取 \`phase_1_output\` 并开始审查。" \
+    "$REPO_ROOT/skills/vibe-review-pr/references/execution-reference.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "初次 spawn 审查当前 PR 时，背景已在初始 prompt 中提供；无需等待额外 SendMessage。" \
+    "$REPO_ROOT/.claude/agents/pr-code-analyst.md" \
+    "$REPO_ROOT/.claude/agents/pr-architect-reviewer.md" \
+    "$REPO_ROOT/.claude/agents/pr-security-reviewer.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "必须先收到 team-lead 通过 SendMessage 发送的 Phase 1 背景报告。" \
+    "$REPO_ROOT/.claude/agents/pr-code-analyst.md" \
+    "$REPO_ROOT/.claude/agents/pr-architect-reviewer.md" \
+    "$REPO_ROOT/.claude/agents/pr-security-reviewer.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "vibe-review-pr architect reviewer documentation matches Bash-enabled diff retrieval" {
+  run grep -F "tools: Read, Grep, Glob, WebSearch, Bash, SendMessage" \
+    "$REPO_ROOT/.claude/agents/pr-architect-reviewer.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "你可以直接使用 Bash 获取所需 diff、提交历史和目标文件内容。" \
+    "$REPO_ROOT/.claude/agents/pr-architect-reviewer.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "你没有 Bash 工具" \
+    "$REPO_ROOT/.claude/agents/pr-architect-reviewer.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "vibe-review-pr result collection and Codex escalation rules stay internally consistent" {
+  run grep -F "从 task-notification（status=completed）收集各 agent 报告" \
+    "$REPO_ROOT/.claude/team-templates/pr-review-team.yaml"
+  [ "$status" -eq 0 ]
+
+  run grep -F "received_agents = [从 task-notification(status=completed) 获取]" \
+    "$REPO_ROOT/.claude/team-templates/pr-review-team.yaml"
+  [ "$status" -eq 0 ]
+
+  run grep -F "第一阶段满足且 Phase 2 完整 → Phase 2.5 保持可选" \
+    "$REPO_ROOT/.claude/team-templates/pr-review-team.yaml" \
+    "$REPO_ROOT/skills/vibe-review-pr/SKILL.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "第一阶段满足且 Phase 2 不完整 → Phase 2.5 升级为强制" \
+    "$REPO_ROOT/.claude/team-templates/pr-review-team.yaml" \
+    "$REPO_ROOT/skills/vibe-review-pr/SKILL.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F "仅第一阶段满足 → 跳过 Phase 2.5，直接进入 Phase 3" \
+    "$REPO_ROOT/.claude/team-templates/pr-review-team.yaml"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

本次改进基于 PR #761 审查流程中的实际踩坑经验，优化了两个关键问题：

### 优化点 1：Architect-reviewer 工具权限（高优先级）

**问题**：
- architect-reviewer 工具集为 `[Read, Grep, Glob, WebSearch]`，无 Bash
- 无法执行 `gh pr diff` 或 `git show`，必须依赖 team-lead 提前提取文件
- 大型 PR（如 #757: +368/-174）会导致巨大的 context 开销
- 违反"agent 自主性"原则

**修复**：
- 给 architect-reviewer 添加 Bash 工具
- 删除 SKILL.md 中"Phase 2 Prep: 提取 PR Diff"章节（不再需要）
- 更新 spawn prompt，引导 architect-reviewer 自主获取 diff 数据

**收益**：
- 减少 team-lead context 开销（不再传递大量文件路径）
- architect-reviewer 可自主探索（如发现需要额外文件，直接 git show）
- 大型 PR 审查时 token 消耗显著降低

### 优化点 2：Task Lifecycle 规范化（中优先级）

**问题**：
- Task 在每个 PR 审查前创建，但未在 PR 间清理
- 会话结束时累积 18 个 task（PR #758/#760/#761 + #777）
- SKILL.md 中没有明确的 task 生命周期文档

**修复**：
- 添加 Step 6.6：Task Lifecycle（跨 PR 管理）
- 明确每个 PR 开始前清理旧 task
- 每个 Phase 执行时更新 task 状态

**收益**：
- 提升 task list 可维护性
- 避免状态不一致和视觉混乱

## Test Plan

- [x] 本地验证：修改后的 YAML 和 SKILL.md 逻辑正确
- [ ] 下一个 PR 审查流程验证：
  - [ ] architect-reviewer 能自主获取 diff（无需 team-lead 预处理）
  - [ ] task list 在 PR 间正确清理和更新
  - [ ] 大型 PR 审查时 token 消耗降低

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)