### PR TITLE
fix(issue-983): resolve CWD-relative path bug in profile config detection

### DIFF
--- a/src/vibe3/config/adapter_manifest.py
+++ b/src/vibe3/config/adapter_manifest.py
@@ -36,6 +36,13 @@ class AdapterManifest(BaseModel):
 
     model_config = {"frozen": True}
 
+    def model_post_init(self, __context: object) -> None:
+        """Build resource index for O(1) lookup after validation."""
+        self._resource_index: dict[tuple[str, str], AdapterResource] = {}
+        for r in self.resources:
+            key = (r.type, r.name)
+            self._resource_index[key] = r
+
     def get_resources_by_type(self, resource_type: str) -> list[AdapterResource]:
         """Get all resources of a specific type.
 
@@ -57,10 +64,8 @@ class AdapterManifest(BaseModel):
         Returns:
             Matching resource or None if not found
         """
-        for r in self.resources:
-            if r.type == resource_type and r.name == name:
-                return r
-        return None
+        key = (resource_type, name)
+        return self._resource_index.get(key)
 
     @field_validator("resources")
     @classmethod

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -70,6 +70,21 @@ class AgentPresetNotFoundError(UserError):
         self.preset_name = preset_name
 
 
+class SkillNotAvailableError(UserError):
+    """Skill not available — no adapter provides it in current profile."""
+
+    def __init__(self, skill: str) -> None:
+        """Initialize SkillNotAvailableError.
+
+        Args:
+            skill: The skill name that was not found
+        """
+        super().__init__(
+            f"Skill '{skill}' not found (no adapter provides it in current profile)"
+        )
+        self.skill = skill
+
+
 # ========== System Errors (Non-recoverable) ==========
 
 

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -16,6 +16,7 @@ from vibe3.agents.run_prompt import (
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.settings import VibeConfig
+from vibe3.exceptions import SkillNotAvailableError
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
 from vibe3.execution.contracts import ExecutionRequest
@@ -105,9 +106,7 @@ def execute_manual_run(
     if skill:
         skill_path = resolve_skill_path(skill)
         if not skill_path:
-            raise ValueError(
-                f"Skill '{skill}' not found (no adapter provides it in current profile)"
-            )
+            raise SkillNotAvailableError(skill)
 
         # Resolve relative path against repo root for CWD-independent access
         from vibe3.clients.git_client import GitClient

--- a/src/vibe3/roles/supervisor.py
+++ b/src/vibe3/roles/supervisor.py
@@ -307,6 +307,8 @@ def iter_supervisor_identified_events(
     raw_issues: Iterable[dict[str, object]],
 ) -> list[SupervisorIssueIdentified]:
     """Filter raw GitHub issues into supervisor observation events."""
+    from loguru import logger
+
     issue_label = config.supervisor_handoff.issue_label
     handoff_label = config.supervisor_handoff.get_handoff_state_label()
 
@@ -317,6 +319,10 @@ def iter_supervisor_identified_events(
     if not supervisor_file:
         # No supervisor configured for current profile (minimal, github-flow)
         # Return empty list since these profiles don't have supervisor templates
+        logger.warning(
+            "No supervisor configured for current profile — "
+            "skipping supervisor handoff events"
+        )
         return []
 
     events: list[SupervisorIssueIdentified] = []

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -114,8 +114,10 @@ class ConventionResolver:
                     config_yaml = yaml.safe_load(f)
                     if isinstance(config_yaml, dict) and "profile" in config_yaml:
                         return str(config_yaml["profile"])
-        except Exception:
-            pass
+        except OSError as e:
+            logger.debug(f"Failed to read .vibe/config.yaml: {e}")
+        except yaml.YAMLError as e:
+            logger.debug(f"Invalid YAML in .vibe/config.yaml: {e}")
 
         # Step 4: Check git remote to detect Vibe Center repo
         try:

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -103,6 +103,7 @@ class ConventionResolver:
             from pathlib import Path
 
             from vibe3.clients.git_client import GitClient
+            from vibe3.exceptions import GitError
 
             # Resolve relative path against repo root for CWD-independent access
             git_client = GitClient()
@@ -118,6 +119,8 @@ class ConventionResolver:
             logger.debug(f"Failed to read .vibe/config.yaml: {e}")
         except yaml.YAMLError as e:
             logger.debug(f"Invalid YAML in .vibe/config.yaml: {e}")
+        except GitError as e:
+            logger.debug(f"Failed to resolve git common dir for .vibe/config.yaml: {e}")
 
         # Step 4: Check git remote to detect Vibe Center repo
         try:

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -87,6 +87,8 @@ class ConventionResolver:
         import os
         import subprocess
 
+        import yaml
+
         # Step 1: Check explicit override
         if self.profile:
             return self.profile
@@ -96,7 +98,20 @@ class ConventionResolver:
         if env_profile:
             return env_profile
 
-        # Step 3: Check git remote to detect Vibe Center repo
+        # Step 3: Check .vibe/config.yaml for profile field
+        try:
+            from pathlib import Path
+
+            config_path = Path(".vibe/config.yaml")
+            if config_path.exists():
+                with config_path.open(encoding="utf-8") as f:
+                    config_yaml = yaml.safe_load(f)
+                    if isinstance(config_yaml, dict) and "profile" in config_yaml:
+                        return str(config_yaml["profile"])
+        except Exception:
+            pass
+
+        # Step 4: Check git remote to detect Vibe Center repo
         try:
             result = subprocess.run(
                 ["git", "remote", "get-url", "origin"],
@@ -115,7 +130,7 @@ class ConventionResolver:
         except Exception as e:
             logger.debug(f"Git remote check failed: {e}")
 
-        # Step 4: Default to minimal
+        # Step 5: Default to minimal
         return "minimal"
 
     def get_policy_path(self, name: str) -> str | None:

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -102,7 +102,13 @@ class ConventionResolver:
         try:
             from pathlib import Path
 
-            config_path = Path(".vibe/config.yaml")
+            from vibe3.clients.git_client import GitClient
+
+            # Resolve relative path against repo root for CWD-independent access
+            git_client = GitClient()
+            git_common_dir = git_client.get_git_common_dir()
+            repo_root = Path(git_common_dir).parent if git_common_dir else Path.cwd()
+            config_path = repo_root / ".vibe/config.yaml"
             if config_path.exists():
                 with config_path.open(encoding="utf-8") as f:
                     config_yaml = yaml.safe_load(f)

--- a/tests/vibe3/test_config/test_adapter_manifest.py
+++ b/tests/vibe3/test_config/test_adapter_manifest.py
@@ -90,3 +90,41 @@ def test_adapter_manifest_empty_name_rejected():
             version="1.0.0",
             resources=[],
         )
+
+
+def test_adapter_manifest_get_resource_lookup():
+    """Test that get_resource uses O(1) index lookup."""
+    manifest = AdapterManifest(
+        name="test-adapter",
+        version="1.0.0",
+        resources=[
+            AdapterResource(type="skill", name="skill-a", path="skills/a/SKILL.md"),
+            AdapterResource(
+                type="policy", name="policy-b", path=".agent/policies/b.md"
+            ),
+            AdapterResource(type="skill", name="skill-c", path="skills/c/SKILL.md"),
+        ],
+    )
+    # Test O(1) lookup finds correct resource
+    result = manifest.get_resource("skill", "skill-a")
+    assert result is not None
+    assert result.name == "skill-a"
+    assert result.path == "skills/a/SKILL.md"
+
+    # Test lookup finds different resource
+    result2 = manifest.get_resource("skill", "skill-c")
+    assert result2 is not None
+    assert result2.name == "skill-c"
+
+    # Test lookup for different type
+    result3 = manifest.get_resource("policy", "policy-b")
+    assert result3 is not None
+    assert result3.type == "policy"
+
+    # Test lookup returns None for missing resource
+    result4 = manifest.get_resource("skill", "nonexistent")
+    assert result4 is None
+
+    # Test lookup returns None for wrong type
+    result5 = manifest.get_resource("policy", "skill-a")
+    assert result5 is None

--- a/tests/vibe3/test_config/test_vibe_config.py
+++ b/tests/vibe3/test_config/test_vibe_config.py
@@ -7,7 +7,7 @@ import yaml
 
 def test_vibe_center_repo_config():
     """Test that current repo has valid .vibe/config.yaml."""
-    config_path = Path(".vibe/config.yaml")
+    config_path = Path(__file__).parents[3] / ".vibe/config.yaml"
     assert config_path.exists(), ".vibe/config.yaml must exist in repo root"
 
     with config_path.open() as f:

--- a/tests/vibe3/test_roles/test_run_command.py
+++ b/tests/vibe3/test_roles/test_run_command.py
@@ -23,23 +23,14 @@ def test_skill_path_returns_none_for_missing():
     assert path is None
 
 
-def test_skill_path_without_resolver_uses_default():
+def test_skill_path_without_resolver_uses_default(monkeypatch):
     """Test that omitting resolver uses default from_repo().
 
     In vibe-center repo (detected via git remote), should find vibe-commit.
     In external repos, should return None (minimal profile).
     """
-    import os
-
     # Force vibe-center profile to make test deterministic
-    original_profile = os.environ.get("VIBE_PROFILE")
-    try:
-        os.environ["VIBE_PROFILE"] = "vibe-center"
-        path = resolve_skill_path("vibe-commit")
-        assert path is not None
-        assert "skills/vibe-commit/SKILL.md" in path
-    finally:
-        if original_profile is None:
-            os.environ.pop("VIBE_PROFILE", None)
-        else:
-            os.environ["VIBE_PROFILE"] = original_profile
+    monkeypatch.setenv("VIBE_PROFILE", "vibe-center")
+    path = resolve_skill_path("vibe-commit")
+    assert path is not None
+    assert "skills/vibe-commit/SKILL.md" in path

--- a/tests/vibe3/test_services/test_convention_resolver.py
+++ b/tests/vibe3/test_services/test_convention_resolver.py
@@ -20,11 +20,15 @@ from vibe3.services.convention_resolver import ConventionResolver
 
 def test_resolver_returns_minimal_defaults_by_default():
     """Test resolver returns minimal defaults when no profile specified."""
-    # Mock git remote to return non-vibe-center repo
-    with patch("subprocess.run") as mock_run:
+    # Mock git remote to return non-vibe-center repo and config file to not exist
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("pathlib.Path.exists") as mock_exists,
+    ):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="https://github.com/other/repo.git\n"
         )
+        mock_exists.return_value = False  # No .vibe/config.yaml
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
         assert convention.branch.task_prefix == "issue-"
@@ -66,10 +70,15 @@ def test_resolver_uses_vibe_profile_env_var():
 
 def test_resolver_detects_vibe_center_repo():
     """Test resolver detects Vibe Center repo via git remote."""
-    with patch("subprocess.run") as mock_run:
+    # Mock config file to not exist so git remote detection is tested
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("pathlib.Path.exists") as mock_exists,
+    ):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
         )
+        mock_exists.return_value = False  # No .vibe/config.yaml
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
         assert convention.branch.task_prefix == "task/issue-"

--- a/tests/vibe3/test_services/test_convention_resolver.py
+++ b/tests/vibe3/test_services/test_convention_resolver.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
+from vibe3.exceptions import GitError
 from vibe3.services.convention_resolver import ConventionResolver
 
 
@@ -87,6 +88,23 @@ def test_resolver_detects_vibe_center_repo():
             returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
         )
         mock_exists.return_value = False  # No .vibe/config.yaml
+        resolver = ConventionResolver.from_repo()
+        convention = resolver.resolve()
+        assert convention.branch.task_prefix == "task/issue-"
+
+
+def test_resolver_falls_back_when_git_common_dir_lookup_fails():
+    """Test resolver fallback when git common dir lookup raises GitError."""
+    with (
+        patch(
+            "vibe3.clients.git_client.GitClient.get_git_common_dir"
+        ) as mock_git_common_dir,
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_git_common_dir.side_effect = GitError("rev-parse", "not a git repository")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
+        )
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
         assert convention.branch.task_prefix == "task/issue-"

--- a/tests/vibe3/test_services/test_convention_resolver.py
+++ b/tests/vibe3/test_services/test_convention_resolver.py
@@ -22,9 +22,13 @@ def test_resolver_returns_minimal_defaults_by_default():
     """Test resolver returns minimal defaults when no profile specified."""
     # Mock git remote to return non-vibe-center repo and config file to not exist
     with (
+        patch(
+            "vibe3.clients.git_client.GitClient.get_git_common_dir"
+        ) as mock_git_common_dir,
         patch("subprocess.run") as mock_run,
         patch("pathlib.Path.exists") as mock_exists,
     ):
+        mock_git_common_dir.return_value = "/tmp/test/.git"
         mock_run.return_value = MagicMock(
             returncode=0, stdout="https://github.com/other/repo.git\n"
         )
@@ -72,9 +76,13 @@ def test_resolver_detects_vibe_center_repo():
     """Test resolver detects Vibe Center repo via git remote."""
     # Mock config file to not exist so git remote detection is tested
     with (
+        patch(
+            "vibe3.clients.git_client.GitClient.get_git_common_dir"
+        ) as mock_git_common_dir,
         patch("subprocess.run") as mock_run,
         patch("pathlib.Path.exists") as mock_exists,
     ):
+        mock_git_common_dir.return_value = "/tmp/test/.git"
         mock_run.return_value = MagicMock(
             returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
         )


### PR DESCRIPTION
## Summary

This PR addresses Copilot review findings from PR #1023 and implements follow-up improvements from issue #983.

## Changes Overview

### Commit 1: PR #982 Review Follow-ups (715acc5b)

**1. Config wiring** - Add `.vibe/config.yaml` as profile resolution source
- ConventionResolver._detect_profile() now checks config file between env var and git remote
- New resolution priority: explicit → env → config.yaml → git remote → minimal
- Tests updated to mock Path.exists() for config file checks

**2. Exception typing** - Add SkillNotAvailableError (UserError subclass)
- Replaces ValueError for skill-not-found in run_command.py
- Proper exception hierarchy for API consumers

**3. Performance** - O(1) resource lookup via model_post_init index
- AdapterManifest builds _resource_index dict in model_post_init
- get_resource() uses index.get() instead of O(n) loop
- New test verifies O(1) lookup correctness

**4. Logging** - Add warning when supervisor not configured
- iter_supervisor_identified_events() logs before early return
- Zero behavioral impact, only observability improvement

**5. Test hygiene** - Replace os.environ mutation with monkeypatch
- test_skill_path_without_resolver_uses_default uses pytest fixture
- Cleaner test isolation, no manual cleanup

**6. Test robustness** - Anchor config.yaml path to test file location
- test_vibe_center_repo_config uses Path(__file__).parents[3]
- CWD-independent, verified from root and subdirectory

### Commit 2: Fix CWD-relative Path Bug (0803942)

**Finding #1 from audit**: Path(".vibe/config.yaml") was CWD-relative
- Use GitClient().get_git_common_dir() to resolve repo root
- Build config_path as repo_root / ".vibe/config.yaml"
- Ensures profile detection works from any subdirectory

**Impact**: 25 callers of ConventionResolver.from_repo() now correctly detect profile from .vibe/config.yaml regardless of working directory.

### Commit 3: Address Copilot Review Findings (this commit)

**Issue 1**: Exception handling
- Replace broad `except Exception: pass` with specific catches
- Catch OSError (file I/O) and yaml.YAMLError (YAML parsing)
- Add debug logging for failures

**Issue 2**: Test mocks
- Add mock for GitClient.get_git_common_dir()
- Ensure tests properly mock the new GitClient dependency

## Tests & Verification

- ✅ All 9 convention_resolver tests passed
- ✅ All 20 related config and run_command tests passed
- ✅ mypy type check: PASS
- ✅ ruff linter: PASS (auto-fixed line length)
- ✅ black formatter: PASS
- ✅ pre-commit hooks: PASS

## Impact Analysis

- **Affected callers**: 25 callers of ConventionResolver.from_repo()
- **Before fix**: Config-based profile detection failed from subdirectories
- **After fix**: Profile detection works correctly from any subdirectory
- **Risk**: Low. GitClient.get_git_common_dir() is well-tested (30+ call sites)

## Related

- Fixes #983 (Copilot PR review follow-ups)
- Follow-up to PR #982 (Vibe Center Adapter Extraction)
- Addresses PR #1023 Copilot review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)