### PR TITLE
fix(handoff): handoff status 显示最近2条 append 记录并提示查看完整内容

### DIFF
--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -179,7 +179,7 @@ def status(
 
         # Aggregate handoff status from service
         status_service = HandoffStatusService(flow_service=flow_service)
-        limit = None if show_all else 5
+        limit = None if show_all else 2
         try:
             result = status_service.get_handoff_status(target_branch, limit=limit)
         except ValueError as error:
@@ -211,6 +211,19 @@ def status(
         if result.worktree_root:
             console.print(f"[dim]worktree: {result.worktree_root}[/]")
         console.print()
+
+        # Show recent updates from handoff file
+        if result.recent_updates:
+            console.print("[bold]--- Recent Handoff Updates ---[/]")
+            console.print()
+            for update in reversed(result.recent_updates):
+                timestamp = update["timestamp"][:19].replace("T", " ")
+                actor = update["actor"]
+                kind = update["kind"]
+                message = update["message"].split("\n")[0]  # First line only
+                console.print(f"[dim]{timestamp}[/]  [cyan]{kind}[/]  [dim]{actor}[/]")
+                console.print(f"  {message}")
+                console.print()
 
         # Show latest verdict at the top
         if result.latest_verdict:
@@ -250,6 +263,13 @@ def status(
             branch=target_branch,
             verbose=verbose,
         )
+        if not show_all and (result.events or result.recent_updates):
+            console.print(
+                f"[dim]Tip: use 'vibe3 handoff show @current"
+                f"{' --branch ' + target_branch if branch else ''}"
+                f"' to view full content, or 'vibe3 handoff status --all'"
+                f" to show all events.[/]"
+            )
 
 
 def register_read_commands(app: typer.Typer) -> None:

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -190,6 +190,7 @@ def status(
             output = {
                 "state": result.state.model_dump(),
                 "events": [e.model_dump() for e in result.events],
+                "recent_updates": result.recent_updates,
             }
             typer.echo(json.dumps(output, indent=2, default=str))
             return
@@ -198,6 +199,7 @@ def status(
             output = {
                 "state": result.state.model_dump(),
                 "events": [e.model_dump() for e in result.events],
+                "recent_updates": result.recent_updates,
             }
             typer.echo(
                 _get_yaml().dump(output, default_flow_style=False, allow_unicode=True)

--- a/src/vibe3/services/handoff_status_service.py
+++ b/src/vibe3/services/handoff_status_service.py
@@ -117,8 +117,9 @@ class HandoffStatusService:
         live_sessions = self._get_live_sessions_for_branch(branch)
 
         # Fetch recent updates from handoff file
+        updates_limit = None if limit is None else 2
         recent_updates = self.handoff_service.storage.get_recent_updates(
-            branch, limit=2
+            branch, limit=updates_limit
         )
 
         # Resolve worktree path for the target branch

--- a/src/vibe3/services/handoff_status_service.py
+++ b/src/vibe3/services/handoff_status_service.py
@@ -25,6 +25,7 @@ class HandoffStatusResult:
         events: List of successful handoff events
         latest_verdict: Latest verdict record if available
         live_sessions: List of truly live runtime sessions
+        recent_updates: List of recent handoff file updates (append records)
     """
 
     flow_slug: str
@@ -33,6 +34,7 @@ class HandoffStatusResult:
     events: list[FlowEvent]
     latest_verdict: VerdictRecord | None
     live_sessions: list[dict[str, Any]]
+    recent_updates: list[dict[str, str]]
 
 
 class HandoffStatusService:
@@ -114,6 +116,11 @@ class HandoffStatusService:
         # Fetch live sessions from registry
         live_sessions = self._get_live_sessions_for_branch(branch)
 
+        # Fetch recent updates from handoff file
+        recent_updates = self.handoff_service.storage.get_recent_updates(
+            branch, limit=2
+        )
+
         # Resolve worktree path for the target branch
         worktree_path = self.git_client.find_worktree_path_for_branch(branch)
         if worktree_path:
@@ -129,6 +136,7 @@ class HandoffStatusService:
             events=events,
             latest_verdict=latest_verdict,
             live_sessions=live_sessions,
+            recent_updates=recent_updates,
         )
 
     def _get_live_sessions_for_branch(self, branch: str) -> list[dict[str, Any]]:

--- a/src/vibe3/services/handoff_storage.py
+++ b/src/vibe3/services/handoff_storage.py
@@ -250,13 +250,13 @@ class HandoffStorage:
         return handoff_path
 
     def get_recent_updates(
-        self, branch: str | None = None, limit: int = 2
+        self, branch: str | None = None, limit: int | None = 2
     ) -> list[dict[str, str]]:
         """Parse and return the last N updates from current.md for a branch.
 
         Args:
             branch: Target branch name (defaults to current branch)
-            limit: Maximum number of updates to return
+            limit: Maximum number of updates to return (None = all, default 2)
 
         Returns:
             List of dicts with 'timestamp', 'actor', 'kind', 'message' keys
@@ -277,11 +277,12 @@ class HandoffStorage:
         # Parse update blocks
         import re
 
-        pattern = r"### ([\d\-T:+]+) \| ([^|]+) \| (\w+)\n(.+?)(?=### |$)"
+        pattern = r"### ([\d\-T:+.]+) \| ([^|\n]+) \| (\w+)\n(.+?)(?=### |$)"
         matches = re.findall(pattern, updates_content, re.DOTALL)
 
         updates = []
-        for timestamp, actor, kind, message in matches[-limit:]:
+        selected = matches if limit is None else matches[-limit:]
+        for timestamp, actor, kind, message in selected:
             updates.append(
                 {
                     "timestamp": timestamp.strip(),

--- a/src/vibe3/services/handoff_storage.py
+++ b/src/vibe3/services/handoff_storage.py
@@ -249,6 +249,50 @@ class HandoffStorage:
         )
         return handoff_path
 
+    def get_recent_updates(
+        self, branch: str | None = None, limit: int = 2
+    ) -> list[dict[str, str]]:
+        """Parse and return the last N updates from current.md for a branch.
+
+        Args:
+            branch: Target branch name (defaults to current branch)
+            limit: Maximum number of updates to return
+
+        Returns:
+            List of dicts with 'timestamp', 'actor', 'kind', 'message' keys
+        """
+        try:
+            content = self.read_current_handoff(branch)
+        except Exception:
+            return []
+
+        updates_heading = "## Updates"
+        if updates_heading not in content:
+            return []
+
+        # Extract updates section
+        updates_start = content.index(updates_heading) + len(updates_heading)
+        updates_content = content[updates_start:].strip()
+
+        # Parse update blocks
+        import re
+
+        pattern = r"### ([\d\-T:+]+) \| ([^|]+) \| (\w+)\n(.+?)(?=### |$)"
+        matches = re.findall(pattern, updates_content, re.DOTALL)
+
+        updates = []
+        for timestamp, actor, kind, message in matches[-limit:]:
+            updates.append(
+                {
+                    "timestamp": timestamp.strip(),
+                    "actor": actor.strip(),
+                    "kind": kind.strip(),
+                    "message": message.strip(),
+                }
+            )
+
+        return updates
+
     def normalize_ref_value(self, ref_value: str, branch: str) -> str:
         """Normalize a reference value (path) relative to branch worktree."""
         return normalize_ref_path(ref_value, branch, self.git_client)

--- a/tests/vibe3/commands/test_handoff_commands_basic.py
+++ b/tests/vibe3/commands/test_handoff_commands_basic.py
@@ -108,6 +108,7 @@ class TestHandoffBasicCommands:
         mock_status_result.events = []
         mock_status_result.latest_verdict = None
         mock_status_result.live_sessions = []
+        mock_status_result.recent_updates = []
         mock_status_service.get_handoff_status.return_value = mock_status_result
         mock_status_service_class.return_value = mock_status_service
 
@@ -115,7 +116,7 @@ class TestHandoffBasicCommands:
 
         assert result.exit_code == 0
         mock_status_service.get_handoff_status.assert_called_once_with(
-            "task/issue-436", limit=5
+            "task/issue-436", limit=2
         )
 
     def test_handoff_show_without_target_shows_help(self):
@@ -255,6 +256,7 @@ class TestHandoffBasicCommands:
             events=[],
             latest_verdict=None,
             live_sessions=[],
+            recent_updates=[],
         )
         mock_status_service.get_handoff_status.return_value = mock_status_result
         mock_handoff_status_service_class.return_value = mock_status_service
@@ -293,6 +295,7 @@ class TestHandoffBasicCommands:
             events=[],
             latest_verdict=None,
             live_sessions=[],
+            recent_updates=[],
         )
         mock_status_service.get_handoff_status.return_value = mock_status_result
         mock_handoff_status_service_class.return_value = mock_status_service
@@ -328,6 +331,7 @@ class TestHandoffBasicCommands:
             events=[],
             latest_verdict=None,
             live_sessions=[],
+            recent_updates=[],
         )
         mock_status_service.get_handoff_status.return_value = mock_status_result
         mock_handoff_status_service_class.return_value = mock_status_service


### PR DESCRIPTION
Closes #1022

## Summary

- **Issue**: #1022 - handoff status/append 读写不一致
- **问题**: handoff append 写入文件但 status 从 SQLite 读取，导致看不到 append 内容
- **解决方案**: 
  - HandoffStorage 新增 get_recent_updates() 方法解析文件中的 updates 区块
  - HandoffStatusResult 新增 recent_updates 字段
  - handoff status 显示最近2条 append 记录（默认）
  - 添加提示：使用 vibe3 handoff show @current 查看完整内容

## Changes

**Core Logic**:
- src/vibe3/services/handoff_storage.py: 新增 get_recent_updates() 方法，解析 handoff 文件中的 updates 区块
- src/vibe3/services/handoff_status_service.py: 扩展结果数据结构，包含 recent_updates 字段
- src/vibe3/commands/handoff_read.py: 更新显示逻辑，默认显示2条事件和最近的 append 记录

**Tests**:
- tests/vibe3/commands/test_handoff_commands_basic.py: 更新测试适配新的默认值和字段

## Test Plan

- [x] mypy 类型检查通过
- [x] pytest handoff 相关测试全部通过
- [x] 手动验证 handoff status 显示效果
- [x] 验证 handoff status --all 显示所有记录
- [x] 验证 vibe3 handoff show @current 可以查看完整内容

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

AI Agent
