### PR TITLE
feat(error-tracking): add composite indexes and record_error compatibility tests (#710)

### DIFF
--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -128,6 +128,14 @@ _CREATE_ERROR_LOG_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_error_log_tick ON error_log(tick_id)",
     "CREATE INDEX IF NOT EXISTS idx_error_log_code ON error_log(error_code)",
     "CREATE INDEX IF NOT EXISTS idx_error_log_created ON error_log(created_at)",
+    (
+        "CREATE INDEX IF NOT EXISTS idx_error_log_issue_created ON "
+        "error_log(issue_number, created_at DESC)"
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_error_log_branch_created ON "
+        "error_log(branch, created_at DESC)"
+    ),
 ]
 
 _CREATE_FAILED_GATE_STATE = """

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -224,3 +224,59 @@ def test_get_status_category_sums_match_total(temp_store: SQLiteClient) -> None:
         status["model_errors"] + status["api_errors"] + status["exec_errors"]
         == status["total_errors"]
     )
+
+
+def test_record_error_minimal_call(temp_store: SQLiteClient) -> None:
+    """record_error should work with only required parameters."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    # Call with minimal parameters (non-API error)
+    threshold_reached, error_count = ErrorTrackingService._instance.record_error(
+        "E_EXEC_ERROR", "Test message"
+    )
+
+    # Verify return values (non-API errors don't trigger threshold)
+    assert threshold_reached is False
+    assert error_count == 0
+
+    # Verify database state - record should be persisted
+    with sqlite3.connect(temp_store.db_path) as conn:
+        row = conn.execute("""
+            SELECT tick_id, error_code, error_message, issue_number, branch
+            FROM error_log
+            ORDER BY created_at DESC LIMIT 1
+            """).fetchone()
+        assert row is not None
+        assert row[0] == 0  # tick_id defaults to 0
+        assert row[1] == "E_EXEC_ERROR"
+        assert row[2] == "Test message"
+        assert row[3] is None  # issue_number is NULL
+        assert row[4] is None  # branch is NULL
+
+
+def test_record_error_tick_only(temp_store: SQLiteClient) -> None:
+    """record_error should work with tick_id but no issue_number/branch."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    # Call with tick_id only (mirrors governance_sync_runner usage)
+    threshold_reached, error_count = ErrorTrackingService._instance.record_error(
+        "E_EXEC_ERROR", "Test message", tick_id=42
+    )
+
+    # Verify return values (non-API errors don't trigger threshold)
+    assert threshold_reached is False
+    assert error_count == 0
+
+    # Verify database state - record should be persisted
+    with sqlite3.connect(temp_store.db_path) as conn:
+        row = conn.execute("""
+            SELECT tick_id, error_code, error_message, issue_number, branch
+            FROM error_log
+            ORDER BY created_at DESC LIMIT 1
+            """).fetchone()
+        assert row is not None
+        assert row[0] == 42  # tick_id preserved
+        assert row[1] == "E_EXEC_ERROR"
+        assert row[2] == "Test message"
+        assert row[3] is None  # issue_number is NULL
+        assert row[4] is None  # branch is NULL

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -230,12 +230,12 @@ def test_record_error_minimal_call(temp_store: SQLiteClient) -> None:
     """record_error should work with only required parameters."""
     ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
 
-    # Call with minimal parameters (non-API error)
+    # Call with minimal parameters (non-API/non-EXEC error)
     threshold_reached, error_count = ErrorTrackingService._instance.record_error(
-        "E_EXEC_ERROR", "Test message"
+        "E_OTHER_ERROR", "Test message"
     )
 
-    # Verify return values (non-API errors don't trigger threshold)
+    # Verify return values (non-API/non-EXEC errors don't trigger threshold)
     assert threshold_reached is False
     assert error_count == 0
 
@@ -248,7 +248,7 @@ def test_record_error_minimal_call(temp_store: SQLiteClient) -> None:
             """).fetchone()
         assert row is not None
         assert row[0] == 0  # tick_id defaults to 0
-        assert row[1] == "E_EXEC_ERROR"
+        assert row[1] == "E_OTHER_ERROR"
         assert row[2] == "Test message"
         assert row[3] is None  # issue_number is NULL
         assert row[4] is None  # branch is NULL
@@ -260,10 +260,10 @@ def test_record_error_tick_only(temp_store: SQLiteClient) -> None:
 
     # Call with tick_id only (mirrors governance_sync_runner usage)
     threshold_reached, error_count = ErrorTrackingService._instance.record_error(
-        "E_EXEC_ERROR", "Test message", tick_id=42
+        "E_OTHER_ERROR", "Test message", tick_id=42
     )
 
-    # Verify return values (non-API errors don't trigger threshold)
+    # Verify return values (non-API/non-EXEC errors don't trigger threshold)
     assert threshold_reached is False
     assert error_count == 0
 
@@ -276,7 +276,7 @@ def test_record_error_tick_only(temp_store: SQLiteClient) -> None:
             """).fetchone()
         assert row is not None
         assert row[0] == 42  # tick_id preserved
-        assert row[1] == "E_EXEC_ERROR"
+        assert row[1] == "E_OTHER_ERROR"
         assert row[2] == "Test message"
         assert row[3] is None  # issue_number is NULL
         assert row[4] is None  # branch is NULL


### PR DESCRIPTION
## Summary
- Add 2 composite indexes to error_log table for diagnostic queries:
  - idx_error_log_issue_created(issue_number, created_at DESC)
  - idx_error_log_branch_created(branch, created_at DESC)
- Add 2 compatibility tests for record_error() API:
  - test_record_error_minimal_call: minimal positional args (error_code + error_message)
  - test_record_error_tick_only: explicit tick_id without issue_number/branch

## Changes
- src/vibe3/clients/sqlite_schema.py: +8 lines (2 composite indexes)
- tests/vibe3/exceptions/test_error_tracking.py: +56 lines (2 tests)

## Test Plan
- pytest tests/vibe3/exceptions/test_error_tracking.py: 10/10 passed
- pytest tests/vibe3/integration/test_fresh_db.py: 5/5 passed (schema migration)
- mypy src/vibe3/clients/sqlite_schema.py: 0 issues
- Manual verification: 5 idx_error_log_* indexes confirmed in SQLite

## Related
- Follow-up to PR #702 review optimization suggestions
- Addresses issue #710 (P2 items)

Generated with Claude Code