### PR TITLE
fix(error-tracking): correct error count logic to sum occurrences not unique codes

### DIFF
--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -287,10 +287,14 @@ class ErrorTrackingService:
             Dict with error statistics
         """
         error_counts = self.get_error_counts()
-        model_errors = sum(1 for code in error_counts.keys() if is_model_error(code))
-        api_errors = sum(1 for code in error_counts.keys() if is_api_error(code))
+        model_errors = sum(
+            count for code, count in error_counts.items() if is_model_error(code)
+        )
+        api_errors = sum(
+            count for code, count in error_counts.items() if is_api_error(code)
+        )
         exec_errors = sum(
-            1 for code in error_counts.keys() if code.startswith("E_EXEC_")
+            count for code, count in error_counts.items() if code.startswith("E_EXEC_")
         )
 
         return {

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -197,3 +197,30 @@ def test_cleanup_does_not_affect_threshold_detection(
     # Verify threshold detection after cleanup
     api_count_after = ErrorTrackingService._instance.get_api_error_count()
     assert api_count_after == 2  # Still same count
+
+
+def test_get_status_category_sums_match_total(temp_store: SQLiteClient) -> None:
+    """get_status() should count actual errors, not unique error codes."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    # Record errors with duplicate codes
+    for _ in range(3):
+        ErrorTrackingService._instance.record_error("E_API_RATE_LIMIT", "Rate limit")
+    for _ in range(5):
+        ErrorTrackingService._instance.record_error(
+            "E_EXEC_UNKNOWN", "Unknown exec error"
+        )
+    for _ in range(2):
+        ErrorTrackingService._instance.record_error("E_EXEC_NO_OUTPUT", "No output")
+
+    status = ErrorTrackingService._instance.get_status()
+
+    # Verify category sums match total
+    assert status["total_errors"] == 10
+    assert status["model_errors"] == 0
+    assert status["api_errors"] == 3
+    assert status["exec_errors"] == 7
+    assert (
+        status["model_errors"] + status["api_errors"] + status["exec_errors"]
+        == status["total_errors"]
+    )


### PR DESCRIPTION
## Summary

- Fixed bug where error count statistics used unique error codes instead of total occurrences
- Changed logic from sum(1 for _ in items) to sum(count for code, count in items)
- Added regression test to verify model_errors + api_errors + exec_errors equals total_errors

## Root Cause

In error_tracking.py:290-294, the error counting logic was summing unique codes instead of total occurrences. This caused incorrect statistics where the sum of category errors didn't equal the total errors.

## Changes

- src/vibe3/exceptions/error_tracking.py: Fixed counting logic (3 lines)
- tests/vibe3/exceptions/test_error_tracking.py: Added regression test for error count verification

## Test Plan

- [x] Run mypy type checking
- [x] Run pytest (all tests pass)
- [x] Run ruff linter
- [x] Run pre-commit hooks
- [x] Verify edge cases (empty dict, duplicate codes)

## Verification

All verification steps passed:
- mypy: No errors
- pytest: All tests pass including new regression test
- ruff: No linting errors
- pre-commit: All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)