### PR TITLE
refactor(cli): Phase 3 follow-ups for unified --format option

### DIFF
--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -1,14 +1,21 @@
 """Flow status commands - show, status."""
 
 import json
-import re
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from loguru import logger
 
 from vibe3.commands.command_options import ActorFilterOption, FormatOption
 from vibe3.commands.common import run_full_check_shortcut, trace_scope
+from vibe3.commands.flow_status_helpers import (
+    _collect_timeline_issue_numbers,
+    _fetch_issue_titles_for_status,
+    _fetch_pr_map,
+    _fetch_worktree_map,
+    _get_yaml,
+    _render_snapshot_format,
+)
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.exceptions import SystemError, UserError
 from vibe3.services.flow_projection_service import FlowProjectionService
@@ -17,7 +24,6 @@ from vibe3.services.task_binding_guard import build_bind_task_hint
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui import (
     render_error,
-    render_flow_status,
     render_flow_timeline,
     render_flows_status_dashboard,
 )
@@ -37,154 +43,6 @@ from vibe3.commands.command_options import (
 StatusOption = Annotated[bool, typer.Option("--snapshot", help="静态快照模式")]
 
 
-def _render_snapshot_format(projection: Any, flow_status: Any, format: str) -> None:
-    """Render snapshot output in json/yaml/table format."""
-    output_data = {
-        "branch": projection.branch,
-        "flow_slug": projection.flow_slug,
-        "flow_status": projection.flow_status,
-        "task_issue_number": projection.task_issue_number,
-        "pr_number": projection.pr_number,
-        "spec_ref": projection.spec_ref,
-        "blocked_by": projection.blocked_by,
-        "next_step": projection.next_step,
-        "offline_mode": projection.offline_mode,
-        "pr_status": projection.pr_status,
-        "pr_is_draft": projection.pr_is_draft,
-        "pr_url": projection.pr_url,
-    }
-    if format == "json":
-        typer.echo(json.dumps(output_data, indent=2, default=str))
-    elif format == "yaml":
-        import yaml
-
-        typer.echo(yaml.dump(output_data, default_flow_style=False, allow_unicode=True))
-    else:
-        if not flow_status:
-            logger.error("Flow not found")
-            raise typer.Exit(1)
-        projection_service = FlowProjectionService()
-        issue_numbers = {flow_status.task_issue_number} | {
-            link.issue_number for link in flow_status.issues
-        }
-        issue_titles, network_error = projection_service.get_issue_titles(
-            list(issue_numbers)
-        )
-        pr_data = (
-            {
-                "number": projection.pr_number,
-                "state": projection.pr_status,
-                "draft": projection.pr_is_draft,
-                "url": projection.pr_url,
-            }
-            if projection.pr_number and not projection.pr_fetch_error
-            else None
-        )
-        if network_error or projection.hydrate_error or projection.pr_fetch_error:
-            render_error("网络故障，远端 issue/PR 信息不可用（本地数据仍显示）")
-        render_flow_status(
-            flow_status,
-            issue_titles,
-            pr_data,
-            parent_branch=find_parent_branch(projection.branch),
-            worktree_root=flow_status.worktree_root,
-        )
-
-
-def _fetch_worktree_map() -> dict[str, str]:
-    """Fetch worktree mapping from git worktree list."""
-    worktree_map: dict[str, str] = {}
-    try:
-        from vibe3.clients.git_client import GitClient
-
-        git = GitClient()
-        worktree_output = git._run(["worktree", "list", "--porcelain"])
-        current_worktree = ""
-        for line in worktree_output.splitlines():
-            line = line.strip()
-            if line.startswith("worktree "):
-                current_worktree = line.split(" ", 1)[1]
-            elif line.startswith("branch ") and current_worktree:
-                branch_ref = line.split(" ", 1)[1]
-                branch = branch_ref.removeprefix("refs/heads/")
-                worktree_name = current_worktree.split("/")[-1]
-                worktree_map[branch] = worktree_name
-    except Exception:
-        pass
-    return worktree_map
-
-
-def _fetch_pr_map(
-    flows: list[Any],
-    projection_service: FlowProjectionService,
-    worktree_map: dict[str, str],
-) -> dict[str, dict[str, object]]:
-    """Batch fetch all PRs for flows."""
-    try:
-        all_prs = projection_service.pr_service.github_client.list_all_prs(state="open")
-        branch_to_pr = {pr.head_branch: pr for pr in all_prs}
-        return {
-            flow.branch: {
-                "number": pr.number,
-                "title": pr.title,
-                "state": pr.state.value,
-                "draft": pr.draft,
-                "url": pr.url,
-                "worktree": worktree_map.get(flow.branch),
-            }
-            for flow in flows
-            if (pr := branch_to_pr.get(flow.branch))
-        }
-    except Exception as exc:
-        logger.bind(domain="flow").warning(f"Failed to fetch PRs: {exc}")
-        return {}
-
-
-def _fetch_issue_titles_for_status(
-    flows: list[Any],
-    projection_service: FlowProjectionService,
-    orch_snapshot: Any,
-    issue_numbers: set[int],
-) -> tuple[dict[int, str], bool]:
-    """Fetch issue titles for flow status dashboard."""
-    if orch_snapshot and orch_snapshot.server_running:
-        titles = {
-            entry.number: entry.title
-            for entry in orch_snapshot.active_issues
-            if entry.number in issue_numbers
-        }
-        missing = issue_numbers - set(titles.keys())
-        if missing:
-            extra_titles, net_err = projection_service.get_issue_titles(list(missing))
-            titles.update(extra_titles)
-            return titles, net_err
-        return titles, False
-
-    # Server not running, use cache service with real branches
-    from vibe3.services.issue_title_cache_service import IssueTitleCacheService
-
-    branches = [flow.branch for flow in flows if flow.branch]
-    title_cache = IssueTitleCacheService(
-        store=projection_service.store, github_client=projection_service.github_client
-    )
-    branch_titles, net_err = title_cache.get_titles_with_fallback(branches)
-    titles = {
-        flow.task_issue_number: branch_titles[flow.branch]
-        for flow in flows
-        if flow.task_issue_number and flow.branch in branch_titles
-    }
-    return titles, net_err
-
-
-def _collect_timeline_issue_numbers(state: Any) -> set[int]:
-    """Collect issue numbers from timeline state for title fetching."""
-    issue_numbers = {state.task_issue_number} if state.task_issue_number else set()
-    issue_numbers.update(link.issue_number for link in state.issues)
-    if state.spec_ref and (match := re.match(r"^#?(\d+)$", state.spec_ref.strip())):
-        issue_numbers.add(int(match.group(1)))
-    return issue_numbers
-
-
 def show(
     branch: Annotated[
         str | None,
@@ -192,7 +50,7 @@ def show(
     ] = None,
     snapshot: StatusOption = False,
     trace: TraceOption = False,
-    format: FormatOption = "table",
+    output_format: FormatOption = "table",
     show_all: Annotated[
         bool, typer.Option("--show-all", help="Show orchestra actor events")
     ] = False,
@@ -208,12 +66,12 @@ def show(
 ) -> None:
     """Show flow details."""
     # Handle deprecated --json flag
-    if json_output and format == "table":
+    if json_output and output_format == "table":
         typer.echo(
             "Warning: --json is deprecated, use --format json instead",
             err=True,
         )
-        format = "json"
+        output_format = "json"
 
     with trace_scope(trace, "flow show", domain="flow"):
         service = FlowService()
@@ -230,7 +88,7 @@ def show(
 
         # Handle non-registered flow or special branches
         if not flow_status or flow_status.flow_status == "aborted":
-            if format == "table":
+            if output_format == "table":
                 from vibe3.services.flow_service import FlowService as FlowService_
 
                 is_safe = target_branch.startswith(FlowService_.SAFE_BRANCH_PREFIX)
@@ -265,13 +123,28 @@ def show(
                         "error": "Flow not registered",
                         "branch": target_branch,
                     }
-                    if format == "json":
+                    if output_format == "json":
                         typer.echo(json.dumps(output_data))
                     else:
-                        import yaml
-
                         typer.echo(
-                            yaml.dump(
+                            _get_yaml().dump(
+                                output_data,
+                                default_flow_style=False,
+                                allow_unicode=True,
+                            )
+                        )
+                    raise typer.Exit(1)
+                elif flow_status and flow_status.flow_status == "aborted":
+                    # Handle aborted flow with json/yaml output
+                    output_data = {
+                        "error": "Flow aborted",
+                        "branch": target_branch,
+                    }
+                    if output_format == "json":
+                        typer.echo(json.dumps(output_data))
+                    else:
+                        typer.echo(
+                            _get_yaml().dump(
                                 output_data,
                                 default_flow_style=False,
                                 allow_unicode=True,
@@ -283,7 +156,7 @@ def show(
             projection_service = FlowProjectionService()
             projection = projection_service.get_projection(target_branch)
             flow_status = service.get_flow_status(target_branch)
-            _render_snapshot_format(projection, flow_status, format)
+            _render_snapshot_format(projection, flow_status, output_format)
             return
 
         timeline = service.get_flow_timeline(target_branch)
@@ -300,18 +173,38 @@ def show(
             projection_service = FlowProjectionService(store=service.store)
             issue_titles, _ = projection_service.get_issue_titles(list(issue_numbers))
 
-        if format in ("json", "yaml"):
+        if output_format in ("json", "yaml"):
+            # Apply filtering for structured output
+            from vibe3.ui.flow_ui_timeline import _filter_passive_if_active_exists
+
+            filtered_events = timeline["events"]
+            filtered_events = _filter_passive_if_active_exists(filtered_events)
+            if not show_all:
+                filtered_events = [
+                    e
+                    for e in filtered_events
+                    if not (e.actor and e.actor.startswith("orchestra:"))
+                ]
+            if actor_filter:
+                import fnmatch
+
+                filtered_events = [
+                    e
+                    for e in filtered_events
+                    if e.actor
+                    and fnmatch.fnmatch(e.actor.lower(), actor_filter.lower())
+                ]
             json_data = {
                 "state": timeline["state"].model_dump(),
-                "events": [e.model_dump() for e in timeline["events"]],
+                "events": [e.model_dump() for e in filtered_events],
             }
-            if format == "json":
+            if output_format == "json":
                 typer.echo(json.dumps(json_data, indent=2, default=str))
             else:
-                import yaml
-
                 typer.echo(
-                    yaml.dump(json_data, default_flow_style=False, allow_unicode=True)
+                    _get_yaml().dump(
+                        json_data, default_flow_style=False, allow_unicode=True
+                    )
                 )
         else:
             parent_branch = find_parent_branch(target_branch)

--- a/src/vibe3/commands/flow_status_helpers.py
+++ b/src/vibe3/commands/flow_status_helpers.py
@@ -1,0 +1,173 @@
+"""Helper functions for flow_status commands."""
+
+import json
+import re
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+import typer
+from loguru import logger
+
+from vibe3.services.flow_projection_service import FlowProjectionService
+from vibe3.ui.flow_ui import render_error, render_flow_status
+from vibe3.utils.branch_utils import find_parent_branch
+
+if TYPE_CHECKING:
+    pass
+
+
+def _get_yaml() -> ModuleType:
+    """Lazy import yaml to avoid unconditional import cost."""
+    import yaml
+
+    return yaml
+
+
+def _render_snapshot_format(
+    projection: Any, flow_status: Any, output_format: str
+) -> None:
+    """Render snapshot output in json/yaml/table format."""
+    output_data = {
+        "branch": projection.branch,
+        "flow_slug": projection.flow_slug,
+        "flow_status": projection.flow_status,
+        "task_issue_number": projection.task_issue_number,
+        "pr_number": projection.pr_number,
+        "spec_ref": projection.spec_ref,
+        "blocked_by": projection.blocked_by,
+        "next_step": projection.next_step,
+        "offline_mode": projection.offline_mode,
+        "pr_status": projection.pr_status,
+        "pr_is_draft": projection.pr_is_draft,
+        "pr_url": projection.pr_url,
+    }
+    if output_format == "json":
+        typer.echo(json.dumps(output_data, indent=2, default=str))
+    elif output_format == "yaml":
+        typer.echo(
+            _get_yaml().dump(output_data, default_flow_style=False, allow_unicode=True)
+        )
+    else:
+        if not flow_status:
+            logger.error("Flow not found")
+            raise typer.Exit(1)
+        projection_service = FlowProjectionService()
+        issue_numbers = {flow_status.task_issue_number} | {
+            link.issue_number for link in flow_status.issues
+        }
+        issue_titles, network_error = projection_service.get_issue_titles(
+            list(issue_numbers)
+        )
+        pr_data = (
+            {
+                "number": projection.pr_number,
+                "state": projection.pr_status,
+                "draft": projection.pr_is_draft,
+                "url": projection.pr_url,
+            }
+            if projection.pr_number and not projection.pr_fetch_error
+            else None
+        )
+        if network_error or projection.hydrate_error or projection.pr_fetch_error:
+            render_error("网络故障，远端 issue/PR 信息不可用（本地数据仍显示）")
+        render_flow_status(
+            flow_status,
+            issue_titles,
+            pr_data,
+            parent_branch=find_parent_branch(projection.branch),
+            worktree_root=flow_status.worktree_root,
+        )
+
+
+def _fetch_worktree_map() -> dict[str, str]:
+    """Fetch worktree mapping from git worktree list."""
+    worktree_map: dict[str, str] = {}
+    try:
+        from vibe3.clients.git_client import GitClient
+
+        git = GitClient()
+        worktree_output = git._run(["worktree", "list", "--porcelain"])
+        current_worktree = ""
+        for line in worktree_output.splitlines():
+            line = line.strip()
+            if line.startswith("worktree "):
+                current_worktree = line.split(" ", 1)[1]
+            elif line.startswith("branch ") and current_worktree:
+                branch_ref = line.split(" ", 1)[1]
+                branch = branch_ref.removeprefix("refs/heads/")
+                worktree_name = current_worktree.split("/")[-1]
+                worktree_map[branch] = worktree_name
+    except Exception:
+        pass
+    return worktree_map
+
+
+def _fetch_pr_map(
+    flows: list[Any],
+    projection_service: FlowProjectionService,
+    worktree_map: dict[str, str],
+) -> dict[str, dict[str, object]]:
+    """Batch fetch all PRs for flows."""
+    try:
+        all_prs = projection_service.pr_service.github_client.list_all_prs(state="open")
+        branch_to_pr = {pr.head_branch: pr for pr in all_prs}
+        return {
+            flow.branch: {
+                "number": pr.number,
+                "title": pr.title,
+                "state": pr.state.value,
+                "draft": pr.draft,
+                "url": pr.url,
+                "worktree": worktree_map.get(flow.branch),
+            }
+            for flow in flows
+            if (pr := branch_to_pr.get(flow.branch))
+        }
+    except Exception as exc:
+        logger.bind(domain="flow").warning(f"Failed to fetch PRs: {exc}")
+        return {}
+
+
+def _fetch_issue_titles_for_status(
+    flows: list[Any],
+    projection_service: FlowProjectionService,
+    orch_snapshot: Any,
+    issue_numbers: set[int],
+) -> tuple[dict[int, str], bool]:
+    """Fetch issue titles for flow status dashboard."""
+    if orch_snapshot and orch_snapshot.server_running:
+        titles = {
+            entry.number: entry.title
+            for entry in orch_snapshot.active_issues
+            if entry.number in issue_numbers
+        }
+        missing = issue_numbers - set(titles.keys())
+        if missing:
+            extra_titles, net_err = projection_service.get_issue_titles(list(missing))
+            titles.update(extra_titles)
+            return titles, net_err
+        return titles, False
+
+    # Server not running, use cache service with real branches
+    from vibe3.services.issue_title_cache_service import IssueTitleCacheService
+
+    branches = [flow.branch for flow in flows if flow.branch]
+    title_cache = IssueTitleCacheService(
+        store=projection_service.store, github_client=projection_service.github_client
+    )
+    branch_titles, net_err = title_cache.get_titles_with_fallback(branches)
+    titles = {
+        flow.task_issue_number: branch_titles[flow.branch]
+        for flow in flows
+        if flow.task_issue_number and flow.branch in branch_titles
+    }
+    return titles, net_err
+
+
+def _collect_timeline_issue_numbers(state: Any) -> set[int]:
+    """Collect issue numbers from timeline state for title fetching."""
+    issue_numbers = {state.task_issue_number} if state.task_issue_number else set()
+    issue_numbers.update(link.issue_number for link in state.issues)
+    if state.spec_ref and (match := re.match(r"^#?(\d+)$", state.spec_ref.strip())):
+        issue_numbers.add(int(match.group(1)))
+    return issue_numbers

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timezone
+from types import ModuleType
 from typing import Annotated
 
 import typer
@@ -75,6 +76,13 @@ See also:
 """
 
 
+def _get_yaml() -> ModuleType:
+    """Lazy import yaml to avoid unconditional import cost."""
+    import yaml
+
+    return yaml
+
+
 def show(
     target: Annotated[
         str | None,
@@ -129,7 +137,7 @@ def status(
     trace: Annotated[
         bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
     ] = False,
-    format: FormatOption = "table",
+    output_format: FormatOption = "table",
     verbose: VerboseOption = False,
     json_output: Annotated[
         bool,
@@ -142,12 +150,12 @@ def status(
 ) -> None:
     """Show current flow handoff status and recent records."""
     # Handle deprecated --json flag
-    if json_output and format == "table":
+    if json_output and output_format == "table":
         typer.echo(
             "Warning: --json is deprecated, use --format json instead",
             err=True,
         )
-        format = "json"
+        output_format = "json"
 
     with trace_scope(trace, "handoff status", domain="handoff"):
         logger.bind(command="handoff status", branch=branch).info(
@@ -175,7 +183,7 @@ def status(
             typer.echo(f"Error: {error}", err=True)
             raise typer.Exit(1) from error
 
-        if format == "json":
+        if output_format == "json":
             output = {
                 "state": result.state.model_dump(),
                 "events": [e.model_dump() for e in result.events],
@@ -183,14 +191,14 @@ def status(
             typer.echo(json.dumps(output, indent=2, default=str))
             return
 
-        if format == "yaml":
-            import yaml
-
+        if output_format == "yaml":
             output = {
                 "state": result.state.model_dump(),
                 "events": [e.model_dump() for e in result.events],
             }
-            typer.echo(yaml.dump(output, default_flow_style=False, allow_unicode=True))
+            typer.echo(
+                _get_yaml().dump(output, default_flow_style=False, allow_unicode=True)
+            )
             return
 
         # Table format (default)

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -42,7 +42,7 @@ def show(
         typer.Argument(help="Issue number (auto-resolves to task branch if exists)"),
     ] = None,
     trace: Annotated[bool, typer.Option("--trace")] = False,
-    format: FormatOption = "table",
+    output_format: FormatOption = "table",
     full: Annotated[
         bool, typer.Option("--full", help="Show complete summary without truncation")
     ] = False,
@@ -61,12 +61,12 @@ def show(
     entering manager/plan/executor/reviewer prompts.
     """
     # Handle deprecated --json flag
-    if json_output and format == "table":
+    if json_output and output_format == "table":
         typer.echo(
             "Warning: --json is deprecated, use --format json instead",
             err=True,
         )
-        format = "json"
+        output_format = "json"
 
     task_svc = TaskService()
 
@@ -92,10 +92,10 @@ def show(
         elif target_branch.isdigit():
             issue_number = int(target_branch)
 
-        render_task_show(task_result, format, full=full)
+        render_task_show(task_result, output_format, full=full)
 
         # Always show recent comments (if issue exists and not json/yaml output)
-        if issue_number and format == "table":
+        if issue_number and output_format == "table":
             issue_data = task_svc.fetch_issue_with_comments(issue_number)
             if issue_data == "network_error":
                 typer.echo("\nIssue comments unavailable: network/auth error")

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -3,6 +3,7 @@
 import json
 import re
 from dataclasses import asdict
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 from vibe3.ui.console import console
@@ -18,6 +19,13 @@ MAX_SUMMARY_LINES = 3  # Maximum summary lines shown in non-full mode
 MAX_COMMENTS_DISPLAY = 3  # Maximum recent comments to display
 
 
+def _get_yaml() -> ModuleType:
+    """Lazy import yaml to avoid unconditional import cost."""
+    import yaml
+
+    return yaml
+
+
 def build_task_show_payload(task_result: "TaskShowResult") -> dict[str, object]:
     """Build a single JSON payload for task show."""
     return task_result.to_payload()
@@ -25,14 +33,14 @@ def build_task_show_payload(task_result: "TaskShowResult") -> dict[str, object]:
 
 def render_task_show(
     task_result: "TaskShowResult",
-    format: str,
+    output_format: str,
     full: bool = False,
 ) -> None:
     """Render task show output.
 
     Args:
         task_result: Task show query result
-        format: Output format (json, yaml, or table)
+        output_format: Output format (json, yaml, or table)
         full: If True, show complete summary without truncation (table mode only)
     """
     # Handle case where no flow exists
@@ -43,12 +51,10 @@ def render_task_show(
             # Branch is an issue number without flow
             # Try to fetch and display basic issue info
             if task_result.issue_title or task_result.issue_state:
-                if format == "json":
-                    pr_data = (
-                        asdict(task_result.pr_summary)
-                        if task_result.pr_summary
-                        else None
-                    )
+                pr_data = (
+                    asdict(task_result.pr_summary) if task_result.pr_summary else None
+                )
+                if output_format == "json":
                     console.print(
                         json.dumps(
                             {
@@ -63,16 +69,9 @@ def render_task_show(
                         ),
                         markup=False,
                     )
-                elif format == "yaml":
-                    import yaml
-
-                    pr_data = (
-                        asdict(task_result.pr_summary)
-                        if task_result.pr_summary
-                        else None
-                    )
+                elif output_format == "yaml":
                     console.print(
-                        yaml.dump(
+                        _get_yaml().dump(
                             {
                                 "branch": branch,
                                 "issue_number": int(branch),
@@ -101,15 +100,13 @@ def render_task_show(
                             console.print(f"Checks: {pr.checks}")
                 return
             # No issue info available
-            if format in ("json", "yaml"):
+            if output_format in ("json", "yaml"):
                 output_data = {"branch": branch, "error": "No flow found"}
-                if format == "json":
+                if output_format == "json":
                     console.print(json.dumps(output_data), markup=False)
                 else:
-                    import yaml
-
                     console.print(
-                        yaml.dump(output_data, default_flow_style=False),
+                        _get_yaml().dump(output_data, default_flow_style=False),
                         markup=False,
                     )
             else:
@@ -117,22 +114,21 @@ def render_task_show(
                 console.print("Tip: Use 'vibe3 flow new' to create a flow")
             return
         # Non-numeric branch without flow
-        if format in ("json", "yaml"):
+        if output_format in ("json", "yaml"):
             output_data = {"branch": branch, "error": "No flow found"}
-            if format == "json":
+            if output_format == "json":
                 console.print(json.dumps(output_data), markup=False)
             else:
-                import yaml
-
                 console.print(
-                    yaml.dump(output_data, default_flow_style=False), markup=False
+                    _get_yaml().dump(output_data, default_flow_style=False),
+                    markup=False,
                 )
         else:
             console.print(f"[yellow]No flow found: {branch}[/]")
         return
 
     task = task_result.local_task
-    if format == "json":
+    if output_format == "json":
         console.print(
             json.dumps(
                 build_task_show_payload(task_result),
@@ -145,11 +141,9 @@ def render_task_show(
         )
         return
 
-    if format == "yaml":
-        import yaml
-
+    if output_format == "yaml":
         console.print(
-            yaml.dump(
+            _get_yaml().dump(
                 build_task_show_payload(task_result),
                 default_flow_style=False,
                 allow_unicode=True,

--- a/tests/vibe3/commands/test_handoff_commands_basic.py
+++ b/tests/vibe3/commands/test_handoff_commands_basic.py
@@ -313,9 +313,9 @@ class TestHandoffBasicCommands:
         result = runner.invoke(app, ["handoff", "status", "--json"])
 
         assert result.exit_code == 0
-        assert "deprecated" in result.output.lower()
+        assert "deprecated" in result.stderr.lower()
         import json
 
         # Output should still be valid JSON
-        output = json.loads(result.output.split("Warning:", 1)[1].split("\n", 1)[1])
+        output = json.loads(result.stdout)
         assert "state" in output

--- a/tests/vibe3/commands/test_task_show.py
+++ b/tests/vibe3/commands/test_task_show.py
@@ -115,13 +115,7 @@ def test_task_show_json_includes_summary_fields(
     result = runner.invoke(app, ["task", "show", "--json"])
 
     assert result.exit_code == 0
-    # Parse JSON output after deprecation warning
-    output_lines = result.output.split("\n", 1)
-    if output_lines[0].startswith("Warning:"):
-        json_output = output_lines[1]
-    else:
-        json_output = result.output
-    payload = json.loads(json_output)
+    payload = json.loads(result.stdout)
     assert payload["issue_title"] == "JSON summary view"
     assert payload["latest_ref"]["kind"] == "plan"
     assert payload["latest_comment"]["author"] == "reviewer-bot"
@@ -235,9 +229,9 @@ def test_task_show_deprecated_json_flag(mock_task_service_cls) -> None:
     result = runner.invoke(app, ["task", "show", "--json"])
 
     assert result.exit_code == 0
-    assert "deprecated" in result.output.lower()
+    assert "deprecated" in result.stderr.lower()
     # Output should still be valid JSON
-    payload = json.loads(result.output.split("Warning:", 1)[1].split("\n", 1)[1])
+    payload = json.loads(result.stdout)
     assert payload["issue_title"] == "Format test"
 
 
@@ -343,12 +337,6 @@ def test_task_show_json_includes_task_issue_numbers(
     result = runner.invoke(app, ["task", "show", "--json"])
 
     assert result.exit_code == 0
-    # Parse JSON output after deprecation warning
-    output_lines = result.output.split("\n", 1)
-    if output_lines[0].startswith("Warning:"):
-        json_output = output_lines[1]
-    else:
-        json_output = result.output
-    payload = json.loads(json_output)
+    payload = json.loads(result.stdout)
     # Should include task_issue_numbers array
     assert payload["task_issue_numbers"] == [123, 456]


### PR DESCRIPTION
## Summary

Bounded refactor across 6 items for Phase 3 --format option cleanup:

1. **Consolidate yaml imports**: Replace conditional imports with lazy _get_yaml() helper in flow_status.py, handoff_read.py, and task_ui.py
2. **Rename format→output_format**: Rename function parameters to avoid shadowing Python builtin, update all internal references
3. **Fix aborted flow json/yaml**: Add structured output for aborted flows (previously fell through to timeline path)
4. **Apply filtering to structured output**: Apply --show-all and --actor filtering to json/yaml events (previously unfiltered)
5. **Defer JsonOption cleanup**: Record in handoff for separate Phase 3 effort
6. **Stabilise test parsing**: Use result.stdout/stderr instead of splitting result.output (Click provides separate attributes by default)

## Test Results
- pytest: **PASS** (241/241 tests)
- ruff: **PASS**
- mypy: **PASS** (all type errors fixed)

## Quality Notes
- Added return type annotations to _get_yaml() helpers (ModuleType)
- Filtering logic duplicated between json/yaml and table modes (accepted tradeoff for json/yaml model_dump() serialization needs)
- CLI interface unchanged (--format flag preserved)
- No regression risks identified

Closes #751