### PR TITLE
feat(run): executor 必须在报告完成前提交代码变更 (#652)

### DIFF
--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -363,6 +363,16 @@ run:
   # and move issue state forward.
   run_task: |
     The auto-saved executor artifact is only for shared handoff or audit and is not the authoritative `report_ref`.
+
+    ### MANDATORY COMMIT STEP — you MUST do this before writing the report:
+    1. Check for uncommitted changes: `git status --short`
+    2. If there are changes:
+       a. Review and stage all relevant changes with `git add <files>`
+       b. Create a commit: `git commit -m "<meaningful message>"`
+       c. Verify the commit: `git log -1 --oneline`
+    3. If there are NO changes, you may skip this step — but ONLY after verifying with `git status --short`
+    4. If `git commit` fails (e.g., pre-commit hook failure), fix the issue and re-commit — do NOT proceed to report
+
     You must write a canonical execution report under `docs/reports/` in the current worktree.
     After writing that file, register it with `uv run python src/vibe3/cli.py handoff report <path-to-report-md>`.
     Use a repository-relative path such as `docs/reports/issue-123-execution-report.md`.

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -110,3 +110,18 @@ def test_build_run_task_section_can_carry_report_ref_guidance() -> None:
 
     assert "docs/reports/" in result
     assert "handoff report" in result
+
+
+def test_build_run_prompt_body_includes_commit_before_report(tmp_path: Path) -> None:
+    """Exit contract must require commit before writing the report."""
+    config = VibeConfig.get_defaults()
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("## Summary\nTest plan\n", encoding="utf-8")
+
+    context = build_run_prompt_body(str(plan_file), config)
+
+    assert "MANDATORY COMMIT STEP" in context
+    assert "git status --short" in context
+    assert "git commit" in context
+    assert "git log -1 --oneline" in context
+    assert "do NOT proceed to report" in context


### PR DESCRIPTION
## Summary
- Added mandatory commit step to executor's exit contract in `config/prompts/prompts.yaml`
- Executor must commit all uncommitted changes before writing execution report
- New test validates prompt contract enforcement

## Changes
- `config/prompts/prompts.yaml`: Added MANDATORY COMMIT STEP section (lines 367-374)
- `tests/vibe3/agents/test_run_prompt.py`: New test `test_build_run_prompt_body_includes_commit_before_report`

## Verification
- ✅ All 20 tests pass (9 in test_run_prompt.py, 11 in test_run.py)
- ✅ No regression in existing tests
- ✅ Commit step verified across all executor paths (coding, retry, skill modes)
- ✅ Structural guarantee from prompt-recipes.yaml

## Test Plan
- Run test suite: `uv run pytest tests/vibe3/agents/test_run_prompt.py -v`
- Verify all 9 tests pass including new test
- Dry-run verification completed

---

## Contributors

claude/sonnet-4.5, claude/opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)