### PR TITLE
fix(serve): improve Recent Errors error message display

### DIFF
--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -47,18 +47,22 @@ class ServeStatusService:
         self._display_error_tracking()
 
     @staticmethod
-    def _clean_error_message(error_message: str, max_length: int = 60) -> str:
+    def _clean_error_message(error_message: str, max_length: int = 100) -> str:
         """Clean error message by removing TMPDIR and other noise.
 
         Args:
             error_message: Raw error message from error_log
-            max_length: Maximum length to truncate (default 60)
+            max_length: Maximum length to truncate (default 100)
 
         Returns:
             Cleaned and truncated error message
         """
+        # Remove codeagent-wrapper prefix
+        pattern = r"^codeagent-wrapper failed \(code \d+\):\s*"
+        cleaned = re.sub(pattern, "", error_message)
+
         # Remove CLAUDE_CODE_TMPDIR and everything after it
-        cleaned = re.split(r"\s*CLAUDE_CODE_TMPDIR:", error_message)[0].strip()
+        cleaned = re.split(r"\s*CLAUDE_CODE_TMPDIR:", cleaned)[0].strip()
 
         # Remove " | === Recent Errors ===" suffix
         cleaned = re.split(r"\s*\|\s*=== Recent Errors ===", cleaned)[0].strip()

--- a/tests/vibe3/services/test_serve_status_service.py
+++ b/tests/vibe3/services/test_serve_status_service.py
@@ -1,0 +1,68 @@
+"""Tests for ServeStatusService."""
+
+from vibe3.services.serve_status_service import ServeStatusService
+
+
+class TestCleanErrorMessage:
+    """Test cases for _clean_error_message static method."""
+
+    def test_strips_codeagent_wrapper_prefix_with_exit_code_1(self):
+        """Prefix with exit code 1 is stripped."""
+        result = ServeStatusService._clean_error_message(
+            "codeagent-wrapper failed (code 1):\nactual error"
+        )
+        assert result == "actual error"
+
+    def test_strips_codeagent_wrapper_prefix_with_exit_code_2(self):
+        """Prefix with exit code 2 is stripped."""
+        result = ServeStatusService._clean_error_message(
+            "codeagent-wrapper failed (code 2):\nsomething broke"
+        )
+        assert result == "something broke"
+
+    def test_strips_tmpdir_noise(self):
+        """CLAUDE_CODE_TMPDIR and everything after is removed."""
+        result = ServeStatusService._clean_error_message(
+            "error message CLAUDE_CODE_TMPDIR: /tmp/path other stuff"
+        )
+        assert result == "error message"
+
+    def test_strips_recent_errors_suffix(self):
+        """'=== Recent Errors ===' suffix is removed."""
+        result = ServeStatusService._clean_error_message(
+            "error message | === Recent Errors ==="
+        )
+        assert result == "error message"
+
+    def test_strips_trailing_pipe(self):
+        """Trailing pipe separator is removed."""
+        result = ServeStatusService._clean_error_message("error message | ")
+        assert result == "error message"
+
+    def test_truncates_messages_over_100_chars(self):
+        """Messages longer than 100 chars are truncated."""
+        long_message = "a" * 150
+        result = ServeStatusService._clean_error_message(long_message)
+        assert len(result) == 100
+        assert result == "a" * 100
+
+    def test_preserves_messages_under_100_chars(self):
+        """Messages under 100 chars are not modified beyond cleaning."""
+        short_message = "short error message"
+        result = ServeStatusService._clean_error_message(short_message)
+        assert result == short_message
+
+    def test_handles_messages_without_prefix(self):
+        """Messages without codeagent-wrapper prefix are handled correctly."""
+        result = ServeStatusService._clean_error_message(
+            "E_MODEL_001: model error CLAUDE_CODE_TMPDIR: /tmp/path"
+        )
+        assert result == "E_MODEL_001: model error"
+
+    def test_combined_cleaning_operations(self):
+        """Multiple cleaning operations are applied in correct order."""
+        result = ServeStatusService._clean_error_message(
+            "codeagent-wrapper failed (code 1):\nactual error | "
+            "CLAUDE_CODE_TMPDIR: /tmp/path | === Recent Errors ==="
+        )
+        assert result == "actual error"


### PR DESCRIPTION
## Summary
- Removed redundant 'codeagent-wrapper failed (code N):' prefix from error messages
- Increased max_length from 60 to 100 characters to display more error information
- Added comprehensive unit tests (9 test cases, all passing)

## Changes
- `src/vibe3/services/serve_status_service.py`: Updated `_clean_error_message()` function
- `tests/vibe3/services/test_serve_status_service.py`: New test file with 9 test cases

## Test Plan
✓ Unit tests: 9/9 passing
✓ Type check: mypy clean
✓ Lint check: ruff clean
✓ Working tree: clean

## Related Issues
Fixes #861

## System Improvements
Identified future refactoring opportunity (issue #939): extract shared error_message_cleaner utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)