### PR TITLE
fix(pr show): 添加 --branch 长选项、移除 body 截断、显示 Reviews

### DIFF
--- a/src/vibe3/clients/github_review_ops.py
+++ b/src/vibe3/clients/github_review_ops.py
@@ -12,6 +12,36 @@ from vibe3.exceptions import GitHubError, UserError
 class ReviewMixin:
     """Mixin for review-related operations."""
 
+    def list_pr_reviews(self: Any, pr_number: int) -> list[dict[str, Any]]:
+        """List reviews (summary-level reviews) on a PR via GitHub API.
+
+        Args:
+            pr_number: PR number
+
+        Returns:
+            List of review dicts (each has body, state, user, submitted_at)
+        """
+        logger.bind(
+            external="github",
+            operation="list_pr_reviews",
+            pr_number=pr_number,
+        ).debug("Calling GitHub API: list pr reviews")
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/:owner/:repo/pulls/{pr_number}/reviews",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return cast(list[dict[str, Any]], json.loads(result.stdout))
+        except Exception as e:
+            logger.error(f"Failed to list PR #{pr_number} reviews: {e}")
+            return []
+
     def list_pr_review_comments(self: Any, pr_number: int) -> list[dict[str, Any]]:
         """List review (inline) comments on a PR via GitHub API.
 

--- a/src/vibe3/clients/protocols.py
+++ b/src/vibe3/clients/protocols.py
@@ -197,6 +197,10 @@ class PRCommentPort(Protocol):
         """List review (inline) comments on a PR."""
         ...
 
+    def list_pr_reviews(self, pr_number: int) -> list[dict[str, Any]]:
+        """List reviews (summary-level reviews) on a PR."""
+        ...
+
     def create_pr_comment(self, pr_number: int, body: str) -> str:
         """Create a comment on a PR. Returns comment URL."""
         ...

--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -271,7 +271,9 @@ def register_query_commands(app: typer.Typer) -> None:
     @app.command()
     def show(
         pr_number: Annotated[int | None, typer.Argument(help="PR number")] = None,
-        branch: Annotated[str | None, typer.Option("-b", help="Branch name")] = None,
+        branch: Annotated[
+            str | None, typer.Option("-b", "--branch", help="Branch name")
+        ] = None,
         trace: Annotated[
             bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
         ] = False,

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -106,6 +106,7 @@ class PRResponse(BaseModel):
     metadata: Optional[PRMetadata] = Field(None, description="PR metadata")
     comments: list[dict[str, Any]] = Field(default_factory=list)
     review_comments: list[dict[str, Any]] = Field(default_factory=list)
+    reviews: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class UpdatePRRequest(BaseModel):

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -144,6 +144,7 @@ class PRService:
         if pr:
             pr.comments = self.github_client.list_pr_comments(pr.number)
             pr.review_comments = self.github_client.list_pr_review_comments(pr.number)
+            pr.reviews = self.github_client.list_pr_reviews(pr.number)
         return pr
 
     def mark_ready(

--- a/src/vibe3/ui/pr_ui.py
+++ b/src/vibe3/ui/pr_ui.py
@@ -71,8 +71,7 @@ def render_pr_details(pr: PRResponse) -> None:
 
     if pr.body:
         console.print("\n[bold]Description:[/]")
-        body_preview = pr.body[:200] + ("..." if len(pr.body) > 200 else "")
-        console.print(body_preview)
+        console.print(pr.body)
 
     if pr.review_comments:
         console.print("\n[bold cyan]### Review Comments[/]")
@@ -91,6 +90,25 @@ def render_pr_details(pr: PRResponse) -> None:
                 f"  [yellow]{user}[/] [dim]({created})[/] [cyan]{path}:{line}[/]"
             )
             console.print(f"    {body}")
+
+    if pr.reviews:
+        console.print("\n[bold cyan]### Reviews[/]")
+        for review in pr.reviews:
+            user = review.get("user", {}).get("login", "unknown")
+            body = review.get("body", "")
+            state = review.get("state", "COMMENTED")
+            submitted = str(review.get("submitted_at", ""))[:16].replace("T", " ")
+            state_color = {
+                "APPROVED": "green",
+                "CHANGES_REQUESTED": "red",
+                "COMMENTED": "yellow",
+            }.get(state, "dim")
+            console.print(
+                f"  [yellow]{user}[/] [dim]({submitted})[/] "
+                f"[{state_color}]{state}[/{state_color}]"
+            )
+            if body:
+                console.print(f"    {body}")
 
     if pr.comments:
         console.print("\n[bold cyan]### General Comments[/]")


### PR DESCRIPTION
## Summary

三个 UI 修复：
- **补全 `--branch` 长选项**：之前只注册了 `-b` 短选项，导致 `--branch` 报错
- **移除 PR body 截断**：取消 200 字符截断，完整显示 PR 描述
- **新增 Reviews 渲染**：添加第三类评论数据（reviews API），显示 Copilot 评审摘要

## Root Cause

1. Typer 参数定义只写了 `typer.Option("-b", ...)`，缺少 `--branch`
2. 从 PR #200 开始就截断 200 字符（设计决策，现已改变）
3. 只获取了 comments 和 review_comments，缺少 reviews API 数据

## Changes

- `github_review_ops.py`: 新增 `list_pr_reviews()` 方法
- `protocols.py`: 补充 `list_pr_reviews` 到 PRCommentPort
- `pr_query.py`: 添加 `--branch` 长选项
- `pr.py`: PRResponse 新增 reviews 字段
- `pr_service.py`: get_pr 获取 reviews 数据
- `pr_ui.py`: 移除截断，添加 reviews 渲染

## Test Plan

- [x] `vibe3 pr show --help` 显示 `--branch -b TEXT`
- [x] `vibe3 pr show --branch task/issue-1025` 正常工作
- [x] `vibe3 pr show -b task/issue-1025` 正常工作
- [x] PR body 完整显示（超过 200 字符）
- [x] Reviews 区块显示 Copilot 评审
- [x] 12 个 pr_service 测试通过
- [x] 11 个 pr_show 测试通过
- [x] Pre-commit 检查通过（black、ruff、mypy）

Closes #1037

---

## Contributors

- **Executor**: claude/sonnet-4.5