### PR TITLE
fix(orchestra): 允许收集 BLOCKED issue 并在派发前检查恢复条件

### DIFF
--- a/src/vibe3/orchestra/dispatch_queue_helpers.py
+++ b/src/vibe3/orchestra/dispatch_queue_helpers.py
@@ -60,16 +60,13 @@ def select_ready_issues(
         if not any(lbl.startswith("state/") for lbl in labels):
             continue
 
-        # Skip blocked issues (FAILED unified to BLOCKED)
-        if IssueState.BLOCKED.to_label() in labels:
-            continue
-
         issue = IssueInfo.from_github_payload(item)
         if issue is None:
             continue
 
         # BLOCKED_ROLE: collect all candidates without qualify gate.
         # Gate runs at intent time in GlobalDispatchCoordinator.
+        # This allows blocked issues to be collected and checked for unblock conditions.
         if role.trigger_name == "blocked":
             selected.append(issue)
             continue


### PR DESCRIPTION
## 问题分析

Orchestra dispatcher 在收集 issue 时，虽然 `_collect_frozen_queue` 包含了 `IssueState.BLOCKED`，
但在 `select_ready_issues` 方法中存在逻辑冲突：

```python
# Line 64-65: 硬性跳过所有有 state/blocked label 的 issue
if IssueState.BLOCKED.to_label() in labels:
    continue

# Line 71-75: BLOCKED_ROLE 特殊处理（意图是收集 BLOCKED issue）
if role.trigger_name == "blocked":
    selected.append(issue)
    continue
```

**实际行为**：
- ✅ 正在变成 blocked 的 issue（没有 `state/blocked` label）会被收集
- ❌ 已经 blocked 的 issue（有 `state/blocked` label，等待恢复）**不会进入 frozen queue**

**派发前检查逻辑**（在 `global_dispatch_coordinator.py` Line 232-242）：
```python
if issue.state == IssueState.BLOCKED:
    target_state = self._qualify_gate.qualify_blocked_issue(issue)
    if target_state is None:
        self._frozen_queue.pop(index)
        continue
```

在 `qualify_gate.py` 中正确检查了 `blocked_reason` 是否清空：
```python
blocked_reason = flow_state.get("blocked_reason")
if blocked_reason and str(blocked_reason).strip():
    return None  # 仍然 blocked，跳过
# 如果 blocked_reason 清空，清除 blocked metadata 并返回 target_label
```

**但是**，这些逻辑永远不会被执行，因为 BLOCKED issue 在收集阶段就被过滤掉了。

## 修改内容

删除 `src/vibe3/orchestra/dispatch_queue_helpers.py` Line 63-65 的硬性跳过逻辑。

**修复后流程**：
1. ✅ 收集 BLOCKED issue（通过 Line 73-75 的 BLOCKED_ROLE 特殊处理）
2. ✅ 进入 frozen queue
3. ✅ 派发前调用 `qualify_gate.qualify_blocked_issue(issue)`
4. ✅ 检查 `blocked_reason` 是否清空
5. ✅ 如果清空，清除 blocked metadata 并派发

## 验证

运行关键测试（44 个测试），所有测试通过：
- ✅ test_dispatch_queue_operations.py (14 passed)
- ✅ test_global_dispatch_coordinator.py (15 passed)
- ✅ test_qualify_gate.py (16 passed)

## 影响范围

- **修改文件**：`src/vibe3/orchestra/dispatch_queue_helpers.py` (删除 3 行，添加 1 行注释)
- **影响行为**：BLOCKED issue 现在能被正确收集和恢复派发
- **无破坏性变更**：所有现有测试通过

## 测试方法

修复后可以通过以下方式验证：

1. 创建一个 blocked issue（有 `state/blocked` label）
2. 清空 `blocked_reason`（通过 `vibe task restore <issue>` 或手动清空）
3. 启动 orchestra server (`vibe serve start`)
4. 观察日志：
   - 应看到 BLOCKED issue 进入 frozen queue
   - 应看到调用 `qualify_blocked_issue` 检查恢复条件
   - 应看到如果 `blocked_reason` 清空，清除 blocked metadata 并派发

## 相关代码

- `src/vibe3/orchestra/dispatch_queue_helpers.py` - Issue 收集逻辑（本修复）
- `src/vibe3/orchestra/global_dispatch_coordinator.py` - Frozen queue 派发逻辑
- `src/vibe3/domain/qualify_gate.py` - Blocked issue 恢复检查逻辑

## Contributors

- **Author**: Claude Sonnet 4.5 (Agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)