### PR TITLE
feat(git): add PR numstat caching for efficiency (#695)

### DIFF
--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -117,6 +117,7 @@ class GitClient:
         self._github_client = github_client
         self._cwd = Path(cwd) if cwd else None
         self._pr_diff_cache: dict[int, str] = {}
+        self._pr_numstat_cache: dict[int, str] = {}
 
     def _run(self, args: list[str], cwd: Path | str | None = None) -> str:
         """执行 git 命令，统一错误处理.
@@ -218,7 +219,13 @@ class GitClient:
 
     def get_numstat(self, source: ChangeSource) -> str:
         """Get git diff --numstat output for a change source."""
-        return _get_numstat(self._run, source, self._github_client, self.get_merge_base)
+        return _get_numstat(
+            self._run,
+            source,
+            self._github_client,
+            self.get_merge_base,
+            self._pr_numstat_cache,
+        )
 
     def get_untracked_files(self) -> list[str]:
         """Return untracked files in the worktree."""

--- a/src/vibe3/clients/git_status_ops.py
+++ b/src/vibe3/clients/git_status_ops.py
@@ -194,6 +194,7 @@ def get_numstat(
     source: ChangeSource,
     github_client: "GitHubClient | None" = None,
     get_merge_base: Callable[[str, str], str] | None = None,
+    pr_numstat_cache: dict[int, str] | None = None,
 ) -> str:
     """Unified interface: get git diff --numstat output.
 
@@ -202,6 +203,7 @@ def get_numstat(
         source: Change source (PR/Commit/Branch/Uncommitted)
         github_client: Optional GitHubClient for PR ref resolution
         get_merge_base: Optional merge-base resolver callable
+        pr_numstat_cache: Optional PR numstat cache dict
 
     Returns:
         numstat output string (tab-separated: added deleted filepath)
@@ -248,15 +250,20 @@ def get_numstat(
             )
         if not get_merge_base:
             raise SystemError("get_merge_base callable required for PRSource")
-        pr_info = github_client.get_pr(source.pr_number)
-        if not pr_info:
-            raise GitError(
-                "get_numstat",
-                f"PR #{source.pr_number} not found",
+        if pr_numstat_cache is not None and source.pr_number in pr_numstat_cache:
+            output = pr_numstat_cache[source.pr_number]
+        else:
+            pr_info = github_client.get_pr(source.pr_number)
+            if not pr_info:
+                raise GitError(
+                    "get_numstat",
+                    f"PR #{source.pr_number} not found",
+                )
+            output = _numstat_via_merge_base(
+                run, get_merge_base, pr_info.head_branch, pr_info.base_branch
             )
-        output = _numstat_via_merge_base(
-            run, get_merge_base, pr_info.head_branch, pr_info.base_branch
-        )
+            if pr_numstat_cache is not None:
+                pr_numstat_cache[source.pr_number] = output
     else:
         raise GitError("get_numstat", f"Unknown source type: {source.type}")
 


### PR DESCRIPTION
## Summary

- Added pr_numstat_cache parameter to get_numstat() function
- Wired cache through GitClient instance following existing get_diff() pattern
- Improves efficiency when fetching PR numstat data

## Changes

**git_status_ops.py**:
- Added pr_numstat_cache parameter to get_numstat()
- Cache is written when fetching PR numstat from GitHub API
- Follows same pattern as existing get_diff() caching

**git_client.py**:
- Wired pr_numstat_cache through GitClient instance
- Maintains backward compatibility with all existing callers

## Verification

- **Tests**: 19 passed (git_status_ops + loc_service)
- **Types**: mypy passes with no issues
- **Pre-commit**: All checks pass (Black, Ruff, MyPy, ShellCheck)
- **LOC**: +14 lines, 2 files changed

## Pattern Validation

Mirrors the proven get_diff() caching design:
- Same cache parameter wiring pattern
- Same guards preservation
- Same cache key construction
- Same cache write timing

🤖 Generated with Claude Code