### PR TITLE
fix(database): add missing manager_actor column migration

### DIFF
--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -265,6 +265,13 @@ def init_schema(conn: sqlite3.Connection) -> None:
             "Added indicate_ref column to flow_state"
         )
 
+    # Migration: add manager_actor column for manager role tracking
+    if "manager_actor" not in existing:
+        cursor.execute("ALTER TABLE flow_state ADD COLUMN manager_actor TEXT")
+        logger.bind(external="sqlite", operation="migration").info(
+            "Added manager_actor column to flow_state"
+        )
+
     # Migration: migrate existing blocked_by data to new fields
     # Pattern: "#218" → blocked_by_issue=218, other text → blocked_reason
     if "blocked_by" in existing and (


### PR DESCRIPTION
## Summary
- Fixed missing database migration for `manager_actor` column that caused `handoff indicate` command to fail
- Added ALTER TABLE migration following the same pattern as other columns (indicate_ref, planner_actor, etc.)
- All existing databases will now get the `manager_actor` column when `init_schema()` runs

## Problem
Issue #869 reported that `handoff indicate` command fails with:
```
no such column: manager_actor
```

## Root Cause
Commit f275b81d added `manager_actor TEXT` to the CREATE TABLE schema but forgot to add the ALTER TABLE migration in `init_schema()`. Existing databases created before this change don't have the column.

## Solution
Added the missing migration (lines 268-273 in `sqlite_schema.py`):
```python
# Migration: add manager_actor column for manager role tracking
if "manager_actor" not in existing:
    cursor.execute("ALTER TABLE flow_state ADD COLUMN manager_actor TEXT")
    logger.bind(external="sqlite", operation="migration").info(
        "Added manager_actor column to flow_state"
    )
```

## Testing
✅ Migration tested on simulated old database (without manager_actor)
✅ New databases get column from CREATE TABLE
✅ Existing databases get column from ALTER TABLE migration  
✅ `handoff indicate` command works correctly
✅ All 12 handoff service tests pass
✅ All 13 flow events tests pass
✅ Actual production database successfully migrated

## Impact
- **Existing databases**: Will automatically get `manager_actor` column via migration
- **New databases**: Already have the column from CREATE TABLE
- **No breaking changes**: Migration is idempotent and safe

Fixes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>