### PR TITLE
fix(agents): use sonnet for context-researcher and add task dependency mechanism

### DIFF
--- a/.claude/agents/pr-context-researcher.md
+++ b/.claude/agents/pr-context-researcher.md
@@ -8,7 +8,7 @@ description: |
   注意：此 agent 是对全局 Explore 的项目特定扩展，
   增加了 PR 特定的时效性检查和依赖关系分析。
 
-model: haiku
+model: sonnet  # 使用 sonnet 避免 haiku thinking budget 限制问题
 tools: Read, Grep, Glob, WebFetch, Bash, SendMessage
 extends: Explore  # 继承全局 Explore 的基础能力
 # Bash 仅用于只读 GitHub/context 命令，不执行写操作或本地状态修改

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -266,7 +266,7 @@ workflow:
           team_name: pr-review-team
           name: context-researcher
           subagent_type: pr-context-researcher
-          model: haiku
+          model: sonnet  # 使用 sonnet 避免 haiku extended thinking 限制
           prompt: "收集 PR #{pr_number} 的背景信息..."
         wait_for_result: true  # 必须等待 Phase 1 完成
       - step: receive_context_report
@@ -297,7 +297,7 @@ workflow:
           team_name: pr-review-team
           name: code-analyst
           subagent_type: pr-code-analyst
-          model: haiku
+          model: sonnet  # 代码分析需要强模型，与 agent 定义一致
           prompt: |
             分析 PR #{pr_number} 的代码质量。
 

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -108,11 +108,25 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
 - tool: TaskCreate
   params:
     subject: "Phase 1: Context research"
-    description: "spawn context-researcher, collect PR background"
+    description: "spawn context-researcher, collect PR background and save to metadata"
+- tool: TaskUpdate
+  params:
+    taskId: "<phase-1-task-id>"
+    status: "in_progress"
+    owner: "team-lead"
+
+# Phase 2 必须等待 Phase 1 完成并通过 task dependency 强制传递背景
 - tool: TaskCreate
   params:
     subject: "Phase 2: Parallel review"
-    description: "spawn code-analyst + architect-reviewer + security-reviewer"
+    description: "spawn code-analyst + architect-reviewer + security-reviewer with Phase 1 background"
+- tool: TaskUpdate
+  params:
+    taskId: "<phase-2-task-id>"
+    addBlockedBy: ["<phase-1-task-id>"]  # 强制依赖 Phase 1
+    metadata:
+      requires_phase_1_output: true  # 标记需要背景信息
+
 - tool: TaskCreate
   params:
     subject: "Phase 2.5: Codex verification"
@@ -125,13 +139,32 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Step 7
   params:
     subject: "Phase 4: Write back"
     description: "ask-each mode; post PR comment; create follow-up issues"
+```
 
-# 每个 task 创建后立即标注 owner 和 in_progress：
+**关键步骤（Phase 1 完成后必须执行）**：
+
+```yaml
+# Phase 1 完成时，必须将背景报告保存到 task metadata
 - tool: TaskUpdate
   params:
     taskId: "<phase-1-task-id>"
-    status: "in_progress"
-    owner: "team-lead"
+    status: "completed"
+    metadata:
+      phase_1_output: |
+        ## PR #<number> 背景报告
+
+        [完整的 context-researcher 报告内容，包括所有章节]
+```
+
+**Phase 2 启动前检查**：
+
+```yaml
+# Phase 2 开始前，必须从 Phase 1 task 获取背景信息
+- tool: TaskGet
+  params:
+    taskId: "<phase-1-task-id>"
+  # 从 metadata.phase_1_output 提取完整背景报告
+  # 然后嵌入 Phase 2 agents 的 prompt 中
 ```
 
 `TaskList` 可随时用于确认进度，避免重复创建。


### PR DESCRIPTION
## Summary

修复 PR 审查 agent 配置问题，并添加 task dependency 机制确保背景正确传递：

1. **修复 agent model 配置**
   - 将 `pr-context-researcher` 从 haiku 改为 sonnet
   - 统一 team template 中 code-analyst 配置（与 agent 定义一致）
   - 原因：haiku 有 thinking budget 限制导致错误

2. **添加 task dependency 机制**
   - Phase 2 task 通过 `addBlockedBy` 依赖 Phase 1
   - Phase 1 完成时必须将背景保存到 `metadata.phase_1_output`
   - Phase 2 启动前必须通过 `TaskGet` 获取背景
   - 防止 team-lead 跳过背景传递步骤

## Motivation

在审查 PR #789 时发现两个问题：

1. **Haiku thinking budget 错误**：context-researcher 使用 haiku model 时报错：
   ```
   thinking budget range is [100, 16384], invalid request error
   ```
   解决方案：改为 sonnet

2. **背景未正确传递**：Phase 2 agents 启动时未收到完整背景报告，导致"盲审"
   解决方案：通过 task dependency 强制约束

## Changes

### 配置修复
- `.claude/agents/pr-context-researcher.md` — model: haiku → sonnet
- `.claude/team-templates/pr-review-team.yaml` — 更新 context-researcher 和 code-analyst model 配置

### 文档改进
- `skills/vibe-review-pr/SKILL.md` — 添加 Step 6.5 task dependency 机制

## Test Coverage

已在 PR #789 审查过程中验证：
- ✅ context-researcher 使用 sonnet 成功运行
- ✅ 背景报告正确生成和传递
- ✅ Task dependency 机制有效

## Related

- Issue #787 — Multi-agent PR review debug guide
- PR #789 — Multi-agent code review (验证修复效果)

🤖 Generated with [Claude Code](https://claude.com/claude-code)