### PR TITLE
test: 补充 PR #821 测试覆盖

### DIFF
--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -22,16 +22,19 @@ from vibe3.ui.handoff_ui import render_handoff_detail
 from vibe3.utils.issue_branch_resolver import resolve_issue_branch_input
 
 
-def _format_relative_time(timestamp: datetime) -> str:
+def _format_relative_time(timestamp: datetime, now: datetime | None = None) -> str:
     """Format datetime as human-readable relative time.
 
     Args:
         timestamp: Datetime to format
+        now: Optional fixed timestamp for testing (defaults to
+            datetime.now(timezone.utc))
 
     Returns:
         Human-readable string like "2 hours ago", "3 days ago", etc.
     """
-    now = datetime.now(timezone.utc)
+    if now is None:
+        now = datetime.now(timezone.utc)
     if timestamp.tzinfo is None:
         # Assume UTC if no timezone
         timestamp = timestamp.replace(tzinfo=timezone.utc)

--- a/tests/vibe3/commands/test_handoff_read.py
+++ b/tests/vibe3/commands/test_handoff_read.py
@@ -1,0 +1,54 @@
+"""Tests for handoff_read helper functions."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vibe3.commands.handoff_read import _format_relative_time
+
+
+@pytest.mark.parametrize(
+    "seconds_offset,expected_output",
+    [
+        pytest.param(0, "just now", id="0_seconds"),
+        pytest.param(30, "just now", id="30_seconds"),
+        pytest.param(59, "just now", id="59_seconds"),
+        pytest.param(60, "1 minute ago", id="60_seconds"),
+        pytest.param(61, "1 minute ago", id="61_seconds"),
+        pytest.param(120, "2 minutes ago", id="120_seconds"),
+        pytest.param(3599, "59 minutes ago", id="3599_seconds"),
+        pytest.param(3600, "1 hour ago", id="3600_seconds"),
+        pytest.param(7200, "2 hours ago", id="7200_seconds"),
+        pytest.param(86399, "23 hours ago", id="86399_seconds"),
+        pytest.param(86400, "1 day ago", id="86400_seconds"),
+        pytest.param(172800, "2 days ago", id="172800_seconds"),
+        pytest.param(2591999, "29 days ago", id="2591999_seconds"),
+        pytest.param(2592000, "1 month ago", id="2592000_seconds"),
+        pytest.param(5184000, "2 months ago", id="5184000_seconds"),
+    ],
+)
+def test_format_relative_time_boundary_values(seconds_offset, expected_output):
+    """Test _format_relative_time at key boundaries.
+
+    Verifies correct pluralization and unit transitions at:
+    - 59s → 60s: just now → 1 minute ago
+    - 59m → 60m: 59 minutes ago → 1 hour ago
+    - 23h → 24h: 23 hours ago → 1 day ago
+    - 29d → 30d: 29 days ago → 1 month ago
+    """
+    now = datetime.now(timezone.utc)
+    timestamp = now - timedelta(seconds=seconds_offset)
+    result = _format_relative_time(timestamp)
+    assert result == expected_output
+
+
+def test_format_relative_time_assumes_utc_for_naive_datetime():
+    """Test that naive datetime (no timezone) is assumed to be UTC."""
+    # Create a naive datetime 5 minutes ago
+    now_utc = datetime.now(timezone.utc)
+    naive_timestamp = (now_utc - timedelta(minutes=5)).replace(tzinfo=None)
+
+    result = _format_relative_time(naive_timestamp)
+
+    # Should treat it as UTC and return "5 minutes ago"
+    assert result == "5 minutes ago"

--- a/tests/vibe3/commands/test_handoff_read.py
+++ b/tests/vibe3/commands/test_handoff_read.py
@@ -36,19 +36,23 @@ def test_format_relative_time_boundary_values(seconds_offset, expected_output):
     - 23h → 24h: 23 hours ago → 1 day ago
     - 29d → 30d: 29 days ago → 1 month ago
     """
-    now = datetime.now(timezone.utc)
-    timestamp = now - timedelta(seconds=seconds_offset)
-    result = _format_relative_time(timestamp)
+    # Use fixed clock to avoid scheduler delay flakiness
+    # Pass explicit now parameter instead of relying on real clock
+    fixed_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    timestamp = fixed_now - timedelta(seconds=seconds_offset)
+    result = _format_relative_time(timestamp, now=fixed_now)
     assert result == expected_output
 
 
 def test_format_relative_time_assumes_utc_for_naive_datetime():
     """Test that naive datetime (no timezone) is assumed to be UTC."""
-    # Create a naive datetime 5 minutes ago
-    now_utc = datetime.now(timezone.utc)
-    naive_timestamp = (now_utc - timedelta(minutes=5)).replace(tzinfo=None)
-
-    result = _format_relative_time(naive_timestamp)
-
+    # Use fixed clock to avoid scheduler delay flakiness
+    # Pass explicit now parameter instead of relying on real clock
+    # If the test reads the real clock twice (once here, once in the function),
+    # and the scheduler delays between calls, "5 minutes ago" could become
+    # "6 minutes ago" and fail the assertion.
+    fixed_now = datetime(2026, 1, 1, 12, 5, 0, tzinfo=timezone.utc)
+    naive_timestamp = (fixed_now - timedelta(minutes=5)).replace(tzinfo=None)
+    result = _format_relative_time(naive_timestamp, now=fixed_now)
     # Should treat it as UTC and return "5 minutes ago"
     assert result == "5 minutes ago"

--- a/tests/vibe3/services/test_handoff_service.py
+++ b/tests/vibe3/services/test_handoff_service.py
@@ -100,6 +100,7 @@ def test_record_indicate_writes_indicate_ref(tmp_path: Path) -> None:
     flow_state = store.get_flow_state("task/issue-304")
     assert flow_state is not None
     assert flow_state["indicate_ref"] == "docs/indicate.md"
+    assert flow_state["manager_actor"] == "codex/gpt-5.4"
 
 
 def test_record_ref_rejects_unknown_active_kind(tmp_path: Path) -> None:

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -184,7 +184,7 @@ def test_link_task_demotes_previous_task_flow_on_fresh_db(tmp_path):
 
 
 def test_select_latest_ref_prefers_newer_valid_authoritative_ref(tmp_path) -> None:
-    """Quick view should prefer the latest valid ref, not blindly prefer audit."""
+    """Quick view should prefer the latest valid ref by mtime when no role is 'done'."""
     db_path = tmp_path / "fresh.db"
     store = SQLiteClient(db_path=str(db_path))
     service = TaskService(store=store)
@@ -202,11 +202,15 @@ def test_select_latest_ref_prefers_newer_valid_authoritative_ref(tmp_path) -> No
     os.utime(audit_ref, (1, 1))
     os.utime(report_ref, (2, 2))
 
+    # Explicitly set statuses to non-"done" to test mtime fallback path
     flow = FlowStatusResponse(
         branch="task/issue-501",
         flow_slug="issue-501",
         flow_status="active",
         task_issue_number=501,
+        planner_status="running",
+        executor_status="running",
+        reviewer_status=None,
         report_ref="notes/report.md",
         audit_ref="notes/audit.md",
         worktree_root=str(tmp_path),
@@ -218,3 +222,185 @@ def test_select_latest_ref_prefers_newer_valid_authoritative_ref(tmp_path) -> No
     assert summary.kind == "report"
     assert summary.ref == "notes/report.md"
     assert "最新一轮已经修好" in summary.summary
+
+
+@pytest.mark.parametrize(
+    "planner_status,executor_status,reviewer_status,plan_ref,report_ref,audit_ref,expected_kind,expected_ref",
+    [
+        # State transition scenarios: reviewer → executor → planner priority
+        pytest.param(
+            "running",
+            None,
+            None,
+            "notes/plan.md",
+            None,
+            None,
+            "plan",
+            "notes/plan.md",
+            id="planner_done_with_plan_ref",
+        ),
+        pytest.param(
+            None,
+            "done",
+            None,
+            None,
+            "notes/report.md",
+            None,
+            "report",
+            "notes/report.md",
+            id="executor_done_with_report_ref",
+        ),
+        pytest.param(
+            None,
+            None,
+            "done",
+            None,
+            None,
+            "notes/audit.md",
+            "audit",
+            "notes/audit.md",
+            id="reviewer_done_with_audit_ref",
+        ),
+        pytest.param(
+            "done",
+            "done",
+            "done",
+            "notes/plan.md",
+            "notes/report.md",
+            "notes/audit.md",
+            "audit",
+            "notes/audit.md",
+            id="all_done_reviewer_priority",
+        ),
+        pytest.param(
+            "pending",
+            "done",
+            "pending",
+            "notes/plan.md",
+            "notes/report.md",
+            "notes/audit.md",
+            "report",
+            "notes/report.md",
+            id="executor_done_others_pending",
+        ),
+        pytest.param(
+            "done",
+            "running",
+            None,
+            "notes/plan.md",
+            "notes/report.md",
+            None,
+            "plan",
+            "notes/plan.md",
+            id="planner_done_executor_running",
+        ),
+        # Fallback scenarios: all non-done
+        pytest.param(
+            "running",
+            None,
+            "pending",
+            None,
+            "notes/report.md",
+            "notes/audit.md",
+            "report",
+            "notes/report.md",
+            id="fallback_two_refs_by_mtime",
+        ),
+        pytest.param(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="no_refs_returns_none",
+        ),
+    ],
+)
+def test_select_latest_ref_with_state_transitions(
+    tmp_path,
+    planner_status,
+    executor_status,
+    reviewer_status,
+    plan_ref,
+    report_ref,
+    audit_ref,
+    expected_kind,
+    expected_ref,
+) -> None:
+    """Test _select_latest_ref state transition logic.
+
+    When a role status is "done", the corresponding ref should be prioritized.
+    Priority order: reviewer → executor → planner (reverse of execution order).
+    Fallback to mtime when no role is "done".
+    """
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(store=store)
+
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+
+    # For mtime fallback scenario, we need actual files with different mtimes
+    if plan_ref and report_ref and audit_ref:
+        # All three refs exist scenario (all_done)
+        plan_file = notes_dir / "plan.md"
+        report_file = notes_dir / "report.md"
+        audit_file = notes_dir / "audit.md"
+        plan_file.write_text("# Plan", encoding="utf-8")
+        report_file.write_text("# Report", encoding="utf-8")
+        audit_file.write_text("# Audit", encoding="utf-8")
+        # Make audit most recent for reviewer priority test
+        os.utime(plan_file, (1, 1))
+        os.utime(report_file, (2, 2))
+        os.utime(audit_file, (3, 3))
+    elif plan_ref and report_ref and not audit_ref:
+        # Planner done, executor active scenario
+        plan_file = notes_dir / "plan.md"
+        report_file = notes_dir / "report.md"
+        plan_file.write_text("# Plan", encoding="utf-8")
+        report_file.write_text("# Report", encoding="utf-8")
+        os.utime(plan_file, (1, 1))
+        os.utime(report_file, (2, 2))
+    elif report_ref and audit_ref and not plan_ref:
+        # Fallback scenario with two refs - audit is older, report is newer
+        report_file = notes_dir / "report.md"
+        audit_file = notes_dir / "audit.md"
+        report_file.write_text("# Report", encoding="utf-8")
+        audit_file.write_text("# Audit", encoding="utf-8")
+        os.utime(audit_file, (1, 1))
+        os.utime(report_file, (2, 2))
+    elif plan_ref:
+        plan_file = notes_dir / "plan.md"
+        plan_file.write_text("# Plan", encoding="utf-8")
+    elif report_ref:
+        report_file = notes_dir / "report.md"
+        report_file.write_text("# Report", encoding="utf-8")
+    elif audit_ref:
+        audit_file = notes_dir / "audit.md"
+        audit_file.write_text("# Audit", encoding="utf-8")
+
+    flow = FlowStatusResponse(
+        branch="task/issue-501",
+        flow_slug="issue-501",
+        flow_status="active",
+        task_issue_number=501,
+        planner_status=planner_status,
+        executor_status=executor_status,
+        reviewer_status=reviewer_status,
+        plan_ref=plan_ref,
+        report_ref=report_ref,
+        audit_ref=audit_ref,
+        worktree_root=str(tmp_path),
+    )
+
+    summary = service._show_service._select_latest_ref("task/issue-501", flow)
+
+    if expected_kind is None:
+        assert summary is None
+    else:
+        assert summary is not None
+        assert summary.kind == expected_kind
+        assert summary.ref == expected_ref

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -183,6 +183,22 @@ def test_link_task_demotes_previous_task_flow_on_fresh_db(tmp_path):
     assert ("remove", 467, "state/claimed") in label_port.calls
 
 
+def _create_ref_files(notes_dir, plan_ref, report_ref, audit_ref):
+    """Create ref files with mtimes ensuring report > audit > plan for fallback."""
+    if plan_ref:
+        f = notes_dir / "plan.md"
+        f.write_text("# Plan", encoding="utf-8")
+        os.utime(f, (1, 1))
+    if audit_ref:
+        f = notes_dir / "audit.md"
+        f.write_text("# Audit", encoding="utf-8")
+        os.utime(f, (2, 2))
+    if report_ref:
+        f = notes_dir / "report.md"
+        f.write_text("# Report", encoding="utf-8")
+        os.utime(f, (3, 3))
+
+
 def test_select_latest_ref_prefers_newer_valid_authoritative_ref(tmp_path) -> None:
     """Quick view should prefer the latest valid ref by mtime when no role is 'done'."""
     db_path = tmp_path / "fresh.db"
@@ -342,45 +358,7 @@ def test_select_latest_ref_with_state_transitions(
 
     notes_dir = tmp_path / "notes"
     notes_dir.mkdir()
-
-    # For mtime fallback scenario, we need actual files with different mtimes
-    if plan_ref and report_ref and audit_ref:
-        # All three refs exist scenario (all_done)
-        plan_file = notes_dir / "plan.md"
-        report_file = notes_dir / "report.md"
-        audit_file = notes_dir / "audit.md"
-        plan_file.write_text("# Plan", encoding="utf-8")
-        report_file.write_text("# Report", encoding="utf-8")
-        audit_file.write_text("# Audit", encoding="utf-8")
-        # Make audit most recent for reviewer priority test
-        os.utime(plan_file, (1, 1))
-        os.utime(report_file, (2, 2))
-        os.utime(audit_file, (3, 3))
-    elif plan_ref and report_ref and not audit_ref:
-        # Planner done, executor active scenario
-        plan_file = notes_dir / "plan.md"
-        report_file = notes_dir / "report.md"
-        plan_file.write_text("# Plan", encoding="utf-8")
-        report_file.write_text("# Report", encoding="utf-8")
-        os.utime(plan_file, (1, 1))
-        os.utime(report_file, (2, 2))
-    elif report_ref and audit_ref and not plan_ref:
-        # Fallback scenario with two refs - audit is older, report is newer
-        report_file = notes_dir / "report.md"
-        audit_file = notes_dir / "audit.md"
-        report_file.write_text("# Report", encoding="utf-8")
-        audit_file.write_text("# Audit", encoding="utf-8")
-        os.utime(audit_file, (1, 1))
-        os.utime(report_file, (2, 2))
-    elif plan_ref:
-        plan_file = notes_dir / "plan.md"
-        plan_file.write_text("# Plan", encoding="utf-8")
-    elif report_ref:
-        report_file = notes_dir / "report.md"
-        report_file.write_text("# Report", encoding="utf-8")
-    elif audit_ref:
-        audit_file = notes_dir / "audit.md"
-        audit_file.write_text("# Audit", encoding="utf-8")
+    _create_ref_files(notes_dir, plan_ref, report_ref, audit_ref)
 
     flow = FlowStatusResponse(
         branch="task/issue-501",


### PR DESCRIPTION
## Summary
补充 PR #821 的测试覆盖，包括：
- `_select_latest_ref` 状态转换测试（6种场景）
- `manager_actor` 字段映射测试
- `_format_relative_time` 边界值测试

## Test plan
- [x] 运行新增测试：42 passed
- [x] 类型检查：mypy pass
- [x] 代码检查：ruff pass

## Changes
- tests/vibe3/commands/test_handoff_read.py (+54 lines)
- tests/vibe3/services/test_handoff_service.py (+1 line)
- tests/vibe3/services/test_task_service_fresh_db.py (+187 lines)

Closes #824

---

## Contributors

claude/sonnet-4.5