### PR TITLE
fix(init): correct zsh parameter expansion in get_profile_path()

### DIFF
--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -161,7 +161,7 @@ get_profile_path() {
             # Extract value after colon
             local value="${entry#*:}"
             # Expand ${HOME} safely using zsh parameter expansion
-            value="${value//\${HOME}/$HOME}"
+            value="${value//\$\{HOME\}/$HOME}"
             echo "$value"
             return
         fi


### PR DESCRIPTION
## Summary

- Fix zsh parameter expansion syntax in `get_profile_path()` (`lib/profiles.sh:164`)
- Change pattern from `\${HOME}` to `\$\{HOME\}` to properly escape all three characters: `$`, `{`, `}`
- Prevents malformed paths like `}/.vibe/assets/policies//Users/jacobcy}` in generated `.vibe/config.yaml`

## Root Cause

In zsh parameter expansion `${value//pattern/replacement}`, the pattern `\${HOME}` only escapes `$`, leaving `{HOME}` unescaped. This causes zsh to interpret `{HOME}` as brace expansion, producing garbage output. The fix `\$\{HOME\}` properly escapes all three special characters.

## Test Plan

- [x] Smoke test: `vibe init --profile minimal --yes` generates clean paths
- [x] Smoke test: `vibe init --profile github-flow --yes --skip-labels` generates clean paths
- [x] Profile-related unit tests pass (6/6)
- [x] vibe-center profile unaffected (uses repo-local paths)

Closes #988