### PR TITLE
fix(ci): 升级 setup-uv 支持 Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Setup Python environment for v3
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 

--- a/.github/workflows/issue-state-sync.yml
+++ b/.github/workflows/issue-state-sync.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 


### PR DESCRIPTION
## Summary
- 升级 `astral-sh/setup-uv@v5` → `v8.1.0` 以支持 Node.js 24 runtime
- 修复 GitHub Actions Node.js 20 deprecation 告警

## 背景
- **紧迫性**：2026-06-02 GitHub 将强制切换到 Node.js 24（距离今天只有 15天）
- Issue #304 虽已关闭，但实际未完成迁移
- 最新版本 `setup-uv@v8.1.0` 发布于 2026-04-16，已支持 Node.js 24
- 使用完整版本号 v8.1.0（v8 tag 不存在）

## 变更
- `.github/workflows/ci.yml`: setup-uv@v5 → v8.1.0
- `.github/workflows/issue-state-sync.yml`: setup-uv@v5 → v8.1.0

## 验收标准
- [ ] CI 不再出现 Node.js 20 deprecation 告警
- [ ] 所有 workflow 正常通过

Resolves #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)