### PR TITLE
refactor(skill): vibe-review-pr 结构整改 — 去重/统一/补漏

### DIFF
--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -470,8 +470,9 @@ workflow:
 
           **等待策略**：
           1. 收到 idle 通知 → 不操作，继续等待（idle 是正常状态，不代表完成）
-          2. 收到 task-notification（status=completed）→ 读取结果
-          3. 超时（5 分钟）→ 标注"审查不完整"，进入 Phase 3
+          2. 如怀疑交付问题（非例行 idle），按 handle_agent_idle_after_task(agent_name) 排查（见 SKILL.md §握手与唤醒协议规范）
+          3. 收到 task-notification（status=completed）→ 读取结果
+          4. 超时（5 分钟）→ 标注"审查不完整"，进入 Phase 3
 
           **重要**：
           - idle 通知是 agent 的正常状态（等待输入），不代表"未开始"或"失败"
@@ -580,7 +581,7 @@ workflow:
   phase_5:
     name: 写回 + 修复
     executor: team-lead  # 由当前 session（team-lead）执行
-    agents: []
+    agents: [fix-executor]  # 条件性 spawn（仅 auto-fix 模式），trigger: on_demand
     actions:
       - evaluate_execution_mode  # 根据配置决定执行路径
       - write_review_comment

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -326,6 +326,9 @@ workflow:
     parallel: true
     requires_phase_1_output: true
     message_passing: SendMessage
+    handshake_protocol: |
+      逐个 agent 握手+派发，具体流程见 SKILL.md §握手与唤醒协议规范。
+      约束：派发完一个 agent 后不得 idle，必须继续下一个；全部完成前 team-lead 不得 idle。
     # 【关键】fresh spawn 初始 prompt 只允许握手
     # Phase 1 背景必须在收到“已就绪”后，通过第二条 SendMessage 下发
     # 执行指令
@@ -353,12 +356,10 @@ workflow:
           message: "【lead_ready】team-lead 已完成握手。请现在执行 ToolSearch(query='select:SendMessage', max_results=1)，然后仅回复“【agent_ready】已就绪”。未完成握手前不得开始审查。"
       - step: verify_code_analyst_handshake
         action: |
-          等待 code-analyst 回复“【agent_ready】已就绪”。
-          未收到"【agent_ready】已就绪" → 标记该 agent blocked，跳过该 agent 的审查结果，并在 Phase 3 标注审查不完整
-          收到"【agent_ready】已就绪"后，同步 Phase 2 task metadata.handshake_status.code-analyst = "ready"
-          下一步必须进入 send_code_analyst_task；不得先发送 idle/待命类消息
-          backlog gate：写入 `lead_ready_sent.code-analyst=true` 后，`expected_next_action=verify_code_analyst_handshake`
-          backlog gate：收到 agent_ready 后，若其他 reviewer 尚未 ready，则保持 `task_activation_allowed=false`；全部 required reviewer ready 后再置 `task_activation_allowed=true`
+          等待 code-analyst 回复”【agent_ready】已就绪”，按 handshake_protocol 执行（见 SKILL.md §握手与唤醒协议规范）。
+          未收到 → 按 handshake_agent() 重试/blocked 逻辑处理。
+          收到 → 同步 handshake_status.code-analyst = “ready”，立即进入 send_code_analyst_task。
+          派发后不得 idle，必须继续处理下一个 agent。
       - step: send_code_analyst_task
         tool: SendMessage
         params:
@@ -393,12 +394,10 @@ workflow:
           message: "【lead_ready】team-lead 已完成握手。请现在执行 ToolSearch(query='select:SendMessage', max_results=1)，然后仅回复“【agent_ready】已就绪”。未完成握手前不得开始审查。"
       - step: verify_architect_handshake
         action: |
-          等待 architect-reviewer 回复“【agent_ready】已就绪”。
-          未收到"【agent_ready】已就绪" → 标记该 agent blocked，跳过该 agent 的审查结果，并在 Phase 3 标注审查不完整
-          收到"【agent_ready】已就绪"后，同步 Phase 2 task metadata.handshake_status.architect-reviewer = "ready"
-          下一步必须进入 send_architect_task；不得先发送 idle/待命类消息
-          backlog gate：写入 `lead_ready_sent.architect-reviewer=true` 后，`expected_next_action=verify_architect_handshake`
-          backlog gate：收到 agent_ready 后，若其他 reviewer 尚未 ready，则保持 `task_activation_allowed=false`；全部 required reviewer ready 后再置 `task_activation_allowed=true`
+          等待 architect-reviewer 回复”【agent_ready】已就绪”，按 handshake_protocol 执行（见 SKILL.md §握手与唤醒协议规范）。
+          未收到 → 按 handshake_agent() 重试/blocked 逻辑处理。
+          收到 → 同步 handshake_status.architect-reviewer = “ready”，立即进入 send_architect_task。
+          派发后不得 idle，必须继续处理下一个 agent。
       - step: send_architect_task
         tool: SendMessage
         params:
@@ -440,12 +439,10 @@ workflow:
           message: "【lead_ready】team-lead 已完成握手。请现在执行 ToolSearch(query='select:SendMessage', max_results=1)，然后仅回复“【agent_ready】已就绪”。未完成握手前不得开始审查。"
       - step: verify_security_handshake
         action: |
-          等待 security-reviewer 回复“【agent_ready】已就绪”。
-          未收到"【agent_ready】已就绪" → 标记该 agent blocked，跳过该 agent 的审查结果，并在 Phase 3 标注审查不完整
-          收到"【agent_ready】已就绪"后，同步 Phase 2 task metadata.handshake_status.security-reviewer = "ready"
-          下一步必须进入 send_security_task；不得先发送 idle/待命类消息
-          backlog gate：写入 `lead_ready_sent.security-reviewer=true` 后，`expected_next_action=verify_security_handshake`
-          backlog gate：收到 agent_ready 后，若其他 reviewer 尚未 ready，则保持 `task_activation_allowed=false`；全部 required reviewer ready 后再置 `task_activation_allowed=true`
+          等待 security-reviewer 回复”【agent_ready】已就绪”，按 handshake_protocol 执行（见 SKILL.md §握手与唤醒协议规范）。
+          未收到 → 按 handshake_agent() 重试/blocked 逻辑处理。
+          收到 → 同步 handshake_status.security-reviewer = “ready”，立即进入 send_security_task。
+          派发后不得 idle，必须继续处理下一个 agent。
       - step: send_security_task
         tool: SendMessage
         params:

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -8,7 +8,7 @@
 #    Agent(team_name="pr-review-team", name="<agent-name>",
 #          subagent_type="<subagent_type>", model="<model>", prompt="<prompt>")
 # 4. fresh spawn 背景优先写入 prompt；复用 teammates 或补充上下文时再用 SendMessage
-# 5. Phase 4 由 team-lead 执行（当前 session），不需要 spawn
+# 5. Phase 5 由 team-lead 执行（当前 session），不需要 spawn
 
 name: pr-review-team
 description: 多代理协作的 PR 审查团队，支持背景调研、代码分析、安全审查、架构评估
@@ -126,8 +126,8 @@ preflight_checks:
 # Team-lead 职责边界（强制）
 # - ✅ spawn agent、组织团队、管理 task 生命周期
 # - ✅ 接收 Phase 1 背景报告，并在握手成功后通过第二条 SendMessage 转发给 Phase 2 agents
-# - ✅ Phase 3 综合判断（收集报告、冲突仲裁、最终决策）
-# - ✅ Phase 4 写回：仅限 gh pr comment 和 gh issue create（禁止其他 gh/git 命令）
+# - ✅ Phase 4 综合判断（收集报告、冲突仲裁、最终决策）
+# - ✅ Phase 5 写回：仅限 gh pr comment 和 gh issue create（禁止其他 gh/git 命令）
 # - ❌ 不得自行收集上下文（gh pr view / git diff 等）——这是 context-researcher 的工作
 # - ❌ 显式 PR 编号入口下，不得为了“确认 PR 状态/标题/标签/改动范围”执行 gh pr view
 # - ❌ 不得在 spawn context-researcher 之前做任何背景调查
@@ -150,7 +150,7 @@ reuse_policy:
   conditions:
     - "相同 agentType"
     - "teammate 状态为 idle"
-    - "上一个 PR 已完成 Phase 4"
+    - "上一个 PR 已完成 Phase 5"
   action: |
     1. 检查 ~/.claude/teams/{team-name}/config.json 中 members
     2. 对每个需要的 agentType，查找匹配的 idle teammate
@@ -214,7 +214,7 @@ agents:
     description: 代码修复执行者，根据审核意见修复代码并提交
     spawn_config:
       tools: [Read, Edit, Write, Bash, Grep, Glob, SendMessage, ToolSearch]
-      run_in_background: false  # Phase 4 需等待修复完成
+      run_in_background: false  # Phase 5 需等待修复完成
     output_format:
       required_fields: [修复列表, 提交记录, 验证结果]
     trigger: on_demand  # 仅在 auto-fix 或用户选择修复时 spawn
@@ -279,19 +279,19 @@ workflow:
           message: "【lead_ready】team-lead 已完成握手。请现在执行 ToolSearch(query='select:SendMessage', max_results=1)，然后仅回复“【agent_ready】已就绪”。未完成握手前不得开始任何调研工作。"
       - step: verify_context_handshake
         action: |
-          等待 context-researcher 回复“【agent_ready】已就绪”。
+          等待 context-researcher 回复”【agent_ready】已就绪”，按 handshake_protocol 执行
+          （见 SKILL.md §握手与唤醒协议规范）。
 
           验证规则：
-          1. 最多重试 3 次握手消息
-          2. 只有收到明确“【agent_ready】已就绪”，才能将该 teammate 视为有效执行者
-          3. 收到“【agent_ready】已就绪”后，立即同步 Phase 1 task metadata.handshake_status.context-researcher = "ready"
-          4. 未收到"【agent_ready】已就绪" → 标记 context-researcher blocked，停止 Phase 1，并回退到单 agent review
+          1. 按 handshake_agent(“context-researcher”) 执行重试/blocked 逻辑
+          2. 只有收到明确”【agent_ready】已就绪”，才能将该 teammate 视为有效执行者
+          3. 收到”【agent_ready】已就绪”后，立即同步 handshake_status.context-researcher = “ready”
+          4. 未收到”【agent_ready】已就绪” → 标记 context-researcher blocked，停止 Phase 1，回退到单 agent review
 
           关键约束：
           - 未通过握手的 context-researcher 即使后续产出报告，也不得作为有效 Phase 1 输出
           - Phase 2 读取背景前必须检查 context-researcher 握手状态为 ready
-          - 一旦收到“已就绪”，下一步必须进入 send_context_task；不得发送 idle/待命类消息
-          - backlog gate：发送 lead_ready 后写入 `lead_ready_sent=true, expected_next_action=verify_context_handshake, activation_state=awaiting_agent_ready`
+          - 收到”已就绪”后，下一步必须进入 send_context_task；不得发送 idle/待命类消息
           - backlog gate：收到 agent_ready 后写入 `task_activation_allowed=true, expected_next_action=send_context_task, activation_state=awaiting_task_dispatch`
       - step: send_context_task
         tool: SendMessage
@@ -484,8 +484,8 @@ workflow:
           - 在报告中标注"部分审查未完整"
           - 不要假设未返回的 agent 同意其他结论
 
-  phase_2_5:
-    name: Codex第三方验证（可选）
+  phase_3:
+    name: Codex复查
     executor: team-lead
     agents: []
     parallel: false
@@ -501,15 +501,15 @@ workflow:
           满足以下任一条件：
           1. PR类型为 `security`
           2. 改动行数 > 500 或影响关键架构（inspect base风险高）
-          3. Phase 3 出现需要第三方裁决的冲突
+          3. Phase 2 多份报告对同一问题结论矛盾
           **第二阶段：Phase 2 完整性判断**
           required_agents = [code-analyst, architect-reviewer, security-reviewer]
           检查是否有 agent 超时/未返回结果
 
           **最终触发条件**：
-          - 第一阶段满足且 Phase 2 完整 → Phase 2.5 保持可选
-          - 第一阶段满足且 Phase 2 不完整 → Phase 2.5 升级为强制
-          - 第一阶段不满足 → 跳过 Phase 2.5，直接进入 Phase 3
+          - 第一阶段满足且 Phase 2 完整 → Phase 3 保持可选
+          - 第一阶段满足且 Phase 2 不完整 → Phase 3 升级为强制
+          - 第一阶段不满足 → 跳过 Phase 3，直接进入 Phase 4
 
           **注意**：
           - "可选"保留给 security / large / conflict_arbitration 的独立复核场景
@@ -537,14 +537,14 @@ workflow:
         wait_for_result: true
 
       - step: receive_codex_report
-        action: 保存codex验证报告，作为Phase 3补充材料
+        action: 保存codex验证报告，作为Phase 4 补充材料
 
-  phase_3:
-    name: 综合判断与改进
+  phase_4:
+    name: 综合判断
     agents: []
     actions:
       - verify_all_reports_received  # 新增：前置检查
-      - check_codex_report_if_exists  # 新增：检查Phase 2.5输出
+      - check_codex_report_if_exists  # 新增：检查 Phase 3 输出
       - collect_results
       - detect_conflicts
       - arbitrate_if_needed
@@ -576,8 +576,8 @@ workflow:
       - step: make_decision
         action: 生成最终决策（APPROVE/REJECT/NEEDS_INFO）
 
-  phase_4:
-    name: 写回与改进
+  phase_5:
+    name: 写回 + 修复
     executor: team-lead  # 由当前 session（team-lead）执行
     agents: []
     actions:
@@ -670,11 +670,10 @@ workflow:
       - step: wait_fix_ready
         condition: mode == "auto_fix"
         action: |
-          等待 fix-executor 回复"【agent_ready】已就绪"。
-          超时未收到（30秒）→ 第1次重试：再次发送 lead_ready
-          超时未收到（再30秒）→ 第2次重试：再次发送 lead_ready
-          超时未收到（再30秒）→ 第3次重试：再次发送 lead_ready
-          3次重试失败 → 标记 fix-executor 为失联，创建 follow-up issue
+          等待 fix-executor 回复"【agent_ready】已就绪"，按 handshake_protocol 执行
+          （见 SKILL.md §握手与唤醒协议规范）。
+          未收到 → 按 handshake_agent() 重试/blocked 逻辑处理。
+          收到 → 同步 handshake_status，立即进入 send_fix_task。
 
       - step: send_fix_task
         condition: mode == "auto_fix"
@@ -750,9 +749,8 @@ workflow:
         - [ ] 高 / 中 / 低
     labels: ["type/follow-up", "scope/<component>"]
 
-# 注意：本 workflow 只有 4 个 phase。
-# Phase 4 完成后，控制权直接回到 SKILL.md 的 Step 9（询问继续 / 结束）。
-# 不存在 "phase_5 / 准备下一个 PR / 保留状态" 这类辅助 phase——
+# 注意：本 workflow 只有 5 个 phase。
+# Phase 5 完成后，控制权直接回到 SKILL.md 的 Step 9（询问继续 / 结束）。
 # teammates 的 idle / pane / inbox 由运行时管理，skill 不感知也不操作。
 # 切换 PR 通过 SendMessage 给已有 agent 发新任务即可。
 

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -226,24 +226,26 @@ codex:
   call_method: bash  # 通过 codex-companion.mjs 调用
 
 # PR 类型判断
+# 权威规则见 SKILL.md §Step 7（PR 分类，内容判定，Phase 1 完成后执行）
+# 此处仅做执行模式映射，不得定义竞争性分类条件
 pr_classification:
   simple:
-    condition: "additions < 50 and not security_related"
+    condition: 见 SKILL.md §Step 7（4 项全部满足：单文件 + <30行 + 仅文档/注释/字符串/重命名 + 无 security/* 标签）
     flow: phase_1_only
     agents: []
 
   refactor:
-    condition: "'refactor' in title.lower()"
+    condition: 见 SKILL.md §Step 7（≥5 文件或大规模重构）
     flow: standard
-    agents: [context-researcher, code-analyst, architect-reviewer]
+    agents: [context-researcher, code-analyst, architect-reviewer, security-reviewer]
 
   security:
-    condition: "has_security_label or 'fix' in labels"
+    condition: 见 SKILL.md §Step 7（涉及认证/授权/数据/凭据/输入验证）
     flow: standard_security
     agents: [context-researcher, code-analyst, architect-reviewer, security-reviewer]
 
   standard:
-    condition: default
+    condition: 见 SKILL.md §Step 7（不属于上述类型）
     flow: standard
     agents: [context-researcher, code-analyst, architect-reviewer, security-reviewer]
 

--- a/.claude/team-templates/pr-review-team.yaml
+++ b/.claude/team-templates/pr-review-team.yaml
@@ -294,7 +294,6 @@ workflow:
           - 未通过握手的 context-researcher 即使后续产出报告，也不得作为有效 Phase 1 输出
           - Phase 2 读取背景前必须检查 context-researcher 握手状态为 ready
           - 收到”已就绪”后，下一步必须进入 send_context_task；不得发送 idle/待命类消息
-          - backlog gate：收到 agent_ready 后写入 `task_activation_allowed=true, expected_next_action=send_context_task, activation_state=awaiting_task_dispatch`
       - step: send_context_task
         tool: SendMessage
         params:

--- a/docs/specs/2026-05-12-vibe-review-pr-backlog-structured-redesign.md
+++ b/docs/specs/2026-05-12-vibe-review-pr-backlog-structured-redesign.md
@@ -1,0 +1,174 @@
+# Vibe-Review-PR Backlog 结构化重构
+
+## 问题
+
+刚完成的唤醒协议单源化重构解决了参数/流程/引用的三层解耦，但 Backlog task 的 description 存在更深层的结构问题：
+
+1. **Phase 编号不一致**：SKILL.md Backlog 用 Phase 1-5，YAML 用 phase_1/2/2.5/3/4，Phase 3 在两边指向完全不同的阶段
+2. **Phase 3-5 的 description 过于简短**：各只有 1 句话，team-lead 执行时缺乏操作指引
+3. **缺少输入/输出/门禁契约**：team-lead 不知道每个阶段需要什么上游产出、应该交付什么、进入下一阶段的条件是什么
+4. **fix-executor 握手硬编码重复**：YAML `wait_fix_ready` 硬编码了 3 次重试，未引用 centralized handshake_protocol
+
+## 设计目标
+
+- **Backlog task 标准化**：每个 Phase 的 description 统一为 `【输入】/【输出】/【步骤】/【门禁】` 四段结构
+- **Phase 编号统一**：YAML phase_2.5→phase_3, phase_3→phase_4, phase_4→phase_5
+- **消除最后一处重复**：fix-executor 唤醒逻辑引用 handshake_protocol
+- **步骤可执行**：每条步骤都是具体动作，不是描述性语句；引用协议而非重复逻辑
+
+## 方案
+
+### Backlog description 标准化模板
+
+```yaml
+description: |
+  【输入】
+  - <上游产出1>
+  - <上游产出2>
+
+  【输出】
+  - <本阶段交付物>
+
+  【步骤】
+  1. <具体动作>（引用协议/工具）
+  2. ...
+
+  【门禁】
+  - <进入下一阶段前必须为真的布尔条件>
+```
+
+### 五阶段契约
+
+#### Phase 1: 背景调研
+
+```
+【输入】PR 编号
+【输出】phase_1_output（结构化背景报告，保存到 task metadata）
+【步骤】
+1. team-lead 自身 ToolSearch
+2. spawn context-researcher，仅握手 prompt
+3. 按 handshake_agent("context-researcher") 执行握手（含 3 次唤醒）
+4. 收到 agent_ready 后，SendMessage 下发正式调研任务（含 PR 编号）
+5. 等待 teammate-message 获取背景报告
+6. TaskUpdate 保存 phase_1_output 到 metadata，标记 status="completed"
+【门禁】
+- handshake_status.context-researcher == "ready"
+- phase_1_output 非空且包含 PR 概述/改动范围/关联 issue/风险评估
+```
+
+#### Phase 2: 专家评审
+
+```
+【输入】phase_1_output（从 Phase 1 task metadata 获取）
+【输出】code-analyst / architect-reviewer / security-reviewer 的审查报告
+【步骤】
+1. TaskGet Phase 1 → 提取 phase_1_output，确认 context-researcher handshake_status == "ready"
+2. 依次对每个 agent（code-analyst → architect → security）：
+   a. spawn agent，仅握手 prompt，run_in_background=true
+   b. 按 handshake_agent(agent_name) 执行握手（含 3 次唤醒）
+   c. 收到 agent_ready 后，SendMessage 下发正式任务（含 phase_1_output）
+   d. 派发后不得 idle，立即继续下一个 agent
+3. 等待所有已握手 agent 的 task-notification（status=completed）
+4. 收集全部报告
+【门禁】
+- 至少 1 个 agent handshake_status == "ready" 且返回了有效报告
+- 未握手 agent 的报告标记为无效，不计入
+```
+
+#### Phase 3: Codex 复查
+
+```
+【输入】Phase 2 全部审查报告
+【输出】codex 验证报告（或 skip 标记及原因）
+【步骤】
+1. 收集 Phase 2 所有报告
+2. 校验各报告基础数据（文件数/行数/涉及模块）是否与 PR 实际 diff 一致
+3. 失真报告标注"报告作废"
+4. 判断触发条件（安全PR / diff>500行 / 报告冲突 / 报告缺失）
+5. 满足且报告质量合格 → codex:rescue（仅传结构化报告，禁止传 diff）
+6. 不满足或全部报告不合格 → 记录 skip 原因
+【门禁】
+- 已做出"启用 codex"或"跳过 codex"的明确决定（不可跳过此判断）
+- 如启用 codex：codex 报告已收到并保存
+- 此阶段不涉及 agent 握手
+```
+
+#### Phase 4: 综合判断
+
+```
+【输入】Phase 2 可用报告（剔除作废） + Phase 3 codex 报告（如有）
+【输出】最终决策（APPROVE / NEEDS_CHANGES / REJECT）+ 结构化审查报告
+【步骤】
+1. 收集 Phase 2 可用报告，剔除 Phase 3 标记为作废的
+2. 收集 Phase 3 codex 报告（如有）
+3. 仲裁不同报告间的冲突，记录仲裁理由
+4. 生成最终决策
+5. 按 output_format 格式化审查报告（禁虚假评分、禁无关指标、强制规则引用）
+6. 缺失 agent 报告标注"审查不完整"，不脑补结论
+【门禁】
+- 最终决策已做出
+- 审查报告已按 Review Quality Standards 自查通过
+- 禁止使用已作废的报告做结论
+```
+
+#### Phase 5: 写回 + 修复
+
+```
+【输入】Phase 4 最终决策和审查报告
+【输出】PR comment + follow-up issues + 可选修复 commit
+【步骤】
+1. 判断执行模式（auto-fix / comment-only / auto-decide / ask-each）
+2. 写 PR comment（必须包含：决策/已解决/遗留/规则引用）
+3. 如 auto-fix 模式：
+   a. spawn fix-executor，仅握手 prompt
+   b. 按 handshake_agent("fix-executor") 执行握手（含 3 次唤醒）
+   c. 收到 agent_ready 后，SendMessage 下发修复任务（含审查报告）
+   d. 等待修复完成并验证
+4. 范围外问题创建 follow-up issues（先搜索去重）
+5. 禁止把阻塞问题转 follow-up
+【门禁】
+- PR comment 已通过 gh pr comment 发布
+- 范围外问题已创建 follow-up issue 或确认无需创建
+```
+
+### YAML 改动
+
+**Phase 编号重排**：
+- `phase_2.5` → `phase_3`（Codex第三方验证 → Codex复查）
+- `phase_3` → `phase_4`（综合判断与改进 → 综合判断）
+- `phase_4` → `phase_5`（写回与改进 → 写回+修复）
+
+**fix-executor 握手去重**：`wait_fix_ready` 步骤改为：
+```yaml
+- step: wait_fix_ready
+  action: |
+    等待 fix-executor 回复"【agent_ready】已就绪"，按 handshake_protocol 执行
+    （见 SKILL.md §握手与唤醒协议规范）。
+    未收到 → 按 handshake_agent() 重试/blocked 逻辑处理。
+    收到 → 立即进入 send_fix_task。
+```
+删除当前硬编码的 3 次 30 秒重试伪代码。
+
+### 效果
+
+| 指标 | 改前 | 改后 |
+|------|------|------|
+| Phase 编号一致性 | SKILL.md≠YAML（2.5 vs 3 错位） | 完全一致（1-5） |
+| Phase 3-5 description 长度 | 各 1 句话 | 各含输入/输出/步骤/门禁 4 段 |
+| 握手逻辑硬编码 | YAML wait_fix_ready 重复 3 次重试 | 全部引用 handshake_protocol |
+| Backlog 格式 | 自然语言叙述 | 统一四段模板 |
+
+## 不变的部分
+
+- 唤醒协议单源结构不变（wakeup_policy + handshake_agent + handle_agent_idle）
+- Phase Contracts 表不变
+- Review Quality Standards 不变
+- Hard Rules 不变
+- Session Lifecycle 不变
+- Recovery 流程不变
+- 握手机制行为语义不变
+
+## 关联文件
+
+- `skills/vibe-review-pr/SKILL.md` §Step 6.5 Backlog Setup — Phase 1-5 TaskCreate description 重写
+- `.claude/team-templates/pr-review-team.yaml` — phase 编号重排 + wait_fix_ready 去重

--- a/docs/specs/2026-05-12-vibe-review-pr-wakeup-consolidation-design.md
+++ b/docs/specs/2026-05-12-vibe-review-pr-wakeup-consolidation-design.md
@@ -1,0 +1,137 @@
+# Vibe-Review-PR 唤醒协议单源化重构
+
+## 问题
+
+b0ea872 引入的 3 次唤醒机制在 SKILL.md 和 YAML 中共散布 8+ 处，修改一个参数需要动 7-8 个位置。历史上同一逻辑至少重写了 4 次，导致：
+
+- 维护成本高：改 `max_attempts` 从 3 到 5 需改 8 处
+- 一致性风险：多处手工重复容易漂移
+- 文件臃肿：YAML 中 3 个 verify 步骤各有 ~15 行几乎相同的伪代码
+
+## 设计目标
+
+- **单源真源**：`max_attempts` / `timeout` 只在一处定义
+- **流程集中**：握手/唤醒伪代码只写一次，在 SKILL.md 中集中描述
+- **YAML 精简化**：每个 verify 步骤从伪代码块变为一行引用
+
+## 方案
+
+### 三层单源结构
+
+```
+Backlog metadata (参数定义)
+  └─ wakeup_policy: {max_attempts: 3, timeout: 30s}
+       │
+       ▼
+SKILL.md "握手与唤醒协议规范" (流程定义)
+  └─ handshake_agent() / handle_agent_idle() 伪代码（各一份）
+  └─ 参数读取自 metadata.wakeup_policy
+       │
+       ▼
+YAML Phase 2 execution (执行引用)
+  └─ verify_X_handshake: 按握手协议规范执行（agent=X）
+  └─ check_agent_pane_status: 按 idle 检查协议执行
+```
+
+### SKILL.md 改动
+
+**新增 "握手与唤醒协议规范" 章节**（约 60 行，替代当前分散在多处的定义）：
+
+```markdown
+## 握手与唤醒协议规范
+
+参数定义见 Backlog metadata `wakeup_policy`。
+
+### handshake_agent(agent_name)
+
+1. SendMessage(to=agent_name, lead_ready)
+2. 等 agent_ready (timeout=wakeup_policy.timeout)
+3. 未收到 & attempts < max_attempts → 重试（告知第 N 次唤醒）
+4. 未收到 & attempts >= max_attempts → blocked
+5. 收到 → ready，重置计数器
+
+### handle_agent_idle_after_task(agent_name)
+
+1. 检查 inbox 送达
+2. check pane: InputValidationError → 重新握手
+3. check pane: Bash/Read → 执行中
+4. check pane: ❯ → 正常 idle
+```
+
+**Backlog metadata** 中新增 `wakeup_policy`：
+
+```yaml
+wakeup_policy:
+  max_attempts: 3
+  timeout: 30s
+```
+
+**删除**当前散布的：
+- 伪代码 `def handshake_agent()` (line ~107-136)
+- Backlog metadata 中散落的 `wakeup_attempts` / `max_wakeup_attempts` 重复定义
+- Phase 2 TaskCreate metadata 中的重复 `wakeup_attempts` 块
+
+### YAML 改动
+
+**Phase 2 新增 `handshake_protocol` 字段**（phase 头部，定义一次）：
+
+```yaml
+phase_2:
+  handshake_protocol: |
+    逐个 agent 握手+派发，具体流程见 SKILL.md §握手与唤醒协议规范。
+    约束：派发完一个 agent 后不得 idle，必须继续下一个；全部完成前 team-lead 不得 idle。
+```
+
+**verify 步骤精简**（3 个 agent 各从 ~20 行伪代码变为 ~5 行引用）：
+
+改前（以 code-analyst 为例）：
+```yaml
+- step: verify_code_analyst_handshake
+  action: |
+    等待 code-analyst 回复"【agent_ready】已就绪"。
+    **3 次唤醒机制**：
+    if not received_agent_ready("code-analyst", timeout=30s):
+      wakeup_attempts.code-analyst += 1
+      if wakeup_attempts.code-analyst < max_wakeup_attempts:
+        SendMessage(to="code-analyst", message="【lead_ready】... (第 {wakeup_attempts.code-analyst} 次唤醒)")
+        return "retry"
+      else:
+        handshake_status.code-analyst = "blocked"
+        ...
+    ...
+```
+
+改后：
+```yaml
+- step: verify_code_analyst_handshake
+  action: |
+    对 code-analyst 执行 handshake_agent("code-analyst")。
+    成功 → 进入 send_code_analyst_task。
+    失败 → 标记 blocked，继续处理下一个 agent。
+    派发后不得 idle，必须继续处理下一个 agent。
+```
+
+**check_agent_pane_status** 同样精简，引用 `handle_agent_idle()` 而非内嵌伪代码。
+
+### 效果
+
+| 指标 | 改前 | 改后 |
+|------|------|------|
+| YAML 行数 | ~910 | ~820 |
+| 唤醒逻辑定义次数 | 8+ | 3（参数1 + 流程1 + 引用1） |
+| 改 max_attempts 需改动 | 8 处 | 1 处 |
+| verify 步骤代码重复 | 3 份 ~15 行伪代码 | 3 份 ~5 行引用 |
+
+## 不变的部分
+
+- Phase 0 双向握手协议不变
+- Session Lifecycle 不变
+- Phase Contracts 表格不变
+- 所有 agent 定义不变
+- 执行模式不变
+- 唤醒机制的行为语义不变
+
+## 关联文件
+
+- `skills/vibe-review-pr/SKILL.md` — 新增协议规范章节，精简 Backlog metadata
+- `.claude/team-templates/pr-review-team.yaml` — Phase 2 新增 handshake_protocol，精简 verify 步骤

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -434,7 +434,7 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Phase 0
 | 2 专项审查 | 多 agent **同一响应**内并行 spawn；fresh spawn 先只做握手，收到“已就绪”后再通过 SendMessage 下发 `phase_1_output` 和正式任务；复用 teammate 或补发上下文时也用 SendMessage | **与 Phase 1 并行启动**；把正式任务直接写进 spawn prompt；让复用语义和首轮语义混在一起 |
 | 3 Codex决策（必选） | **必选动作**：校验各报告的基础数据（文件数/行数/涉及模块）是否与 PR 实际 diff 一致，失真报告标注”报告作废”；**决定是否启用 codex**——报告质量合格且满足触发条件（安全PR、大型PR>500行、冲突仲裁）时调用 `codex:rescue`；**调用时只传 Phase 2 结构化报告（禁止传 diff/代码片段）**；任一报告存在严重幻觉 → 跳过 codex 直接进入 Phase 4 | 与 Phase 2 并行执行；未收集完整 Phase 2 报告就做决策；**在报告质量不合格时仍调用 codex（幻觉数据无法被 codex 验证）**；**给 codex 传 diff 而不是报告**；**未将 Phase 2 报告发给 codex** |
 | 4 综合判断 | 收集 Phase 2 可用报告（剔除 Phase 3 标记为作废的）和 Phase 3 codex 报告（如有）；仲裁不同报告间的冲突；做出最终判断 | 使用已作废的报告做结论；替缺失 agent 脑补结论 |
-| 5 写回 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue | 把范围外技术债塞进当前 PR comment |
+| 5 写回 + 修复 | 模式决定路径；仅 `auto-fix` 可 spawn `pr-fix-executor`；范围外问题转 follow-up issue | 把范围外技术债塞进当前 PR comment |
 
 > **没有 Phase 6**。完成 Phase 5 直接回 Step 9。teammates 的 idle / pane / inbox 由运行时管理，**skill 不感知不操作**。如果你正在思考"清理 inbox"或"保留状态"，停下——这不是你的工作。
 

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -187,123 +187,171 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Phase 0
 先为 Phase 1 创建 task，并用 `TaskUpdate(owner="team-lead")` 设置归属；**显式 PR 编号入口不得在这里让 team-lead 先做 `gh pr view/diff` 验证**。必须先完成 Phase 0 Step 1 和 context-researcher 握手，由 Phase 1 报告提供 PR 事实，再判定为 `standard` / `refactor` / `security`，随后补建 Phase 2 / 3 / 4 / 5 的 task：
 
 ```yaml
+# ============================================================
+# Phase 1: 背景调研
+# ============================================================
 - tool: TaskCreate
   params:
-    subject: "Phase 1: Context research"
+    subject: “Phase 1: 背景调研”
     description: |
-      spawn context-researcher, collect PR background and save to metadata
-      【强制握手协议】：
-      1. team-lead 先执行 ToolSearch(query="select:SendMessage") 确认自身可用
-      2. spawn context-researcher 后，立即发送 `【lead_ready】`：
-         SendMessage(to="context-researcher", message="【lead_ready】team-lead 已完成握手，请执行 ToolSearch(query='select:SendMessage', max_results=1) 并回复'【agent_ready】已就绪'")
-      3. 收到"【agent_ready】已就绪"后，才能分配调研任务
-      4. 未握手成功前，不得给该 agent 分配任何工作
-      5. 显式指定 PR 编号时，team-lead 不得为“确认 PR 是否存在/状态/基本信息”执行 `gh pr view`；首次接触 PR 的主体必须是 context-researcher
+      【输入】PR 编号
+      【输出】phase_1_output（结构化背景报告，保存到 task metadata）
+      【步骤】
+      1. team-lead 执行 ToolSearch(query=”select:SendMessage”) 确认自身可用
+      2. spawn context-researcher，prompt 仅含握手指令，不得含调研任务
+      3. 按 handshake_agent(“context-researcher”) 执行握手（含 3 次唤醒，见 §握手与唤醒协议规范）
+      4. 收到 agent_ready 后，SendMessage 下发正式调研任务（含 PR 编号）
+      5. 等待 teammate-message 获取背景报告
+      6. TaskUpdate 保存 phase_1_output 到 metadata，标记 status=”completed”
+      【门禁】
+      - handshake_status.context-researcher == “ready”
+      - phase_1_output 非空，包含 PR 概述 / 改动范围 / 关联 issue / 风险评估
+      - team-lead 不得自行执行 gh pr view/diff（这是 context-researcher 的工作）
 - tool: TaskUpdate
   params:
-    taskId: "<phase-1-task-id>"
-    status: "in_progress"
-    owner: "team-lead"
+    taskId: “<phase-1-task-id>”
+    status: “in_progress”
+    owner: “team-lead”
     metadata:
-      handshake_protocol: "ordered_v1"
+      handshake_protocol: “ordered_v1”
       handshake_required: true
-      lead_handshake_status: "ready"
+      lead_handshake_status: “ready”
       lead_ready_sent: false
       task_activation_allowed: false
-      expected_next_action: "send_context_lead_ready"
-      activation_state: "awaiting_lead_ready"
-      handshake_agents: ["context-researcher"]
+      expected_next_action: “send_context_lead_ready”
+      activation_state: “awaiting_lead_ready”
+      handshake_agents: [“context-researcher”]
       handshake_status:
-        context-researcher: "pending"
-      on_handshake_failure: "skip_phase_and_fallback_to_single_agent"
+        context-researcher: “pending”
+      on_handshake_failure: “skip_phase_and_fallback_to_single_agent”
 
-# Phase 2 必须等待 Phase 1 完成并通过 task dependency 强制传递背景
+# ============================================================
+# Phase 2: 专家评审（依赖 Phase 1 完成）
+# ============================================================
 - tool: TaskCreate
   params:
-    subject: "Phase 2: Parallel review"
+    subject: “Phase 2: 专家评审”
     description: |
-      spawn code-analyst + architect-reviewer + security-reviewer with Phase 1 background
-      【强制握手协议】（逐个进行，非批量）：
-      1. 依次 spawn 每个 agent，每 spawn 一个立即握手：
-         SendMessage(to="<agent-name>", message="【lead_ready】team-lead 已完成握手，请执行 ToolSearch(query='select:SendMessage', max_results=1) 并回复'【agent_ready】已就绪'")
-      2. 收到该 agent "【agent_ready】已就绪"后，才能分配审查任务
-      3. 每个 agent 必须单独握手确认
-      4. 握手阶段不得内嵌 `phase_1_output` 或任何正式审查任务；收到"已就绪"后，再通过第二条 SendMessage 发送 phase_1_output（从 task #1 metadata 获取）
+      【输入】phase_1_output（从 Phase 1 task metadata 获取）
+      【输出】code-analyst / architect-reviewer / security-reviewer 的审查报告
+      【步骤】
+      1. TaskGet Phase 1 → 提取 phase_1_output
+      2. 确认 context-researcher handshake_status == “ready”（未 ready → 停止，回退单 agent）
+      3. 依次对 code-analyst → architect-reviewer → security-reviewer：
+         a. spawn agent，prompt 仅含握手指令，run_in_background=true
+         b. 按 handshake_agent(agent_name) 执行握手（含 3 次唤醒，见 §握手与唤醒协议规范）
+         c. 收到 agent_ready 后，SendMessage 下发正式任务（含 phase_1_output）
+         d. 派发后不得 idle，立即继续下一个 agent
+      4. 等待所有已握手 agent 的 task-notification（status=completed）
+      5. 收集全部报告
+      【门禁】
+      - 至少 1 个 agent handshake_status == “ready” 且返回了有效报告
+      - 未握手 agent 的报告标记为无效，不计入 Phase 3/4
 - tool: TaskUpdate
   params:
-    taskId: "<phase-2-task-id>"
-    addBlockedBy: ["<phase-1-task-id>"]  # 强制依赖 Phase 1
+    taskId: “<phase-2-task-id>”
+    addBlockedBy: [“<phase-1-task-id>”]
     metadata:
-      handshake_protocol: "ordered_v1"
-      requires_phase_1_output: true  # 标记需要背景信息
+      handshake_protocol: “ordered_v1”
+      requires_phase_1_output: true
       handshake_required: true
       task_activation_allowed: false
-      expected_next_action: "send_code_analyst_lead_ready"
-      activation_state: "awaiting_first_lead_ready"
-      handshake_agents: ["code-analyst", "architect-reviewer", "security-reviewer"]
+      expected_next_action: “send_code_analyst_lead_ready”
+      activation_state: “awaiting_first_lead_ready”
+      handshake_agents: [“code-analyst”, “architect-reviewer”, “security-reviewer”]
       lead_ready_sent:
         code-analyst: false
         architect-reviewer: false
         security-reviewer: false
       handshake_status:
-        code-analyst: "pending"
-        architect-reviewer: "pending"
-        security-reviewer: "pending"
-      on_handshake_failure: "skip_unready_agent_and_mark_review_incomplete"
+        code-analyst: “pending”
+        architect-reviewer: “pending”
+        security-reviewer: “pending”
+      on_handshake_failure: “skip_unready_agent_and_mark_review_incomplete”
       wakeup_policy:
         max_attempts: 3
         timeout: 30s
 
+# ============================================================
+# Phase 3: Codex 复查（依赖 Phase 2 完成）
+# ============================================================
 - tool: TaskCreate
   params:
-    subject: "Phase 3: Codex decision"
+    subject: “Phase 3: Codex 复查”
     description: |
-      （必选）校验 Phase 2 报告质量，决定是否启用 codex
-      【强制触发条件】满足任一项即启动 codex:rescue：
-      - 安全 PR（涉及认证/授权/路径解析/输入验证）
-      - 大型 PR（diff > 500 行）
-      - 报告冲突（Phase 2 多份报告对同一问题结论矛盾）
-      - 报告缺失（Phase 2 应有报告未送达）
-      【执行步骤】：
-      1. 收集 Phase 2 全部报告，校验各报告基础数据（文件数/行数/涉及模块）是否与 PR 实际 diff 一致
-      2. 失真报告标注"报告作废"，不作为 codex 输入
-      3. 满足触发条件且报告质量合格 → 调用 codex:rescue
-         必须将 Phase 2 完整报告（剔除作废的）作为输入发给 codex
-      4. 不满足触发条件或全部报告均不合格 → 跳过 codex，直接进入 Phase 4
-      
-      【关键约束】：
-      - **绝对禁止传 diff 给 codex**：codex 的输入只能是 Phase 2 的结构化报告
-      - **绝对禁止传 diff 给 codex**：codex 的输入只能是 Phase 2 的结构化报告（文件列表、行数、安全声明、红队测试结果等），不得包含 git diff、代码片段、代码变更内容
-      - 不得在 Phase 2 完成前启动（严格串行）
-      - 不得用幻觉报告喂 codex（失效数据无法被 codex 验证）
-      - 此阶段不涉及 agent 握手。
+      【输入】Phase 2 全部审查报告
+      【输出】codex 验证报告（或 skip 标记及原因）
+      【步骤】
+      1. 收集 Phase 2 全部报告
+      2. 校验各报告基础数据（文件数/行数/涉及模块）是否与 PR 实际 diff 一致
+      3. 失真报告标注”报告作废”，不作为 codex 输入
+      4. 判断触发条件（安全PR / diff>500行 / 报告冲突 / 报告缺失）
+      5. 满足且报告质量合格 → 调用 codex:rescue（仅传结构化报告，禁止传 diff/代码片段）
+      6. 不满足或全部报告不合格 → 记录 skip 原因，直接进入 Phase 4
+      【门禁】
+      - 已做出”启用 codex”或”跳过 codex”的明确决定（不可跳过此判断）
+      - 如启用 codex：codex 报告已收到并保存
+      - 此阶段不涉及 agent 握手
 - tool: TaskUpdate
   params:
-    taskId: "<phase-3-task-id>"
-    addBlockedBy: ["<phase-2-task-id>"]  # 强制依赖 Phase 2
+    taskId: “<phase-3-task-id>”
+    addBlockedBy: [“<phase-2-task-id>”]
     metadata:
-      requires_phase_2_reports: true  # 标记需要 Phase 2 报告
+      requires_phase_2_reports: true
+
+# ============================================================
+# Phase 4: 综合判断（依赖 Phase 3 完成）
+# ============================================================
 - tool: TaskCreate
   params:
-    subject: "Phase 4: Synthesis"
+    subject: “Phase 4: 综合判断”
     description: |
-      收集 Phase 2 可用报告（剔除 Phase 3 标记为作废的）和 Phase 3 codex 报告（如有）
-      仲裁不同报告间的冲突，做出最终判断
-      禁止使用已作废的报告做结论
+      【输入】Phase 2 可用报告（剔除作废） + Phase 3 codex 报告（如有）
+      【输出】最终决策（APPROVE / NEEDS_CHANGES / REJECT）+ 结构化审查报告
+      【步骤】
+      1. 收集 Phase 2 可用报告，剔除 Phase 3 标记为作废的
+      2. 收集 Phase 3 codex 报告（如有）
+      3. 仲裁不同报告间的冲突，记录仲裁理由
+      4. 生成最终决策
+      5. 按 Review Quality Standards 自审查报告（禁虚假评分、禁无关指标、强制规则引用）
+      6. 缺失 agent 报告标注”审查不完整”，不脑补结论
+      【门禁】
+      - 最终决策已做出
+      - 审查报告已通过 Review Quality Standards 全部 8 条自查
+      - 未使用已作废的报告做结论
 - tool: TaskUpdate
   params:
-    taskId: "<phase-4-task-id>"
-    addBlockedBy: ["<phase-3-task-id>"]  # 强制依赖 Phase 3
+    taskId: “<phase-4-task-id>”
+    addBlockedBy: [“<phase-3-task-id>”]
     metadata:
       requires_phase_2_and_3_output: true
+
+# ============================================================
+# Phase 5: 写回 + 修复（依赖 Phase 4 完成）
+# ============================================================
 - tool: TaskCreate
   params:
-    subject: "Phase 5: Write back"
-    description: "ask-each mode; post PR comment; create follow-up issues。此阶段不涉及 agent 握手。仅限 gh pr comment 和 gh issue create。"
+    subject: “Phase 5: 写回 + 修复”
+    description: |
+      【输入】Phase 4 最终决策和审查报告
+      【输出】PR comment + follow-up issues + 可选修复 commit
+      【步骤】
+      1. 判断执行模式（auto-fix / comment-only / auto-decide / ask-each）
+      2. 写 PR comment（含：决策/已解决技术债/遗留问题/规则引用/follow-up 链接）
+      3. 如 auto-fix 模式：
+         a. spawn fix-executor，prompt 仅含握手指令
+         b. 按 handshake_agent(“fix-executor”) 执行握手（含 3 次唤醒，见 §握手与唤醒协议规范）
+         c. 收到 agent_ready 后，SendMessage 下发修复任务（含审查报告）
+         d. 等待修复完成并验证
+      4. 范围外问题创建 follow-up issues（先搜索去重，禁止重复创建）
+      【门禁】
+      - PR comment 已通过 gh pr comment 发布
+      - 范围外问题已创建 follow-up issue 或确认无需创建
+      - 禁止把当前 PR 阻塞问题转为 follow-up
 - tool: TaskUpdate
   params:
-    taskId: "<phase-5-task-id>"
-    addBlockedBy: ["<phase-4-task-id>"]  # 强制依赖 Phase 4
+    taskId: “<phase-5-task-id>”
+    addBlockedBy: [“<phase-4-task-id>”]
 ```
 
 **关键步骤（Phase 1 完成后必须执行）**：

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -105,6 +105,33 @@ tmux capture-pane -t <pane-id> -p -S -1000 | grep -E "ToolSearch|SendMessage|Inp
 
 详见：`.claude/agents/pr-*.md` 的 "握手协议" 章节。
 
+## 握手与唤醒协议规范
+
+参数定义见 Backlog metadata `wakeup_policy`（`max_attempts`、`timeout`）。以下流程是**单源真源**，修改参数只需改 metadata 一处，以下伪代码自动跟随。
+
+### handshake_agent(agent_name)
+
+```
+1. SendMessage(to=agent_name, lead_ready)
+2. 等待 agent_ready 回复（timeout=wakeup_policy.timeout）
+3. 超时 & 重试次数 < wakeup_policy.max_attempts → 重试（告知第 N 次唤醒）
+4. 超时 & 重试次数 >= wakeup_policy.max_attempts → 标记 blocked，继续处理下一个 agent
+5. 收到 agent_ready → 该 agent ready，重置计数器，立即分配正式任务
+```
+
+**约束**：派发完一个 agent 后 team-lead 不得进入 idle；必须继续处理下一个 agent，直到全部完成。
+
+### handle_agent_idle_after_task(agent_name)
+
+```
+收到 agent 的 idle 通知后（仅用于排查交付问题，不用于常规状态检查）：
+
+1. 检查 inbox：任务结果是否已送达
+2. check pane: InputValidationError → 该 agent 可能未加载 SendMessage，重新握手
+3. check pane: Bash/Read 输出 → agent 正在执行中，正常等待
+4. check pane: ❯ 等待输入 → 正常 idle，任务尚未完成，继续等待
+```
+
 ### 其他常见陷阱
 
 详见 `references/debug-guide.md`：
@@ -223,6 +250,9 @@ TeamCreate → TaskCreate(Phase 1) → TaskUpdate(owner="team-lead") → Phase 0
         architect-reviewer: "pending"
         security-reviewer: "pending"
       on_handshake_failure: "skip_unready_agent_and_mark_review_incomplete"
+      wakeup_policy:
+        max_attempts: 3
+        timeout: 30s
 
 - tool: TaskCreate
   params:

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -47,63 +47,23 @@ description: |
 > - 重复操作最多 3 次
 > - 3 次后仍失败 → 标记该 agent 为阻塞，大声说自己是傻瓜
 
-### Deferred Tools 加载（有序双向握手协议，issue #787，强制执行）
+### Deferred Tools 加载（issue #787）
 
 **核心问题**：`SendMessage` 是 deferred tool，声明在 agent 定义中不等于加载 schema。调用前必须先 `ToolSearch` 加载，否则报 `InputValidationError`。
 
-**死锁陷阱**：如果 agent 不执行 `ToolSearch`，就没有 `SendMessage` 能力，**根本无法汇报被阻塞**——之前"失败时报告给 team-lead"的设计是自相矛盾的。
+**死锁陷阱**：如果 agent 不执行 `ToolSearch`，就没有 `SendMessage` 能力，**根本无法汇报被阻塞**。
 
-**正确方案：Phase 0 有序双向握手（强制执行，不可跳过）**
-
-```
-Phase 0: 有序双向握手协议（lead_ready → agent_ready → send_task）
-
-Step 1 - team-lead 自身握手（整个 Phase 0 的第一步，仅一次，强制执行）：
-  【强制】team-lead 必须执行：
-    ToolSearch(query="select:SendMessage", max_results=1)
-  
-  【关键说明】：
-  - 即使会话开始时 UserPromptSubmit hook 自动触发了其他 ToolSearch，
-    team-lead 也必须重新执行此步骤作为 Phase 0 的正式握手
-  - 会话开始时的 ToolSearch 是响应 hook，不是 Phase 0 的正式握手
-  - Deferred tools 机制：声明在 agent 定义中 ≠ schema 已加载
-  - 必须显式执行 ToolSearch 才能加载 SendMessage schema
-  
-  失败 → 立即停止，禁止 spawn 任何 agent
-
-Step 2 - team-lead 每 spawn 一个 agent，立即发送 lead_ready：
-  SendMessage(to="<agent-name>", message="【lead_ready】team-lead 已完成握手。请现在执行 ToolSearch，并在成功后回复【agent_ready】已就绪。")
-
-Step 3 - agent 在收到 lead_ready 后响应：
-  agent 执行 ToolSearch(query="select:SendMessage", max_results=1)
-  成功 → SendMessage(to="team-lead", message="【agent_ready】已就绪")
-  失败 → agent 无法发送消息，team-lead 超时检测
-
-Step 4 - team-lead 确认该 agent：
-  收到"【agent_ready】已就绪" → 该 agent 可参与后续工作，下一步必须发送正式任务
-  超时未收到 → 再次发送 lead_ready 握手消息通知 agent
-  多次超时 → 标记该 agent 为阻塞，后续 Phase 标注"审查不完整"
-```
-
-**关键理解**：这是**有方向、有时序**的握手，不是双方同时各说一次“已就绪”。
-
-- **Phase 1 阶段**：spawn context-researcher → lead 发送 `lead_ready` → agent 回复 `agent_ready` → 分配调研任务
-- **Phase 2 阶段**：spawn code-analyst + architect + security → lead 分别发送 `lead_ready` → 各 agent 分别回复 `agent_ready` → 并行分配任务
-
-team-lead 在 spawn 一个 agent 后，必须先发 `lead_ready`，等该 agent 返回 `agent_ready`，才能继续该阶段的工作。
-不等到该 agent 的 `agent_ready`，不得给该 agent 分配任何工作。
+**方案**：Phase 0 有序双向握手协议（`lead_ready → agent_ready → send_task`），详见 §握手与唤醒协议规范。
 
 **强制规则**：
-- **team-lead**：spawn agent 后必须立即发送 `lead_ready`；收到 `agent_ready` 前不得给该 agent 分配工作
+- **team-lead**：Phase 0 第一步自身先执行 `ToolSearch(query=”select:SendMessage”)`；spawn agent 后必须立即发送 `lead_ready`；收到 `agent_ready` 前不得给该 agent 分配工作
 - **teammate**：收到 `lead_ready` 消息后，**唯一合法操作**是执行 ToolSearch 并回复 `agent_ready`
 - **任何 agent**：在 Deferred Tools 完成加载前，**不得执行任何其他操作**
 
 **诊断**（如 agent 未发送报告）：
 ```bash
-tmux capture-pane -t <pane-id> -p -S -1000 | grep -E "ToolSearch|SendMessage|InputValidationError"
+tmux capture-pane -t <pane-id> -p -S -1000 | grep -E “ToolSearch|SendMessage|InputValidationError”
 ```
-
-详见：`.claude/agents/pr-*.md` 的 "握手协议" 章节。
 
 ## 握手与唤醒协议规范
 
@@ -177,6 +137,10 @@ Team 名称固定为 `pr-review-team`（**不要**用 `pr-review-713` 这种 PR-
 ### Step 6.5: Backlog Setup（TeamCreate 后先建 Phase 1，后续按 PR 类型补建）
 
 > **踩坑记录**：TeamCreate 之前创建的 TaskCreate 不会关联到 team 的 task list，`TaskList` 返回空。必须先 TeamCreate 再 TaskCreate。
+
+> **Phase 0（有序双向握手）是 Backlog 的前置条件，不是 Backlog task。**
+> team-lead 自身 ToolSearch + 逐个 agent 的 `lead_ready → agent_ready` 握手流程在进入 Step 6.5 之前完成。
+> Phase 0 失败 → 立即停止，不创建任何 Backlog task。
 
 **强制顺序**：
 
@@ -536,24 +500,25 @@ LLM 拟合不出小数点评分，强行打分就是幻觉。
 - 唯一的 context 传递是：从 Phase 1 报告通过第二条 SendMessage **转发**到 Phase 2 agents，不做预收集
 - `保持空闲 / 等待新 PR` 只适用于**上一轮任务已完成的复用 teammate**；不适用于本轮 fresh spawn 且刚完成握手的 agent
 
-### 握手协议（强制，按阶段分别执行）
+### 握手协议（强制）
 
-**握手不是一次性集合操作，而是"spawn 谁 → 跟谁握手"的逐个确认过程。**
+**流程定义见 §握手与唤醒协议规范**（`handshake_agent()` / `handle_agent_idle_after_task()`）。以下为不可违反的硬边界：
 
-**Phase 1**：spawn context-researcher → 握手 → 等"已就绪" → 分配调研任务
-**Phase 2**：spawn code-analyst + architect + security → 分别与每个握手 → 都"已就绪" → 并行分配任务
+**按阶段执行**：
+- **Phase 1**：spawn context-researcher → 握手 → 等"已就绪" → 分配调研任务
+- **Phase 2**：spawn code-analyst + architect + security → 分别与每个握手 → 逐个派发正式任务
 
 **team-lead 必须**：
 1. 整个 Phase 0 的第一步：自身先执行 `ToolSearch(query="select:SendMessage")`
 2. 每 spawn 一个 agent，立即发送 `【lead_ready】` 握手消息
 3. 收到该 agent 的 `【agent_ready】已就绪` 回复后，必须立即发送该 phase 的正式任务；fresh spawn 不得先进入 idle / 待命态
-4. 超时未收到 → 再次发送 `lead_ready` 通知；多次超时 → 标记该 agent 为阻塞
+4. 超时未收到 → 按 `handshake_agent()` 重试/blocked 逻辑处理
 
 **team-lead 禁止**：
 - 自身未 ToolSearch 就 spawn 任何 agent
 - spawn 后不发 `lead_ready`，假设 agent 会自动执行
 - 未收到 `agent_ready` 就给该 agent 分配工作
-- 对 fresh spawn 且刚回复"【agent_ready】已就绪"的 agent 发送"保持空闲 / 等待新 PR / 等待以后再分配"
+- 对 fresh spawn 且刚回复"【agent_ready】已就绪"的 agent 发送"保持空闲 / 等待新 PR"
 - 替未响应的 agent 脑补结论
 
 ### 状态操作


### PR DESCRIPTION
## 摘要

对 vibe-review-pr 技能进行三阶段结构整改，消除 SKILL.md 与 YAML 之间的逻辑重复、规则不一致和死代码。

### Phase A: 唤醒协议单源化
- 将 8+ 处分散的唤醒逻辑集中为三层结构（metadata 参数 → SKILL.md 流程 → YAML 引用）
- YAML 3 个 verify 步骤从 ~15 行伪代码缩减为 ~5 行引用

### Phase B: Backlog 结构化重构
- 5 个 Phase 的 description 统一为【输入】/【输出】/【步骤】/【门禁】四段模板
- YAML Phase 编号统一（2.5→3, 3→4, 4→5）
- fix-executor 握手逻辑引用 handshake_protocol 而非硬编码 3 次重试

### Phase C: 8 项结构问题修复
1. PR 分类规则统一 — YAML pr_classification 引用 SKILL.md Step 7 为真源
2. Refactor agent 列表补全 security-reviewer
3. 握手协议去重 — Common Pitfalls 和 Hard Rules 引用中央规范
4. 删除 YAML verify_context_handshake 残留 backlog gate 行
5. Phase Contracts 表 Phase 5 命名改为 "写回 + 修复"
6. YAML phase_5.agents 加入 fix-executor
7. Backlog 标注 Phase 0 为前置条件
8. handle_agent_idle_after_task 在 YAML wait_for_phase_2_results 中引用

## 测试验证

- Python 测试套件全部通过
- YAML 语法校验通过
- 交叉引用完整性检查通过

## 涉及文件

- `skills/vibe-review-pr/SKILL.md` — 583 行
- `.claude/team-templates/pr-review-team.yaml` — 801 行
- `docs/specs/2026-05-12-vibe-review-pr-*.md` — 2 份设计文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)