### PR TITLE
fix(docs): align 3 stale V3 docs to current CLI semantics

### DIFF
--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -166,22 +166,45 @@ src/vibe3/
 | Phase 1 | Infrastructure（基础设施层） | ✅ 已完成 | 100% |
 | Phase 2 | Trace（调试追踪层） | ⏸️ 待启动 | 0% |
 | Phase 3 | Handoff（责任链层） | ✅ 已完成 | 100% |
-| Phase 4 | Orchestra（自动编排层） | ✅ 运行中 | 80% |
+| Phase 4 | Orchestra（自动编排层） | ✅ 运行中 | 持续优化 |
 
 ### 已完成
 
 - ✅ 目录结构创建（[src/vibe3/](../../src/vibe3/)）
 - ✅ Client 隔离（clients/ 包含 GitClient、GitHubClient）
 - ✅ Models 定义（models/）
-- ✅ Commands 骨架（commands/）
-- ✅ Services 骨架（services/）
+- ✅ Commands 实现（commands/）
+- ✅ Services 实现（services/）
 - ✅ UI 层（ui/）
 - ✅ Config 模块（config/）
-- ✅ **observability/** - 日志系统（logger.py, trace.py, audit.py）
-- ✅ **exceptions/** - 异常定义（VibeError 层级，error_codes, error_tracking）
-- ✅ 核心参数集集成（`--trace`, `-v`, `--json`, `-y`）
+- ✅ **observability/** - 日志系统 + degraded mode
+- ✅ **exceptions/** - VibeError 层级 + error codes + error tracking
+- ✅ 核心参数集（`--trace`, `-v`, `--json`, `-y`）
 - ✅ Handoff 责任链系统（SQLite handoff store, HandoffService）
 - ✅ Orchestra 自动编排（Manager, dispatcher, ready queue）
+
+### 现行 CLI 命令面
+
+```
+vibe3
+├── flow: update, bind, blocked, show, status, list-deleted, restore
+├── task: show, status, resume
+├── handoff: show, status, init, append, plan, report, indicate, audit, next, verdict
+├── inspect: pr, base, symbols, files, commit
+├── review: pr
+├── check
+├── plan
+├── pr
+├── scan
+├── snapshot
+├── serve
+├── mcp
+├── ask
+├── run
+└── version
+```
+
+> `task status` 是唯一 `vibe3 task` 的聚合入口；`task show` 仅展示轻量摘要。
 
 ### Phase 2 验收状态
 
@@ -194,6 +217,8 @@ Orchestra 已实现核心调度功能：
 - ✅ Driver/Tick/Async Child 架构
 - ✅ Event-driven dispatch
 - ✅ Capacity control (live worker sessions)
+- ✅ Health check + circuit breaker
+- ✅ Supervisor governance 扫描
 - 🔄 持续优化调度稳定性与恢复机制
 
 ---
@@ -202,19 +227,13 @@ Orchestra 已实现核心调度功能：
 
 ### Phase 1 执行计划
 
-详见 [execution_plan/phase_2_execution_plan.md](execution_plan/phase_2_execution_plan.md)
-
-**当前优先级**:
-1. 实现 `observability/logger.py` - Agent-Centric Logging
-2. 实现 `exceptions/` - 统一的 VibeError 层级
-3. 为所有命令添加核心参数集
-4. 提升测试覆盖率至 80%
+Phase 1 已完成，后续优先级由 Orchestra 和 supervisor issue 驱动。
 
 ### 后续阶段
 
 - Phase 2 执行计划（待制定）
-- Phase 3 执行计划（待制定）
-- Phase 4 冻结，不制定计划
+- Phase 3 已交付，无需进一步计划
+- Phase 4 持续优化，不制定独立计划
 
 ---
 

--- a/docs/v3/infrastructure/07-command-standards.md
+++ b/docs/v3/infrastructure/07-command-standards.md
@@ -27,15 +27,16 @@ Vibe 3.0 CLI 分为三层：
 ```
 vibe3                          ← 全局层（Global）
 ├── flow                       ← 命令组层（Group）
-│   ├── new
-│   ├── list
-│   └── ...
+│   ├── update
+│   ├── bind
+│   ├── blocked
+│   ├── show
+│   ├── status
+│   ├── list-deleted
+│   └── restore
 ├── inspect                    ← 命令组层（Group）
-│   ├── pr
-│   ├── metrics
 │   └── ...
 └── review                     ← 命令组层（Group）
-    ├── pr                     ← 子命令层（Subcommand）
     └── ...
 ```
 
@@ -105,7 +106,7 @@ vibe3                          ← 全局层（Global）
 
 **使用场景**:
 ```bash
-vibe3 -v flow list          # INFO 日志
+vibe3 -v flow status          # INFO 日志
 vibe3 -vv inspect pr 42     # DEBUG 日志
 ```
 
@@ -164,8 +165,7 @@ RESULT=$(vibe3 inspect base main --json)
 
 **使用场景**:
 ```bash
-vibe3 clean --yes
-vibe3 reset --yes
+vibe3 flow blocked --reason "waiting on #42" --yes
 ```
 
 ---

--- a/docs/v3/infrastructure/08-command-quick-ref.md
+++ b/docs/v3/infrastructure/08-command-quick-ref.md
@@ -20,7 +20,7 @@ related_docs:
 ```
 全局层     vibe3 -v/-vv [COMMAND]
 命令组层   vibe3 flow/inspect/review/... [-h]
-子命令层   vibe3 flow new NAME [--trace] [--json] [-y]
+子命令层   vibe3 flow update [--trace] [--json] [-y]
 ```
 
 ---
@@ -35,7 +35,7 @@ related_docs:
 | （无参数） | 显示帮助 |
 
 ```bash
-vibe3 -v flow list
+vibe3 -v flow status
 vibe3 -vv inspect pr 42
 vibe3 -h
 vibe3 help
@@ -57,7 +57,7 @@ vibe3 inspect pr 42 --trace
 vibe3 inspect pr 42 --json | jq '.score'
 vibe3 inspect pr 42 --trace --json
 vibe3 review pr 42 --help
-vibe3 flow new my-feature -h
+vibe3 flow show -h
 ```
 
 ---
@@ -76,7 +76,7 @@ vibe3 flow new my-feature -h
 
 ## Handoff Commands
 
-### `vibe handoff init`
+### `vibe3 handoff init`
 
 Ensure shared handoff file exists for current branch.
 
@@ -88,23 +88,25 @@ Ensure shared handoff file exists for current branch.
 vibe3 handoff init
 ```
 
-### `vibe handoff show`
+### `vibe3 handoff show`
 
-Show shared handoff file for current branch.
+Show a handoff artifact.
 
 ```bash
 vibe3 handoff show
+vibe3 handoff show @current
+vibe3 handoff show @task-476/run-1.md
 ```
 
-### `vibe handoff append <message>`
+### `vibe3 handoff append <message>`
 
-Append a lightweight update block to shared handoff file for current branch.
+Append a lightweight update block to handoff file.
 
 ```bash
 vibe3 handoff append "Need to align event taxonomy" --actor "codex/gpt-5.4" --kind finding
 ```
 
-### `vibe handoff plan <plan_ref>`
+### `vibe3 handoff plan <plan_ref>`
 
 Record plan handoff.
 
@@ -112,7 +114,7 @@ Record plan handoff.
 vibe3 handoff plan docs/plans/feature-x.md --actor "claude/sonnet-4.6"
 ```
 
-### `vibe handoff report <report_ref>`
+### `vibe3 handoff report <report_ref>`
 
 Record report handoff.
 
@@ -120,7 +122,7 @@ Record report handoff.
 vibe3 handoff report docs/reports/review-2026-03-21.md --actor "claude/sonnet-4.6"
 ```
 
-### `vibe handoff audit <audit_ref>`
+### `vibe3 handoff audit <audit_ref>`
 
 Record audit handoff.
 
@@ -185,9 +187,9 @@ vibe3 review pr 42 --publish
 vibe3 -v review pr 42          # INFO 日志 + 审核
 
 # 查看流程
-vibe3 flow list
 vibe3 flow status
-vibe3 -vv flow new my-feature  # DEBUG 日志 + 创建
+vibe3 flow show
+vibe3 -vv flow update  # DEBUG 日志 + 更新
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Align deprecated command examples in `07-command-standards.md` and `08-command-quick-ref.md` to current `vibe3 flow` subcommands
- Fix `vibe handoff` → `vibe3 handoff` prefix inconsistency in quick-ref handoff section
- Refresh `docs/v3/README.md` progress table, add current CLI command face, update completed items

## Changed Files
- `docs/v3/infrastructure/07-command-standards.md` — flow hierarchy diagram + examples
- `docs/v3/infrastructure/08-command-quick-ref.md` — handoff prefix, deprecated examples
- `docs/v3/README.md` — status refresh, current CLI command face

## Test plan
- [ ] Review diff for accuracy against `vibe3 --help` and `vibe3 flow --help`
- [ ] Verify no structural rewrites, only semantic alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)