### PR TITLE
fix(executor): change PR creation default from draft to regular

### DIFF
--- a/.agent/policies/run.md
+++ b/.agent/policies/run.md
@@ -226,6 +226,14 @@
 - 关键输出契约被破坏
 - 发现自己正在越过项目边界
 
+## PR 创建规则
+
+创建 PR 时，必须创建正式 PR（非 draft），除非 plan 或 handoff 明确要求 draft：
+
+- 使用 `gh pr create` 时，显式传递 `--draft=false`
+- 使用 `vibe3 pr create` 时，默认已创建正式 PR（非 draft）
+- 如果 PR 已经是 draft 状态，使用 `gh pr edit <number> --draft=false` 修正
+
 ## 交付要求
 
 执行结果必须能回答：

--- a/src/vibe3/commands/pr.py
+++ b/src/vibe3/commands/pr.py
@@ -4,7 +4,7 @@ This module provides the main PR command group with all subcommands
 organized in separate modules for maintainability.
 
 Public commands:
-- create: Create draft PR
+- create: Create a pull request
 - ready: Mark PR as ready for review
 - show: Show PR details
 

--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -213,7 +213,7 @@ def register_create_command(app: typer.Typer) -> None:
             # - Human mode: None
             actor = "ai-assistant" if ai else None
 
-            pr = pr_service.create_draft_pr(
+            pr = pr_service.create_pr(
                 title=pr_title,
                 body=pr_body,
                 base_branch=resolved_base,

--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -83,7 +83,7 @@ def register_create_command(app: typer.Typer) -> None:
             typer.Option(
                 "--yes",
                 "-y",
-                help="Confirm you are human and want to create a draft PR",
+                help="Confirm you are human and want to create a pull request",
             ),
         ] = False,
         trace: Annotated[
@@ -96,7 +96,7 @@ def register_create_command(app: typer.Typer) -> None:
             bool, typer.Option("--yaml", help="YAML 格式输出")
         ] = False,
     ) -> None:
-        """Create draft PR.
+        """Create a pull request.
 
         Human entrance: use --yes to confirm.
         Agent entrance: use --agent to bypass human confirmation (requires -t and -b).

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -82,7 +82,7 @@ class CreatePRRequest(BaseModel):
     body: str = Field(..., description="PR body/description")
     head_branch: str = Field(..., description="Head branch name")
     base_branch: str = Field("main", description="Base branch name")
-    draft: bool = Field(True, description="Create as draft PR")
+    draft: bool = Field(False, description="Create as regular (non-draft) PR")
     metadata: Optional[PRMetadata] = Field(None, description="PR metadata")
 
 

--- a/src/vibe3/observability/README.md
+++ b/src/vibe3/observability/README.md
@@ -44,10 +44,10 @@ from loguru import logger
 
 # 绑定语义上下文（Agent 友好）
 logger.bind(
-    command="pr draft",
+    command="pr create",
     domain="pr",
-    action="create_draft"
-).info("Creating draft PR")
+    action="create_pr"
+).info("Creating PR")
 
 # 记录错误时保留完整堆栈
 try:
@@ -63,13 +63,13 @@ except Exception as e:
 from vibe3.observability import Tracer, TraceContext
 
 # 方式 1: 使用上下文管理器
-with TraceContext(command="pr draft", domain="pr"):
+with TraceContext(command="pr create", domain="pr"):
     # 执行命令
     pass
 
 # 方式 2: 使用 Tracer API
 tracer = Tracer()
-span = tracer.trace_call("service.pr.create_draft", args={"title": "Fix"})
+span = tracer.trace_call("service.pr.create", args={"title": "Fix"})
 span.result = {"pr_number": 123}
 ```
 

--- a/src/vibe3/observability/logger.py
+++ b/src/vibe3/observability/logger.py
@@ -16,8 +16,8 @@ Usage:
     from loguru import logger
 
     logger.bind(
-        command="pr draft", domain="pr", action="create_draft"
-    ).info("Creating draft PR")
+        command="pr create", domain="pr", action="create_pr"
+    ).info("Creating PR")
 
 Reference: docs/v3/infrastructure/05-logging.md
 """

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -112,7 +112,7 @@ class PRService:
             body=enhanced_body,
             head_branch=head_branch,
             base_branch=base_branch,
-            draft=True,
+            draft=False,
             metadata=metadata,
         )
 

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -52,21 +52,21 @@ class PRService:
             self.github_client
         )
 
-    def create_draft_pr(
+    def create_pr(
         self,
         title: str,
         body: str,
         base_branch: str = "main",
         actor: str | None = None,
     ) -> PRResponse:
-        """Create a draft PR."""
+        """Create a pull request."""
         logger.bind(
             domain="pr",
-            action="create_draft",
+            action="create",
             title=title,
             base_branch=base_branch,
             actor=actor,
-        ).info("Creating draft PR")
+        ).info("Creating pull request")
 
         if not self.github_client.check_auth():
             raise UserError("Not authenticated to GitHub. Run 'gh auth login' first.")
@@ -121,12 +121,12 @@ class PRService:
         self._sync_pr_flow_state(pr, actor=effective_actor)
         self.store.add_event(
             head_branch,
-            "pr_draft",
+            "pr_created",
             effective_actor,
-            f"Draft PR #{pr.number} created: {pr.url}",
+            f"Pull request #{pr.number} created: {pr.url}",
         )
 
-        logger.bind(pr_number=pr.number, url=pr.url).success("Draft PR created")
+        logger.bind(pr_number=pr.number, url=pr.url).success("Pull request created")
         return pr
 
     def get_pr(

--- a/src/vibe3/ui/pr_ui.py
+++ b/src/vibe3/ui/pr_ui.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def render_pr_created(pr: PRResponse) -> None:
-    console.print("[green]✓[/] Draft PR created successfully!")
+    console.print("[green]✓[/] PR created successfully!")
     console.print(f"\n[cyan]PR #{pr.number}[/]: {pr.title}")
     console.print(f"[dim]{pr.url}[/]")
     console.print(

--- a/tests/vibe3/commands/test_pr_create_ai.py
+++ b/tests/vibe3/commands/test_pr_create_ai.py
@@ -39,7 +39,7 @@ class TestPRCreateCommandAI:
         mock_service.return_value.sync_pr_state_from_remote.assert_called_once_with(
             existing_pr, actor=None
         )
-        mock_service.return_value.create_draft_pr.assert_not_called()
+        mock_service.return_value.create_pr.assert_not_called()
 
     def test_pr_create_existing_pr_shows_confirmed_status(
         self, runner: CliRunner
@@ -84,7 +84,7 @@ class TestPRCreateCommandAI:
             patch("vibe3.commands.pr_create.PRService") as mock_service,
         ):
             mock_service.return_value.get_pr.return_value = None
-            mock_service.return_value.create_draft_pr.return_value = MagicMock(
+            mock_service.return_value.create_pr.return_value = MagicMock(
                 number=123,
                 title="Test PR",
                 body="Test body",
@@ -92,7 +92,7 @@ class TestPRCreateCommandAI:
             )
             result = runner.invoke(app, ["pr", "create", "-t", "Test PR", "--yes"])
         assert result.exit_code == 0
-        mock_service.return_value.create_draft_pr.assert_called_once_with(
+        mock_service.return_value.create_pr.assert_called_once_with(
             title="Test PR",
             body="",
             base_branch="main",
@@ -104,7 +104,7 @@ class TestPRCreateCommandAI:
         with patch.dict(os.environ, {}, clear=True):
             with patch("vibe3.commands.pr_create.PRService") as mock_service:
                 mock_service.return_value.get_pr.return_value = None
-                mock_service.return_value.create_draft_pr.return_value = MagicMock(
+                mock_service.return_value.create_pr.return_value = MagicMock(
                     number=123,
                     title="Test PR",
                     body="Test body",
@@ -167,9 +167,9 @@ class TestPRCreateCommandAI:
                                         "body": "Summary\n\n- change",
                                     },
                                 )
-                                (
-                                    mock_service.return_value.create_draft_pr.return_value
-                                ) = mock_pr
+                                mock_service.return_value.create_pr.return_value = (
+                                    mock_pr
+                                )
                                 result = runner.invoke(
                                     app,
                                     ["pr", "create", "--ai", "--json", "--yes"],

--- a/tests/vibe3/commands/test_task_hints.py
+++ b/tests/vibe3/commands/test_task_hints.py
@@ -60,7 +60,7 @@ def test_pr_create_requires_human_confirmation(
     assert "此命令需要明确确认" in result.output
     assert "--yes" in result.output
     assert "--agent" in result.output
-    mock_pr_service.create_draft_pr.assert_not_called()
+    mock_pr_service.create_pr.assert_not_called()
 
 
 @patch("vibe3.commands.pr_create.render_pr_created")
@@ -83,13 +83,13 @@ def test_pr_create_allows_yes_when_task_issue_missing(
 
     mock_pr_service = MagicMock()
     mock_pr_service.get_pr.return_value = None
-    mock_pr_service.create_draft_pr.return_value = MagicMock(model_dump=lambda: {})
+    mock_pr_service.create_pr.return_value = MagicMock(model_dump=lambda: {})
     mock_pr_service_cls.return_value = mock_pr_service
 
     result = runner.invoke(app, ["pr", "create", "-t", "Test PR", "--yes"])
 
     assert result.exit_code == 0
-    mock_pr_service.create_draft_pr.assert_called_once()
+    mock_pr_service.create_pr.assert_called_once()
 
 
 @patch("vibe3.commands.pr_query.FlowService")

--- a/tests/vibe3/services/test_pr_lifecycle_cache.py
+++ b/tests/vibe3/services/test_pr_lifecycle_cache.py
@@ -9,7 +9,7 @@ from vibe3.models.pr import PRResponse, PRState
 from vibe3.services.pr_service import PRService
 
 
-def test_create_draft_pr_updates_cache_title() -> None:
+def test_create_pr_updates_cache_title() -> None:
     """PR creation should cache PR number and title."""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
@@ -52,7 +52,7 @@ def test_create_draft_pr_updates_cache_title() -> None:
             mock_git_class.return_value = mock_git
 
             service = PRService(store=store)
-            result = service.create_draft_pr(
+            result = service.create_pr(
                 title="Fix orchestra async startup recursion",
                 body="Body",
                 base_branch="main",
@@ -178,7 +178,7 @@ def test_pr_create_appends_handoff_update() -> None:
             mock_git_class.return_value = mock_git
 
             service = PRService(store=store)
-            service.create_draft_pr(
+            service.create_pr(
                 title="Fix recursion",
                 body="Body",
                 base_branch="main",

--- a/tests/vibe3/services/test_pr_service.py
+++ b/tests/vibe3/services/test_pr_service.py
@@ -34,10 +34,8 @@ def no_conflict_git():
     return git
 
 
-def test_create_draft_pr_success(
-    pr_service: PRService, no_conflict_git: MagicMock
-) -> None:
-    """Test create draft PR success."""
+def test_create_pr_success(pr_service: PRService, no_conflict_git: MagicMock) -> None:
+    """Test create PR success."""
     gh_instance = pr_service.github_client
     gh_instance.check_auth.return_value = True
     gh_instance.get_current_branch.return_value = "feature-branch"
@@ -60,10 +58,11 @@ def test_create_draft_pr_success(
     with patch.object(pr_service, "git_client", no_conflict_git):
         with patch.object(pr_service, "store", mock_store):
             no_conflict_git.get_current_branch.return_value = "feature-branch"
-            pr = pr_service.create_draft_pr(title="Test PR", body="Test body")
+            pr = pr_service.create_pr(title="Test PR", body="Test body")
 
             assert pr.number == 123
             gh_instance.create_pr.assert_called_once()
+            assert gh_instance.create_pr.call_args[0][0].draft is False
             mock_store.update_flow_state.assert_called_once()
             mock_store.add_event.assert_called_once()
 
@@ -163,7 +162,7 @@ def test_pr_service_preserves_falsey_injected_dependencies() -> None:
     assert service.briefing_service.github_client is github_client
 
 
-def test_create_draft_pr_push_failure_surfaces_upstream_guidance(
+def test_create_pr_push_failure_surfaces_upstream_guidance(
     pr_service: PRService, no_conflict_git: MagicMock
 ) -> None:
     gh_instance = pr_service.github_client
@@ -178,7 +177,7 @@ def test_create_draft_pr_push_failure_surfaces_upstream_guidance(
 
     with patch.object(pr_service, "git_client", no_conflict_git):
         with pytest.raises(UserError) as exc_info:
-            pr_service.create_draft_pr(title="Test PR", body="Test body")
+            pr_service.create_pr(title="Test PR", body="Test body")
 
     message = str(exc_info.value)
     assert "git branch -vv" in message


### PR DESCRIPTION
## Summary
- Changed PR creation default from draft to regular PR to eliminate unnecessary state transitions
- Renamed `create_draft_pr` to `create_pr` for naming consistency
- Updated UI and CLI documentation to reflect non-draft default

## Changes
1. **Core Logic** (`src/vibe3/services/pr_service.py`): Changed `draft=True` to `draft=False` as the default
2. **Function Naming**: Renamed `create_draft_pr` to `create_pr` across codebase
3. **Documentation**: Updated CLI help text and UI messages to reflect new default
4. **Tests**: Updated test cases to verify `draft=False` behavior

## Motivation
Previously, executor created draft PRs by default, causing:
- Extra manager review cycles to identify draft status mismatch
- Unnecessary state transitions and corrections
- Increased review burden

Now executor directly creates regular PRs, aligning with expected workflow in `state/merge-ready`.

Fixes #644

## Test plan
- [ ] Verify PR creation creates regular PR (not draft) by default
- [ ] Check UI message shows "PR created successfully!" (not "Draft PR...")
- [ ] Confirm CLI documentation reflects new default
- [ ] Run test suite: `pytest tests/vibe3/services/test_pr_service.py`
- [ ] Run integration tests: `pytest tests/vibe3/commands/test_pr_create_ai.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)