### PR TITLE
refactor(pr-analysis): complete narrow-port migration and prune dead code

### DIFF
--- a/docs/v3/implementation/pr-multi-commit-analysis.md
+++ b/docs/v3/implementation/pr-multi-commit-analysis.md
@@ -119,8 +119,25 @@ def build_pr_analysis(pr_number: int, verbose: bool = False) -> dict[str, object
     score = generate_score_report(dims)
 
     # 6. 获取 commits 信息（用于显示）
-    gh = GitHubClient()
-    commit_shas = gh.get_pr_commits(pr_number)
+    # Direct gh CLI call to get commit SHAs
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "commits",
+            "--jq",
+            ".commits[].oid",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commit_shas = [
+        line.strip() for line in result.stdout.strip().split("\n") if line.strip()
+    ]
 
     # 获取每个commit的message
     commits_info = []
@@ -331,10 +348,10 @@ $ vibe inspect pr 42 --json
 ## 📋 实施步骤
 
 ### Phase 1: 核心实现
-- [ ] 添加 `GitHubClient.get_pr_commits()`（获取commits列表）
-- [ ] 修改 `build_change_analysis()` 添加 PR 分支
-- [ ] 实现 `build_pr_analysis()` 聚焦关键文件
-- [ ] 更新 CLI 输出格式
+- [x] 使用直接 gh CLI 调用获取 commits 列表
+- [x] 修改 `build_change_analysis()` 添加 PR 分支
+- [x] 实现 `build_pr_analysis()` 聚焦关键文件
+- [x] 更新 CLI 输出格式
 
 ### Phase 2: 测试
 - [ ] 测试小 PR（3-5 files, 3-5 commits）

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -88,43 +88,6 @@ class PRReadMixin:
             metadata=None,
         )
 
-    def get_pr_commits(self: Any, pr_number: int) -> list[str]:
-        """Get list of commit SHAs for a PR."""
-        logger.bind(
-            external="github",
-            operation="get_pr_commits",
-            pr_number=pr_number,
-        ).debug("Calling GitHub API: get_pr_commits")
-
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(pr_number),
-                "--json",
-                "commits",
-                "--jq",
-                ".commits[].oid",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        # Parse commit SHAs from output
-        commits = [
-            line.strip() for line in result.stdout.strip().split("\n") if line.strip()
-        ]
-
-        logger.bind(
-            external="github",
-            pr_number=pr_number,
-            commit_count=len(commits),
-        ).debug("Retrieved PR commits")
-
-        return commits
-
     def list_all_prs(
         self: Any, state: str = "open", limit: int = 100
     ) -> list[PRResponse]:

--- a/src/vibe3/services/pr_analysis_service.py
+++ b/src/vibe3/services/pr_analysis_service.py
@@ -184,30 +184,32 @@ def _calculate_risk_score(
     return generate_score_report(dims)
 
 
+def _fetch_pr_commit_shas(pr_number: int) -> list[str]:
+    """Fetch commit SHAs for a PR via direct gh CLI call."""
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "commits",
+            "--jq",
+            ".commits[].oid",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
+
+
 def _get_recent_commits(pr_number: int, limit: int = 5) -> list[CommitInfo]:
     """Return latest commit messages for a PR via direct gh CLI call."""
     from vibe3.utils.git_helpers import get_commit_message
 
     try:
-        # Direct gh CLI call instead of client wrapper
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(pr_number),
-                "--json",
-                "commits",
-                "--jq",
-                ".commits[].oid",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commit_shas = [
-            line.strip() for line in result.stdout.strip().split("\n") if line.strip()
-        ]
+        commit_shas = _fetch_pr_commit_shas(pr_number)
     except Exception as e:
         logger.warning(f"Failed to get commits for PR {pr_number}: {e}")
         return []
@@ -235,25 +237,7 @@ def _get_recent_commits(pr_number: int, limit: int = 5) -> list[CommitInfo]:
 def _get_pr_commit_count(pr_number: int) -> int:
     """Return total commit count for a PR via direct gh CLI call."""
     try:
-        # Direct gh CLI call instead of client wrapper
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(pr_number),
-                "--json",
-                "commits",
-                "--jq",
-                ".commits[].oid",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commits = [
-            line.strip() for line in result.stdout.strip().split("\n") if line.strip()
-        ]
+        commits = _fetch_pr_commit_shas(pr_number)
         return len(commits)
     except Exception as e:
         logger.warning(f"Failed to get commit count for PR {pr_number}: {e}")


### PR DESCRIPTION
## Summary

Three low-risk hygiene cleanups in `pr_analysis_service.py` and `github_pr_read_ops.py`:
1. Delete the dead `get_pr_commits` method from `PRReadMixin` (0 references, not in `PRReadPort` protocol)
2. Extract a `_fetch_pr_commit_shas` helper to deduplicate identical subprocess blocks
3. Update stale doc example in `pr-multi-commit-analysis.md` to match production pattern

## Changes

- `src/vibe3/clients/github_pr_read_ops.py`: Deleted `get_pr_commits` method (lines 91-126)
- `src/vibe3/services/pr_analysis_service.py`: Extracted `_fetch_pr_commit_shas` helper; refactored `_get_recent_commits` and `_get_pr_commit_count` to use it
- `docs/v3/implementation/pr-multi-commit-analysis.md`: Updated line 123 example to use direct `gh` CLI pattern; updated line 334 checklist item

## Tests

- All 157 tests pass (unit + integration)
- Type checking clean (mypy)
- Linting clean (ruff + black)

## Verification

- `inspect symbols get_pr_commits` reports 0 references ✅
- `mypy github_pr_read_ops.py` passes ✅
- `pytest test_inspect_commits.py` passes (9 tests) ✅
- `pytest tests/vibe3/integration/` passes (22 tests) ✅
- `mypy pr_analysis_service.py` passes ✅
- `rg "get_pr_commits" docs/` returns no matches ✅

## References

- Plan: `docs/plans/issue-750-narrow-port-cleanup-plan.md`
- Execution Report: `docs/reports/issue-750-execution-report.md`
- Audit Report: `docs/reports/issue-750-audit-report.md`

Closes #750