### PR TITLE
fix(review): vibe-review-pr PR 编号路由错误缓解方案

### DIFF
--- a/.claude/agents/pr-architect-reviewer.md
+++ b/.claude/agents/pr-architect-reviewer.md
@@ -110,8 +110,8 @@ SendMessage 调用前必须检查：
 # 握手成功
 SendMessage(to="team-lead", message="【agent_ready】已就绪")
 
-# 提交架构审查报告
-SendMessage(to="team-lead", message="""【agent_report】
+# 提交架构审查报告（显式标注 PR 编号）
+SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ## PR #843 架构审查报告
 ...
@@ -126,6 +126,13 @@ SendMessage(to="team-lead", message="已就绪")
 
 # ❌ 报告无前缀
 SendMessage(to="team-lead", message="已完成架构审查")
+
+# ❌ 报告未标注 PR 编号
+SendMessage(to="team-lead", message="""【agent_report】
+
+## PR #843 架构审查报告
+...
+""")
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
 SendMessage(to="team-lead", message="[agent_ready] ready")
@@ -396,15 +403,20 @@ SendMessage(
   to: "team-lead",
   summary: "PR #<number> 架构审查报告完成",
   message: |
+    【agent_report】(PR #<number>)
+    
     ## PR #<number> 架构审查报告
     
     [完整报告内容]
 )
 ```
 
+**重要**：报告开头必须显式标注 PR 编号，格式为 `【agent_report】(PR #N)`
+
 **禁止**：
 - ❌ 只打印到终端不发送
 - ❌ 发送不完整的报告
+- ❌ 报告未标注 PR 编号
 
 ## 工作方式
 

--- a/.claude/agents/pr-code-analyst.md
+++ b/.claude/agents/pr-code-analyst.md
@@ -118,8 +118,8 @@ SendMessage 调用前必须检查：
 # 握手成功
 SendMessage(to="team-lead", message="【agent_ready】已就绪")
 
-# 提交代码分析报告
-SendMessage(to="team-lead", message="""【agent_report】
+# 提交代码分析报告（显式标注 PR 编号）
+SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ## PR #843 代码分析报告
 ...
@@ -134,6 +134,13 @@ SendMessage(to="team-lead", message="已就绪")
 
 # ❌ 报告无前缀
 SendMessage(to="team-lead", message="已完成代码分析")
+
+# ❌ 报告未标注 PR 编号
+SendMessage(to="team-lead", message="""【agent_report】
+
+## PR #843 代码分析报告
+...
+""")
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
 SendMessage(to="team-lead", message="[agent_ready] ready")
@@ -348,15 +355,20 @@ SendMessage(
   to: "team-lead",
   summary: "PR #<number> 代码分析报告完成",
   message: |
+    【agent_report】(PR #<number>)
+    
     ## PR #<number> 代码分析报告
     
     [完整报告内容]
 )
 ```
 
+**重要**：报告开头必须显式标注 PR 编号，格式为 `【agent_report】(PR #N)`
+
 **禁止**：
 - ❌ 只打印到终端不发送
 - ❌ 发送不完整的报告
+- ❌ 报告未标注 PR 编号
 
 ## 工作方式
 

--- a/.claude/agents/pr-context-researcher.md
+++ b/.claude/agents/pr-context-researcher.md
@@ -111,8 +111,8 @@ SendMessage 调用前必须检查：
 # 握手成功
 SendMessage(to="team-lead", message="【agent_ready】已就绪")
 
-# 提交背景报告
-SendMessage(to="team-lead", message="""【agent_report】
+# 提交背景报告（显式标注 PR 编号）
+SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ## PR #843 背景报告
 ...
@@ -127,6 +127,13 @@ SendMessage(to="team-lead", message="已就绪")
 
 # ❌ 报告无前缀
 SendMessage(to="team-lead", message="已完成背景调研")
+
+# ❌ 报告未标注 PR 编号
+SendMessage(to="team-lead", message="""【agent_report】
+
+## PR #843 背景报告
+...
+""")
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
 SendMessage(to="team-lead", message="[agent_ready] ready")
@@ -283,15 +290,20 @@ SendMessage(
   to: "team-lead",
   summary: "PR #<number> 背景调研报告完成",
   message: |
+    【agent_report】(PR #<number>)
+    
     ## PR #<number> 背景报告
     
     [完整报告内容]
 )
 ```
 
+**重要**：报告开头必须显式标注 PR 编号，格式为 `【agent_report】(PR #N)`
+
 **禁止**：
 - ❌ 只打印到终端不发送
 - ❌ 发送不完整的报告
+- ❌ 报告未标注 PR 编号
 
 ## 工作方式
 

--- a/.claude/agents/pr-fix-executor.md
+++ b/.claude/agents/pr-fix-executor.md
@@ -119,10 +119,10 @@ SendMessage 调用前必须检查：
 # 握手成功
 SendMessage(to="team-lead", message="【agent_ready】已就绪")
 
-# 提交修复报告
-SendMessage(to="team-lead", message="""【agent_report】
+# 提交修复报告（显式标注 PR 编号）
+SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
-## 修复报告
+## PR #843 修复报告
 ...
 """)
 ```
@@ -135,6 +135,13 @@ SendMessage(to="team-lead", message="已就绪")
 
 # ❌ 报告无前缀
 SendMessage(to="team-lead", message="已完成修复")
+
+# ❌ 报告未标注 PR 编号
+SendMessage(to="team-lead", message="""【agent_report】
+
+## 修复报告
+...
+""")
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
 SendMessage(to="team-lead", message="[agent_ready] ready")
@@ -319,15 +326,20 @@ SendMessage(
   to: "team-lead",
   summary: "PR #<number> 修复报告完成",
   message: |
-    ## 修复报告
+    【agent_report】(PR #<number>)
+    
+    ## PR #<number> 修复报告
     
     [完整报告内容，包括修复列表、提交记录、验证结果]
 )
 ```
 
+**重要**：报告开头必须显式标注 PR 编号，格式为 `【agent_report】(PR #N)`
+
 **禁止**：
 - ❌ 只执行修复不发送报告
 - ❌ 发送不完整的报告
+- ❌ 报告未标注 PR 编号
 
 ## 注意事项
 

--- a/.claude/agents/pr-security-reviewer.md
+++ b/.claude/agents/pr-security-reviewer.md
@@ -122,8 +122,8 @@ SendMessage 调用前必须检查：
 # 握手成功
 SendMessage(to="team-lead", message="【agent_ready】已就绪")
 
-# 提交安全审查报告
-SendMessage(to="team-lead", message="""【agent_report】
+# 提交安全审查报告（显式标注 PR 编号）
+SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ## PR #843 安全审查报告
 ...
@@ -138,6 +138,13 @@ SendMessage(to="team-lead", message="已就绪")
 
 # ❌ 报告无前缀
 SendMessage(to="team-lead", message="已完成安全审查")
+
+# ❌ 报告未标注 PR 编号
+SendMessage(to="team-lead", message="""【agent_report】
+
+## PR #843 安全审查报告
+...
+""")
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
 SendMessage(to="team-lead", message="[agent_ready] ready")
@@ -356,15 +363,20 @@ SendMessage(
   to: "team-lead",
   summary: "PR #<number> 安全审查报告完成",
   message: |
+    【agent_report】(PR #<number>)
+    
     ## PR #<number> 安全审查报告
     
     [完整报告内容]
 )
 ```
 
+**重要**：报告开头必须显式标注 PR 编号，格式为 `【agent_report】(PR #N)`
+
 **禁止**：
 - ❌ 只打印到终端不发送
 - ❌ 发送不完整的报告
+- ❌ 报告未标注 PR 编号
 
 ## 工作方式
 

--- a/docs/analysis/flow-blocked-vs-bind-dependency-analysis.md
+++ b/docs/analysis/flow-blocked-vs-bind-dependency-analysis.md
@@ -1,0 +1,454 @@
+# Flow Blocked vs Bind Dependency：现状梳理与统一方向分析
+
+**日期**：2026-05-15  
+**文档类型**：现状分析  
+**目标问题**：梳理 `vibe3 flow bind --role dependency`、`vibe3 flow blocked --task`、`blocked_reason`、`blocked_by_issue` 与 Orchestra 派发之间的真实关系，并明确当前不统一点，为后续执行文档提供依据。
+
+---
+
+## 执行摘要
+
+当前实现里，`vibe3 flow bind --role dependency` 和 `vibe3 flow blocked --task` **已经部分复用同一底层逻辑**，都走到 `FlowService.block_flow()`，最终都会：
+
+- 在 `flow_issue_links` 写入 `issue_role='dependency'`
+- 在 `flow_state` 写入 `blocked_by_issue`
+- 把 task issue label 切到 `state/blocked`
+- 写入 `flow_blocked` 事件
+
+但两者**不能简单视为“完全等价”**，原因有三：
+
+1. `flow bind --role dependency` 是“绑定依赖 + 触发 blocked 副作用”的兼容入口，路径上有冗余 `link_issue()` 调用。
+2. `flow blocked --task --reason ...` 会同时写 `blocked_reason`，而当前 Orchestra 会把 `blocked_reason` 视为**人工阻塞信号**，优先级高于 dependency auto-unblock。
+3. `--branch` / `--pr` 是“定位当前要改哪条 flow”的参数，不是“阻塞原因”的一部分；真正的阻塞语义参数只有 `--reason`、`--task` 和历史别名 `--by`。
+
+因此，**当前框架不是完全混乱，但也没有真正统一**。  
+更准确的描述是：
+
+- `flow_issue_links(role='dependency')`：依赖关系真源
+- `blocked_by_issue`：当前主阻塞 issue 的显示/快捷字段
+- `blocked_reason`：人工阻塞或诊断性阻塞原因
+- `flow bind --role dependency`：历史兼容入口
+- `flow blocked --task`：更接近统一 blocked 入口，但和 `--reason` 混用时会改变语义
+
+---
+
+## 一、当前代码中的真实执行路径
+
+### 1.1 `vibe3 flow bind <issue> --role dependency`
+
+入口：`src/vibe3/commands/flow_manage.py:bind()`
+
+当前逻辑：
+
+1. `TaskService.link_issue(branch, issue_number, role="dependency")`
+   - 写 `flow_issue_links`
+   - 视情况写 `issue_linked` 事件
+2. 因为 `role == "dependency"`，继续调用：
+   - `FlowService.block_flow(branch, blocked_by_issue=issue_number, actor=None)`
+3. `block_flow()` 内部再次执行：
+   - `TaskService.link_issue(branch, issue_number, role="dependency")`
+   - 写 `flow_state.blocked_by_issue`
+   - 若有 `reason` 才写 `blocked_reason`
+   - task issue 切到 `state/blocked`
+   - 若有 `reason` 才加 comment
+   - 写 `flow_blocked`
+
+结论：
+
+- 这条路径**已经在行为上委托给 `block_flow()`**
+- 但不是纯 alias，因为它在进入 `block_flow()` 之前先手动做了一次 `link_issue()`
+- 这导致依赖写入存在**重复调用但大体幂等**
+
+### 1.2 `vibe3 flow blocked --task <issue>`
+
+入口：`src/vibe3/commands/flow_lifecycle.py:blocked()`
+
+当前逻辑：
+
+1. 解析目标 flow：
+   - `--branch` 直接指定 branch
+   - `--pr` 先解析 PR head branch
+   - 默认使用当前分支
+2. 解析阻塞参数：
+   - `blocked_by_issue = task if task is not None else by`
+3. 调用：
+   - `FlowService.block_flow(branch, reason=reason, blocked_by_issue=blocked_by_issue)`
+4. `block_flow()` 内部：
+   - 若 `blocked_by_issue` 存在，则写 dependency link
+   - 写 `flow_state.blocked_by_issue`
+   - 若 `reason` 存在，则写 `blocked_reason`
+   - task issue 切到 `state/blocked`
+   - 若 `reason` 存在，则加 comment
+   - 写 `flow_blocked`
+
+结论：
+
+- 这是当前最接近“统一 blocked 入口”的 CLI
+- `--task` 与 `--by` 在这里是同义参数
+- `--branch` / `--pr` 只负责定位 flow，不表达阻塞类型
+
+### 1.3 现状对比
+
+| 维度 | `flow bind --role dependency` | `flow blocked --task` |
+|------|-------------------------------|------------------------|
+| 入口职责 | 绑定 issue role | 设置 blocked 状态 |
+| 是否复用 `block_flow()` | 是 | 是 |
+| 是否写 dependency link | 是 | 是 |
+| 是否写 `blocked_by_issue` | 是 | 是 |
+| 是否可能写 `blocked_reason` | 否（当前调用不传 `reason`） | 是（如果传 `--reason`） |
+| 是否切 `state/blocked` | 是 | 是 |
+| 是否加 comment | 否（当前无 `reason`） | 仅有 `--reason` 时 |
+| 是否有多余 `link_issue()` | 有 | 无 |
+
+---
+
+## 二、当前数据模型的真实语义
+
+### 2.1 `flow_issue_links`
+
+表意：**完整依赖关系真源**
+
+```text
+branch + issue_number + issue_role='dependency'
+```
+
+它回答的问题是：
+
+- 当前 flow 依赖哪些 issue？
+- Orchestra 应该检查哪些 dependency 是否满足？
+
+这是 dependency 机制的主真源，不是 `blocked_by_issue`。
+
+### 2.2 `blocked_by_issue`
+
+表意：**当前主阻塞 issue 的快捷字段**
+
+它回答的问题是：
+
+- 这个 flow 现在主要被哪个 issue 挡住？
+- UI / status / unblock 时优先展示哪个 blocker？
+
+它不是完整 dependency 集合，只能表示一个“主 blocker”。  
+如果一个 flow 有多个 dependency，完整集合仍然只能看 `flow_issue_links`。
+
+### 2.3 `blocked_reason`
+
+表意：**人工阻塞或诊断性阻塞原因**
+
+当前代码里，`QualifyGateService.run_qualify_gate()` 会先看 `blocked_reason`：
+
+- 只要 `blocked_reason` 非空，直接视为 blocked
+- 不继续进入 dependency auto-unblock 分支
+
+这意味着当前系统实际把 `blocked_reason` 当作：
+
+- 人工阻塞说明
+- 执行失败说明
+- 需要人工确认后再恢复的阻塞信号
+
+而不是“dependency 附带说明文字”。
+
+这点非常关键，因为它决定了下面这件事：
+
+```bash
+vibe3 flow blocked --task 218 --reason "需要 #218 先完成"
+```
+
+在当前实现里，这**不是**“纯 dependency block + 可读文案”，而是：
+
+- 写 dependency link
+- 写 `blocked_by_issue = 218`
+- 同时再写 `blocked_reason`
+- 结果被 Orchestra 当成 manual block 优先处理
+
+也就是说，这条命令会改变 unblock 语义。
+
+---
+
+## 三、Orchestra 当前到底如何处理 blocked
+
+### 3.1 当前 gate 顺序
+
+入口：`src/vibe3/domain/qualify_gate.py:run_qualify_gate()`
+
+当前顺序是：
+
+1. 先检查 `blocked_reason`
+2. 再检查 dependency links 是否都已满足
+3. 若满足且当前是 dependency block，则自动清理 blocked 元数据并恢复目标状态
+
+这个顺序意味着：
+
+- `blocked_reason` 的语义强于 dependency
+- dependency auto-unblock 只适用于“没有人工 blocked_reason”的 blocked flow
+
+### 3.2 dependency 数据从哪里来
+
+当前 dependency 检查不是从 `blocked_by_issue` 开始，而是：
+
+1. 先根据 task issue 找到对应 flow
+2. 再从 `flow_issue_links` 取出所有 `role='dependency'` 的 issue
+3. 对每个 dependency 调 GitHub 查看是否 `state == "closed"`
+
+所以 Orchestra 真正依赖的是：
+
+- `flow_issue_links`：完整 dependency 集合
+- `blocked_by_issue`：补充展示 / unblock 元数据
+
+### 3.3 自动恢复条件
+
+当前自动恢复只在以下条件下发生：
+
+- `blocked_reason` 为空
+- dependency links 全部满足
+- 当前 flow 处于 blocked 相关状态
+
+恢复时会：
+
+- 清 `blocked_by_issue`
+- 清 `blocked_reason`
+- 写 `flow_unblocked`
+- 把 task issue 从 `state/blocked` 切回推断目标状态
+
+因此，当前机制确实已经有“收集 blocked flow，派发前再检查能否解封”的雏形，但它不是只看 issue 关闭与否，还会被 `blocked_reason` 短路。
+
+---
+
+## 四、你提出的统一方向，与现状的关系
+
+### 4.1 “`flow bind --role dependency` 只作为兼容层，背后统一到 `flow blocked --task`”
+
+这个方向是合理的，而且**和当前代码趋势一致**。
+
+原因：
+
+- 现在 `flow bind --role dependency` 本来就会落到 `block_flow()`
+- 它和 `flow blocked --task` 的差异主要只剩：
+  - 命令表意不同
+  - 前置多做了一次 `link_issue()`
+
+更清晰的未来结构应当是：
+
+- `flow bind --role task|related`：保留为 issue role 绑定入口
+- `flow bind --role dependency`：兼容入口，内部直接转发到统一的 dependency-block 逻辑
+- 统一 blocked 真入口：`flow blocked --task`
+
+### 4.2 “`flow blocked --task / --pr / --by / --branch` 是否都统一到一个逻辑上”
+
+这里需要拆开看：
+
+- `--task`
+  - 是阻塞语义的一部分
+  - 表示“被哪个 issue 阻塞”
+- `--by`
+  - 当前只是 `--task` 的重复别名
+  - 适合废弃
+- `--branch`
+  - 不是阻塞语义
+  - 只是“这次要修改哪条 flow”
+- `--pr`
+  - 也不是阻塞语义
+  - 只是“通过 PR 找到 branch”
+
+所以更准确的统一方式不是“都统一成 `--task`”，而是分成两组：
+
+1. **目标 flow 定位参数**
+   - `--branch`
+   - `--pr`
+   - 默认当前 branch
+2. **blocked 语义参数**
+   - `--reason`
+   - `--task`
+   - `--by`（待废弃）
+
+你的方向是对的，但要避免把“定位目标 flow”和“描述为什么 blocked”混成一类参数。
+
+### 4.3 “manager 标准：具体原因用 `--reason`，被 issue 阻塞用 `--task`”
+
+这个规则本身是清晰的，但和**当前实现**有一个冲突：
+
+- 当前 `--reason` 会把 flow 变成 manual block 语义
+- 当前 `--task` 才是 dependency block 语义
+
+所以如果未来要采用你这个规则，需要进一步明确：
+
+#### 方案 A：`--reason` 与 `--task` 互斥
+
+含义：
+
+- `--reason` = 人工阻塞，需要手动恢复
+- `--task` = 依赖阻塞，可自动恢复
+
+优点：
+
+- 语义最干净
+- 和当前 Qualify Gate 的优先级天然一致
+
+代价：
+
+- 不能写“依赖 issue + 补充原因文字”
+
+#### 方案 B：允许同时传，但重定义语义
+
+含义：
+
+- `--task` = auto-unblock 真源
+- `--reason` = 纯展示说明，不阻断 auto-unblock
+
+优点：
+
+- 表达能力强
+- manager prompt 可读性更好
+
+代价：
+
+- 需要改当前 gate 逻辑
+- 需要把 `blocked_reason` 拆分，或引入新字段区分：
+  - manual_block_reason
+  - dependency_note
+
+当前代码**不是**方案 B，而更接近方案 A，只是 CLI 没有强制互斥，导致语义混杂。
+
+### 4.4 “Orchestra 只收集 blocked flow，派发前检查 blocked reason 是否消除、blocked issue 是否关闭”
+
+这个方向也是合理的，而且和当前实现已经部分一致：
+
+- 当前 Qualify Gate 已经在派发前检查 blocked 条件
+- 当前也已经会检查 dependency issue 是否 closed
+
+但还有一个必须说清的点：
+
+- `blocked_reason 是否消除` 不是自动可判定条件
+- 它本质上还是“人工是否确认可继续”的信号
+
+所以对 Orchestra 来说：
+
+- `blocked issue 是否关闭` 可以自动判断
+- `blocked_reason 是否消除` 只能依赖显式清除或明确状态迁移
+
+换句话说，未来即使统一成“先收集 blocked flow，再派发前检查”，也应该保留这条边界：
+
+- dependency block：自动判断、自动恢复
+- manual block：显式清除后才允许恢复
+
+---
+
+## 五、当前框架到底哪里不统一
+
+### 5.1 命令入口不统一
+
+现状：
+
+- `flow bind --role dependency` 能创建 dependency block
+- `flow blocked --task` 也能创建 dependency block
+
+问题：
+
+- 同一件事有两个入口
+- 一个是“role 绑定”的命令，一个是“状态设置”的命令
+- 用户和 manager prompt 都容易混淆
+
+### 5.2 `blocked_reason` 同时承担了两种职责
+
+现状：
+
+- 它既记录人工 blocked 原因
+- 也可能被拿来描述 dependency blocked
+
+问题：
+
+- 当前 gate 把它当 manual block 信号
+- 所以只要 dependency block 也写了它，就会改变恢复行为
+
+这是现在最核心的不统一点。
+
+### 5.3 `blocked_by_issue` 不是 dependency 真源，却经常被误读成真源
+
+现状：
+
+- 真正的 dependency 集合在 `flow_issue_links`
+- `blocked_by_issue` 只是一个主 blocker 字段
+
+问题：
+
+- 容易被文档和调用方误写成“依赖关系真源”
+- 这会掩盖多依赖场景
+
+### 5.4 `--by` 没有独立存在价值
+
+现状：
+
+- `--by` 与 `--task` 完全同义
+
+问题：
+
+- 增加学习成本
+- 没带来额外语义
+
+---
+
+## 六、对后续执行文档的建议边界
+
+这份文档只描述现状。  
+如果后续要写“统一 blocked 策略”的执行文档，建议明确回答以下问题：
+
+### 6.1 统一后的 blocked 语义模型
+
+至少要先选定下面两种之一：
+
+1. `--reason` = manual block，`--task` = dependency block，两者互斥
+2. `--task` 为 blocker 真源，`--reason` 只做展示，不阻断 auto-unblock
+
+如果选 2，就不能继续复用当前 `blocked_reason` 语义，必须重构字段或 gate。
+
+### 6.2 `flow bind --role dependency` 的去留
+
+建议方向：
+
+- 保留 CLI 兼容性
+- 语义上降级为兼容别名
+- 内部统一转发到同一个 dependency-block service
+
+### 6.3 blocked flow 的收集与恢复策略
+
+建议执行文档明确：
+
+- Orchestra 收集对象是否统一为 `state/blocked`
+- dependency block 的自动恢复条件
+- manual block 的清除入口
+- 当一个 flow 同时存在 dependency 和 manual reason 时，以谁为准
+
+### 6.4 manager prompt 的标准动作
+
+后续可以收敛成类似规则：
+
+- 有外部 issue 作为前置依赖：用 `--task`
+- 有纯文本阻塞原因，需要人工确认：用 `--reason`
+- 两者是否允许并存，必须由执行文档定死
+
+---
+
+## 七、结论
+
+当前实现并不是“`flow bind --role dependency` 和 `flow blocked --task` 在写完全不同的数据库字段”，这一点需要纠正。
+
+更准确的现状是：
+
+- 两者都写 `flow_issue_links(role='dependency')`
+- 两者都写 `blocked_by_issue`
+- 两者都走 `block_flow()` 这条主路径
+- 真正不统一的是 `blocked_reason` 的职责，以及 dependency block 是否允许附带 `reason`
+
+因此，你提出的统一方向总体上是成立的：
+
+- 把 `flow bind --role dependency` 收敛成兼容层
+- 把 dependency blocked 的主入口收敛到 `flow blocked --task`
+- 让 Orchestra 统一在 blocked 队列里做派发前解封判断
+
+但要真正清晰，必须先解决一个架构问题：
+
+**`blocked_reason` 到底是“人工阻塞真源”，还是“所有 blocked 的通用说明字段”？**
+
+在这个问题没有被重新定义之前，当前框架仍然会在 `--task` 和 `--reason` 混用时产生语义冲突。
+
+这也是后续执行文档最需要先定死的核心决策。

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -128,6 +128,34 @@ if <脚本失败>: @stop("哪个脚本、什么错误")
 
 以下函数在整个审查流程中复用，定义一次，各 Phase 引用。
 
+## extract_pr_number(report_text) → int | None
+
+```
+extract_pr_number(report_text):
+  """从报告中提取 PR 编号。
+  
+  支持格式：
+  - 【agent_report】(PR #892)
+  - ## PR #892 背景报告
+  - PR #892 审查报告"""
+  
+  import re
+  patterns = [
+    r"【agent_report】\(PR #(\d+)\)",  # 格式1：显式标注
+    r"## PR #(\d+)",                   # 格式2：标题
+    r"PR #(\d+)"                       # 格式3：正文提及
+  ]
+  
+  for pattern in patterns:
+    match = re.search(pattern, report_text)
+    if match:
+      return int(match.group(1))
+  
+  return None
+```
+
+> 优先匹配显式标注格式（格式1），确保 agent 按要求在报告开头标注 PR 编号。
+
 ## @handshake(agent_name) → OK | TIMEOUT
 
 ```
@@ -159,22 +187,37 @@ if <脚本失败>: @stop("哪个脚本、什么错误")
 - 超时 3 次 → 标记 agent 为 blocked，继续处理下一个 agent
 - team-lead 自身必须先 `ToolSearch("select:SendMessage")` 再 spawn 任何 agent
 
-## @wait_for_report(agent_name, timeout=90, max_attempts=3) → report | TIMEOUT
+## @wait_for_report(agent_name, expected_pr_number, timeout=90, max_attempts=3) → report | TIMEOUT | RETRY
 
 ```
-@wait_for_report(agent_name):
+@wait_for_report(agent_name, expected_pr_number):
   """主动轮询等待 agent 报告。禁止被动 idle。
   
   注意：stale 状态只表示长时间无消息，不代表 agent 失联。
   如果 agent-exist.sh 显示 stale/inactive，应先捕获 tmux pane 内容确认是否有输出。
   如果 pane 有输出（agent 正在工作），继续等待，不要重新握手。
-  只有 pane 无输出时才重新握手。"""
+  只有 pane 无输出时才重新握手。
+  
+  校验逻辑：
+  - 提取报告中的 PR 编号（格式：【agent_report】(PR #N) 或 ## PR #N）
+  - 如果不匹配目标 PR，通过 SendMessage 确认（已知路由 bug #40166/#39651）"""
   
   for attempt in 1..max_attempts:
     sleep(timeout)
     $ agent-report.sh {agent_name}
     if exit code == 0:        // 报告已送达
-      return stdout            // 完整报告文本（agent= / timestamp= / body_start / 正文）
+      report_text = stdout      // 完整报告文本（agent= / timestamp= / body_start / 正文）
+      # 提取 PR 编号
+      actual_pr = extract_pr_number(report_text)
+      if actual_pr and actual_pr != expected_pr_number:
+        # PR 编号路由错误，SendMessage 确认
+        SendMessage(to=agent_name, summary="PR 编号路由错误", message=f"""
+          检测到 PR 编号路由错误（收到 PR #{actual_pr}，目标 PR #{expected_pr_number}）。
+          这是已知 bug (#40166/#39651)。
+          请确认你正在审查哪个 PR，并提供正确报告。
+        """)
+        return RETRY
+      return report_text
     // exit 3 = 暂无报告, exit 2 = 未定义 agent, exit 1 = inbox 不存在
   return TIMEOUT
 ```
@@ -254,10 +297,12 @@ if <脚本失败>: @stop("哪个脚本、什么错误")
 
 ```
 Phase_0():
-  // Step 1: 环境检查
+  // Step 1: 环境检查 + 工具加载
   assert tmux is set
   assert AGENT_TEAMS=1
-  assert TeamCreate, TaskCreate, ToolSearch, SendMessage available
+  ToolSearch(query="select:SendMessage")  // SendMessage 是 deferred tool，必须先加载 schema
+  if failed: @stop("ToolSearch SendMessage 失败")
+  assert TeamCreate, TaskCreate, TaskUpdate available
   // 禁止在此步执行 gh pr view / gh pr diff / git diff
 
   // Step 2: 选择执行模式
@@ -269,7 +314,7 @@ Phase_0():
     "options": [
       {
         "label": "ask-each（推荐）",
-        "description": "每步操作前询问用户确认，适合标准 PR 和安全 PR"
+        "description": "每步操作前询问用户确认（所有操作都可执行，包括修复）。适合标准 PR 和安全 PR"
       },
       {
         "label": "auto-decide",
@@ -277,11 +322,11 @@ Phase_0():
       },
       {
         "label": "auto-fix",
-        "description": "自动修复阻塞问题，适合阻塞项 < 3 个、修改面 < 3 文件"
+        "description": "自动修复阻塞问题（跳过确认，直接执行）。适合阻塞项 < 3 个、修改面 < 3 文件"
       },
       {
         "label": "comment-only",
-        "description": "只写 comment，不修复，适合大型 PR、高风险改动"
+        "description": "只写 comment，不修复（禁止 spawn fix-executor）。适合大型 PR、高风险改动"
       }
     ]
   }])
@@ -298,12 +343,7 @@ Phase_0():
   // Team 名称固定为 pr-review-team（不用 pr-review-<number>）
   // 复用判断 = 握手结果（不检查 isActive/config.json）
 
-  // Step 4: team-lead 自身 ToolSearch
-  ToolSearch(query="select:SendMessage")
-  if failed: @stop("team-lead ToolSearch 失败")
-  // SendMessage 是 deferred tool，必须先加载 schema
-
-  // Step 5: 一次性创建全部 5 个 Backlog Task
+  // Step 4: 一次性创建全部 5 个 Backlog Task
   // 验证清单（提交前必须输出）:
   //   Phase 1: subject="Phase 1: 背景调研", metadata={phase_order:1, depends_on_phase:0}
   //   Phase 2: subject="Phase 2: 专家评审", metadata={phase_order:2, depends_on_phase:1}
@@ -331,7 +371,7 @@ Phase_0():
     description="写 PR comment → 可选 spawn fix-executor 修复 → 创建 follow-up issues",
     metadata={phase_order:5, depends_on_phase:4})
 
-  // Step 6: 激活 Phase 1
+  // Step 5: 激活 Phase 1
   TaskUpdate(phase_1_task_id, status="in_progress")
 ```
 
@@ -362,7 +402,9 @@ Phase_1():
     职责：
     1. 阅读 CLAUDE.md、AGENTS.md、glossary.md、PR description、PR diff
     2. 不要修改任何文件
-    3. 完成后用 SendMessage(to="team-lead", message="【agent_report】\n\n## PR #N 背景报告\n...")
+    3. 完成后用 SendMessage(to="team-lead", message="【agent_report】(PR #N)\n\n## PR #N 背景报告\n...")
+
+    重要：报告开头必须显式标注 PR 编号，格式为【agent_report】(PR #N)
 
     脚本错误处理：如脚本执行失败，立即发送【agent_blocked】+ 错误详情，停止执行。
   """)
@@ -370,9 +412,14 @@ Phase_1():
   // 禁止：显式 PR 编号入口下 lead 预调查（确认状态/标题/标签/变更范围）
 
   // Step 3: 等待报告
-  report = @wait_for_report("context-researcher")
+  report = @wait_for_report("context-researcher", expected_pr_number=N)
   if report == TIMEOUT:
     @stop("context-researcher 报告超时，回退单 agent 审查")
+  if report == RETRY:
+    // PR 编号路由错误，已在 @wait_for_report 中 SendMessage 确认，继续等待
+    report = @wait_for_report("context-researcher", expected_pr_number=N)
+    if report == TIMEOUT or RETRY:
+      @stop("context-researcher 报告路由错误未纠正，回退单 agent 审查")
 
   // Step 4: PR 分类
   pr_type = @classify_pr(report)
@@ -462,7 +509,9 @@ Phase_2():
       读取 Phase 1 背景报告：
         skills/vibe-review-pr/scripts/agent-report.sh context-researcher
 
-      完成审查后用 SendMessage(to="team-lead", message="【agent_report】\n\n## <角色>报告\n...")
+      完成审查后用 SendMessage(to="team-lead", message="【agent_report】(PR #N)\n\n## <角色>报告\n...")
+
+      重要：报告开头必须显式标注 PR 编号，格式为【agent_report】(PR #N)
 
       脚本错误处理：如脚本执行失败，立即发送【agent_blocked】+ 错误详情，停止执行。
     """)
@@ -471,9 +520,14 @@ Phase_2():
   // Step 4: 等待全部报告
   reports = {}
   for agent in active_agents:
-    report = @wait_for_report(agent)
+    report = @wait_for_report(agent, expected_pr_number=N)
     if report == TIMEOUT:
       @mark_blocked(agent)
+    elif report == RETRY:
+      // PR 编号路由错误，继续等待一次
+      report = @wait_for_report(agent, expected_pr_number=N)
+      if report == TIMEOUT or RETRY:
+        @mark_blocked(agent)
     else:
       reports[agent] = report
 
@@ -510,6 +564,7 @@ Phase_2():
 ```
 Phase_3():
   // Step 1: 校验 Phase 2 报告基础数据
+  // 注意：PR 编号路由错误已在 Phase 1/2 通过 @wait_for_report 校验处理
   for report in phase_2_reports:
     // 检查文件数/行数/涉及模块是否与 PR 实际 diff 一致
     if report has 严重幻觉（数据与 diff 明显矛盾）:
@@ -638,12 +693,12 @@ Phase_4():
 
 ## Execution Modes
 
-| 模式 | 行为 | 适用场景 |
-|------|------|---------|
-| `ask-each`（默认） | 每步操作前询问用户 | 标准 PR、安全 PR |
-| `auto-decide` | team-lead 根据复杂度自动决策 | 简单 PR（< 50 行，无安全相关） |
-| `auto-fix` | 自动修复阻塞问题 | 阻塞项 < 3 个，修改面 < 3 文件 |
-| `comment-only` | 只写 comment，不修复 | 大型 PR、高风险改动 |
+| 模式 | 确认粒度 | 修复能力 | 适用场景 |
+|------|---------|---------|---------|
+| `ask-each`（默认） | 每步操作前询问用户确认 | ✅ 可 spawn fix-executor（需确认修复范围） | 标准 PR、安全 PR |
+| `auto-decide` | team-lead 自动决策（跳过确认） | ✅ 可 spawn fix-executor | 简单 PR（< 50 行，无安全相关） |
+| `auto-fix` | 跳过确认，直接执行 | ✅ 自动 spawn fix-executor | 阻塞项 < 3 个，修改面 < 3 文件 |
+| `comment-only` | 无需确认（只写 comment） | ❌ 禁止 spawn fix-executor | 大型 PR、高风险改动 |
 
 ```
 Phase_5():

--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -7,38 +7,7 @@ from loguru import logger
 
 from vibe3.commands.common import trace_scope
 from vibe3.services.flow_service import FlowService
-from vibe3.services.pr_service import PRService
-
-
-def resolve_pr_to_branch(pr: int) -> str:
-    """Resolve a PR number to its head branch name.
-
-    Returns the head branch name, or exits on error.
-    """
-    pr_data = PRService().get_pr(pr_number=pr)
-    if pr_data is None:
-        typer.echo(f"Error: 未找到 PR #{pr}", err=True)
-        raise typer.Exit(1)
-    return pr_data.head_branch
-
-
-def validate_mutually_exclusive_branch_pr(branch: str | None, pr: int | None) -> None:
-    """Ensure --branch and --pr are not both specified."""
-    if branch is not None and pr is not None:
-        typer.echo("Error: 不能同时指定 --branch 与 --pr", err=True)
-        raise typer.Exit(1)
-
-
-def resolve_target_branch(branch: str | None, pr: int | None) -> str | None:
-    """Resolve target branch from --branch, --pr, or None.
-
-    Returns None when neither option is provided (caller should fallback
-    to current branch).
-    """
-    validate_mutually_exclusive_branch_pr(branch, pr)
-    if pr is not None:
-        return resolve_pr_to_branch(pr)
-    return branch
+from vibe3.utils.branch_arg import resolve_branch_arg
 
 
 def require_flow(service: FlowService, branch: str) -> None:
@@ -54,9 +23,8 @@ def require_flow(service: FlowService, branch: str) -> None:
 
 
 def blocked(
-    branch: Annotated[str | None, typer.Option("--branch", help="Branch name")] = None,
-    pr: Annotated[
-        int | None, typer.Option("--pr", help="PR number to resolve head branch from")
+    branch: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
     ] = None,
     reason: Annotated[
         str | None, typer.Option("--reason", help="Blocking reason")
@@ -64,48 +32,42 @@ def blocked(
     task: Annotated[
         int | None, typer.Option("--task", help="Dependency issue number")
     ] = None,
-    by: Annotated[
-        int | None, typer.Option("--by", help="Dependency issue number")
-    ] = None,
     trace: Annotated[
         bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
     ] = False,
 ) -> None:
     """Mark flow as blocked.
 
-    If --task/--by is provided, automatically adds dependency issue link.
+    If --task is provided, automatically adds dependency issue link.
 
     Examples:
         vibe3 flow blocked --reason "等待外部反馈"
         vibe3 flow blocked --task 218
-        vibe3 flow blocked --task 218 --reason "需要 #218 先完成"
     """
+    if reason is not None and task is not None:
+        typer.echo("Error: 不能同时指定 --reason 与 --task", err=True)
+        raise typer.Exit(1)
+
     with trace_scope(trace, "flow blocked", domain="flow"):
         service = FlowService()
-        target_branch = (
-            resolve_target_branch(branch, pr) or service.get_current_branch()
-        )
+        target_branch = resolve_branch_arg(branch)
 
         logger.bind(
             command="flow blocked",
             branch=target_branch,
             reason=reason,
             task=task,
-            by=by,
         ).info("Blocking flow")
 
         require_flow(service, target_branch)
 
-        blocked_by_issue = task if task is not None else by
-        service.block_flow(
-            target_branch, reason=reason, blocked_by_issue=blocked_by_issue
-        )
+        service.block_flow(target_branch, reason=reason, blocked_by_issue=task)
 
         msg = f"Flow blocked on branch '{target_branch}'"
         if reason:
             msg += f": {reason}"
-        if blocked_by_issue:
-            msg += f" (blocked by #{blocked_by_issue})"
+        if task:
+            msg += f" (blocked by #{task})"
         typer.echo(msg)
 
 

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -233,6 +233,12 @@ def bind(
                     # `flow bind --role dependency` no longer performs independent
                     # dependency writes. It delegates to blocked dependency logic
                     # for a single source of behavior.
+                    # Multi-ref compatibility remains ordered and per-ref:
+                    # each dependency delegates to `block_flow()` in sequence,
+                    # while the outward CLI output is synthesized from IssueLink.
+                    # Because blocked state stores a singular `blocked_by_issue`,
+                    # the effective primary blocker after multi-ref delegation is
+                    # the last dependency ref processed here.
                     flow_service.block_flow(
                         target_branch, blocked_by_issue=issue_number, actor=None
                     )

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -11,6 +11,7 @@ from vibe3.commands.command_options import (
     TraceOption,
 )
 from vibe3.commands.common import trace_scope
+from vibe3.models.flow import IssueLink
 from vibe3.services.flow_service import FlowService
 from vibe3.services.task_service import TaskService
 from vibe3.services.worktree_ownership_guard import (
@@ -227,6 +228,23 @@ def bind(
             for ref in refs:
                 issue_number = parse_issue_number(ref)
 
+                if role == "dependency":
+                    # Compatibility path:
+                    # `flow bind --role dependency` no longer performs independent
+                    # dependency writes. It delegates to blocked dependency logic
+                    # for a single source of behavior.
+                    flow_service.block_flow(
+                        target_branch, blocked_by_issue=issue_number, actor=None
+                    )
+                    links.append(
+                        IssueLink(
+                            branch=target_branch,
+                            issue_number=issue_number,
+                            issue_role="dependency",
+                        )
+                    )
+                    continue
+
                 # Create the persistent link in flow_issue_links (Source of Truth)
                 link = task_service.link_issue(
                     target_branch,
@@ -235,13 +253,6 @@ def bind(
                     actor=None,
                 )
                 links.append(link)
-
-                # If it's a dependency, trigger the block side-effects
-                # (label & display field)
-                if role == "dependency":
-                    flow_service.block_flow(
-                        target_branch, blocked_by_issue=issue_number, actor=None
-                    )
 
             if json_output:
                 if len(links) == 1:

--- a/src/vibe3/commands/handoff_write.py
+++ b/src/vibe3/commands/handoff_write.py
@@ -9,6 +9,7 @@ from vibe3.commands.common import trace_scope
 from vibe3.services.handoff_service import HandoffService
 from vibe3.services.verdict_service import VerdictService
 from vibe3.ui.console import console
+from vibe3.utils.branch_arg import resolve_branch_arg
 
 
 def _record_handoff_reference(
@@ -16,8 +17,6 @@ def _record_handoff_reference(
     command: str,
     ref_label: str,
     ref_value: str,
-    next_step: str | None,
-    blocked_by: str | None,
     actor: str | None,
     trace: bool,
     method_name: str,
@@ -36,7 +35,7 @@ def _record_handoff_reference(
         method = getattr(service, method_name)
         # Support optional 'action' kwarg for indicate command
         extra_kwargs = {k: v for k, v in extra_kw.items() if v is not None}
-        method(ref_value, next_step, blocked_by, actor, **extra_kwargs)
+        method(ref_value, actor, **extra_kwargs)
         console.print(f"[green]✓[/] {ref_label} handoff recorded: {ref_value}")
 
 
@@ -92,12 +91,6 @@ def append(
 
 def plan(
     plan_ref: Annotated[str, typer.Argument(help="Plan document reference")],
-    next_step: Annotated[
-        str | None, typer.Option("--next-step", "-n", help="Next step suggestion")
-    ] = None,
-    blocked_by: Annotated[
-        str | None, typer.Option("--blocked-by", "-b", help="Blocker description")
-    ] = None,
     actor: Annotated[
         str | None,
         typer.Option(
@@ -118,8 +111,6 @@ def plan(
         command="handoff plan",
         ref_label="Plan",
         ref_value=plan_ref,
-        next_step=next_step,
-        blocked_by=blocked_by,
         actor=actor,
         trace=trace,
         method_name="record_plan",
@@ -128,12 +119,6 @@ def plan(
 
 def report(
     report_ref: Annotated[str, typer.Argument(help="Report document reference")],
-    next_step: Annotated[
-        str | None, typer.Option("--next-step", "-n", help="Next step suggestion")
-    ] = None,
-    blocked_by: Annotated[
-        str | None, typer.Option("--blocked-by", "-b", help="Blocker description")
-    ] = None,
     actor: Annotated[
         str | None,
         typer.Option(
@@ -154,8 +139,6 @@ def report(
         command="handoff report",
         ref_label="Report",
         ref_value=report_ref,
-        next_step=next_step,
-        blocked_by=blocked_by,
         actor=actor,
         trace=trace,
         method_name="record_report",
@@ -166,13 +149,6 @@ def indicate(
     indicate_ref: Annotated[
         str, typer.Argument(help="Manager indicate document reference")
     ],
-    next_step: Annotated[
-        str | None,
-        typer.Option("--next-step", "-n", help="Next step for downstream agents"),
-    ] = None,
-    blocked_by: Annotated[
-        str | None, typer.Option("--blocked-by", "-b", help="Blocker description")
-    ] = None,
     actor: Annotated[
         str | None,
         typer.Option(
@@ -197,8 +173,6 @@ def indicate(
         command="handoff indicate",
         ref_label="Indicate",
         ref_value=indicate_ref,
-        next_step=next_step,
-        blocked_by=blocked_by,
         actor=actor,
         trace=trace,
         method_name="record_indicate",
@@ -207,12 +181,6 @@ def indicate(
 
 def audit(
     audit_ref: Annotated[str, typer.Argument(help="Audit document reference")],
-    next_step: Annotated[
-        str | None, typer.Option("--next-step", "-n", help="Next step suggestion")
-    ] = None,
-    blocked_by: Annotated[
-        str | None, typer.Option("--blocked-by", "-b", help="Blocker description")
-    ] = None,
     actor: Annotated[
         str | None,
         typer.Option(
@@ -233,12 +201,29 @@ def audit(
         command="handoff audit",
         ref_label="Audit",
         ref_value=audit_ref,
-        next_step=next_step,
-        blocked_by=blocked_by,
         actor=actor,
         trace=trace,
         method_name="record_audit",
     )
+
+
+def next_step(
+    message: Annotated[str, typer.Argument(help="Next step text")],
+    branch: Annotated[
+        str | None,
+        typer.Option("--branch", "-b", help="Branch name or issue number"),
+    ] = None,
+    actor: Annotated[str | None, typer.Option("--actor", "-a")] = None,
+    trace: Annotated[
+        bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
+    ] = False,
+) -> None:
+    """Write next step to flow state for a target branch."""
+    with trace_scope(trace, "handoff next", domain="handoff"):
+        target_branch = resolve_branch_arg(branch)
+        service = HandoffService()
+        service.record_next_step(target_branch, message, actor)
+        console.print(f"[green]✓[/] Next step updated: {message}")
 
 
 def verdict(
@@ -306,4 +291,5 @@ def register_write_commands(app: typer.Typer) -> None:
     app.command()(report)
     app.command()(indicate)
     app.command()(audit)
+    app.command("next")(next_step)
     app.command()(verdict)

--- a/src/vibe3/commands/handoff_write.py
+++ b/src/vibe3/commands/handoff_write.py
@@ -222,6 +222,17 @@ def next_step(
     with trace_scope(trace, "handoff next", domain="handoff"):
         target_branch = resolve_branch_arg(branch)
         service = HandoffService()
+
+        # Validate flow exists before writing next_step
+        flow_state = service.store.get_flow_state(target_branch)
+        if not flow_state:
+            typer.echo(
+                f"Error: 目标分支 '{target_branch}' 没有 flow\n"
+                "先执行 `vibe3 flow add <name>` 或切到已有 flow 的分支",
+                err=True,
+            )
+            raise typer.Exit(1)
+
         service.record_next_step(target_branch, message, actor)
         console.print(f"[green]✓[/] Next step updated: {message}")
 

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -56,6 +56,7 @@ class HandoffService:
         "handoff_run",  # backward-compat: legacy event type
         "handoff_audit",
         "handoff_indicate",
+        "next_step_set",
         "plan_recorded",
         "report_recorded",  # new canonical name
         "run_recorded",  # backward-compat: legacy event type
@@ -188,9 +189,8 @@ class HandoffService:
         self,
         ref_kind: str,
         ref_value: str,
-        next_step: str | None,
-        blocked_by: str | None,
         actor: str | None,
+        *legacy_args: str | None,
         verdict: str | None = None,
     ) -> Path:
         """Internal helper to record an active handoff reference.
@@ -198,6 +198,16 @@ class HandoffService:
         Note: For passive artifact recording, use record_passive_artifact() instead.
         This method only handles active handoff events (handoff_plan/report/audit).
         """
+        if actor is None and legacy_args:
+            actor = next(
+                (
+                    candidate
+                    for candidate in reversed(legacy_args)
+                    if candidate is not None
+                ),
+                None,
+            )
+
         branch = self.git_client.get_current_branch()
         validate_authoritative_ref(
             ref_kind,
@@ -228,10 +238,6 @@ class HandoffService:
         actor_field = self._KIND_TO_ACTOR_FIELD.get(normalized_kind)
         if actor_field:
             flow_updates[actor_field] = effective_actor
-        if next_step:
-            flow_updates["next_step"] = next_step
-        if blocked_by:
-            flow_updates["blocked_reason"] = blocked_by
 
         if verdict:
             role = extract_role_from_actor(effective_actor)
@@ -240,8 +246,8 @@ class HandoffService:
                 actor=effective_actor,
                 role=role,
                 timestamp=datetime.now(UTC),
-                reason=next_step or f"Recorded {ref_kind} reference",
-                issues=blocked_by,
+                reason=f"Recorded {ref_kind} reference",
+                issues=None,
                 flow_branch=branch,
             )
             flow_updates["latest_verdict"] = record.model_dump_json()
@@ -249,10 +255,6 @@ class HandoffService:
         message = f"Recorded {ref_kind} reference: {ref_value}"
         if verdict:
             message = f"verdict: {verdict}\n{message}"
-        if next_step:
-            message += f"\nNext Step: {next_step}"
-        if blocked_by:
-            message += f"\nBlocked By: {blocked_by}"
 
         self.store.update_flow_state(branch, **flow_updates)
 
@@ -290,28 +292,22 @@ class HandoffService:
     def record_plan(
         self,
         plan_ref: str,
-        next_step: str | None = None,
-        blocked_by: str | None = None,
         actor: str | None = None,
     ) -> Path:
         """Record plan handoff reference."""
-        return self._record_ref("plan", plan_ref, next_step, blocked_by, actor)
+        return self._record_ref("plan", plan_ref, actor)
 
     def record_report(
         self,
         report_ref: str,
-        next_step: str | None = None,
-        blocked_by: str | None = None,
         actor: str | None = None,
     ) -> Path:
         """Record report handoff reference."""
-        return self._record_ref("report", report_ref, next_step, blocked_by, actor)
+        return self._record_ref("report", report_ref, actor)
 
     def record_audit(
         self,
         audit_ref: str,
-        next_step: str | None = None,
-        blocked_by: str | None = None,
         actor: str | None = None,
         verdict: str | None = None,
         is_system_auto: bool = False,
@@ -329,8 +325,6 @@ class HandoffService:
                 actor=actor,
                 branch=None,
                 verdict=verdict,
-                next_step=next_step,
-                blocked_by=blocked_by,
             )
             # record_passive_artifact returns Path or None, but this method
             # always returns Path
@@ -344,8 +338,6 @@ class HandoffService:
             return self._record_ref(
                 "audit",
                 audit_ref,
-                next_step,
-                blocked_by,
                 actor,
                 verdict=verdict,
             )
@@ -353,12 +345,33 @@ class HandoffService:
     def record_indicate(
         self,
         indicate_ref: str,
-        next_step: str | None = None,
-        blocked_by: str | None = None,
         actor: str | None = None,
     ) -> Path:
         """Record manager indicate handoff reference."""
-        return self._record_ref("indicate", indicate_ref, next_step, blocked_by, actor)
+        return self._record_ref("indicate", indicate_ref, actor)
+
+    def record_next_step(
+        self,
+        branch: str,
+        next_step: str,
+        actor: str | None = None,
+    ) -> None:
+        effective_actor = SignatureService.resolve_for_branch(
+            self.store,
+            branch,
+            explicit_actor=actor,
+        )
+        self.store.update_flow_state(
+            branch,
+            next_step=next_step,
+            latest_actor=effective_actor,
+        )
+        self.store.add_event(
+            branch,
+            "next_step_set",
+            effective_actor,
+            detail=f"Next Step: {next_step}",
+        )
 
     def record_passive_artifact(
         self,

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -190,7 +190,6 @@ class HandoffService:
         ref_kind: str,
         ref_value: str,
         actor: str | None,
-        *legacy_args: str | None,
         verdict: str | None = None,
     ) -> Path:
         """Internal helper to record an active handoff reference.
@@ -198,16 +197,6 @@ class HandoffService:
         Note: For passive artifact recording, use record_passive_artifact() instead.
         This method only handles active handoff events (handoff_plan/report/audit).
         """
-        if actor is None and legacy_args:
-            actor = next(
-                (
-                    candidate
-                    for candidate in reversed(legacy_args)
-                    if candidate is not None
-                ),
-                None,
-            )
-
         branch = self.git_client.get_current_branch()
         validate_authoritative_ref(
             ref_kind,

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -189,7 +189,8 @@ class HandoffService:
         self,
         ref_kind: str,
         ref_value: str,
-        actor: str | None,
+        actor: str | None = None,
+        *,
         verdict: str | None = None,
     ) -> Path:
         """Internal helper to record an active handoff reference.

--- a/tests/vibe3/commands/test_flow_blocked.py
+++ b/tests/vibe3/commands/test_flow_blocked.py
@@ -6,7 +6,6 @@ from typer.testing import CliRunner
 
 from vibe3.cli import app
 from vibe3.models.flow import FlowStatusResponse
-from vibe3.models.pr import PRResponse, PRState
 
 runner = CliRunner()
 
@@ -50,54 +49,49 @@ def test_flow_blocked_succeeds_when_flow_exists() -> None:
     )
 
 
-def test_flow_blocked_supports_pr_option() -> None:
-    """--pr should resolve head branch and block that flow."""
+def test_flow_blocked_resolves_numeric_branch_to_canonical_task_branch() -> None:
+    """Numeric --branch should normalize to canonical task branch before block."""
     flow_service = MagicMock()
-    pr_service = MagicMock()
-    pr_service.get_pr.return_value = PRResponse(
-        number=789,
-        title="Test PR",
-        body="",
-        state=PRState.OPEN,
-        head_branch="task/from-pr",
-        base_branch="main",
-        url="https://example.com/pr/789",
-        merged_at=None,
+    flow_service.get_flow_status.return_value = FlowStatusResponse(
+        branch="task/issue-235",
+        flow_slug="issue-235",
+        flow_status="active",
+        task_issue_number=235,
+        issues=[],
     )
 
-    with (
-        patch("vibe3.commands.flow_lifecycle.FlowService", return_value=flow_service),
-        patch("vibe3.commands.flow_lifecycle.PRService", return_value=pr_service),
-    ):
+    with patch("vibe3.commands.flow_lifecycle.FlowService", return_value=flow_service):
         result = runner.invoke(
-            app, ["flow", "blocked", "--pr", "789", "--reason", "waiting"]
+            app, ["flow", "blocked", "--branch", "235", "--task", "246"]
         )
 
     assert result.exit_code == 0
-    pr_service.get_pr.assert_called_once_with(pr_number=789)
     flow_service.block_flow.assert_called_once_with(
-        "task/from-pr", reason="waiting", blocked_by_issue=None
+        "task/issue-235", reason=None, blocked_by_issue=246
     )
 
 
-def test_flow_blocked_rejects_branch_and_pr_together() -> None:
-    """--branch and --pr are mutually exclusive for blocked."""
+def test_flow_blocked_rejects_reason_and_task_together() -> None:
+    """--reason and --task are mutually exclusive for blocked."""
     result = runner.invoke(
         app,
-        ["flow", "blocked", "--branch", "task/demo", "--pr", "789"],
+        ["flow", "blocked", "--branch", "235", "--task", "246", "--reason", "wait"],
     )
 
     assert result.exit_code == 1
-    assert "不能同时指定 --branch 与 --pr" in result.output
+    assert "--reason" in result.output
+    assert "--task" in result.output
 
 
-def test_flow_blocked_reports_missing_pr() -> None:
-    """--pr should fail clearly when PR number cannot be resolved."""
-    pr_service = MagicMock()
-    pr_service.get_pr.return_value = None
+def test_flow_blocked_no_longer_supports_pr_option() -> None:
+    """CLI should reject removed --pr option."""
+    result = runner.invoke(app, ["flow", "blocked", "--pr", "789", "--reason", "x"])
 
-    with patch("vibe3.commands.flow_lifecycle.PRService", return_value=pr_service):
-        result = runner.invoke(app, ["flow", "blocked", "--pr", "999"])
+    assert result.exit_code != 0
 
-    assert result.exit_code == 1
-    assert "未找到 PR #999" in result.output
+
+def test_flow_blocked_no_longer_supports_by_alias() -> None:
+    """CLI should reject removed --by alias."""
+    result = runner.invoke(app, ["flow", "blocked", "--by", "246"])
+
+    assert result.exit_code != 0

--- a/tests/vibe3/commands/test_handoff_commands_advanced.py
+++ b/tests/vibe3/commands/test_handoff_commands_advanced.py
@@ -104,7 +104,8 @@ class TestHandoffAdvancedCommands:
         assert "✓" in result.output
         assert "Plan handoff recorded" in result.output
         mock_service.record_plan.assert_called_once_with(
-            "docs/plans/test-plan.md", None, None, "claude/sonnet-4.6"
+            "docs/plans/test-plan.md",
+            "claude/sonnet-4.6",
         )
 
     @patch("vibe3.commands.handoff_write.HandoffService")
@@ -119,8 +120,6 @@ class TestHandoffAdvancedCommands:
                 "handoff",
                 "report",
                 "docs/reports/test-report.md",
-                "--next-step",
-                "Address feedback",
                 "--actor",
                 "claude/sonnet-4.6",
             ],
@@ -131,8 +130,6 @@ class TestHandoffAdvancedCommands:
         assert "Report handoff recorded" in result.output
         mock_service.record_report.assert_called_once_with(
             "docs/reports/test-report.md",
-            "Address feedback",
-            None,
             "claude/sonnet-4.6",
         )
 
@@ -148,8 +145,6 @@ class TestHandoffAdvancedCommands:
                 "handoff",
                 "audit",
                 "docs/audits/test-audit.md",
-                "--blocked-by",
-                "Waiting for review",
                 "--actor",
                 "claude/sonnet-4.6",
             ],
@@ -160,17 +155,10 @@ class TestHandoffAdvancedCommands:
         assert "Audit handoff recorded" in result.output
         mock_service.record_audit.assert_called_once_with(
             "docs/audits/test-audit.md",
-            None,
-            "Waiting for review",
             "claude/sonnet-4.6",
         )
 
-    @patch("vibe3.commands.handoff_write.HandoffService")
-    def test_handoff_with_options(self, mock_service_class):
-        """Test handoff commands with optional parameters."""
-        mock_service = MagicMock()
-        mock_service_class.return_value = mock_service
-
+    def test_handoff_plan_rejects_legacy_next_step_option(self):
         result = runner.invoke(
             app,
             [
@@ -179,20 +167,24 @@ class TestHandoffAdvancedCommands:
                 "docs/plans/test-plan.md",
                 "--next-step",
                 "Start implementation",
-                "--blocked-by",
-                "API key needed",
-                "--actor",
-                "claude/sonnet-4.6",
             ],
         )
 
-        assert result.exit_code == 0
-        mock_service.record_plan.assert_called_once_with(
-            "docs/plans/test-plan.md",
-            "Start implementation",
-            "API key needed",
-            "claude/sonnet-4.6",
+        assert result.exit_code != 0
+
+    def test_handoff_audit_rejects_legacy_blocked_by_option(self):
+        result = runner.invoke(
+            app,
+            [
+                "handoff",
+                "audit",
+                "docs/audits/test-audit.md",
+                "--blocked-by",
+                "Waiting for review",
+            ],
         )
+
+        assert result.exit_code != 0
 
     def test_handoff_audit_command_real_service_path(self, tmp_path, monkeypatch):
         """Test the real service path for handoff audit command with minimal mocking."""
@@ -222,8 +214,6 @@ class TestHandoffAdvancedCommands:
                 "handoff",
                 "audit",
                 audit_ref,
-                "--next-step",
-                "Finalize PR",
                 "--actor",
                 "test-actor",
             ],
@@ -242,12 +232,11 @@ class TestHandoffAdvancedCommands:
         assert handoff_file.exists()
         content = handoff_file.read_text()
         assert audit_ref in content
-        assert "Finalize PR" in content
         assert "test-actor" in content
 
         # Verify side effects in database
         flow_state = real_store.get_flow_state("main")
         assert flow_state is not None
         assert flow_state["audit_ref"] == audit_ref
-        assert flow_state["next_step"] == "Finalize PR"
+        assert flow_state["next_step"] is None
         assert flow_state["reviewer_actor"] == "test-actor"

--- a/tests/vibe3/commands/test_handoff_next_command.py
+++ b/tests/vibe3/commands/test_handoff_next_command.py
@@ -1,0 +1,34 @@
+"""Tests for the handoff next command."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from vibe3.cli import app
+
+runner = CliRunner()
+
+
+def test_handoff_next_sets_next_step_for_numeric_branch() -> None:
+    service = MagicMock()
+
+    with patch("vibe3.commands.handoff_write.HandoffService", return_value=service):
+        result = runner.invoke(
+            app,
+            [
+                "handoff",
+                "next",
+                "Finalize PR",
+                "--branch",
+                "235",
+                "--actor",
+                "test-actor",
+            ],
+        )
+
+    assert result.exit_code == 0
+    service.record_next_step.assert_called_once_with(
+        "task/issue-235",
+        "Finalize PR",
+        "test-actor",
+    )

--- a/tests/vibe3/commands/test_handoff_next_command.py
+++ b/tests/vibe3/commands/test_handoff_next_command.py
@@ -32,3 +32,21 @@ def test_handoff_next_sets_next_step_for_numeric_branch() -> None:
         "Finalize PR",
         "test-actor",
     )
+
+
+def test_handoff_next_rejects_nonexistent_flow() -> None:
+    """Should reject if target branch has no flow."""
+    service = MagicMock()
+    # Mock get_flow_state to return None (flow doesn't exist)
+    service.store.get_flow_state.return_value = None
+
+    with patch("vibe3.commands.handoff_write.HandoffService", return_value=service):
+        result = runner.invoke(
+            app,
+            ["handoff", "next", "message", "--branch", "999"],
+        )
+
+    assert result.exit_code == 1
+    assert "没有 flow" in result.output
+    # Should NOT call record_next_step when flow doesn't exist
+    service.record_next_step.assert_not_called()

--- a/tests/vibe3/commands/test_task_management_bind.py
+++ b/tests/vibe3/commands/test_task_management_bind.py
@@ -1,6 +1,7 @@
 """Tests for flow bind command role semantics."""
 
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import MagicMock, call, patch
 
 from typer.testing import CliRunner
 
@@ -84,6 +85,90 @@ def test_flow_bind_dependency_delegates_without_direct_link_issue() -> None:
     flow_service.block_flow.assert_called_once_with(
         "task/demo", blocked_by_issue=218, actor=None
     )
+
+
+def test_flow_bind_dependency_json_output_single_ref() -> None:
+    """dependency compatibility path should keep single-item JSON output shape."""
+    with patch(
+        "vibe3.commands.flow_manage.TaskService", create=True
+    ) as task_service_cls:
+        task_service = MagicMock()
+        task_service_cls.return_value = task_service
+
+        flow_service = MagicMock()
+        flow_service.get_current_branch.return_value = "task/demo"
+        with patch("vibe3.commands.flow_manage.FlowService", return_value=flow_service):
+            result = runner.invoke(
+                flow_app, ["bind", "218", "--role", "dependency", "--json"]
+            )
+
+    assert result.exit_code == 0
+    task_service.link_issue.assert_not_called()
+    payload = json.loads(result.stdout)
+    assert payload["branch"] == "task/demo"
+    assert payload["issue_number"] == 218
+    assert payload["issue_role"] == "dependency"
+    assert isinstance(payload["created_at"], str)
+
+
+def test_flow_bind_dependency_json_output_multiple_refs() -> None:
+    """dependency compatibility path should keep list JSON output for multiple refs."""
+    with patch(
+        "vibe3.commands.flow_manage.TaskService", create=True
+    ) as task_service_cls:
+        task_service = MagicMock()
+        task_service_cls.return_value = task_service
+
+        flow_service = MagicMock()
+        flow_service.get_current_branch.return_value = "task/demo"
+        with patch("vibe3.commands.flow_manage.FlowService", return_value=flow_service):
+            result = runner.invoke(
+                flow_app,
+                ["bind", "218", "219", "--role", "dependency", "--json"],
+            )
+
+    assert result.exit_code == 0
+    task_service.link_issue.assert_not_called()
+    payload = json.loads(result.stdout)
+    assert payload == [
+        {
+            "branch": "task/demo",
+            "issue_number": 218,
+            "issue_role": "dependency",
+            "created_at": payload[0]["created_at"],
+        },
+        {
+            "branch": "task/demo",
+            "issue_number": 219,
+            "issue_role": "dependency",
+            "created_at": payload[1]["created_at"],
+        },
+    ]
+    assert all(isinstance(item["created_at"], str) for item in payload)
+    flow_service.block_flow.assert_has_calls(
+        [
+            call("task/demo", blocked_by_issue=218, actor=None),
+            call("task/demo", blocked_by_issue=219, actor=None),
+        ]
+    )
+
+
+def test_flow_bind_dependency_stdout_output_non_json() -> None:
+    """dependency compatibility path should keep legacy stdout messaging."""
+    with patch(
+        "vibe3.commands.flow_manage.TaskService", create=True
+    ) as task_service_cls:
+        task_service = MagicMock()
+        task_service_cls.return_value = task_service
+
+        flow_service = MagicMock()
+        flow_service.get_current_branch.return_value = "task/demo"
+        with patch("vibe3.commands.flow_manage.FlowService", return_value=flow_service):
+            result = runner.invoke(flow_app, ["bind", "218", "--role", "dependency"])
+
+    assert result.exit_code == 0
+    task_service.link_issue.assert_not_called()
+    assert "Issue #218 linked as dependency to flow task/demo" in result.stdout
 
 
 def test_flow_bind_with_explicit_branch_option() -> None:

--- a/tests/vibe3/commands/test_task_management_bind.py
+++ b/tests/vibe3/commands/test_task_management_bind.py
@@ -66,8 +66,8 @@ def test_flow_bind_with_related_role() -> None:
     )
 
 
-def test_flow_bind_with_dependency_role() -> None:
-    """flow bind 218 --role dependency should bind as dependency."""
+def test_flow_bind_dependency_delegates_without_direct_link_issue() -> None:
+    """flow bind 218 --role dependency should only use blocked compatibility logic."""
     with patch(
         "vibe3.commands.flow_manage.TaskService", create=True
     ) as task_service_cls:
@@ -80,6 +80,7 @@ def test_flow_bind_with_dependency_role() -> None:
             result = runner.invoke(flow_app, ["bind", "218", "--role", "dependency"])
 
     assert result.exit_code == 0
+    task_service.link_issue.assert_not_called()
     flow_service.block_flow.assert_called_once_with(
         "task/demo", blocked_by_issue=218, actor=None
     )

--- a/tests/vibe3/services/test_handoff_service.py
+++ b/tests/vibe3/services/test_handoff_service.py
@@ -114,6 +114,21 @@ def test_record_ref_rejects_unknown_active_kind(tmp_path: Path) -> None:
     )
 
     with pytest.raises(UserError, match="Unsupported handoff kind: mystery"):
+        service._record_ref("mystery", "docs/unknown.md", "codex/gpt-5.4")
+
+
+def test_record_ref_rejects_legacy_positional_shape(tmp_path: Path) -> None:
+    worktree_root = tmp_path / "wt"
+    git_common = tmp_path / ".git"
+    worktree_root.mkdir()
+    git_common.mkdir()
+
+    service = HandoffService(
+        store=SQLiteClient(db_path=str(tmp_path / "handoff.db")),
+        git_client=_StubGitClient(worktree_root, git_common, "task/issue-304"),
+    )
+
+    with pytest.raises(TypeError):
         service._record_ref("mystery", "docs/unknown.md", None, None, "codex/gpt-5.4")
 
 

--- a/tests/vibe3/services/test_handoff_service.py
+++ b/tests/vibe3/services/test_handoff_service.py
@@ -114,7 +114,7 @@ def test_record_ref_rejects_unknown_active_kind(tmp_path: Path) -> None:
     )
 
     with pytest.raises(UserError, match="Unsupported handoff kind: mystery"):
-        service._record_ref("mystery", "docs/unknown.md", "codex/gpt-5.4")
+        service._record_ref("mystery", "docs/unknown.md", actor="codex/gpt-5.4")
 
 
 def test_record_ref_rejects_legacy_positional_shape(tmp_path: Path) -> None:
@@ -130,6 +130,21 @@ def test_record_ref_rejects_legacy_positional_shape(tmp_path: Path) -> None:
 
     with pytest.raises(TypeError):
         service._record_ref("mystery", "docs/unknown.md", None, None, "codex/gpt-5.4")
+
+
+def test_record_ref_requires_keyword_verdict(tmp_path: Path) -> None:
+    worktree_root = tmp_path / "wt"
+    git_common = tmp_path / ".git"
+    worktree_root.mkdir()
+    git_common.mkdir()
+
+    service = HandoffService(
+        store=SQLiteClient(db_path=str(tmp_path / "handoff.db")),
+        git_client=_StubGitClient(worktree_root, git_common, "task/issue-304"),
+    )
+
+    with pytest.raises(TypeError):
+        service._record_ref("audit", "docs/unknown.md", "codex/gpt-5.4", "BLOCK")
 
 
 def test_get_handoff_events_excludes_non_handoff_runtime_events(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- 统一 agent_report 格式为 `【agent_report】(PR #N)`，显式标注 PR 编号
- SKILL.md 新增 `extract_pr_number()` 和 `@wait_for_report()` PR 编号校验逻辑
- 更新全部 5 个 agent 定义文件的报告格式示例和工作协议
- Shell 脚本无需修改（已支持前缀匹配，校验逻辑在 Skill 层）

## 问题背景

teammate-message 系统已知 bug (#40166/#39651) 导致 PR 编号路由错误，PR #892 审查中 security-reviewer 的报告被路由到错误的 PR。

## 修改内容

### SKILL.md (6 处修改)
1. 执行模式表格增加"确认粒度"+"修复能力"列
2. Phase 0 ToolSearch 合并到 Step 1
3. 新增 `extract_pr_number()` 函数
4. `@wait_for_report()` 增加 `expected_pr_number` 参数和路由错误处理
5. Phase 1 任务分配 prompt 要求显式标注 PR 编号
6. Phase 1 报告等待逻辑增加 RETRY 分支

### Agent 定义文件 (5 个)
每个文件更新事件前缀示例和工作协议，增加正确格式和禁止反例

## Test plan

- [ ] 下次 PR 审查时验证 agent_report 格式包含 PR 编号
- [ ] PR 编号路由错误场景下 SendMessage 确认机制可用

Refs: #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)