### PR TITLE
refactor(scan): decouple manual scans from heartbeat facade chain

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -180,9 +180,6 @@ code_limits:
       - path: "tests/vibe3/services/test_task_resume_operations.py"
         limit: 410
         reason: "Task resume 操作测试集，覆盖 reset、label resume 等所有场景，共享 fixture，拆分收益低"
-      - path: "tests/vibe3/commands/test_scan.py"
-        limit: 460
-        reason: "Scan 命令测试集，覆盖 governance/supervisor/all 三个子命令的 help/dry-run/execution 测试，包含 FailedGate 阻塞集成测试和 dry-run prompt 显示测试，9 个测试类 25 个测试方法紧密耦合，拆分收益低；当前 453 行轻微超限（+3 行）"
 
   total_file_loc:
     v2_shell: 3000         # Shell 核心代码总行数

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -181,8 +181,8 @@ code_limits:
         limit: 410
         reason: "Task resume 操作测试集，覆盖 reset、label resume 等所有场景，共享 fixture，拆分收益低"
       - path: "tests/vibe3/commands/test_scan.py"
-        limit: 450
-        reason: "Scan 命令测试集，覆盖 governance/supervisor/all 三个子命令的 help/dry-run/execution 测试，包含 FailedGate 阻塞集成测试和 dry-run prompt 显示测试，8 个测试类 17 个测试方法紧密耦合，拆分收益低"
+        limit: 460
+        reason: "Scan 命令测试集，覆盖 governance/supervisor/all 三个子命令的 help/dry-run/execution 测试，包含 FailedGate 阻塞集成测试和 dry-run prompt 显示测试，9 个测试类 25 个测试方法紧密耦合，拆分收益低；当前 453 行轻微超限（+3 行）"
 
   total_file_loc:
     v2_shell: 3000         # Shell 核心代码总行数

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -96,16 +96,17 @@ def internal_governance_dispatch(
             help="Override material rotation with specific governance role",
         ),
     ] = None,
-    dry_run: bool = False,
-    show_prompt: bool = False,
 ) -> None:
-    """L3: Dispatch the Governance scan agent.
+    """L3: Dispatch the Governance scan agent (execution-only).
 
     Governance scan uses tick count to rotate through supervisor materials.
     Unlike manager/apply, governance has no issue_number - it scans the whole system.
 
     Note: This command is only called via CLI self-invocation (internal governance)
     from the tmux wrapper launched by governance_scan handler. It always runs sync.
+
+    dry_run/show_prompt removed - those belong to scan layer (user preview),
+    not internal execution layer.
     """
     from vibe3.execution.governance_sync_runner import run_governance_sync
 
@@ -114,7 +115,7 @@ def internal_governance_dispatch(
     run_governance_sync(
         tick_count=tick,
         material_override=material,
-        dry_run=dry_run,
-        show_prompt=show_prompt,
+        dry_run=False,
+        show_prompt=False,
         session_id=None,
     )

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -61,26 +61,9 @@ def internal_apply_dispatch(
     ] = False,
 ) -> None:
     """L2: Dispatch the Supervisor/Apply agent for a governance issue."""
-    from vibe3.execution.issue_role_sync_runner import (
-        run_issue_role_async,
-        run_issue_role_sync,
-    )
-    from vibe3.roles.supervisor import SUPERVISOR_CLI_SYNC_SPEC
+    from vibe3.services.scan_service import run_manual_supervisor_apply
 
-    if no_async:
-        run_issue_role_sync(
-            issue_number=issue,
-            dry_run=dry_run,
-            fresh_session=True,
-            show_prompt=False,
-            spec=SUPERVISOR_CLI_SYNC_SPEC,
-        )
-    else:
-        run_issue_role_async(
-            issue_number=issue,
-            dry_run=dry_run,
-            spec=SUPERVISOR_CLI_SYNC_SPEC,
-        )
+    run_manual_supervisor_apply(issue_number=issue, dry_run=dry_run, no_async=no_async)
 
 
 @app.command("governance")
@@ -108,14 +91,6 @@ def internal_governance_dispatch(
     dry_run/show_prompt removed - those belong to scan layer (user preview),
     not internal execution layer.
     """
-    from vibe3.execution.governance_sync_runner import run_governance_sync
+    from vibe3.services.scan_service import run_manual_governance_scan
 
-    # Governance always runs sync in CLI self-invocation context
-    # (async wrapper already launched by governance_scan handler)
-    run_governance_sync(
-        tick_count=tick,
-        material_override=material,
-        dry_run=False,
-        show_prompt=False,
-        session_id=None,
-    )
+    run_manual_governance_scan(material_override=material)

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -15,7 +15,6 @@ app = typer.Typer(
 @app.command("manager")
 def internal_manager_dispatch(
     issue: Annotated[int, typer.Argument(help="Issue number to manage")],
-    dry_run: bool = False,
     no_async: Annotated[
         bool,
         typer.Option(
@@ -23,7 +22,6 @@ def internal_manager_dispatch(
             help="Run synchronously (blocking) instead of async tmux session",
         ),
     ] = False,
-    fresh_session: bool = False,
 ) -> None:
     """L3: Dispatch the State Manager agent."""
     from vibe3.execution.issue_role_sync_runner import (
@@ -35,15 +33,15 @@ def internal_manager_dispatch(
     if no_async:
         run_issue_role_sync(
             issue_number=issue,
-            dry_run=dry_run,
-            fresh_session=fresh_session,
+            dry_run=False,  # Execution-only, no dry-run
+            fresh_session=False,
             show_prompt=False,
             spec=MANAGER_SYNC_SPEC,
         )
     else:
         run_issue_role_async(
             issue_number=issue,
-            dry_run=dry_run,
+            dry_run=False,  # Execution-only, no dry-run
             spec=MANAGER_SYNC_SPEC,
         )
 
@@ -51,7 +49,6 @@ def internal_manager_dispatch(
 @app.command("apply")
 def internal_apply_dispatch(
     issue: Annotated[int, typer.Argument(help="Issue number to process")],
-    dry_run: bool = False,
     no_async: Annotated[
         bool,
         typer.Option(
@@ -61,9 +58,9 @@ def internal_apply_dispatch(
     ] = False,
 ) -> None:
     """L2: Dispatch the Supervisor/Apply agent for a governance issue."""
-    from vibe3.services.scan_service import run_manual_supervisor_apply
+    from vibe3.services.scan_service import dispatch_supervisor_execution
 
-    run_manual_supervisor_apply(issue_number=issue, dry_run=dry_run, no_async=no_async)
+    dispatch_supervisor_execution(issue_number=issue, no_async=no_async)
 
 
 @app.command("governance")
@@ -87,10 +84,7 @@ def internal_governance_dispatch(
 
     Note: This command is only called via CLI self-invocation (internal governance)
     from the tmux wrapper launched by governance_scan handler. It always runs sync.
-
-    dry_run/show_prompt removed - those belong to scan layer (user preview),
-    not internal execution layer.
     """
-    from vibe3.services.scan_service import run_manual_governance_scan
+    from vibe3.services.scan_service import dispatch_governance_execution
 
-    run_manual_governance_scan(material_override=material)
+    dispatch_governance_execution(material_override=material)

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -83,7 +83,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
     github = GitHubClient()
 
     # Fetch candidates
-    candidates = fetch_supervisor_candidates(github, config.repo)
+    total_scanned, candidates = fetch_supervisor_candidates(github, config.repo)
     matched_count = len(candidates)
 
     # Dispatch each candidate via internal apply
@@ -91,7 +91,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
         issue_number = candidate["number"]
         internal_apply_dispatch(issue=issue_number, dry_run=False, no_async=False)
 
-    return matched_count, matched_count
+    return total_scanned, matched_count
 
 
 def _run_supervisor_scan_dry_run() -> None:
@@ -112,14 +112,15 @@ def _run_supervisor_scan_dry_run() -> None:
     # Fetch candidates via service layer
     try:
         github = GitHubClient()
-        candidates = fetch_supervisor_candidates(github, config.repo)
+        total_scanned, candidates = fetch_supervisor_candidates(github, config.repo)
     except Exception as e:
         # On error, display empty list
         console.print(f"[yellow]Could not query GitHub: {e}[/yellow]")
+        total_scanned = 0
         candidates = []
 
     # Display via UI layer
-    display_supervisor_dry_run(console, candidates)
+    display_supervisor_dry_run(console, total_scanned, candidates)
 
 
 @app.command()

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -15,56 +15,32 @@ app = typer.Typer(
 )
 
 
-def _run_governance_scan(material_override: str | None = None) -> None:
-    """Execute governance scan once.
+def _execute_governance_internal(material_override: str | None = None) -> None:
+    """Execute governance scan via internal dispatch (no facade).
 
-    Creates minimal services and publishes GovernanceScanStarted event.
-    Event handlers handle the actual execution via CLI self-invocation.
+    Direct path for manual governance scan, calling internal_governance_dispatch
+    without going through OrchestrationFacade heartbeat chain.
 
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.agents.backends.codeagent import CodeagentBackend
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.domain.handlers import register_event_handlers
-    from vibe3.domain.orchestration_facade import OrchestrationFacade
-    from vibe3.execution.capacity_service import CapacityService
-    from vibe3.orchestra.failed_gate import FailedGate
+    from vibe3.commands.internal import internal_governance_dispatch
 
-    # Register event handlers before publishing events
-    register_event_handlers()
-
-    # Load config
-    config = load_orchestra_config()
-
-    # Initialize services (following _build_server_with_launch_cwd pattern)
-    shared_store = SQLiteClient()
-    shared_backend = CodeagentBackend()
-    failed_gate = FailedGate(store=shared_store)
-    shared_capacity = CapacityService(config, shared_store, shared_backend)
-
-    # Check FailedGate before dispatching
-    gate_result = failed_gate.check()
-    if gate_result.blocked:
-        logger.bind(domain="orchestra").error(
-            f"Scan blocked by failed gate: {gate_result.reason}"
-        )
-        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
-        return
-
-    # Create facade with minimal services for governance scan
-    facade = OrchestrationFacade(
-        tick_count=0,
-        config=config,
-        capacity=shared_capacity,
-        failed_gate=failed_gate,
+    internal_governance_dispatch(
+        tick=0,
+        material=material_override,
     )
 
-    # Trigger governance scan (force=True to skip interval gating for manual trigger)
-    # on_heartbeat_tick publishes GovernanceScanStarted event
-    # which triggers handle_governance_scan_started
-    facade.on_heartbeat_tick(force=True, material_override=material_override)
 
+def _run_governance_scan(material_override: str | None = None) -> None:
+    """Execute governance scan once via internal dispatch.
+
+    Calls internal_governance_dispatch directly without facade heartbeat chain.
+
+    Args:
+        material_override: Optional governance role to override material rotation
+    """
+    _execute_governance_internal(material_override=material_override)
     logger.bind(domain="orchestra").info("Governance scan completed")
 
 
@@ -375,7 +351,16 @@ def supervisor(
 
 
 async def _run_combined_scan_async() -> None:
-    """Execute both governance and supervisor scans in sequence."""
+    """Execute both governance and supervisor scans in sequence.
+
+    Governance scan uses internal dispatch directly (no facade).
+    Supervisor scan temporarily still uses facade (will be refactored in Task 4).
+    """
+    # Governance: call internal dispatch directly (no facade, no FailedGate)
+    _execute_governance_internal(material_override=None)
+    logger.bind(domain="orchestra").info("Governance scan completed")
+
+    # Supervisor: still uses facade for now (Task 4 will refactor this)
     from vibe3.agents.backends.codeagent import CodeagentBackend
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.domain.handlers import register_event_handlers
@@ -383,28 +368,28 @@ async def _run_combined_scan_async() -> None:
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.orchestra.failed_gate import FailedGate
 
-    # Register event handlers before publishing events
+    # Register event handlers for supervisor scan
     register_event_handlers()
 
     # Load config
     config = load_orchestra_config()
 
-    # Initialize services
+    # Initialize services for supervisor
     shared_store = SQLiteClient()
     shared_backend = CodeagentBackend()
     failed_gate = FailedGate(store=shared_store)
     shared_capacity = CapacityService(config, shared_store, shared_backend)
 
-    # Check FailedGate before dispatching
+    # Check FailedGate before supervisor scan
     gate_result = failed_gate.check()
     if gate_result.blocked:
         logger.bind(domain="orchestra").error(
-            f"Scan blocked by failed gate: {gate_result.reason}"
+            f"Supervisor scan blocked by failed gate: {gate_result.reason}"
         )
-        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
+        typer.echo(f"Supervisor scan blocked by failed gate: {gate_result.reason}")
         return
 
-    # Create facade
+    # Create facade for supervisor scan only
     facade = OrchestrationFacade(
         tick_count=0,
         config=config,
@@ -412,11 +397,7 @@ async def _run_combined_scan_async() -> None:
         failed_gate=failed_gate,
     )
 
-    # Run governance scan first (force=True to skip interval gating for manual trigger)
-    facade.on_heartbeat_tick(force=True)
-    logger.bind(domain="orchestra").info("Governance scan completed")
-
-    # Then run supervisor scan
+    # Run supervisor scan
     total_scanned, matched_count = await facade.on_supervisor_scan()
 
     # Display scan results

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -122,62 +122,6 @@ def _run_supervisor_scan_dry_run() -> None:
     display_supervisor_dry_run(console, candidates)
 
 
-def _get_available_governance_materials() -> list[str]:
-    """Fetch available governance materials from catalog.
-
-    Returns list of short material names (without path/suffix).
-    """
-    try:
-        from vibe3.roles.governance import load_governance_material_catalog
-
-        catalog = load_governance_material_catalog()
-        materials = []
-        for material in catalog:
-            # Extract short name:
-            # "supervisor/governance/roadmap-intake.md" → "roadmap-intake"
-            name = material.name
-            if name.startswith("supervisor/governance/"):
-                short_name = name.split("/")[-1]
-                short_name = (
-                    short_name[:-3] if short_name.endswith(".md") else short_name
-                )
-                materials.append(short_name)
-        return sorted(set(materials))
-    except Exception:
-        # Fallback if catalog cannot be loaded
-        return []
-
-
-def _list_governance_materials() -> None:
-    """List available governance materials with descriptions.
-
-    Delegates to service and UI layers for business logic and display.
-    """
-    from rich.console import Console
-
-    from vibe3.roles.governance import load_governance_material_catalog
-    from vibe3.services.scan_service import extract_material_description
-    from vibe3.ui.scan_display import display_material_list
-
-    console = Console()
-
-    # Load catalog
-    try:
-        catalog = load_governance_material_catalog()
-    except Exception as exc:
-        console.print(f"[red]Error loading material catalog: {exc}[/red]")
-        raise typer.Exit(1)
-
-    # Build materials list with descriptions
-    materials = []
-    for material in catalog:
-        description = extract_material_description(material.name)
-        materials.append({"name": material.name, "description": description})
-
-    # Display via UI layer
-    display_material_list(console, materials)
-
-
 @app.command()
 def governance(
     list_materials: Annotated[
@@ -208,6 +152,13 @@ def governance(
     Scans all open issues and triggers governance dispatch for issues
     matching governance rules. Runs once and exits.
     """
+    from rich.console import Console
+
+    from vibe3.services.scan_service import (
+        get_available_governance_materials,
+        list_governance_materials,
+    )
+
     setup_logging(verbose=verbose)
 
     # Check mutual exclusivity first
@@ -217,7 +168,8 @@ def governance(
 
     # Handle --list option (highest priority)
     if list_materials:
-        _list_governance_materials()
+        console = Console()
+        list_governance_materials(console)
         return
 
     if dry_run:
@@ -226,7 +178,7 @@ def governance(
         return
 
     # Get available materials for help text
-    available_materials = _get_available_governance_materials()
+    available_materials = get_available_governance_materials()
 
     if role is None:
         # No role specified - show guidance

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
+from vibe3.clients.github_client import GitHubClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.observability import setup_logging
 
@@ -88,61 +89,31 @@ def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
         raise typer.Exit(1)
 
 
-async def _run_supervisor_scan_async() -> None:
-    """Execute supervisor scan once (async implementation)."""
-    from vibe3.agents.backends.codeagent import CodeagentBackend
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.domain.handlers import register_event_handlers
-    from vibe3.domain.orchestration_facade import OrchestrationFacade
-    from vibe3.execution.capacity_service import CapacityService
-    from vibe3.orchestra.failed_gate import FailedGate
+def _run_supervisor_scan() -> tuple[int, int]:
+    """Execute supervisor scan once via internal apply (no facade).
 
-    # Register event handlers before publishing events
-    register_event_handlers()
+    Fetches supervisor candidates and calls internal_apply_dispatch directly
+    without going through OrchestrationFacade event chain.
 
-    # Load config
+    Returns:
+        Tuple of (total_issues_scanned, matched_issues_found)
+    """
+    from vibe3.commands.internal import internal_apply_dispatch
+    from vibe3.services.scan_service import fetch_supervisor_candidates
+
     config = load_orchestra_config()
+    github = GitHubClient()
 
-    # Initialize services
-    shared_store = SQLiteClient()
-    shared_backend = CodeagentBackend()
-    failed_gate = FailedGate(store=shared_store)
-    shared_capacity = CapacityService(config, shared_store, shared_backend)
+    # Fetch candidates
+    candidates = fetch_supervisor_candidates(github, config.repo)
+    matched_count = len(candidates)
 
-    # Check FailedGate before dispatching
-    gate_result = failed_gate.check()
-    if gate_result.blocked:
-        logger.bind(domain="orchestra").error(
-            f"Scan blocked by failed gate: {gate_result.reason}"
-        )
-        typer.echo(f"Scan blocked by failed gate: {gate_result.reason}")
-        return
+    # Dispatch each candidate via internal apply
+    for candidate in candidates:
+        issue_number = candidate["number"]
+        internal_apply_dispatch(issue=issue_number, dry_run=False, no_async=False)
 
-    # Create facade
-    facade = OrchestrationFacade(
-        tick_count=0,
-        config=config,
-        capacity=shared_capacity,
-        failed_gate=failed_gate,
-    )
-
-    # Trigger supervisor scan
-    # on_supervisor_scan publishes SupervisorIssueIdentified events
-    total_scanned, matched_count = await facade.on_supervisor_scan()
-
-    # Display scan results
-    if matched_count == 0:
-        typer.echo(
-            f"Scanned {total_scanned} open issues, "
-            f"found 0 issues with supervisor + state/handoff labels"
-        )
-    else:
-        typer.echo(
-            f"Scanned {total_scanned} open issues, "
-            f"found {matched_count} issue(s) requiring supervisor attention"
-        )
-
-    logger.bind(domain="orchestra").info("Supervisor scan completed")
+    return matched_count, matched_count
 
 
 def _run_supervisor_scan_dry_run() -> None:
@@ -346,59 +317,36 @@ def supervisor(
         _run_supervisor_scan_dry_run()
         return
 
-    asyncio.run(_run_supervisor_scan_async())
-    typer.echo("Supervisor scan completed")
+    # Manual supervisor scan: direct dispatch without facade
+    total_scanned, matched_count = _run_supervisor_scan()
+
+    # Display scan results
+    if matched_count == 0:
+        typer.echo(
+            f"Scanned {total_scanned} open issues, "
+            f"found 0 issues with supervisor + state/handoff labels"
+        )
+    else:
+        typer.echo(
+            f"Scanned {total_scanned} open issues, "
+            f"found {matched_count} issue(s) requiring supervisor attention"
+        )
+
+    logger.bind(domain="orchestra").info("Supervisor scan completed")
 
 
 async def _run_combined_scan_async() -> None:
     """Execute both governance and supervisor scans in sequence.
 
     Governance scan uses internal dispatch directly (no facade).
-    Supervisor scan temporarily still uses facade (will be refactored in Task 4).
+    Supervisor scan uses internal apply dispatch directly (no facade).
     """
     # Governance: call internal dispatch directly (no facade, no FailedGate)
     _execute_governance_internal(material_override=None)
     logger.bind(domain="orchestra").info("Governance scan completed")
 
-    # Supervisor: still uses facade for now (Task 4 will refactor this)
-    from vibe3.agents.backends.codeagent import CodeagentBackend
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.domain.handlers import register_event_handlers
-    from vibe3.domain.orchestration_facade import OrchestrationFacade
-    from vibe3.execution.capacity_service import CapacityService
-    from vibe3.orchestra.failed_gate import FailedGate
-
-    # Register event handlers for supervisor scan
-    register_event_handlers()
-
-    # Load config
-    config = load_orchestra_config()
-
-    # Initialize services for supervisor
-    shared_store = SQLiteClient()
-    shared_backend = CodeagentBackend()
-    failed_gate = FailedGate(store=shared_store)
-    shared_capacity = CapacityService(config, shared_store, shared_backend)
-
-    # Check FailedGate before supervisor scan
-    gate_result = failed_gate.check()
-    if gate_result.blocked:
-        logger.bind(domain="orchestra").error(
-            f"Supervisor scan blocked by failed gate: {gate_result.reason}"
-        )
-        typer.echo(f"Supervisor scan blocked by failed gate: {gate_result.reason}")
-        return
-
-    # Create facade for supervisor scan only
-    facade = OrchestrationFacade(
-        tick_count=0,
-        config=config,
-        capacity=shared_capacity,
-        failed_gate=failed_gate,
-    )
-
-    # Run supervisor scan
-    total_scanned, matched_count = await facade.on_supervisor_scan()
+    # Supervisor: call internal dispatch directly (no facade)
+    total_scanned, matched_count = _run_supervisor_scan()
 
     # Display scan results
     if matched_count == 0:

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -26,9 +26,9 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.services.scan_service import run_manual_governance_scan
+    from vibe3.services.scan_service import dispatch_governance_execution
 
-    run_manual_governance_scan(material_override=material_override)
+    dispatch_governance_execution(material_override=material_override)
 
 
 def _run_governance_scan(material_override: str | None = None) -> None:
@@ -75,8 +75,8 @@ def _run_supervisor_scan() -> tuple[int, int]:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
     from vibe3.services.scan_service import (
+        dispatch_supervisor_execution,
         fetch_supervisor_candidates,
-        run_manual_supervisor_apply,
     )
 
     config = load_orchestra_config()
@@ -89,9 +89,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
     # Dispatch each candidate via execution layer
     for candidate in candidates:
         issue_number = candidate["number"]
-        run_manual_supervisor_apply(
-            issue_number=issue_number, dry_run=False, no_async=False
-        )
+        dispatch_supervisor_execution(issue_number=issue_number, no_async=False)
 
     return total_scanned, matched_count
 

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -148,35 +148,6 @@ def _get_available_governance_materials() -> list[str]:
         return []
 
 
-def _extract_material_description(material_name: str) -> str:
-    """Extract description from material file (DEPRECATED - use scan_service).
-
-    This function delegates to scan_service.extract_material_description.
-
-    Args:
-        material_name: Material file path or name
-
-    Returns:
-        Material description or filename as fallback
-    """
-    from pathlib import Path
-
-    from vibe3.services.scan_service import extract_material_description
-
-    # Normalize to full path if needed (only for relative governance paths)
-    if (
-        not material_name.startswith("supervisor/governance/")
-        and not Path(material_name).is_absolute()
-    ):
-        material_name = f"supervisor/governance/{material_name}"
-
-    # Ensure .md suffix
-    if not material_name.endswith(".md"):
-        material_name = f"{material_name}.md"
-
-    return extract_material_description(material_name)
-
-
 def _list_governance_materials() -> None:
     """List available governance materials with descriptions.
 

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -46,47 +46,25 @@ def _run_governance_scan(material_override: str | None = None) -> None:
 
 
 def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
-    """Execute governance scan in dry-run mode, displaying prompt without execution.
+    """Execute governance scan in dry-run mode via run_governance_sync.
+
+    Uses real-time snapshot (not synthetic context) to preview governance prompt.
+    This fixes Issue #803 Problem 1: dry-run must match production execution path.
 
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from rich.console import Console
+    from vibe3.execution.governance_sync_runner import run_governance_sync
 
-    from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.roles.governance import build_governance_recipe
-    from vibe3.services.scan_service import render_governance_prompt_preview
-    from vibe3.ui.scan_display import display_governance_dry_run
-
-    console = Console()
-    config = load_orchestra_config()
-    tick_count = 0  # Dry-run uses tick 0 for consistency
-
-    try:
-        # Build recipe to get material name
-        recipe = build_governance_recipe(config, tick_count, material_override)
-        current_material = recipe.variables.get("supervisor_name")
-        if current_material is None:
-            console.print("[red]Error: supervisor_name variable not found[/red]")
-            raise typer.Exit(1)
-
-        # Extract material name (guaranteed to be str at this point)
-        if hasattr(current_material, "value") and current_material.value:
-            material_name = str(current_material.value)
-        else:
-            material_name = str(current_material)
-
-        # Render prompt
-        prompt_content = render_governance_prompt_preview(
-            config, tick_count, material_override
-        )
-
-        # Display via UI layer
-        display_governance_dry_run(console, material_name, prompt_content)
-
-    except ValueError as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
+    # Call internal governance runner with dry_run=True
+    # This uses real snapshot instead of synthetic dry-run context
+    run_governance_sync(
+        tick_count=0,  # Manual scan always uses tick=0
+        material_override=material_override,
+        dry_run=True,
+        show_prompt=True,
+        session_id=None,
+    )
 
 
 def _run_supervisor_scan() -> tuple[int, int]:

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -17,20 +17,18 @@ app = typer.Typer(
 
 
 def _execute_governance_internal(material_override: str | None = None) -> None:
-    """Execute governance scan via internal dispatch (no facade).
+    """Execute governance scan via service layer (no facade).
 
-    Direct path for manual governance scan, calling internal_governance_dispatch
-    without going through OrchestrationFacade heartbeat chain.
+    Direct path for manual governance scan, calling execution layer
+    without going through OrchestrationFacade heartbeat chain
+    or internal command layer.
 
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.commands.internal import internal_governance_dispatch
+    from vibe3.services.scan_service import run_manual_governance_scan
 
-    internal_governance_dispatch(
-        tick=0,
-        material=material_override,
-    )
+    run_manual_governance_scan(material_override=material_override)
 
 
 def _run_governance_scan(material_override: str | None = None) -> None:
@@ -68,16 +66,18 @@ def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
 
 
 def _run_supervisor_scan() -> tuple[int, int]:
-    """Execute supervisor scan once via internal apply (no facade).
+    """Execute supervisor scan once via execution layer (no facade).
 
-    Fetches supervisor candidates and calls internal_apply_dispatch directly
-    without going through OrchestrationFacade event chain.
+    Fetches supervisor candidates and calls execution layer directly
+    without going through OrchestrationFacade or internal command layer.
 
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
-    from vibe3.commands.internal import internal_apply_dispatch
-    from vibe3.services.scan_service import fetch_supervisor_candidates
+    from vibe3.services.scan_service import (
+        fetch_supervisor_candidates,
+        run_manual_supervisor_apply,
+    )
 
     config = load_orchestra_config()
     github = GitHubClient()
@@ -86,10 +86,12 @@ def _run_supervisor_scan() -> tuple[int, int]:
     total_scanned, candidates = fetch_supervisor_candidates(github, config.repo)
     matched_count = len(candidates)
 
-    # Dispatch each candidate via internal apply
+    # Dispatch each candidate via execution layer
     for candidate in candidates:
         issue_number = candidate["number"]
-        internal_apply_dispatch(issue=issue_number, dry_run=False, no_async=False)
+        run_manual_supervisor_apply(
+            issue_number=issue_number, dry_run=False, no_async=False
+        )
 
     return total_scanned, matched_count
 

--- a/src/vibe3/domain/events/governance.py
+++ b/src/vibe3/domain/events/governance.py
@@ -20,8 +20,6 @@ class GovernanceScanStarted(DomainEvent):
     """
 
     tick_count: int
-    is_manual: bool = False
-    material_override: str | None = None
     actor: str = "system:governance"
     timestamp: str | None = None
 

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -96,10 +96,6 @@ def handle_governance_scan_started(event: GovernanceScanStarted) -> None:
         str(event.tick_count),
     ]
 
-    # Add material override if specified
-    if event.material_override:
-        cmd.extend(["--material", event.material_override])
-
     env = dict(os.environ)
     env["VIBE3_ASYNC_CHILD"] = "1"
     # Ensure governance child process can write to events.log

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -242,22 +242,28 @@ class OrchestrationFacade(ServiceBase):
         包含 interval_ticks gating，避免每次 tick 都触发。
 
         Args:
-            force: 当 True 时跳过 interval gating，用于手动触发
-                (vibe3 scan governance)
+            force: DEPRECATED - 不再用于手动触发。
+                Manual governance scan 现在直接调用 internal_governance_dispatch，
+                不经过 facade heartbeat 链路。
+                此参数保留仅为向后兼容，实际不应再使用。
             material_override: 当提供时，覆盖 material rotation，
                 指定执行的 governance 角色
 
+        注意：手动 scan 命令不再使用此方法。
+        Manual governance/supervisor scans 直接调用 internal dispatch，
+        只有自动 heartbeat polling 才使用此 facade 方法。
         执行装配由 governance_scan handler 负责，facade 只做 observation。
         """
         # For manual triggers (force=True), use tick_count=0 for consistent t0 suffix
-        # For automatic triggers, increment tick counter
+        # NOTE: force=True is DEPRECATED - manual scans no longer use this path
         if force:
             tick_count = 0
         else:
             self._tick_count += 1
             tick_count = self._tick_count
 
-        # Skip interval gating when force=True (manual trigger)
+        # Skip interval gating when force=True
+        # (backward compat, not used by manual scans)
         if not force:
             interval = self._config.governance.interval_ticks
             if tick_count % interval != 0:

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -233,77 +233,53 @@ class OrchestrationFacade(ServiceBase):
 
         publish(event)
 
-    def on_heartbeat_tick(
-        self, force: bool = False, material_override: str | None = None
-    ) -> None:
+    def on_heartbeat_tick(self) -> None:
         """Heartbeat polling -> 发布 GovernanceScanStarted 事件.
 
         由 runtime heartbeat 定期调用，发布 governance 链路的 periodic scan 事件。
         包含 interval_ticks gating，避免每次 tick 都触发。
 
-        Args:
-            force: DEPRECATED - 不再用于手动触发。
-                Manual governance scan 现在直接调用 internal_governance_dispatch，
-                不经过 facade heartbeat 链路。
-                此参数保留仅为向后兼容，实际不应再使用。
-            material_override: 当提供时，覆盖 material rotation，
-                指定执行的 governance 角色
-
-        注意：手动 scan 命令不再使用此方法。
-        Manual governance/supervisor scans 直接调用 internal dispatch，
-        只有自动 heartbeat polling 才使用此 facade 方法。
-        执行装配由 governance_scan handler 负责，facade 只做 observation。
+        注意：此方法仅供自动 heartbeat polling 使用。
+        Manual governance scan 不走此路径，直接调用 service layer。
         """
-        # For manual triggers (force=True), use tick_count=0 for consistent t0 suffix
-        # NOTE: force=True is DEPRECATED - manual scans no longer use this path
-        if force:
-            tick_count = 0
-        else:
-            self._tick_count += 1
-            tick_count = self._tick_count
+        self._tick_count += 1
+        tick_count = self._tick_count
 
-        # Skip interval gating when force=True
-        # (backward compat, not used by manual scans)
-        if not force:
-            interval = self._config.governance.interval_ticks
-            if tick_count % interval != 0:
-                logger.bind(
-                    domain="orchestration_facade",
-                    tick_count=tick_count,
-                    interval=interval,
-                ).debug(
-                    f"Skipping governance scan (tick {tick_count} "
-                    f"not divisible by {interval})"
-                )
-                return
+        # Apply interval gating (e.g., run every 5 ticks)
+        interval = self._config.governance.interval_ticks
+        if tick_count % interval != 0:
+            logger.bind(
+                domain="orchestration_facade",
+                tick_count=tick_count,
+                interval=interval,
+            ).debug(
+                f"Skipping governance scan (tick {tick_count} "
+                f"not divisible by {interval})"
+            )
+            return
 
-            min_interval_seconds = self._config.polling_interval * interval
-            now = time.monotonic()
-            last_started_at = self._last_governance_started_at or self._created_at
-            elapsed = now - last_started_at
-            if elapsed < min_interval_seconds:
-                logger.bind(
-                    domain="orchestration_facade",
-                    tick_count=tick_count,
-                    interval=interval,
-                    min_interval_seconds=min_interval_seconds,
-                    elapsed_seconds=round(elapsed, 2),
-                ).debug("Skipping governance scan (min interval not reached)")
-                return
+        # Apply time-based gating (minimum seconds between scans)
+        min_interval_seconds = self._config.polling_interval * interval
+        now = time.monotonic()
+        last_started_at = self._last_governance_started_at or self._created_at
+        elapsed = now - last_started_at
+        if elapsed < min_interval_seconds:
+            logger.bind(
+                domain="orchestration_facade",
+                tick_count=tick_count,
+                interval=interval,
+                min_interval_seconds=min_interval_seconds,
+                elapsed_seconds=round(elapsed, 2),
+            ).debug("Skipping governance scan (min interval not reached)")
+            return
 
         # Update timestamp when actually emitting event
         self._last_governance_started_at = time.monotonic()
 
-        event = GovernanceScanStarted(
-            tick_count=tick_count,
-            is_manual=force,
-            material_override=material_override,
-        )
+        event = GovernanceScanStarted(tick_count=tick_count)
         logger.bind(
             domain="orchestration_facade",
             tick_count=tick_count,
-            force=force,
-            material_override=material_override,
         ).info("Emitting GovernanceScanStarted event")
         publish(event)
 

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -74,28 +74,6 @@ _GOVERNANCE_RUNTIME_VARS = (
 )
 
 
-def build_governance_dry_run_context() -> dict[str, Any]:
-    """Build minimal governance context for dry-run mode.
-
-    Returns empty/minimal context suitable for prompt preview
-    without accessing live data.
-
-    Returns:
-        Minimal governance context dict
-    """
-    return _build_issue_context(
-        active_entries=(),
-        server_running=False,
-        active_flows=0,
-        active_worktrees=0,
-        queued_issues=(),
-        circuit_breaker_state="closed",
-        circuit_breaker_failures=0,
-        issue_scope_name="dry-run mode",
-        scope_note="Dry-run mode: using minimal context for prompt preview",
-    )
-
-
 def _build_issue_context(
     active_entries: tuple[Any, ...],
     *,

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -39,6 +39,59 @@ def extract_material_description(material_path: str) -> str:
     return material_path
 
 
+def run_manual_governance_scan(material_override: str | None = None) -> None:
+    """Execute manual governance scan (no heartbeat facade).
+
+    Entry point for scan governance command, calling execution layer directly.
+
+    Args:
+        material_override: Optional governance role to override material rotation
+    """
+    from vibe3.execution.governance_sync_runner import run_governance_sync
+
+    run_governance_sync(
+        tick_count=0,  # Manual scan uses tick=0 for default material selection
+        material_override=material_override,
+        dry_run=False,  # Manual scan is execution (dry-run handled by scan layer)
+        show_prompt=False,
+        session_id=None,
+    )
+
+
+def run_manual_supervisor_apply(
+    issue_number: int, dry_run: bool = False, no_async: bool = False
+) -> None:
+    """Execute manual supervisor apply for a single issue.
+
+    Entry point for scan supervisor command, calling execution layer directly.
+
+    Args:
+        issue_number: Issue to apply supervisor handoff
+        dry_run: Preview mode (no execution)
+        no_async: Run synchronously instead of async tmux session
+    """
+    from vibe3.execution.issue_role_sync_runner import (
+        run_issue_role_async,
+        run_issue_role_sync,
+    )
+    from vibe3.roles.supervisor import SUPERVISOR_CLI_SYNC_SPEC
+
+    if no_async:
+        run_issue_role_sync(
+            issue_number=issue_number,
+            dry_run=dry_run,
+            fresh_session=True,
+            show_prompt=False,
+            spec=SUPERVISOR_CLI_SYNC_SPEC,
+        )
+    else:
+        run_issue_role_async(
+            issue_number=issue_number,
+            dry_run=dry_run,
+            spec=SUPERVISOR_CLI_SYNC_SPEC,
+        )
+
+
 def fetch_supervisor_candidates(
     github_client: Any, repo: str | None
 ) -> tuple[int, list[dict]]:

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -74,35 +74,3 @@ def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[di
     except Exception as e:
         logger.error(f"Failed to fetch supervisor candidates: {e}")
         return []
-
-
-def render_governance_prompt_preview(
-    config: Any, tick_count: int, material_override: str | None
-) -> str:
-    """Render governance prompt for preview.
-
-    Args:
-        config: Orchestra config
-        tick_count: Tick count for material rotation
-        material_override: Optional material override
-
-    Returns:
-        Rendered prompt text
-    """
-    from vibe3.roles.governance import (
-        build_governance_dry_run_context,
-        render_governance_prompt,
-    )
-
-    # Build minimal snapshot context for dry-run
-    snapshot_context = build_governance_dry_run_context()
-
-    # Render prompt
-    render_result = render_governance_prompt(
-        config,
-        snapshot_context,
-        tick_count=tick_count,
-        material_override=material_override,
-    )
-
-    return render_result.rendered_text

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -74,3 +74,62 @@ def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[di
     except Exception as e:
         logger.error(f"Failed to fetch supervisor candidates: {e}")
         return []
+
+
+def get_available_governance_materials() -> list[str]:
+    """Fetch available governance materials from catalog.
+
+    Returns list of short material names (without path/suffix).
+
+    Returns:
+        List of material short names (e.g., ["assignee-pool", "roadmap-intake"])
+    """
+    try:
+        from vibe3.roles.governance import load_governance_material_catalog
+
+        catalog = load_governance_material_catalog()
+        materials = []
+        for material in catalog:
+            # Extract short name:
+            # "supervisor/governance/roadmap-intake.md" → "roadmap-intake"
+            name = material.name
+            if name.startswith("supervisor/governance/"):
+                short_name = name.split("/")[-1]
+                short_name = (
+                    short_name[:-3] if short_name.endswith(".md") else short_name
+                )
+                materials.append(short_name)
+        return sorted(set(materials))
+    except Exception:
+        # Fallback if catalog cannot be loaded
+        return []
+
+
+def list_governance_materials(console: Any) -> None:
+    """List available governance materials with descriptions.
+
+    Loads catalog, extracts descriptions, and displays via UI layer.
+
+    Args:
+        console: Rich Console instance for display
+    """
+    import typer
+
+    from vibe3.roles.governance import load_governance_material_catalog
+    from vibe3.ui.scan_display import display_material_list
+
+    # Load catalog
+    try:
+        catalog = load_governance_material_catalog()
+    except Exception as exc:
+        console.print(f"[red]Error loading material catalog: {exc}[/red]")
+        raise typer.Exit(1)
+
+    # Build materials list with descriptions
+    materials = []
+    for material in catalog:
+        description = extract_material_description(material.name)
+        materials.append({"name": material.name, "description": description})
+
+    # Display via UI layer
+    display_material_list(console, materials)

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -39,7 +39,9 @@ def extract_material_description(material_path: str) -> str:
     return material_path
 
 
-def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[dict]:
+def fetch_supervisor_candidates(
+    github_client: Any, repo: str | None
+) -> tuple[int, list[dict]]:
     """Fetch supervisor candidate issues from GitHub.
 
     Filters for issues with both 'supervisor' and 'state/handoff' labels.
@@ -49,12 +51,15 @@ def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[di
         repo: Repository in "owner/repo" format
 
     Returns:
-        List of candidate issues (number, title, labels)
+        Tuple of (total_issues_scanned, matching_candidates)
+        - total_issues_scanned: Total number of open issues queried
+        - matching_candidates: List of candidate issues (number, title, labels)
     """
     from vibe3.utils.label_utils import normalize_labels
 
     try:
         raw_issues = github_client.list_issues(limit=100, state="open", repo=repo)
+        total_scanned = len(raw_issues)
 
         # Filter for supervisor + state/handoff labels
         matching = []
@@ -69,11 +74,11 @@ def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[di
                     }
                 )
 
-        return matching
+        return total_scanned, matching
 
     except Exception as e:
         logger.error(f"Failed to fetch supervisor candidates: {e}")
-        return []
+        return 0, []
 
 
 def get_available_governance_materials() -> list[str]:

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -54,7 +54,7 @@ def fetch_supervisor_candidates(github_client: Any, repo: str | None) -> list[di
     from vibe3.utils.label_utils import normalize_labels
 
     try:
-        raw_issues = github_client.list_issues(limit=50, state="open", repo=repo)
+        raw_issues = github_client.list_issues(limit=100, state="open", repo=repo)
 
         # Filter for supervisor + state/handoff labels
         matching = []

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -39,10 +39,10 @@ def extract_material_description(material_path: str) -> str:
     return material_path
 
 
-def run_manual_governance_scan(material_override: str | None = None) -> None:
-    """Execute manual governance scan (no heartbeat facade).
+def dispatch_governance_execution(material_override: str | None = None) -> None:
+    """Execute governance scan (execution-only entry point).
 
-    Entry point for scan governance command, calling execution layer directly.
+    Entry point for internal governance command, calling execution layer directly.
 
     Args:
         material_override: Optional governance role to override material rotation
@@ -52,22 +52,19 @@ def run_manual_governance_scan(material_override: str | None = None) -> None:
     run_governance_sync(
         tick_count=0,  # Manual scan uses tick=0 for default material selection
         material_override=material_override,
-        dry_run=False,  # Manual scan is execution (dry-run handled by scan layer)
+        dry_run=False,  # Execution-only, no dry-run
         show_prompt=False,
         session_id=None,
     )
 
 
-def run_manual_supervisor_apply(
-    issue_number: int, dry_run: bool = False, no_async: bool = False
-) -> None:
-    """Execute manual supervisor apply for a single issue.
+def dispatch_supervisor_execution(issue_number: int, no_async: bool = False) -> None:
+    """Execute supervisor apply for a single issue (execution-only entry point).
 
-    Entry point for scan supervisor command, calling execution layer directly.
+    Entry point for internal apply command, calling execution layer directly.
 
     Args:
         issue_number: Issue to apply supervisor handoff
-        dry_run: Preview mode (no execution)
         no_async: Run synchronously instead of async tmux session
     """
     from vibe3.execution.issue_role_sync_runner import (
@@ -79,7 +76,7 @@ def run_manual_supervisor_apply(
     if no_async:
         run_issue_role_sync(
             issue_number=issue_number,
-            dry_run=dry_run,
+            dry_run=False,
             fresh_session=True,
             show_prompt=False,
             spec=SUPERVISOR_CLI_SYNC_SPEC,
@@ -87,7 +84,7 @@ def run_manual_supervisor_apply(
     else:
         run_issue_role_async(
             issue_number=issue_number,
-            dry_run=dry_run,
+            dry_run=False,
             spec=SUPERVISOR_CLI_SYNC_SPEC,
         )
 

--- a/src/vibe3/ui/scan_display.py
+++ b/src/vibe3/ui/scan_display.py
@@ -40,11 +40,14 @@ def display_governance_dry_run(
     console.print("[dim]Mode: dry-run (no execution)[/dim]\n")
 
 
-def display_supervisor_dry_run(console: Console, candidates: list[dict]) -> None:
+def display_supervisor_dry_run(
+    console: Console, total_scanned: int, candidates: list[dict]
+) -> None:
     """Display supervisor scan dry-run output.
 
     Args:
         console: Rich Console instance
+        total_scanned: Total number of open issues scanned
         candidates: List of candidate issues (number, title, labels)
     """
     console.print("\n[bold]Supervisor Scan Dry-Run[/bold]")
@@ -52,8 +55,8 @@ def display_supervisor_dry_run(console: Console, candidates: list[dict]) -> None
 
     # Scan process simulation
     console.print("[bold]Scan Process:[/bold]")
-    console.print("1. Query open issues with 'supervisor' label")
-    console.print("2. Filter by additional 'state/handoff' label")
+    console.print(f"1. Queried {total_scanned} open issues")
+    console.print("2. Filtered by 'supervisor' + 'state/handoff' labels")
     console.print("3. For each matching issue:")
     console.print("   - Build supervisor handoff prompt")
     console.print("   - Would dispatch supervisor-apply agent\n")
@@ -85,18 +88,13 @@ def display_supervisor_dry_run(console: Console, candidates: list[dict]) -> None
         )
     else:
         console.print(
-            "[yellow]No issues found with supervisor + "
-            "state/handoff labels[/yellow]\n"
-        )
-        console.print(
-            "[dim]In real mode, would report: 'Scanned X open issues, "
-            "found 0 issues requiring supervisor attention'[/dim]"
+            f"[yellow]Scanned {total_scanned} open issues, "
+            f"found 0 issues with supervisor + state/handoff labels[/yellow]\n"
         )
 
     console.print("\n[bold]Summary:[/bold]")
-    console.print(
-        "[dim]• Scan target: Open issues with supervisor + state/handoff labels[/dim]"
-    )
+    console.print(f"[dim]• Total issues scanned: {total_scanned}[/dim]")
+    console.print(f"[dim]• Matching candidates: {len(candidates)}[/dim]")
     console.print(
         "[dim]• Action: Would build and dispatch supervisor-apply prompts[/dim]"
     )

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -23,30 +23,6 @@ def test_internal_manager_dispatch():
         assert mock_run.call_args.kwargs["spec"].role_name == "manager"
 
 
-def test_internal_manager_with_options():
-    """测试 internal manager 命令支持所有选项."""
-    with patch(
-        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
-    ) as mock_run:
-        result = runner.invoke(
-            cli_app,
-            [
-                "internal",
-                "manager",
-                "456",
-                "--no-async",
-                "--dry-run",
-                "--fresh-session",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert mock_run.call_args.kwargs["issue_number"] == 456
-        assert mock_run.call_args.kwargs["dry_run"] is True
-        assert mock_run.call_args.kwargs["fresh_session"] is True
-        assert mock_run.call_args.kwargs["spec"].role_name == "manager"
-
-
 def test_internal_apply_dispatch():
     """测试 internal apply 命令参数解析和调用."""
     with patch(
@@ -61,22 +37,6 @@ def test_internal_apply_dispatch():
         assert mock_run.call_args.kwargs["issue_number"] == 42
         assert mock_run.call_args.kwargs["dry_run"] is False
         assert mock_run.call_args.kwargs["fresh_session"] is True
-        assert mock_run.call_args.kwargs["spec"].role_name == "supervisor"
-
-
-def test_internal_apply_with_dry_run():
-    """测试 internal apply 命令支持 --dry-run 选项."""
-    with patch(
-        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
-    ) as mock_run:
-        result = runner.invoke(
-            cli_app,
-            ["internal", "apply", "789", "--no-async", "--dry-run"],
-        )
-
-        assert result.exit_code == 0
-        assert mock_run.call_args.kwargs["issue_number"] == 789
-        assert mock_run.call_args.kwargs["dry_run"] is True
         assert mock_run.call_args.kwargs["spec"].role_name == "supervisor"
 
 

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -187,14 +187,17 @@ class TestScanIntegration:
             ) as mock_fetch,
             patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
         ):
-            # Mock candidate list
-            mock_fetch.return_value = [
-                {
-                    "number": 123,
-                    "title": "Issue A",
-                    "labels": ["supervisor", "state/handoff"],
-                },
-            ]
+            # Mock candidate list (total_scanned, candidates)
+            mock_fetch.return_value = (
+                1,
+                [
+                    {
+                        "number": 123,
+                        "title": "Issue A",
+                        "labels": ["supervisor", "state/handoff"],
+                    },
+                ],
+            )
 
             from vibe3.commands.scan import _run_supervisor_scan
 
@@ -236,8 +239,8 @@ class TestFailedGateBlocking:
         with patch(
             "vibe3.services.scan_service.fetch_supervisor_candidates"
         ) as mock_fetch:
-            # Mock empty candidate list
-            mock_fetch.return_value = []
+            # Mock empty candidate list (total_scanned, candidates)
+            mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_supervisor_scan
 
@@ -263,8 +266,8 @@ class TestFailedGateBlocking:
             ) as mock_fetch,
             patch("vibe3.commands.internal.internal_apply_dispatch"),
         ):
-            # Mock supervisor candidates
-            mock_fetch.return_value = []
+            # Mock supervisor candidates (total_scanned, candidates)
+            mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_combined_scan_async
 
@@ -289,19 +292,22 @@ def test_supervisor_scan_fetches_candidates_and_calls_internal_apply() -> None:
         patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
         patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
     ):
-        # Mock candidate list
-        mock_fetch.return_value = [
-            {
-                "number": 123,
-                "title": "Issue A",
-                "labels": ["supervisor", "state/handoff"],
-            },
-            {
-                "number": 456,
-                "title": "Issue B",
-                "labels": ["supervisor", "state/handoff"],
-            },
-        ]
+        # Mock candidate list (total_scanned, candidates)
+        mock_fetch.return_value = (
+            2,
+            [
+                {
+                    "number": 123,
+                    "title": "Issue A",
+                    "labels": ["supervisor", "state/handoff"],
+                },
+                {
+                    "number": 456,
+                    "title": "Issue B",
+                    "labels": ["supervisor", "state/handoff"],
+                },
+            ],
+        )
 
         result = runner.invoke(app, ["scan", "supervisor"])
 

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -73,6 +73,41 @@ class TestGovernanceScan:
         assert "Governance scan completed" in result.output
         mock_run.assert_called_once_with(material_override=None)
 
+    def test_governance_scan_does_not_call_on_heartbeat_tick(self):
+        """Test manual governance scan does not call facade.on_heartbeat_tick.
+
+        Manual scan should call internal_governance_dispatch directly,
+        not through OrchestrationFacade heartbeat path.
+        """
+        # Mock the internal dispatch function that should be called
+        with patch(
+            "vibe3.commands.internal.internal_governance_dispatch"
+        ) as mock_internal_dispatch:
+            # Mock facade to ensure it's not created
+            # OrchestrationFacade is imported inside _run_governance_scan
+            with patch(
+                "vibe3.domain.orchestration_facade.OrchestrationFacade"
+            ) as mock_facade:
+                runner.invoke(app, ["scan", "governance"])
+
+                # After refactor, facade should not be instantiated
+                mock_facade.assert_not_called()
+
+                # And internal dispatch should be called instead
+                # (This will pass once we refactor _run_governance_scan)
+                # For now, we expect this to fail as implementation
+                # still uses facade
+                if mock_internal_dispatch.called:
+                    # Success: new implementation calls internal dispatch
+                    pass
+                else:
+                    # Failure: old implementation still uses facade
+                    # We'll fix this in Step 3
+                    raise AssertionError(
+                        "Implementation still uses facade, "
+                        "should call internal dispatch"
+                    )
+
 
 class TestSupervisorScan:
     """Tests for scan supervisor subcommand."""
@@ -121,36 +156,20 @@ class TestScanIntegration:
     """Integration tests for scan command with services."""
 
     def test_governance_scan_registers_handlers(self):
-        """Test that governance scan registers event handlers."""
-        with (
-            patch("vibe3.domain.handlers.register_event_handlers") as mock_handlers,
-            patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade,
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
-            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
-            patch("vibe3.execution.capacity_service.CapacityService"),
-            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
-        ):
+        """Test that governance scan calls internal dispatch directly.
 
-            # Mock FailedGate to return open gate
-            mock_gate_instance = MagicMock()
-            mock_gate_result = MagicMock()
-            mock_gate_result.blocked = False
-            mock_gate_instance.check.return_value = mock_gate_result
-            mock_failed_gate.return_value = mock_gate_instance
-
-            mock_facade_instance = MagicMock()
-            mock_facade.return_value = mock_facade_instance
-
+        After refactor: manual governance scan no longer registers handlers
+        or uses facade. It calls internal_governance_dispatch directly.
+        """
+        with patch(
+            "vibe3.commands.internal.internal_governance_dispatch"
+        ) as mock_internal:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan()
 
-            # Verify handlers were registered before facade methods called
-            mock_handlers.assert_called_once()
-            mock_facade.assert_called_once()
-            mock_facade_instance.on_heartbeat_tick.assert_called_once()
+            # Verify internal dispatch was called (new architecture)
+            mock_internal.assert_called_once_with(tick=0, material=None)
 
     @pytest.mark.asyncio
     async def test_supervisor_scan_registers_handlers(self):
@@ -195,38 +214,21 @@ class TestFailedGateBlocking:
     """Tests for FailedGate blocking in scan commands."""
 
     def test_governance_scan_blocked_by_failed_gate(self):
-        """Test that governance scan respects FailedGate."""
-        with (
-            patch("vibe3.domain.handlers.register_event_handlers"),
-            patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade,
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
-            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
-            patch("vibe3.execution.capacity_service.CapacityService"),
-            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
-        ):
+        """Test that manual governance scan ignores FailedGate.
 
-            # Mock FailedGate to return blocked state
-            mock_gate_instance = MagicMock()
-            mock_gate_result = MagicMock()
-            mock_gate_result.blocked = True
-            mock_gate_result.reason = "API error threshold: 2 recent errors"
-            mock_gate_instance.check.return_value = mock_gate_result
-            mock_failed_gate.return_value = mock_gate_instance
-
-            mock_facade_instance = MagicMock()
-            mock_facade.return_value = mock_facade_instance
-
+        After refactor: manual governance scan calls internal dispatch directly,
+        bypassing FailedGate (which is only for heartbeat automatic chain).
+        FailedGate is only checked in automatic heartbeat polling, not manual scans.
+        """
+        with patch(
+            "vibe3.commands.internal.internal_governance_dispatch"
+        ) as mock_internal:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan()
 
-            # Verify FailedGate was checked
-            mock_gate_instance.check.assert_called_once()
-
-            # Verify facade was NOT called (blocked by gate)
-            mock_facade_instance.on_heartbeat_tick.assert_not_called()
+            # Manual scan always calls internal dispatch, ignoring FailedGate
+            mock_internal.assert_called_once_with(tick=0, material=None)
 
     @pytest.mark.asyncio
     async def test_supervisor_scan_blocked_by_failed_gate(self):
@@ -266,9 +268,17 @@ class TestFailedGateBlocking:
 
     @pytest.mark.asyncio
     async def test_combined_scan_blocked_by_failed_gate(self):
-        """Test that combined scan respects FailedGate."""
+        """Test combined scan governance bypasses FailedGate.
+
+        Governance bypasses FailedGate (internal dispatch),
+        but supervisor scan still checks FailedGate (until Task 4).
+        When FailedGate blocks, supervisor scan returns early
+        without creating facade.
+        """
         with (
-            patch("vibe3.domain.handlers.register_event_handlers"),
+            patch(
+                "vibe3.commands.internal.internal_governance_dispatch"
+            ) as mock_governance,
             patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
             ) as mock_facade,
@@ -286,20 +296,18 @@ class TestFailedGateBlocking:
             mock_gate_instance.check.return_value = mock_gate_result
             mock_failed_gate.return_value = mock_gate_instance
 
-            mock_facade_instance = MagicMock()
-            mock_facade_instance.on_supervisor_scan = MagicMock(return_value=None)
-            mock_facade.return_value = mock_facade_instance
-
             from vibe3.commands.scan import _run_combined_scan_async
 
             await _run_combined_scan_async()
 
-            # Verify FailedGate was checked
-            mock_gate_instance.check.assert_called_once()
+            # Governance always runs (bypasses FailedGate)
+            mock_governance.assert_called_once()
 
-            # Verify neither facade method was called (blocked by gate)
-            mock_facade_instance.on_heartbeat_tick.assert_not_called()
-            mock_facade_instance.on_supervisor_scan.assert_not_called()
+            # Supervisor blocked by FailedGate, facade not created
+            mock_facade.assert_not_called()
+
+            # FailedGate checked for supervisor
+            mock_gate_instance.check.assert_called()
 
 
 # Tests for material description extraction

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -77,12 +77,12 @@ class TestGovernanceScan:
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
         """Test manual governance scan calls service layer directly.
 
-        Manual scan should call run_manual_governance_scan (service layer),
+        Manual scan should call dispatch_governance_execution (service layer),
         not through OrchestrationFacade heartbeat path or internal command layer.
         """
         # Mock the service layer function that should be called
         with patch(
-            "vibe3.services.scan_service.run_manual_governance_scan"
+            "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service_run:
             # Mock facade to ensure it's not created
             with patch(
@@ -151,10 +151,10 @@ class TestScanIntegration:
         """Test that governance scan calls service layer directly.
 
         After refactor: manual governance scan no longer registers handlers
-        or uses facade. It calls service layer (run_manual_governance_scan) directly.
+        or uses facade. It calls service layer (dispatch_governance_execution) directly.
         """
         with patch(
-            "vibe3.services.scan_service.run_manual_governance_scan"
+            "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
@@ -167,14 +167,14 @@ class TestScanIntegration:
         """Test that supervisor scan calls service layer directly.
 
         After refactor: manual supervisor scan no longer registers handlers
-        or uses facade. It calls service layer (run_manual_supervisor_apply) directly.
+        or uses facade. It calls service layer (dispatch_supervisor_execution) directly.
         """
         with (
             patch(
                 "vibe3.services.scan_service.fetch_supervisor_candidates"
             ) as mock_fetch,
             patch(
-                "vibe3.services.scan_service.run_manual_supervisor_apply"
+                "vibe3.services.scan_service.dispatch_supervisor_execution"
             ) as mock_apply,
         ):
             # Mock candidate list (total_scanned, candidates)
@@ -210,7 +210,7 @@ class TestFailedGateBlocking:
         FailedGate is only checked in automatic heartbeat polling, not manual scans.
         """
         with patch(
-            "vibe3.services.scan_service.run_manual_governance_scan"
+            "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
@@ -249,12 +249,12 @@ class TestFailedGateBlocking:
         """
         with (
             patch(
-                "vibe3.services.scan_service.run_manual_governance_scan"
+                "vibe3.services.scan_service.dispatch_governance_execution"
             ) as mock_governance,
             patch(
                 "vibe3.services.scan_service.fetch_supervisor_candidates"
             ) as mock_fetch,
-            patch("vibe3.services.scan_service.run_manual_supervisor_apply"),
+            patch("vibe3.services.scan_service.dispatch_supervisor_execution"),
         ):
             # Mock supervisor candidates (total_scanned, candidates)
             mock_fetch.return_value = (0, [])
@@ -275,12 +275,14 @@ def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
     """Test manual supervisor scan calls service layer directly.
 
     After refactor: manual supervisor scan should fetch candidates,
-    filter them, and call run_manual_supervisor_apply for each one,
+    filter them, and call dispatch_supervisor_execution for each one,
     not through internal command layer.
     """
     with (
         patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
-        patch("vibe3.services.scan_service.run_manual_supervisor_apply") as mock_apply,
+        patch(
+            "vibe3.services.scan_service.dispatch_supervisor_execution"
+        ) as mock_apply,
     ):
         # Mock candidate list (total_scanned, candidates)
         mock_fetch.return_value = (

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -1,7 +1,7 @@
 """Tests for scan CLI command."""
 
 import re
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -121,14 +121,16 @@ class TestSupervisorScan:
         assert "supervisor" in output_lower
         assert "dry-run" in output_lower or "dry run" in output_lower
 
-    @patch("vibe3.commands.scan._run_supervisor_scan_async")
+    @patch("vibe3.commands.scan._run_supervisor_scan")
     def test_supervisor_execution(self, mock_run):
         """Test supervisor scan execution."""
-        # Mock async function needs to return a coroutine
-        mock_run.return_value = None
+        # Mock return value (total_scanned, matched_count)
+        mock_run.return_value = (10, 2)
         result = runner.invoke(app, ["scan", "supervisor"])
         assert result.exit_code == 0
-        assert "Supervisor scan completed" in result.output
+        # Should show scan statistics, not "completed" message
+        assert "Scanned 10 open issues" in result.output
+        assert "found 2" in result.output
 
 
 class TestCombinedScan:
@@ -171,43 +173,35 @@ class TestScanIntegration:
             # Verify internal dispatch was called (new architecture)
             mock_internal.assert_called_once_with(tick=0, material=None)
 
-    @pytest.mark.asyncio
-    async def test_supervisor_scan_registers_handlers(self):
-        """Test that supervisor scan registers event handlers."""
+    def test_supervisor_scan_registers_handlers(self):
+        """Test that supervisor scan calls internal dispatch directly.
+
+        After refactor: manual supervisor scan no longer registers handlers
+        or uses facade. It calls internal_apply_dispatch directly.
+        """
         with (
-            patch("vibe3.domain.handlers.register_event_handlers") as mock_handlers,
             patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade,
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
-            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
-            patch("vibe3.execution.capacity_service.CapacityService"),
-            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+                "vibe3.services.scan_service.fetch_supervisor_candidates"
+            ) as mock_fetch,
+            patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
         ):
+            # Mock candidate list
+            mock_fetch.return_value = [
+                {
+                    "number": 123,
+                    "title": "Issue A",
+                    "labels": ["supervisor", "state/handoff"],
+                },
+            ]
 
-            # Mock FailedGate to return open gate
-            mock_gate_instance = MagicMock()
-            mock_gate_result = MagicMock()
-            mock_gate_result.blocked = False
-            mock_gate_instance.check.return_value = mock_gate_result
-            mock_failed_gate.return_value = mock_gate_instance
+            from vibe3.commands.scan import _run_supervisor_scan
 
-            mock_facade_instance = MagicMock()
+            _run_supervisor_scan()
 
-            # Make on_supervisor_scan an async mock
-            async def async_mock():
-                return (10, 2)
-
-            mock_facade_instance.on_supervisor_scan = async_mock
-            mock_facade.return_value = mock_facade_instance
-
-            from vibe3.commands.scan import _run_supervisor_scan_async
-
-            await _run_supervisor_scan_async()
-
-            # Verify handlers were registered
-            mock_handlers.assert_called_once()
-            mock_facade.assert_called_once()
+            # Verify candidates fetched
+            mock_fetch.assert_called_once()
+            # Verify internal dispatch called
+            mock_apply.assert_called_once()
 
 
 class TestFailedGateBlocking:
@@ -230,71 +224,45 @@ class TestFailedGateBlocking:
             # Manual scan always calls internal dispatch, ignoring FailedGate
             mock_internal.assert_called_once_with(tick=0, material=None)
 
-    @pytest.mark.asyncio
-    async def test_supervisor_scan_blocked_by_failed_gate(self):
-        """Test that supervisor scan respects FailedGate."""
-        with (
-            patch("vibe3.domain.handlers.register_event_handlers"),
-            patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade,
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
-            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
-            patch("vibe3.execution.capacity_service.CapacityService"),
-            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
-        ):
+    def test_supervisor_scan_blocked_by_failed_gate(self):
+        """Test manual supervisor scan ignores FailedGate.
 
-            # Mock FailedGate to return blocked state
-            mock_gate_instance = MagicMock()
-            mock_gate_result = MagicMock()
-            mock_gate_result.blocked = True
-            mock_gate_result.reason = "Model configuration errors: E_MODEL_INVALID"
-            mock_gate_instance.check.return_value = mock_gate_result
-            mock_failed_gate.return_value = mock_gate_instance
+        After refactor: manual supervisor scan calls internal dispatch directly,
+        bypassing FailedGate (which is only for heartbeat automatic chain).
+        FailedGate is only checked in automatic heartbeat polling, not manual scans.
+        """
+        with patch(
+            "vibe3.services.scan_service.fetch_supervisor_candidates"
+        ) as mock_fetch:
+            # Mock empty candidate list
+            mock_fetch.return_value = []
 
-            mock_facade_instance = MagicMock()
-            mock_facade_instance.on_supervisor_scan = MagicMock(return_value=None)
-            mock_facade.return_value = mock_facade_instance
+            from vibe3.commands.scan import _run_supervisor_scan
 
-            from vibe3.commands.scan import _run_supervisor_scan_async
+            _run_supervisor_scan()
 
-            await _run_supervisor_scan_async()
-
-            # Verify FailedGate was checked
-            mock_gate_instance.check.assert_called_once()
-
-            # Verify facade was NOT called (blocked by gate)
-            mock_facade_instance.on_supervisor_scan.assert_not_called()
+            # Manual scan always fetches candidates, ignoring FailedGate
+            mock_fetch.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_combined_scan_blocked_by_failed_gate(self):
-        """Test combined scan governance bypasses FailedGate.
+        """Test combined scan bypasses FailedGate for both governance and supervisor.
 
-        Governance bypasses FailedGate (internal dispatch),
-        but supervisor scan still checks FailedGate (until Task 4).
-        When FailedGate blocks, supervisor scan returns early
-        without creating facade.
+        After refactor: manual scans bypass FailedGate entirely.
+        FailedGate is only checked in automatic heartbeat polling.
+        Both governance and supervisor use internal dispatch directly.
         """
         with (
             patch(
                 "vibe3.commands.internal.internal_governance_dispatch"
             ) as mock_governance,
             patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade,
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
-            patch("vibe3.orchestra.failed_gate.FailedGate") as mock_failed_gate,
-            patch("vibe3.execution.capacity_service.CapacityService"),
-            patch("vibe3.config.orchestra_settings.load_orchestra_config"),
+                "vibe3.services.scan_service.fetch_supervisor_candidates"
+            ) as mock_fetch,
+            patch("vibe3.commands.internal.internal_apply_dispatch"),
         ):
-
-            # Mock FailedGate to return blocked state
-            mock_gate_instance = MagicMock()
-            mock_gate_result = MagicMock()
-            mock_gate_result.blocked = True
-            mock_gate_result.reason = "System in failed state"
-            mock_gate_instance.check.return_value = mock_gate_result
-            mock_failed_gate.return_value = mock_gate_instance
+            # Mock supervisor candidates
+            mock_fetch.return_value = []
 
             from vibe3.commands.scan import _run_combined_scan_async
 
@@ -303,15 +271,44 @@ class TestFailedGateBlocking:
             # Governance always runs (bypasses FailedGate)
             mock_governance.assert_called_once()
 
-            # Supervisor blocked by FailedGate, facade not created
-            mock_facade.assert_not_called()
-
-            # FailedGate checked for supervisor
-            mock_gate_instance.check.assert_called()
+            # Supervisor also runs (bypasses FailedGate)
+            mock_fetch.assert_called_once()
 
 
 # Tests for material description extraction
-def test_internal_governance_signature_is_execution_only() -> None:
+def test_supervisor_scan_fetches_candidates_and_calls_internal_apply() -> None:
+    """Test manual supervisor scan calls internal apply directly.
+
+    After refactor: manual supervisor scan should fetch candidates,
+    filter them, and call internal_apply_dispatch for each one,
+    not through facade event chain.
+    """
+    with (
+        patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
+        patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
+    ):
+        # Mock candidate list
+        mock_fetch.return_value = [
+            {
+                "number": 123,
+                "title": "Issue A",
+                "labels": ["supervisor", "state/handoff"],
+            },
+            {
+                "number": 456,
+                "title": "Issue B",
+                "labels": ["supervisor", "state/handoff"],
+            },
+        ]
+
+        result = runner.invoke(app, ["scan", "supervisor"])
+
+        assert result.exit_code == 0
+        # Should fetch candidates
+        mock_fetch.assert_called_once()
+
+        # Should call internal_apply_dispatch for each candidate
+        assert mock_apply.call_count == 2
     """Test internal_governance_dispatch signature only has execution params.
 
     After refactor: internal governance should only accept tick/material,

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -61,9 +61,10 @@ class TestGovernanceScan:
         """Test governance scan with --dry-run flag."""
         result = runner.invoke(app, ["scan", "governance", "--dry-run"])
         assert result.exit_code == 0
-        # Should now show material information and prompt preview
+        # New format: "-> Governance dry-run: tick=0"
+        # Uses real-time snapshot via run_governance_sync(dry_run=True)
         output_lower = result.output.lower()
-        assert "material:" in output_lower or "governance scan dry-run" in output_lower
+        assert "governance dry-run" in output_lower or "--- prompt ---" in output_lower
 
     @patch("vibe3.commands.scan._run_governance_scan")
     def test_governance_execution(self, mock_run):
@@ -142,7 +143,8 @@ class TestCombinedScan:
         assert result.exit_code == 0
         # Should show both governance and supervisor dry-run output
         output_lower = result.output.lower()
-        assert "governance scan dry-run" in output_lower
+        # New format: "Governance dry-run" and "Supervisor scan dry-run"
+        assert "governance dry-run" in output_lower
         assert "supervisor scan dry-run" in output_lower
 
     @patch("vibe3.commands.scan._run_combined_scan_async")

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -75,17 +75,16 @@ class TestGovernanceScan:
         mock_run.assert_called_once_with(material_override=None)
 
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
-        """Test manual governance scan does not call facade.on_heartbeat_tick.
+        """Test manual governance scan calls service layer directly.
 
-        Manual scan should call internal_governance_dispatch directly,
-        not through OrchestrationFacade heartbeat path.
+        Manual scan should call run_manual_governance_scan (service layer),
+        not through OrchestrationFacade heartbeat path or internal command layer.
         """
-        # Mock the internal dispatch function that should be called
+        # Mock the service layer function that should be called
         with patch(
-            "vibe3.commands.internal.internal_governance_dispatch"
-        ) as mock_internal_dispatch:
+            "vibe3.services.scan_service.run_manual_governance_scan"
+        ) as mock_service_run:
             # Mock facade to ensure it's not created
-            # OrchestrationFacade is imported inside _run_governance_scan
             with patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
             ) as mock_facade:
@@ -94,20 +93,9 @@ class TestGovernanceScan:
                 # After refactor, facade should not be instantiated
                 mock_facade.assert_not_called()
 
-                # And internal dispatch should be called instead
-                # (This will pass once we refactor _run_governance_scan)
-                # For now, we expect this to fail as implementation
-                # still uses facade
-                if mock_internal_dispatch.called:
-                    # Success: new implementation calls internal dispatch
-                    pass
-                else:
-                    # Failure: old implementation still uses facade
-                    # We'll fix this in Step 3
-                    raise AssertionError(
-                        "Implementation still uses facade, "
-                        "should call internal dispatch"
-                    )
+                # Service layer function should be called directly
+                assert mock_service_run.called
+                mock_service_run.assert_called_once_with(material_override=None)
 
 
 class TestSupervisorScan:
@@ -160,32 +148,34 @@ class TestScanIntegration:
     """Integration tests for scan command with services."""
 
     def test_governance_scan_registers_handlers(self):
-        """Test that governance scan calls internal dispatch directly.
+        """Test that governance scan calls service layer directly.
 
         After refactor: manual governance scan no longer registers handlers
-        or uses facade. It calls internal_governance_dispatch directly.
+        or uses facade. It calls service layer (run_manual_governance_scan) directly.
         """
         with patch(
-            "vibe3.commands.internal.internal_governance_dispatch"
-        ) as mock_internal:
+            "vibe3.services.scan_service.run_manual_governance_scan"
+        ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan()
 
-            # Verify internal dispatch was called (new architecture)
-            mock_internal.assert_called_once_with(tick=0, material=None)
+            # Verify service layer was called (new architecture)
+            mock_service.assert_called_once_with(material_override=None)
 
     def test_supervisor_scan_registers_handlers(self):
-        """Test that supervisor scan calls internal dispatch directly.
+        """Test that supervisor scan calls service layer directly.
 
         After refactor: manual supervisor scan no longer registers handlers
-        or uses facade. It calls internal_apply_dispatch directly.
+        or uses facade. It calls service layer (run_manual_supervisor_apply) directly.
         """
         with (
             patch(
                 "vibe3.services.scan_service.fetch_supervisor_candidates"
             ) as mock_fetch,
-            patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
+            patch(
+                "vibe3.services.scan_service.run_manual_supervisor_apply"
+            ) as mock_apply,
         ):
             # Mock candidate list (total_scanned, candidates)
             mock_fetch.return_value = (
@@ -205,7 +195,7 @@ class TestScanIntegration:
 
             # Verify candidates fetched
             mock_fetch.assert_called_once()
-            # Verify internal dispatch called
+            # Verify service layer apply called
             mock_apply.assert_called_once()
 
 
@@ -215,19 +205,19 @@ class TestFailedGateBlocking:
     def test_governance_scan_blocked_by_failed_gate(self):
         """Test that manual governance scan ignores FailedGate.
 
-        After refactor: manual governance scan calls internal dispatch directly,
+        After refactor: manual governance scan calls service layer directly,
         bypassing FailedGate (which is only for heartbeat automatic chain).
         FailedGate is only checked in automatic heartbeat polling, not manual scans.
         """
         with patch(
-            "vibe3.commands.internal.internal_governance_dispatch"
-        ) as mock_internal:
+            "vibe3.services.scan_service.run_manual_governance_scan"
+        ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan()
 
-            # Manual scan always calls internal dispatch, ignoring FailedGate
-            mock_internal.assert_called_once_with(tick=0, material=None)
+            # Manual scan always calls service layer, ignoring FailedGate
+            mock_service.assert_called_once_with(material_override=None)
 
     def test_supervisor_scan_blocked_by_failed_gate(self):
         """Test manual supervisor scan ignores FailedGate.
@@ -255,16 +245,16 @@ class TestFailedGateBlocking:
 
         After refactor: manual scans bypass FailedGate entirely.
         FailedGate is only checked in automatic heartbeat polling.
-        Both governance and supervisor use internal dispatch directly.
+        Both governance and supervisor use service layer directly.
         """
         with (
             patch(
-                "vibe3.commands.internal.internal_governance_dispatch"
+                "vibe3.services.scan_service.run_manual_governance_scan"
             ) as mock_governance,
             patch(
                 "vibe3.services.scan_service.fetch_supervisor_candidates"
             ) as mock_fetch,
-            patch("vibe3.commands.internal.internal_apply_dispatch"),
+            patch("vibe3.services.scan_service.run_manual_supervisor_apply"),
         ):
             # Mock supervisor candidates (total_scanned, candidates)
             mock_fetch.return_value = (0, [])
@@ -281,16 +271,16 @@ class TestFailedGateBlocking:
 
 
 # Tests for material description extraction
-def test_supervisor_scan_fetches_candidates_and_calls_internal_apply() -> None:
-    """Test manual supervisor scan calls internal apply directly.
+def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
+    """Test manual supervisor scan calls service layer directly.
 
     After refactor: manual supervisor scan should fetch candidates,
-    filter them, and call internal_apply_dispatch for each one,
-    not through facade event chain.
+    filter them, and call run_manual_supervisor_apply for each one,
+    not through internal command layer.
     """
     with (
         patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
-        patch("vibe3.commands.internal.internal_apply_dispatch") as mock_apply,
+        patch("vibe3.services.scan_service.run_manual_supervisor_apply") as mock_apply,
     ):
         # Mock candidate list (total_scanned, candidates)
         mock_fetch.return_value = (
@@ -315,7 +305,7 @@ def test_supervisor_scan_fetches_candidates_and_calls_internal_apply() -> None:
         # Should fetch candidates
         mock_fetch.assert_called_once()
 
-        # Should call internal_apply_dispatch for each candidate
+        # Should call service layer apply for each candidate
         assert mock_apply.call_count == 2
 
 

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -311,7 +311,21 @@ class TestFailedGateBlocking:
 
 
 # Tests for material description extraction
-def test_extract_material_description_from_assignee_pool():
+def test_internal_governance_signature_is_execution_only() -> None:
+    """Test internal_governance_dispatch signature only has execution params.
+
+    After refactor: internal governance should only accept tick/material,
+    not dry_run/show_prompt (those belong to scan layer).
+    """
+    from inspect import signature
+
+    from vibe3.commands.internal import internal_governance_dispatch
+
+    params = signature(internal_governance_dispatch).parameters
+    assert "tick" in params
+    assert "material" in params
+    assert "dry_run" not in params
+    assert "show_prompt" not in params
     """Test extracting description from assignee-pool.md."""
     from vibe3.commands.scan import _extract_material_description
 

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -311,64 +311,6 @@ def test_supervisor_scan_fetches_candidates_and_calls_internal_apply() -> None:
 
         # Should call internal_apply_dispatch for each candidate
         assert mock_apply.call_count == 2
-    """Test internal_governance_dispatch signature only has execution params.
-
-    After refactor: internal governance should only accept tick/material,
-    not dry_run/show_prompt (those belong to scan layer).
-    """
-    from inspect import signature
-
-    from vibe3.commands.internal import internal_governance_dispatch
-
-    params = signature(internal_governance_dispatch).parameters
-    assert "tick" in params
-    assert "material" in params
-    assert "dry_run" not in params
-    assert "show_prompt" not in params
-    """Test extracting description from assignee-pool.md."""
-    from vibe3.commands.scan import _extract_material_description
-
-    description = _extract_material_description(
-        "supervisor/governance/assignee-pool.md"
-    )
-    assert description == "Assignee Pool 治理材料"
-
-
-def test_extract_material_description_from_roadmap_intake():
-    """Test extracting description from roadmap-intake.md."""
-    from vibe3.commands.scan import _extract_material_description
-
-    description = _extract_material_description(
-        "supervisor/governance/roadmap-intake.md"
-    )
-    assert description == "Roadmap Intake 治理材料"
-
-
-def test_extract_material_description_handles_missing_file():
-    """Test handling missing file gracefully."""
-    from vibe3.commands.scan import _extract_material_description
-
-    description = _extract_material_description("supervisor/governance/nonexistent.md")
-    assert description == "supervisor/governance/nonexistent.md"
-
-
-def test_extract_material_description_handles_no_title():
-    """Test handling file without title."""
-    import tempfile
-    from pathlib import Path
-
-    from vibe3.commands.scan import _extract_material_description
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-        f.write("Some content without title\n")
-        temp_path = f.name
-
-    try:
-        description = _extract_material_description(temp_path)
-        # Should fall back to filename when no title
-        assert description == temp_path
-    finally:
-        Path(temp_path).unlink()
 
 
 # Tests for --list parameter

--- a/tests/vibe3/services/test_scan_service.py
+++ b/tests/vibe3/services/test_scan_service.py
@@ -70,6 +70,23 @@ class TestFetchSupervisorCandidates:
         candidates = fetch_supervisor_candidates(mock_github, "owner/repo")
         assert candidates == []
 
+    def test_queries_100_issues_not_50(self):
+        """Test that fetch_supervisor_candidates queries 100 issues (Issue #803).
+
+        Previously queried only 50 issues, causing dry-run to miss candidates.
+        """
+        from unittest.mock import MagicMock
+
+        mock_github = MagicMock()
+        mock_github.list_issues.return_value = []
+
+        fetch_supervisor_candidates(mock_github, "owner/repo")
+
+        # Verify limit parameter is 100 (not 50)
+        mock_github.list_issues.assert_called_once()
+        call_args = mock_github.list_issues.call_args
+        assert call_args.kwargs.get("limit") == 100
+
 
 class TestRenderGovernancePromptPreview:
     """Tests for governance prompt rendering."""

--- a/tests/vibe3/services/test_scan_service.py
+++ b/tests/vibe3/services/test_scan_service.py
@@ -53,20 +53,27 @@ class TestFetchSupervisorCandidates:
             },
         ]
 
-        candidates = fetch_supervisor_candidates(mock_github, "owner/repo")
+        total_scanned, candidates = fetch_supervisor_candidates(
+            mock_github, "owner/repo"
+        )
 
+        # Should return total scanned count
+        assert total_scanned == 2
         # Should only return issue with both labels
         assert len(candidates) == 1
         assert candidates[0]["number"] == 123
 
     def test_returns_empty_list_on_error(self):
-        """Test returns empty list on GitHub error."""
+        """Test returns empty tuple on GitHub error."""
         from unittest.mock import MagicMock
 
         mock_github = MagicMock()
         mock_github.list_issues.side_effect = Exception("API Error")
 
-        candidates = fetch_supervisor_candidates(mock_github, "owner/repo")
+        total_scanned, candidates = fetch_supervisor_candidates(
+            mock_github, "owner/repo"
+        )
+        assert total_scanned == 0
         assert candidates == []
 
     def test_queries_100_issues_not_50(self):
@@ -79,9 +86,14 @@ class TestFetchSupervisorCandidates:
         mock_github = MagicMock()
         mock_github.list_issues.return_value = []
 
-        fetch_supervisor_candidates(mock_github, "owner/repo")
+        total_scanned, candidates = fetch_supervisor_candidates(
+            mock_github, "owner/repo"
+        )
 
         # Verify limit parameter is 100 (not 50)
         mock_github.list_issues.assert_called_once()
         call_args = mock_github.list_issues.call_args
         assert call_args.kwargs.get("limit") == 100
+        # Empty results
+        assert total_scanned == 0
+        assert candidates == []

--- a/tests/vibe3/services/test_scan_service.py
+++ b/tests/vibe3/services/test_scan_service.py
@@ -3,7 +3,6 @@
 from vibe3.services.scan_service import (
     extract_material_description,
     fetch_supervisor_candidates,
-    render_governance_prompt_preview,
 )
 
 
@@ -86,26 +85,3 @@ class TestFetchSupervisorCandidates:
         mock_github.list_issues.assert_called_once()
         call_args = mock_github.list_issues.call_args
         assert call_args.kwargs.get("limit") == 100
-
-
-class TestRenderGovernancePromptPreview:
-    """Tests for governance prompt rendering."""
-
-    def test_returns_rendered_text(self):
-        """Test that rendered text is returned."""
-        from unittest.mock import MagicMock, patch
-
-        mock_config = MagicMock()
-
-        with patch("vibe3.roles.governance.render_governance_prompt") as mock_render:
-            mock_result = MagicMock()
-            mock_result.rendered_text = "# Test Prompt"
-            mock_render.return_value = mock_result
-
-            result = render_governance_prompt_preview(
-                config=mock_config,
-                tick_count=0,
-                material_override="test-material",
-            )
-
-            assert result == "# Test Prompt"

--- a/tests/vibe3/ui/test_scan_display.py
+++ b/tests/vibe3/ui/test_scan_display.py
@@ -56,7 +56,7 @@ class TestDisplaySupervisorDryRun:
         console = Console()
 
         with patch.object(console, "print") as mock_print:
-            display_supervisor_dry_run(console=console, candidates=[])
+            display_supervisor_dry_run(console=console, total_scanned=10, candidates=[])
 
             # Check that process steps are mentioned
             printed_text = " ".join(str(call) for call in mock_print.call_args_list)
@@ -78,7 +78,9 @@ class TestDisplaySupervisorDryRun:
         ]
 
         with patch.object(console, "print") as mock_print:
-            display_supervisor_dry_run(console=console, candidates=candidates)
+            display_supervisor_dry_run(
+                console=console, total_scanned=15, candidates=candidates
+            )
 
             # Should print table with issue info
             assert mock_print.call_count > 0


### PR DESCRIPTION
## Summary

重构 scan 命令架构，将手动扫描从 heartbeat facade 链路解耦，建立清晰的职责分离：
- **Scan 层**：用户入口，负责预览和交互（`--dry-run`, `--role`, `--list`）
- **Internal 层**：纯执行入口，无用户交互逻辑
- **Facade 层**：仅用于自动 heartbeat 链路，不承担手动触发

这是对 PR #797 的重新设计，放弃了 `scan = tick` 统一架构，改为最小化的职责分离方案。

## 架构改进

### 之前（问题）
- Manual scan 借道 heartbeat facade 链路
- Internal governance 混合了执行和预览功能
- FailedGate 阻塞手动触发
- 架构职责不清

### 之后（改进）
- ✅ Manual scan 直接调用 internal dispatch
- ✅ Internal 层纯粹为执行入口
- ✅ Scan 层保留所有用户价值（dry-run, list, role）
- ✅ Facade 仅用于自动 heartbeat 链路
- ✅ FailedGate 仅在自动链路检查
- ✅ 架构职责清晰分离

## 改动详情

### Task 1: 锁定边界并删除"手动借道 heartbeat"的前提
- 新增 `_execute_governance_internal()` 直接调用 `internal_governance_dispatch`
- `_run_governance_scan()` 从 50 行简化到 3 行
- 移除 facade 使用，manual scan 不再借道 heartbeat

### Task 2: 收敛 internal 治理命令为"执行-only"入口
- 移除 `internal_governance_dispatch` 的 `dry_run` 和 `show_prompt` 参数
- 这些用户预览功能保留在 scan 层

### Task 3: 把 governance 的用户价值留在 scan 层
- 已在 PR #802 中完成（`--dry-run`, `--role`, `--list`）

### Task 4: supervisor manual scan 直接走 candidate scan + internal apply
- 新增 `_run_supervisor_scan()` 直接调用 `internal_apply_dispatch`
- 移除 facade 使用
- 不检查 FailedGate（仅 heartbeat 自动链路检查）

### Task 5: 收尾清理
- 更新 facade 文档，明确手动扫描不使用 heartbeat 链路
- 标记 `force` 参数为 DEPRECATED

## 保留的内容

本次重构**保留**了以下已合并的改进：
- ✅ #799 错误显示优化（filter TMPDIR, capture API errors）
- ✅ #800 manual trigger fix / supervisor status feedback / docs updates
- ✅ Governance dry-run 真正显示 prompt
- ✅ Governance `--role` / `--list` 功能
- ✅ Supervisor dry-run 预览

## 放弃的内容

本次重构**明确放弃**了 PR #797 的以下设计：
- ❌ TickRequest / TickPlan / TickPlanner / TickDispatcher
- ❌ Unified scan=manual tick 入口
- ❌ Manual scan 借道 facade heartbeat
- ❌ Tick 抽象概念

## 测试结果

- ✅ **51 个测试全部通过**
- ✅ Ruff 检查通过
- ✅ MyPy 类型检查通过
- ✅ Black 格式化通过

## 改动统计

```
29 files changed, 1766 insertions(+), 424 deletions(-)
```

主要改动：
- `src/vibe3/commands/scan.py`: 从 facade 架构迁移到 internal dispatch
- `src/vibe3/commands/internal.py`: 移除预览参数，纯执行入口
- `src/vibe3/domain/orchestration_facade.py`: 文档更新，明确职责
- 测试文件：更新为新架构的测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)