### PR TITLE
fix(governance): supervisor issue intake 流程定义

### DIFF
--- a/supervisor/governance/cron-supervisor.md
+++ b/supervisor/governance/cron-supervisor.md
@@ -59,9 +59,9 @@ Forbidden:
 - 直接修改代码或文档
 - 进入 plan/run/review 执行链
 - 修改调度配置
-- 执行 `state/*` label 变更（除以下两种场景外）：
-  - 新建 supervisor issue 时设置 `state/ready`（备选池）
-  - 对已存在的 open `supervisor` issue 补齐 `state/handoff` 以交给 `supervisor/apply`（需经 roadmap-intake 三级审查）
+- 执行 `state/*` label 变更（除新建 supervisor issue 时设置 `state/ready` 外）
+  - 新建 supervisor issue 时设置 `state/ready`（备选池），进入 roadmap-intake 三级审查队列
+  - 已存在的 supervisor issue 的 state 变更由 roadmap-intake 负责（三级审查后决定 handoff/close）
 - 把范围扩大到“顺手修更多文档”
 - 把明确不打算执行的 issue 留在 open 状态继续悬浮
 
@@ -139,7 +139,7 @@ Forbidden:
 - `supervisor`
 - `state/ready`
 
-若 issue 已存在且经过 roadmap-intake 三级审查后决定继续执行，补 `state/handoff`；不要为同一批文档重复创建新的 supervisor issue。
+创建后进入 roadmap-intake 三级审查队列。若通过审查，roadmap-intake 会补 `state/handoff` 并移除 `state/ready`，然后交给 `supervisor/apply` 执行。不要为同一批文档重复创建新的 supervisor issue。
 
 ## Comment Contract
 

--- a/supervisor/governance/cron-supervisor.md
+++ b/supervisor/governance/cron-supervisor.md
@@ -60,8 +60,8 @@ Forbidden:
 - 进入 plan/run/review 执行链
 - 修改调度配置
 - 执行 `state/*` label 变更（除以下两种场景外）：
-  - 新建 supervisor issue 时设置 `state/handoff`
-  - 对已存在的 open `supervisor` issue 补齐 `state/handoff` 以交给 `supervisor/apply`
+  - 新建 supervisor issue 时设置 `state/ready`（备选池）
+  - 对已存在的 open `supervisor` issue 补齐 `state/handoff` 以交给 `supervisor/apply`（需经 roadmap-intake 三级审查）
 - 把范围扩大到“顺手修更多文档”
 - 把明确不打算执行的 issue 留在 open 状态继续悬浮
 
@@ -137,9 +137,9 @@ Forbidden:
 默认 labels：
 
 - `supervisor`
-- `state/handoff`
+- `state/ready`
 
-若 issue 已存在且决定继续执行，直接在原 issue 上补 `state/handoff`；不要为同一批文档重复创建新的 supervisor issue。
+若 issue 已存在且经过 roadmap-intake 三级审查后决定继续执行，补 `state/handoff`；不要为同一批文档重复创建新的 supervisor issue。
 
 ## Comment Contract
 

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -138,14 +138,14 @@ Assignee Pool（第二道）：
 - 不涉及已变更的配置/架构
 
 **Level 3: 生命周期检查**
-- 非重复（与其他 open `supervisor + state/handoff` issue 不冲突）
+- 非重复（与其他所有 open `supervisor` issues 不冲突，包括 `state/ready` 和 `state/handoff`）
 - 未过时（治理目标仍有效，文档/真源关系未改变）
 - 不需要先关闭其他依赖 issue
 
 **决策与动作**：
 
 - **通过三级审查**：
-  - 补 `state/handoff`（从备选池进入执行池）
+  - 移除 `state/ready`，补 `state/handoff`（从备选池进入执行池）
   - 交给 supervisor/apply 执行
   - 在 Actions 中记录：`Supervisor #XXX: handoff (passed Level 1-3)`
 - **不通过**：
@@ -157,7 +157,7 @@ Assignee Pool（第二道）：
 
 **输出要求**：
 
-在原有 `Actions` 中增加 `Supervisor issues` 分段，与 `Accepted`/`Skipped` 并列：
+新增顶层 section `Supervisor issues`，与 `Accepted`/`Skipped`/`Actions` 并列：
 
 ```
 Candidates: ...
@@ -270,7 +270,7 @@ Forbidden:
 6. 对不适合纳入的对象记录简短原因
 7. **扫描 `supervisor + state/ready` issues**，对每个执行：
    - 三级审查（基础条件 + 架构一致性 + 生命周期）
-   - 通过：补 `state/handoff`，记录到 Actions
+   - 通过：移除 `state/ready`，补 `state/handoff`，记录到 Actions
    - 不通过：建议关闭，记录到 Actions
    - 不确定：保守等待，记录到 Actions
 8. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -146,10 +146,22 @@ Assignee Pool（第二道）：
 
 - **通过三级审查**：
   - 移除 `state/ready`，补 `state/handoff`（从备选池进入执行池）
+  - **Label 操作命令**（参考 manager.md 标准，确保单一 state label）：
+    ```bash
+    # 单个 issue handoff 操作
+    gh issue edit <issue-number> --add-label "state/handoff" --remove-label "state/ready"
+    
+    # 示例：issue #770 通过审查
+    gh issue edit 770 --add-label "state/handoff" --remove-label "state/ready"
+    ```
   - 交给 supervisor/apply 执行
   - 在 Actions 中记录：`Supervisor #XXX: handoff (passed Level 1-3)`
 - **不通过**：
   - 建议关闭，写明原因（duplicate、过时、范围失真）
+  - **关闭命令**：
+    ```bash
+    gh issue close <issue-number> --comment "关闭理由：<具体理由>"
+    ```
   - 在 Actions 中记录：`Supervisor #YYY: suggest close (duplicate with #ZZZ)`
 - **不确定**：
   - 保守等待，不修改 state
@@ -227,14 +239,14 @@ Allowed:
 - `labels.write`: allowed（仅最小必要的 routing / priority / roadmap 类调整；避免扩大动作）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
-- `state/labels.write`: allowed（仅限 supervisor issues：补 `state/handoff`）
+- `state/labels.write`: allowed（仅限 supervisor issues：移除 `state/ready` 并补 `state/handoff`，确保单一 state label）
 
 Forbidden:
 
 - 修改代码
 - 创建或关闭 issue
 - 进入 plan/run/review 执行链
-- 执行 `state/*` label 变更（除 supervisor issues 补 handoff 外）
+- 执行 `state/*` label 变更（除 supervisor issues 移除 ready 并补 handoff 外，必须同时操作两个 label 确保单一 state）
 - 对不确定是否适合自动化的 issue 强行纳入 assignee issue pool
 - **分配给错误的人类 assignee（如 `jacobcy`、`alice`）** ⭐ 新增
 
@@ -271,7 +283,14 @@ Forbidden:
 7. **扫描 `supervisor + state/ready` issues**，对每个执行：
    - 三级审查（基础条件 + 架构一致性 + 生命周期）
    - 通过：移除 `state/ready`，补 `state/handoff`，记录到 Actions
+     ```bash
+     # 确保 issue 只有一个 state label
+     gh issue edit <issue-number> --add-label "state/handoff" --remove-label "state/ready"
+     ```
    - 不通过：建议关闭，记录到 Actions
+     ```bash
+     gh issue close <issue-number> --comment "关闭理由：<具体理由>"
+     ```
    - 不确定：保守等待，记录到 Actions
 8. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
    - 是因为候选确实都不满足三级审查

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -117,6 +117,59 @@ Assignee Pool（第二道）：
   └─ 决策：接受为重构任务 / 建议 manager 处理
 ```
 
+### Supervisor Issue Intake
+
+除了 assignee issue pool 的候选，还需扫描：
+
+- `supervisor + state/ready` issues（supervisor 备选池）
+
+**三级审查**：
+
+对 supervisor issues 执行同样的三级审查框架，但针对治理任务特点调整：
+
+**Level 1: 基础条件**
+- 治理目标明确（文档对齐、测试修补、label/comment 治理）
+- 范围可控（不涉及主代码、不扩大语义）
+- 验收标准清楚（可明确判断"完成"）
+
+**Level 2: 架构一致性**
+- 目标文档/文件仍存在
+- 引用的真源（glossary、standards、entry docs）未废弃
+- 不涉及已变更的配置/架构
+
+**Level 3: 生命周期检查**
+- 非重复（与其他 open `supervisor + state/handoff` issue 不冲突）
+- 未过时（治理目标仍有效，文档/真源关系未改变）
+- 不需要先关闭其他依赖 issue
+
+**决策与动作**：
+
+- **通过三级审查**：
+  - 补 `state/handoff`（从备选池进入执行池）
+  - 交给 supervisor/apply 执行
+  - 在 Actions 中记录：`Supervisor #XXX: handoff (passed Level 1-3)`
+- **不通过**：
+  - 建议关闭，写明原因（duplicate、过时、范围失真）
+  - 在 Actions 中记录：`Supervisor #YYY: suggest close (duplicate with #ZZZ)`
+- **不确定**：
+  - 保守等待，不修改 state
+  - 在 Actions 中记录：`Supervisor #ZZZ: waiting (unclear scope, needs human review)`
+
+**输出要求**：
+
+在原有 `Actions` 中增加 `Supervisor issues` 分段，与 `Accepted`/`Skipped` 并列：
+
+```
+Candidates: ...
+Accepted: ...
+Skipped: ...
+Supervisor issues:
+  - #770: handoff (passed Level 1-3, align stale docs)
+  - #743: suggest close (duplicate with #770)
+  - #655: waiting (unclear scope)
+Why: ...
+```
+
 ### 默认原则
 
 - **架构检查优先于标签分类**：不只是看 bug/feature 标签，要看代码架构是否仍相关
@@ -174,27 +227,31 @@ Allowed:
 - `labels.write`: allowed（仅最小必要的 routing / priority / roadmap 类调整；避免扩大动作）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
+- `state/labels.write`: allowed（仅限 supervisor issues：补 `state/handoff`）
 
 Forbidden:
 
 - 修改代码
 - 创建或关闭 issue
 - 进入 plan/run/review 执行链
-- 执行 `state/*` label 变更
+- 执行 `state/*` label 变更（除 supervisor issues 补 handoff 外）
 - 对不确定是否适合自动化的 issue 强行纳入 assignee issue pool
 - **分配给错误的人类 assignee（如 `jacobcy`、`alice`）** ⭐ 新增
 
 ## What It Reads
 
 - broader repo issue pool 中的 open issues
+- `supervisor + state/ready` issues（supervisor 备选池）
 - issue title / body / labels / comments
 - 必要时当前 assignee issue pool 现场
 - 必要时 flow / task status，用于避免把已在主链中的对象重复纳入
+- 必要时其他 open `supervisor + state/handoff` issues（用于查重）
 
 ## What It Produces
 
 - intake decisions
 - assignee-pool additions
+- supervisor issue handoff decisions
 - skipped candidates with reasons
 - minimal routing comments
 
@@ -211,11 +268,16 @@ Forbidden:
    - 派为 assignee issue，并明确指派给一个配置中的 manager assignee（必须使用 `vibe-manager-agent`，禁止使用人类用户名）
    - 如有必要补最小 routing labels
 6. 对不适合纳入的对象记录简短原因
-7. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
+7. **扫描 `supervisor + state/ready` issues**，对每个执行：
+   - 三级审查（基础条件 + 架构一致性 + 生命周期）
+   - 通过：补 `state/handoff`，记录到 Actions
+   - 不通过：建议关闭，记录到 Actions
+   - 不确定：保守等待，记录到 Actions
+8. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
    - 是因为候选确实都不满足三级审查
-   - 还是因为当前材料把“实现选择”误当成了“人类拍板”
+   - 还是因为当前材料把”实现选择”误当成了”人类拍板”
    - 若 ready queue 偏浅，优先重新检查是否存在被误判可纳入的 bounded refactor / bugfix
-8. 输出结论后停止
+9. 输出结论后停止
 
 ## Comment Contract
 
@@ -238,9 +300,18 @@ Forbidden:
 - `Candidates`
 - `Accepted`
 - `Skipped`
+- `Supervisor issues`（新增）
 - `Actions`
 - `Why`
 
+`Supervisor issues` 格式：
+```
+Supervisor issues:
+  - #XXX: handoff (passed Level 1-3, <brief reason>)
+  - #YYY: suggest close (<reason: duplicate/过时/范围失真>)
+  - #ZZZ: waiting (<reason>)
+```
+
 ## Stop Point
 
-完成 intake 判断与最小纳入动作后停止。不要进入具体实现或单 flow 管理。
+完成 intake 判断、supervisor issue 审查与最小纳入动作后停止。不要进入具体实现或单 flow 管理。


### PR DESCRIPTION
## Summary
- 定义 supervisor issue intake 流程：创建时用 state/ready，roadmap-intake 三级审查后补 handoff
- cron-supervisor: 修改创建默认 labels 为 state/ready（备选池）
- roadmap-intake: 新增 supervisor issue intake 逻辑，包括 Permission Contract、I/O Contract、Execution Pattern

## Changes
1. **cron-supervisor.md**
   - L62-64: Permission Contract 新增创建时设置 state/ready
   - L137-142: Supervisor Issue Contract 改用 state/ready 作为默认 labels

2. **roadmap-intake.md**
   - 新增 Supervisor Issue Intake 章节（三级审查 + handoff 决策）
   - Permission Contract: 允许 supervisor issues 补 state/handoff
   - What It Reads: 新增 supervisor + state/ready issues 检查
   - What It Produces: 新增 supervisor issue handoff decisions
   - Execution Pattern: Step 7 新增 supervisor issue review 逻辑
   - Output Contract: 新增 Supervisor issues 输出格式

## Test plan
- [ ] 验证 cron-supervisor 创建 supervisor issue 时使用 state/ready
- [ ] 验证 roadmap-intake 能正确识别和审查 supervisor + state/ready issues
- [ ] 验证 roadmap-intake 能补齐 state/handoff 或给出关闭建议
- [ ] 手动处理现有 12 个 supervisor issues（补 handoff 或关闭）

## Related issues
Fixes #1031
Related to #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)