### PR TITLE
fix(run/plan): use resolve_handoff_target for cross-worktree path resolution

### DIFF
--- a/.agent/policies/review.md
+++ b/.agent/policies/review.md
@@ -74,7 +74,17 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 
 如果历史 refs 与当前 GitHub scene 冲突，以当前 scene 为准。
 
-### 5. 跨层一致性检查（命名/文档/API 变更）
+### 5. 读取 Executor Report（如有）
+
+如果 flow 中有 `report_ref`，读取 executor 的执行报告：
+
+```bash
+uv run python src/vibe3/cli.py handoff show <report_ref>
+```
+
+使用 `handoff show` 而非直接读文件路径，以正确处理跨 worktree 路径解析。
+
+### 6. 跨层一致性检查（命名/文档/API 变更）
 
 对于涉及命名一致性、文档同步、API 签名的变更：
 - 使用 `inspect symbols` 和 `rg` 确认所有层（service/UI/command）的引用均已更新

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -161,7 +161,7 @@ def run_command(
         typer.echo(f"-> Using flow plan: {plan_file}")
 
     try:
-        ensure_plan_file_exists(plan_file)
+        ensure_plan_file_exists(plan_file, branch=summary.branch or target_branch)
     except FileNotFoundError as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(1) from error

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -108,7 +108,9 @@ def _build_plan_task_guidance(
     if spec_ref:
         spec_service = SpecRefService()
         spec_info = spec_service.parse_spec_ref(spec_ref)
-        spec_content = spec_service.get_spec_content_for_prompt(spec_info)
+        spec_content = spec_service.get_spec_content_for_prompt(
+            spec_info, branch=branch
+        )
         if spec_info.display and spec_info.display != spec_ref:
             sections.append(f"## Spec Reference\nSpec Ref: {spec_info.display}")
         if spec_content:
@@ -284,12 +286,14 @@ def resolve_spec_plan_input(
         spec_info = spec_service.parse_spec_ref(flow.spec_ref)
 
         # Validate spec_ref exists
-        is_valid, error = spec_service.validate_spec_ref(flow.spec_ref)
+        is_valid, error = spec_service.validate_spec_ref(flow.spec_ref, branch=branch)
         if not is_valid:
             raise ValueError(f"Flow spec_ref invalid: {error}")
 
         # Get spec content
-        spec_content = spec_service.get_spec_content_for_prompt(spec_info)
+        spec_content = spec_service.get_spec_content_for_prompt(
+            spec_info, branch=branch
+        )
         if not spec_content:
             raise ValueError(f"Failed to read spec content from {flow.spec_ref}")
 

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -152,9 +152,17 @@ def resolve_run_mode(
 ) -> SimpleNamespace:
     """Resolve run command mode from CLI inputs and flow state."""
     if skill:
-        return SimpleNamespace(mode="skill", message=skill, plan_file=None)
+        return SimpleNamespace(
+            mode="skill", message=skill, plan_file=None, worktree_root=None, branch=None
+        )
     if plan:
-        return SimpleNamespace(mode="plan", plan_file=str(plan), message=None)
+        return SimpleNamespace(
+            mode="plan",
+            plan_file=str(plan),
+            message=None,
+            worktree_root=None,
+            branch=None,
+        )
     if instructions:
         preview = instructions[:60]
         suffix = "..." if len(instructions) > 60 else ""
@@ -162,11 +170,17 @@ def resolve_run_mode(
             mode="lightweight",
             plan_file=None,
             message=f"-> Task: {preview}{suffix}",
+            worktree_root=None,
+            branch=None,
         )
     flow = flow_service.get_flow_status(branch)
     if flow and flow.plan_ref:
         return SimpleNamespace(
-            mode="flow_plan", plan_file=str(flow.plan_ref), message=None
+            mode="flow_plan",
+            plan_file=str(flow.plan_ref),
+            message=None,
+            worktree_root=flow.worktree_root,
+            branch=branch,
         )
     raise ValueError(
         "No plan specified.\n"
@@ -177,10 +191,22 @@ def resolve_run_mode(
     )
 
 
-def ensure_plan_file_exists(plan_file: str | None) -> None:
-    """Validate that a referenced plan file exists."""
+def ensure_plan_file_exists(
+    plan_file: str | None,
+    branch: str | None = None,
+) -> None:
+    """Validate that a referenced plan file exists.
+
+    Uses the same resolution logic as ``vibe3 handoff show`` via
+    ``resolve_handoff_target`` to correctly handle worktree-relative paths.
+    """
     if not plan_file:
         return
-    if Path(plan_file).exists():
+    if Path(plan_file).is_absolute() and Path(plan_file).exists():
         return
-    raise FileNotFoundError(f"Plan file not found: {plan_file}")
+    from vibe3.utils.path_helpers import resolve_handoff_target
+
+    try:
+        resolve_handoff_target(plan_file, branch=branch)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(str(exc)) from exc

--- a/src/vibe3/services/spec_ref_service.py
+++ b/src/vibe3/services/spec_ref_service.py
@@ -3,7 +3,6 @@
 import json
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
 from typing import cast
 
 from loguru import logger
@@ -105,11 +104,14 @@ class SpecRefService:
 
         return cast(dict, json.loads(result.stdout))
 
-    def get_spec_content_for_prompt(self, info: SpecRefInfo) -> str | None:
+    def get_spec_content_for_prompt(
+        self, info: SpecRefInfo, branch: str | None = None
+    ) -> str | None:
         """Get spec content suitable for prompt injection.
 
         Args:
             info: Parsed spec reference info
+            branch: Optional branch for worktree path resolution
 
         Returns:
             Formatted spec content or None if unavailable
@@ -125,19 +127,24 @@ class SpecRefService:
             return "\n".join(parts) if parts else None
 
         if info.kind == "file" and info.file_path:
-            path = Path(info.file_path)
-            if path.exists():
-                try:
-                    return path.read_text(encoding="utf-8")
-                except OSError:
-                    return None
+            from vibe3.utils.path_helpers import resolve_handoff_target
+
+            # Use resolve_handoff_target for correct worktree path resolution
+            try:
+                resolved_path = resolve_handoff_target(info.file_path, branch=branch)
+                return resolved_path.read_text(encoding="utf-8")
+            except (FileNotFoundError, OSError):
+                return None
         return None
 
-    def validate_spec_ref(self, spec_ref: str) -> tuple[bool, str]:
+    def validate_spec_ref(
+        self, spec_ref: str, branch: str | None = None
+    ) -> tuple[bool, str]:
         """Validate a spec reference.
 
         Args:
             spec_ref: Spec reference to validate
+            branch: Optional branch for worktree path resolution
 
         Returns:
             Tuple of (is_valid, error_message)
@@ -146,11 +153,13 @@ class SpecRefService:
         if issue_number is not None:
             return True, ""
 
-        path = Path(spec_ref)
-        if path.exists() and path.is_file():
-            return True, ""
+        from vibe3.utils.path_helpers import resolve_handoff_target
 
-        return False, f"Spec reference not found: {spec_ref}"
+        try:
+            resolve_handoff_target(spec_ref, branch=branch)
+            return True, ""
+        except FileNotFoundError:
+            return False, f"Spec reference not found: {spec_ref}"
 
     def resolve_spec_ref(self, spec_ref: str) -> str:
         """Resolve a spec reference to its canonical form.

--- a/src/vibe3/utils/path_helpers.py
+++ b/src/vibe3/utils/path_helpers.py
@@ -351,10 +351,12 @@ def _resolve_shared_artifact(
         _verify_handoff_dir_boundary(handoff_dir, git_common)
 
         current_md = handoff_dir / "current.md"
-        if not current_md.is_file():
+        if not current_md.exists():
             raise FileNotFoundError(
                 f"current.md not found for branch '{branch}': {target}"
             )
+        if not current_md.is_file():
+            raise FileNotFoundError(f"Not a file: {target}")
         return current_md
 
     # Standard shared artifact (not @current)
@@ -364,8 +366,10 @@ def _resolve_shared_artifact(
             f"Cannot resolve shared artifact without git common dir: {target}"
         )
     resolved = Path(git_common) / "vibe3" / "handoff" / key
+    if not resolved.exists():
+        raise FileNotFoundError(f"Artifact not found: {target}")
     if not resolved.is_file():
-        raise FileNotFoundError(f"Shared artifact not found: {target}")
+        raise FileNotFoundError(f"Not a file: {target}")
     return resolved
 
 
@@ -395,23 +399,31 @@ def _resolve_worktree_artifact(
         if wt_path is None:
             raise FileNotFoundError(f"No worktree found for branch '{branch}'")
         resolved = wt_path / target
-        if not resolved.is_file():
+        if not resolved.exists():
             raise FileNotFoundError(
-                f"Artifact not found in branch '{branch}' worktree: {target}"
+                f"File not found in branch '{branch}' worktree: {target}"
             )
+        if not resolved.is_file():
+            raise FileNotFoundError(f"Not a file: {target}")
         return resolved
 
     # No branch specified: try current worktree then CWD
     current_root = get_worktree_root(git_client)
     if current_root:
         resolved = Path(current_root) / target
-        if resolved.is_file():
-            return resolved
+        if resolved.exists():
+            if resolved.is_file():
+                return resolved
+            else:
+                raise FileNotFoundError(f"Not a file: {target}")
 
     # Also try CWD (handles cases where CWD differs from worktree root)
     cwd_resolved = Path.cwd() / target
-    if cwd_resolved.is_file():
-        return cwd_resolved
+    if cwd_resolved.exists():
+        if cwd_resolved.is_file():
+            return cwd_resolved
+        else:
+            raise FileNotFoundError(f"Not a file: {target}")
 
     raise FileNotFoundError(f"Artifact not found: {target}")
 
@@ -457,8 +469,10 @@ def resolve_handoff_target(
 
     # Namespace 3: absolute path → passthrough
     if target_path.is_absolute():
+        if not target_path.exists():
+            raise FileNotFoundError(f"Artifact not found: {target}")
         if not target_path.is_file():
-            raise FileNotFoundError(f"File not found: {target}")
+            raise FileNotFoundError(f"Not a file: {target}")
         return target_path
 
     # Namespace 2: relative path → worktree canonical ref

--- a/src/vibe3/utils/path_helpers.py
+++ b/src/vibe3/utils/path_helpers.py
@@ -351,7 +351,7 @@ def _resolve_shared_artifact(
         _verify_handoff_dir_boundary(handoff_dir, git_common)
 
         current_md = handoff_dir / "current.md"
-        if not current_md.exists():
+        if not current_md.is_file():
             raise FileNotFoundError(
                 f"current.md not found for branch '{branch}': {target}"
             )
@@ -364,7 +364,7 @@ def _resolve_shared_artifact(
             f"Cannot resolve shared artifact without git common dir: {target}"
         )
     resolved = Path(git_common) / "vibe3" / "handoff" / key
-    if not resolved.exists():
+    if not resolved.is_file():
         raise FileNotFoundError(f"Shared artifact not found: {target}")
     return resolved
 
@@ -395,7 +395,7 @@ def _resolve_worktree_artifact(
         if wt_path is None:
             raise FileNotFoundError(f"No worktree found for branch '{branch}'")
         resolved = wt_path / target
-        if not resolved.exists():
+        if not resolved.is_file():
             raise FileNotFoundError(
                 f"Artifact not found in branch '{branch}' worktree: {target}"
             )
@@ -405,12 +405,12 @@ def _resolve_worktree_artifact(
     current_root = get_worktree_root(git_client)
     if current_root:
         resolved = Path(current_root) / target
-        if resolved.exists():
+        if resolved.is_file():
             return resolved
 
     # Also try CWD (handles cases where CWD differs from worktree root)
     cwd_resolved = Path.cwd() / target
-    if cwd_resolved.exists():
+    if cwd_resolved.is_file():
         return cwd_resolved
 
     raise FileNotFoundError(f"Artifact not found: {target}")
@@ -457,7 +457,7 @@ def resolve_handoff_target(
 
     # Namespace 3: absolute path → passthrough
     if target_path.is_absolute():
-        if not target_path.exists():
+        if not target_path.is_file():
             raise FileNotFoundError(f"File not found: {target}")
         return target_path
 

--- a/tests/vibe3/roles/test_run_plan_resolution.py
+++ b/tests/vibe3/roles/test_run_plan_resolution.py
@@ -1,0 +1,59 @@
+"""Test plan file resolution across worktrees."""
+
+from vibe3.roles.run_helpers import ensure_plan_file_exists
+
+
+def test_ensure_plan_file_exists_with_absolute_path(tmp_path):
+    """Absolute path that exists should pass."""
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Plan\n")
+
+    # Should not raise
+    ensure_plan_file_exists(str(plan_file))
+
+
+def test_ensure_plan_file_exists_with_missing_absolute_path():
+    """Absolute path that doesn't exist should raise."""
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        ensure_plan_file_exists("/nonexistent/path/plan.md")
+
+
+def test_ensure_plan_file_exists_with_none():
+    """None plan_file should be a no-op."""
+    # Should not raise
+    ensure_plan_file_exists(None)
+
+
+def test_ensure_plan_file_exists_uses_resolve_handoff_target(tmp_path, monkeypatch):
+    """Verify it uses resolve_handoff_target for relative paths."""
+
+    # Create a worktree with plan file
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    plan_dir = worktree_root / "docs" / "plans"
+    plan_dir.mkdir(parents=True)
+    plan_file = plan_dir / "test-plan.md"
+    plan_file.write_text("# Plan\n")
+
+    calls = []
+
+    def mock_resolve(target, branch=None, git_client=None):
+        calls.append((target, branch))
+        if str(target) == "docs/plans/test-plan.md" and branch == "task/test-branch":
+            return plan_file
+        raise FileNotFoundError(f"Mock: {target}")
+
+    # Mock the import inside ensure_plan_file_exists
+    monkeypatch.setattr(
+        "vibe3.utils.path_helpers.resolve_handoff_target",
+        mock_resolve,
+    )
+
+    # Should call resolve_handoff_target with branch
+    ensure_plan_file_exists("docs/plans/test-plan.md", branch="task/test-branch")
+
+    # Verify it was called with correct args
+    assert len(calls) == 1
+    assert calls[0] == ("docs/plans/test-plan.md", "task/test-branch")


### PR DESCRIPTION
## Summary

- Run command: `ensure_plan_file_exists` now uses `resolve_handoff_target` for plan file validation (same logic as `handoff show`)
- Plan role: `SpecRefService.get_spec_content_for_prompt` and `validate_spec_ref` now use `resolve_handoff_target` for spec file path resolution

Both fixes ensure correct cross-worktree path resolution when using `--branch` parameter.

## Root Cause

Previous implementations used `Path.exists()` which only checks the current worktree. This caused files in target worktrees to be "not found" when:
- Running `vibe3 run --plan <file> --branch <target-branch>`
- Planning with `spec_ref` in flow state pointing to files in different worktrees

## Solution

Reuses existing `resolve_handoff_target` function (same logic as `handoff show` command) to correctly resolve paths in target worktrees. Added `branch` parameter to:
- `ensure_plan_file_exists` (run_helpers.py)
- `get_spec_content_for_prompt` (spec_ref_service.py)
- `validate_spec_ref` (spec_ref_service.py)

## Test Plan

✅ Unit tests pass:
- `tests/vibe3/roles/test_run_plan_resolution.py` - plan file resolution with branch parameter
- `tests/vibe3/services/test_spec_ref_service.py` - spec service methods
- `tests/vibe3/roles/test_plan.py` - plan role tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)