### PR TITLE
fix(orchestration): add warning log when coordinator is None

### DIFF
--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -146,6 +146,12 @@ class OrchestrationFacade(ServiceBase):
 
         # Poll issue labels for all trigger states
         if self._coordinator is None:
+            logger.bind(
+                domain="orchestration_facade",
+            ).warning(
+                "GlobalDispatchCoordinator not initialized, dispatch skipped "
+                "(capacity not provided)"
+            )
             return
 
         # Always reconcile session state to prevent stale capacity tracking.


### PR DESCRIPTION
## Summary
- Add warning log in `OrchestrationFacade.on_tick()` when `coordinator is None` before early return
- Improves observability for configuration errors (capacity not provided)
- Follows existing structured logging pattern with domain field

## Changes
- `src/vibe3/domain/orchestration_facade.py`: Lines 148-154
  - Added `logger.warning()` call before `return` when coordinator is None
  - Message indicates GlobalDispatchCoordinator not initialized and dispatch skipped

## Verification
- ✅ Ruff lint check passed
- ✅ MyPy type check passed  
- ✅ All 15 existing tests passed

## Related
Closes #768
Follow-up to #759