### PR TITLE
refactor(error-tracking): use class constants for threshold values

### DIFF
--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -200,17 +200,20 @@ class ErrorTrackingService:
         return rows[0] > 0 if rows else False
 
     def get_api_error_count(self) -> int:
-        """Get count of recent API errors (10-minute time window).
+        """Get count of recent API errors within configured time window.
 
         Returns:
-            Count of E_API_* errors in the last 10 minutes
+            Count of E_API_* errors in the last TIME_WINDOW_MINUTES minutes
         """
         with sqlite3.connect(self.db_path) as conn:
-            rows = conn.execute("""
+            rows = conn.execute(
+                """
                 SELECT COUNT(*) FROM error_log
                 WHERE error_code LIKE 'E_API_%'
-                  AND created_at >= datetime('now', '-10 minutes')
-                """).fetchone()
+                  AND created_at >= datetime('now', ? || ' minutes')
+                """,
+                (f"-{self.TIME_WINDOW_MINUTES}",),
+            ).fetchone()
 
         return rows[0] if rows else 0
 

--- a/src/vibe3/orchestra/failed_gate.py
+++ b/src/vibe3/orchestra/failed_gate.py
@@ -53,7 +53,7 @@ class FailedGate:
 
     Trigger rules:
     - E_MODEL_* → immediate trigger
-    - E_API_* (2+ in 3 ticks) → trigger
+    - E_API_* (2+ in 10 minutes) → trigger
 
     Persistence:
     - State saved to failed_gate_state table
@@ -168,11 +168,19 @@ class FailedGate:
         # Check for frequent API errors (threshold: 2+ in window)
         api_error_count = error_tracking.get_api_error_count()
 
-        if api_error_count >= 2:
-            log.error(f"API error threshold reached: {api_error_count} errors")
+        if api_error_count >= ErrorTrackingService.THRESHOLD_COUNT:
+            log.error(
+                f"API error threshold reached: {api_error_count} errors "
+                f"(threshold: {ErrorTrackingService.THRESHOLD_COUNT} in "
+                f"{ErrorTrackingService.TIME_WINDOW_MINUTES} minutes)"
+            )
             return GateResult(
                 blocked=True,
-                reason=f"API error threshold: {api_error_count} recent errors",
+                reason=(
+                    f"API error threshold: {api_error_count} recent errors "
+                    f"(threshold: {ErrorTrackingService.THRESHOLD_COUNT} in "
+                    f"{ErrorTrackingService.TIME_WINDOW_MINUTES} minutes)"
+                ),
             )
 
         # No threshold reached

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -64,7 +64,7 @@ def test_failed_gate_blocked_by_api_threshold(temp_store: SQLiteClient) -> None:
     # Create ErrorTrackingService with test database
     ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
 
-    # Record 2 API errors (threshold is 2 in 3 ticks)
+    # Record 2 API errors (threshold is 2 in 10 minutes)
     ErrorTrackingService._instance.record_error(
         "E_API_RATE_LIMIT", "Rate limit", tick_id=1
     )


### PR DESCRIPTION
## Summary
Replace hardcoded threshold values in FailedGate API error detection with class constants.

- Replaced hardcoded `2` threshold with `ErrorTrackingService.THRESHOLD_COUNT`
- Replaced hardcoded `-10 minutes` time window with `ErrorTrackingService.TIME_WINDOW_MINUTES`
- Updated SQL parameterization in `get_api_error_count()` for safety
- Fixed outdated comments (docstrings and test comments)

**No behavior change** — pure refactor. Constants already held the same values (2, 10).

## Changes
- `src/vibe3/exceptions/error_tracking.py`: Parameterized SQL to use `TIME_WINDOW_MINUTES`
- `src/vibe3/orchestra/failed_gate.py`: Uses `THRESHOLD_COUNT` in threshold checks
- `tests/vibe3/orchestra/test_failed_gate.py`: Comment corrected

## Verification
- Tests: 20/20 passed ✓
- Type checking: mypy clean ✓
- Lint: ruff/black clean ✓
- SQL parameterization: safe (no string interpolation)

## Notes
- Pure refactor with zero behavior change
- Improves code maintainability and debuggability
- Audit finding: error_codes.py:16 has stale comment (outside scope, non-blocking)

Fixes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)