### PR TITLE
fix: tmux session already exists 降级为 WARNING 而非 ERROR

### DIFF
--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -312,6 +312,45 @@ class ExecutionCoordinator:
                 raise ValueError(f"Unknown mode: {request.mode}")
 
         except Exception as exc:
+            error_msg = str(exc)
+
+            # Detect tmux session already exists - treat as expected skip,
+            # not hard error
+            if (
+                isinstance(exc, RuntimeError)
+                and "Tmux session '" in error_msg
+                and "already exists" in error_msg
+            ):
+                match = re.search(r"Tmux session '([^']+)' already exists", error_msg)
+                session_name = match.group(1) if match else "unknown"
+
+                formatted_msg = (
+                    f"{error_msg} (previous session still alive: {session_name}; "
+                    "launch skipped to avoid duplicate worker)"
+                )
+
+                append_orchestra_event(
+                    "dispatcher",
+                    f"{request.role} launch skipped for "
+                    f"#{request.target_id}: {formatted_msg}",
+                )
+                logger.bind(
+                    domain="execution_coordinator",
+                    role=request.role,
+                    target_id=request.target_id,
+                ).warning(f"Execution launch skipped: {formatted_msg}")
+
+                # Still mark as launch_failed (test expectation), but with WARNING level
+                if request.mode == "async" and runtime_session_id is not None:
+                    self.registry.mark_failed(runtime_session_id)
+
+                return ExecutionLaunchResult(
+                    launched=False,
+                    reason=formatted_msg,
+                    reason_code="launch_failed",
+                )
+
+            # Generic error handling for other exceptions
             error_msg = self._format_launch_error(exc)
             if request.mode == "async" and runtime_session_id is not None:
                 self.registry.mark_failed(runtime_session_id)


### PR DESCRIPTION
## Summary

修复 ExecutionCoordinator 异常处理逻辑，当 tmux session 已存在时，使用 WARNING 日志级别而不是 ERROR。

## 背景

在 `temp/logs/orchestra/events.log` 中发现退化问题：
- Registry dedup 检查通过，但实际启动时 tmux session 已存在
- 可能是僵尸 session 或 race condition 导致
- 用户期望视为"跳过"而非"报错"

## 修改

**文件**: `src/vibe3/execution/coordinator.py`

- 在异常处理器中检测 `RuntimeError("Tmux session '...' already exists")`
- 格式化错误消息包含上下文：`(previous session still alive: {session_name}; launch skipped to avoid duplicate worker)`
- 日志级别改为 **WARNING** 而非 ERROR
- 保持 `reason_code="launch_failed"`（符合测试期望）

## 测试

- ✅ 所有 12 个 coordinator 测试通过
- ✅ `test_coordinator_dispatch_launch_failed_duplicate_tmux_gets_context` 验证行为正确

## Test plan

- [x] 运行 `uv run pytest tests/vibe3/execution/test_coordinator.py` - 全部通过
- [x] 验证日志输出：现有 tmux session 使用 WARNING 级别

🤖 Generated with [Claude Code](https://claude.com/claude-code)