### PR TITLE
refactor: 标记兼容性层为废弃，引导调用者迁移到 ExecutionRolePolicyService (#873)

### DIFF
--- a/src/vibe3/execution/agent_resolver.py
+++ b/src/vibe3/execution/agent_resolver.py
@@ -1,12 +1,12 @@
 """Thin compatibility wrappers for role -> AgentOptions resolution.
 
-The actual policy truth lives in ExecutionRolePolicyService. This module keeps
-the existing public helpers so callers can migrate without re-introducing
-role-specific config logic.
+DEPRECATED: Use ExecutionRolePolicyService directly instead of these wrappers.
+This module will be removed in a future version.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
@@ -21,7 +21,20 @@ def resolve_assignee_dispatch_agent_options(
     config: OrchestraConfig,
     runtime_config: VibeConfig,
 ) -> AgentOptions:
-    """Resolve agent options from shared assignee-dispatch configuration."""
+    """Resolve agent options from shared assignee-dispatch configuration.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService(config).resolve_effective_agent_options(
+            "manager"
+        ) instead.
+    """
+    warnings.warn(
+        "resolve_assignee_dispatch_agent_options is deprecated. "
+        "Use ExecutionRolePolicyService(config).resolve_effective_agent_options("
+        "'manager') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _ = runtime_config
     ad = config.assignee_dispatch
     if not ad.agent and not ad.backend:
@@ -35,14 +48,40 @@ def resolve_assignee_dispatch_agent_options(
 
 
 def resolve_governance_agent_options(config: OrchestraConfig) -> AgentOptions:
-    """Resolve governance agent options from orchestra config."""
+    """Resolve governance agent options from orchestra config.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService(config).resolve_effective_agent_options(
+            "governance"
+        ) instead.
+    """
+    warnings.warn(
+        "resolve_governance_agent_options is deprecated. "
+        "Use ExecutionRolePolicyService(config).resolve_effective_agent_options("
+        "'governance') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return ExecutionRolePolicyService(config).resolve_effective_agent_options(
         "governance"
     )
 
 
 def resolve_supervisor_agent_options(config: OrchestraConfig) -> AgentOptions:
-    """Resolve supervisor agent options from orchestra config."""
+    """Resolve supervisor agent options from orchestra config.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService(config).resolve_effective_agent_options(
+            "supervisor"
+        ) instead.
+    """
+    warnings.warn(
+        "resolve_supervisor_agent_options is deprecated. "
+        "Use ExecutionRolePolicyService(config).resolve_effective_agent_options("
+        "'supervisor') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return ExecutionRolePolicyService(config).resolve_effective_agent_options(
         "supervisor"
     )
@@ -52,7 +91,19 @@ def resolve_planner_agent_options(
     config: OrchestraConfig,
     runtime_config: VibeConfig,
 ) -> AgentOptions:
-    """Resolve planner agent options from plan.agent_config."""
+    """Resolve planner agent options from plan.agent_config.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService or directly construct AgentOptions from
+        runtime_config.plan.agent_config instead.
+    """
+    warnings.warn(
+        "resolve_planner_agent_options is deprecated. "
+        "Directly construct AgentOptions from runtime_config.plan.agent_config "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     plan_config = runtime_config.plan
     return AgentOptions(
         agent=plan_config.agent_config.agent,
@@ -74,7 +125,19 @@ def resolve_executor_agent_options(
     config: OrchestraConfig,
     runtime_config: VibeConfig,
 ) -> AgentOptions:
-    """Resolve executor agent options from run.agent_config."""
+    """Resolve executor agent options from run.agent_config.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService or directly construct AgentOptions from
+        runtime_config.run.agent_config instead.
+    """
+    warnings.warn(
+        "resolve_executor_agent_options is deprecated. "
+        "Directly construct AgentOptions from runtime_config.run.agent_config "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     run_config = runtime_config.run
     return AgentOptions(
         agent=run_config.agent_config.agent,
@@ -94,7 +157,19 @@ def resolve_reviewer_agent_options(
     config: OrchestraConfig,
     runtime_config: VibeConfig,
 ) -> AgentOptions:
-    """Resolve reviewer agent options from review.agent_config."""
+    """Resolve reviewer agent options from review.agent_config.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService or directly construct AgentOptions from
+        runtime_config.review.agent_config instead.
+    """
+    warnings.warn(
+        "resolve_reviewer_agent_options is deprecated. "
+        "Directly construct AgentOptions from runtime_config.review.agent_config "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     review_config = runtime_config.review
     return AgentOptions(
         agent=review_config.agent_config.agent,
@@ -116,5 +191,18 @@ def resolve_manager_agent_options(
     config: OrchestraConfig,
     runtime_config: VibeConfig,
 ) -> AgentOptions:
-    """Resolve manager agent options."""
+    """Resolve manager agent options.
+
+    .. deprecated::
+        Use ExecutionRolePolicyService(config).resolve_effective_agent_options(
+            "manager"
+        ) instead.
+    """
+    warnings.warn(
+        "resolve_manager_agent_options is deprecated. "
+        "Use ExecutionRolePolicyService(config).resolve_effective_agent_options("
+        "'manager') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return resolve_assignee_dispatch_agent_options(config, runtime_config)


### PR DESCRIPTION
## Summary

- 标记 `agent_resolver.py` 中的兼容性包装器为废弃，引导调用者迁移到 `ExecutionRolePolicyService`
- 为所有 7 个兼容性函数添加 `warnings.warn(DeprecationWarning)` 和 `.. deprecated::` 文档指令
- 更新模块级文档字符串标注 DEPRECATED 状态

## Changes

### 第1步：标记废弃（已完成）

| 文件 | 修改内容 |
|------|----------|
| `src/vibe3/execution/agent_resolver.py` | 添加 `warnings.warn()` 和 `.. deprecated::` 指令 |

### 后续步骤（将在后续 commit/PR 中完成）

| 步骤 | 状态 | 说明 |
|------|------|------|
| 更新调用者 | 待完成 | 迁移 6 个角色文件使用新接口 |
| 删除兼容性层 | 待完成 | 所有调用者迁移后删除 |
| 清理协议参数 | 需评估 | `dry_run_summary`, `tick_id`, `fallback_prompt` 需确认使用情况 |

## Verification

- ✅ pre-commit 检查通过（ruff, black, mypy）
- ✅ 1687 测试通过
- ✅ mypy 类型检查通过

## Risk Assessment

- **风险等级**: 低（仅添加废弃警告，不改变任何行为）
- **影响范围**: 兼容性层：7 个函数的调用者（约 15 处）
- **预期收益**: 为后续迁移提供清晰指引，消除重复逻辑

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)