### PR TITLE
refactor(qualify_gate): move dependency query to SQLiteFlowStateRepo

### DIFF
--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -161,6 +161,23 @@ class SQLiteFlowStateRepo:
             ).debug("Retrieved issue links")
             return links
 
+    def get_dependency_links(self, branch: str) -> list[int]:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT issue_number FROM flow_issue_links "
+                "WHERE branch = ? AND issue_role = 'dependency'",
+                (branch,),
+            )
+            deps = [row[0] for row in cursor.fetchall()]
+            logger.bind(
+                external="sqlite",
+                operation="get_dependency_links",
+                branch=branch,
+                count=len(deps),
+            ).debug("Retrieved dependency links")
+            return deps
+
     def get_all_flows(self) -> list[dict[str, Any]]:
         """Get all flows (excludes soft-deleted flows)."""
         with sqlite3.connect(self.db_path) as conn:

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -227,17 +227,7 @@ class QualifyGateService:
         if not branch:
             return []
 
-        # Query dependency links for this branch
-        import sqlite3
-
-        with sqlite3.connect(self._store.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT issue_number FROM flow_issue_links "
-                "WHERE branch = ? AND issue_role = 'dependency'",
-                (branch,),
-            )
-            return [row[0] for row in cursor.fetchall()]
+        return self._store.get_dependency_links(branch)
 
     def _is_dependency_satisfied(self, dep_issue_number: int) -> bool:
         """Check if dependency issue has completed.

--- a/tests/vibe3/domain/test_qualify_gate.py
+++ b/tests/vibe3/domain/test_qualify_gate.py
@@ -302,20 +302,12 @@ class TestGetIssueDependencies:
     def test_dependencies_found(self, qualify_gate_service, mock_store):
         """Should return dependency issue numbers."""
         mock_store.get_flows_by_issue.return_value = [{"branch": "task/issue-123-test"}]
+        mock_store.get_dependency_links.return_value = [456, 789]
 
-        # Mock sqlite3 connection
-        mock_cursor = Mock()
-        mock_cursor.fetchall.return_value = [(456,), (789,)]
-
-        mock_conn = Mock()
-        mock_conn.cursor.return_value = mock_cursor
-        mock_conn.__enter__ = Mock(return_value=mock_conn)
-        mock_conn.__exit__ = Mock(return_value=False)
-
-        with patch("sqlite3.connect", return_value=mock_conn):
-            result = qualify_gate_service._get_issue_dependencies(123)
+        result = qualify_gate_service._get_issue_dependencies(123)
 
         assert result == [456, 789]
+        mock_store.get_dependency_links.assert_called_once_with("task/issue-123-test")
 
 
 class TestIsDependencySatisfied:


### PR DESCRIPTION
Add get_dependency_links to SQLiteFlowStateRepo and refactor QualifyGateService._get_issue_dependencies to call it instead of bypassing SQLiteClient encapsulation with raw sqlite3.

This change:
- Adds get_dependency_links method to SQLiteFlowStateRepo
- Removes direct sqlite3 usage from QualifyGateService
- Improves testability by allowing proper mocking of the repository layer
- Maintains the same SQL query and return type for backward compatibility

Fixes #771