### PR TITLE
fix(agents): add summary field to all SendMessage examples

### DIFF
--- a/.claude/agents/pr-architect-reviewer.md
+++ b/.claude/agents/pr-architect-reviewer.md
@@ -108,10 +108,10 @@ SendMessage 调用前必须检查：
 
 ```python
 # 握手成功
-SendMessage(to="team-lead", message="【agent_ready】已就绪")
+SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
 
 # 提交架构审查报告（显式标注 PR 编号）
-SendMessage(to="team-lead", message="""【agent_report】(PR #843)
+SendMessage(to="team-lead", summary="架构审查报告完成", message="""【agent_report】(PR #843)
 
 ## PR #843 架构审查报告
 ...
@@ -122,20 +122,20 @@ SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ```python
 # ❌ 握手无前缀
-SendMessage(to="team-lead", message="已就绪")
+SendMessage(to="team-lead", summary="已就绪", message="已就绪")
 
 # ❌ 报告无前缀
-SendMessage(to="team-lead", message="已完成架构审查")
+SendMessage(to="team-lead", summary="已完成架构审查", message="已完成架构审查")
 
 # ❌ 报告未标注 PR 编号
-SendMessage(to="team-lead", message="""【agent_report】
+SendMessage(to="team-lead", summary="架构审查报告完成", message="""【agent_report】
 
 ## PR #843 架构审查报告
 ...
 """)
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
-SendMessage(to="team-lead", message="[agent_ready] ready")
+SendMessage(to="team-lead", summary="ready", message="[agent_ready] ready")
 ```
 
 ## 项目特有工具（必须使用）

--- a/.claude/agents/pr-code-analyst.md
+++ b/.claude/agents/pr-code-analyst.md
@@ -116,10 +116,10 @@ SendMessage 调用前必须检查：
 
 ```python
 # 握手成功
-SendMessage(to="team-lead", message="【agent_ready】已就绪")
+SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
 
 # 提交代码分析报告（显式标注 PR 编号）
-SendMessage(to="team-lead", message="""【agent_report】(PR #843)
+SendMessage(to="team-lead", summary="代码分析报告完成", message="""【agent_report】(PR #843)
 
 ## PR #843 代码分析报告
 ...
@@ -130,20 +130,20 @@ SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ```python
 # ❌ 握手无前缀
-SendMessage(to="team-lead", message="已就绪")
+SendMessage(to="team-lead", summary="已就绪", message="已就绪")
 
 # ❌ 报告无前缀
-SendMessage(to="team-lead", message="已完成代码分析")
+SendMessage(to="team-lead", summary="已完成代码分析", message="已完成代码分析")
 
 # ❌ 报告未标注 PR 编号
-SendMessage(to="team-lead", message="""【agent_report】
+SendMessage(to="team-lead", summary="代码分析报告完成", message="""【agent_report】
 
 ## PR #843 代码分析报告
 ...
 """)
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
-SendMessage(to="team-lead", message="[agent_ready] ready")
+SendMessage(to="team-lead", summary="ready", message="[agent_ready] ready")
 ```
 
 ## 项目特有工具（必须使用）

--- a/.claude/agents/pr-context-researcher.md
+++ b/.claude/agents/pr-context-researcher.md
@@ -109,10 +109,10 @@ SendMessage 调用前必须检查：
 
 ```python
 # 握手成功
-SendMessage(to="team-lead", message="【agent_ready】已就绪")
+SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
 
 # 提交背景报告（显式标注 PR 编号）
-SendMessage(to="team-lead", message="""【agent_report】(PR #843)
+SendMessage(to="team-lead", summary="背景报告完成", message="""【agent_report】(PR #843)
 
 ## PR #843 背景报告
 ...
@@ -123,20 +123,20 @@ SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ```python
 # ❌ 握手无前缀
-SendMessage(to="team-lead", message="已就绪")
+SendMessage(to="team-lead", summary="已就绪", message="已就绪")
 
 # ❌ 报告无前缀
-SendMessage(to="team-lead", message="已完成背景调研")
+SendMessage(to="team-lead", summary="已完成背景调研", message="已完成背景调研")
 
 # ❌ 报告未标注 PR 编号
-SendMessage(to="team-lead", message="""【agent_report】
+SendMessage(to="team-lead", summary="背景报告完成", message="""【agent_report】
 
 ## PR #843 背景报告
 ...
 """)
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
-SendMessage(to="team-lead", message="[agent_ready] ready")
+SendMessage(to="team-lead", summary="ready", message="[agent_ready] ready")
 ```
 
 ## 项目特有工具（必须使用）

--- a/.claude/agents/pr-fix-executor.md
+++ b/.claude/agents/pr-fix-executor.md
@@ -117,10 +117,10 @@ SendMessage 调用前必须检查：
 
 ```python
 # 握手成功
-SendMessage(to="team-lead", message="【agent_ready】已就绪")
+SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
 
 # 提交修复报告（显式标注 PR 编号）
-SendMessage(to="team-lead", message="""【agent_report】(PR #843)
+SendMessage(to="team-lead", summary="修复报告完成", message="""【agent_report】(PR #843)
 
 ## PR #843 修复报告
 ...
@@ -131,20 +131,20 @@ SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ```python
 # ❌ 握手无前缀
-SendMessage(to="team-lead", message="已就绪")
+SendMessage(to="team-lead", summary="已就绪", message="已就绪")
 
 # ❌ 报告无前缀
-SendMessage(to="team-lead", message="已完成修复")
+SendMessage(to="team-lead", summary="已完成修复", message="已完成修复")
 
 # ❌ 报告未标注 PR 编号
-SendMessage(to="team-lead", message="""【agent_report】
+SendMessage(to="team-lead", summary="修复报告完成", message="""【agent_report】
 
 ## 修复报告
 ...
 """)
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
-SendMessage(to="team-lead", message="[agent_ready] ready")
+SendMessage(to="team-lead", summary="ready", message="[agent_ready] ready")
 ```
 
 ## 项目特有约束（必须遵守）

--- a/.claude/agents/pr-security-reviewer.md
+++ b/.claude/agents/pr-security-reviewer.md
@@ -120,10 +120,10 @@ SendMessage 调用前必须检查：
 
 ```python
 # 握手成功
-SendMessage(to="team-lead", message="【agent_ready】已就绪")
+SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
 
 # 提交安全审查报告（显式标注 PR 编号）
-SendMessage(to="team-lead", message="""【agent_report】(PR #843)
+SendMessage(to="team-lead", summary="安全审查报告完成", message="""【agent_report】(PR #843)
 
 ## PR #843 安全审查报告
 ...
@@ -134,20 +134,20 @@ SendMessage(to="team-lead", message="""【agent_report】(PR #843)
 
 ```python
 # ❌ 握手无前缀
-SendMessage(to="team-lead", message="已就绪")
+SendMessage(to="team-lead", summary="已就绪", message="已就绪")
 
 # ❌ 报告无前缀
-SendMessage(to="team-lead", message="已完成安全审查")
+SendMessage(to="team-lead", summary="已完成安全审查", message="已完成安全审查")
 
 # ❌ 报告未标注 PR 编号
-SendMessage(to="team-lead", message="""【agent_report】
+SendMessage(to="team-lead", summary="安全审查报告完成", message="""【agent_report】
 
 ## PR #843 安全审查报告
 ...
 """)
 
 # ❌ 使用英文方括号（虽然 shell 兼容，但 prompt 要求中文）
-SendMessage(to="team-lead", message="[agent_ready] ready")
+SendMessage(to="team-lead", summary="ready", message="[agent_ready] ready")
 ```
 
 ## 项目特有工具（必须使用）


### PR DESCRIPTION
## Summary

为所有 agent 定义文件中的 SendMessage 工具示例添加 `summary` 字段，解决 JSON 消息发送时的 InputValidationError 问题。

## Root Cause

SendMessage 工具 schema 要求：当 `message` 参数是字符串内容时（包括 JSON 格式字符串），必须提供 `summary` 字段用于 UI 预览。

原 agent 定义文件中的示例未包含此字段，导致实际使用时出现 InputValidationError。

## Changes

修改 5 个 agent 定义文件：

1. `.claude/agents/pr-architect-reviewer.md`
2. `.claude/agents/pr-code-analyst.md`
3. `.claude/agents/pr-context-researcher.md`
4. `.claude/agents/pr-fix-executor.md`
5. `.claude/agents/pr-security-reviewer.md`

### 具体修改

**正确示例（添加 summary 字段）**：

```python
# 修改前
SendMessage(to="team-lead", message="【agent_ready】已就绪")

# 修改后
SendMessage(to="team-lead", summary="握手成功", message="【agent_ready】已就绪")
```

**错误示例（展示缺少 summary 的错误）**：

```python
# 修改前
SendMessage(to="team-lead", message="已完成架构审查")

# 修改后
SendMessage(to="team-lead", summary="已完成架构审查", message="已完成架构审查")
```

### 修改统计

- **总修改行数**: 30 行（每个文件 6 行）
- **新增字段**: 30 个 summary 字段
- **保持兼容性**: 维持各文件原有引号风格

## Verification

### 一致性检查

```bash
# 检查所有 SendMessage 调用是否包含 summary
grep -n "SendMessage(" .claude/agents/pr-*.md | grep -v "summary="
# 结果：无输出，所有调用均包含 summary 字段
```

### 格式检查

```bash
git diff --stat HEAD~1
# 结果：5 files changed, 30 insertions(+), 30 deletions(-)
```

## Impact

- **直接影响**: agent 运行时 prompt 定义
- **间接影响**: 多代理协作场景的 SendMessage 使用规范
- **风险等级**: 低（仅修改示例代码，不影响可执行逻辑）

## Test Plan

- [x] 所有 agent 定义文件的 SendMessage 示例已更新
- [x] grep 检查确认无遗漏
- [x] 修改内容符合各文件原有风格
- [x] 提交信息包含 issue 关联和说明

## References

- Issue: #826
- Discovery: PR #821 清理过程（2026-05-11）
- Related memory: sendmessage-summary-requirement.md

## Contributors

- **Planner**: vibe-manager-agent (manager & plan phases)
- **Executor**: Claude Sonnet 4.5 (implementation)
- **Reviewer**: governance review (intake approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)