### PR TITLE
chore(docs): align 5 stale docs terminology to glossary standards

### DIFF
--- a/.agent/workflows/vibe:issue.md
+++ b/.agent/workflows/vibe:issue.md
@@ -1,6 +1,6 @@
 ---
 name: "vibe:issue"
-description: Skill-backed workflow that routes repo issue intake to the vibe-issue skill before roadmap planning.
+description: Skill-backed workflow that routes GitHub issue intake to the vibe-issue skill before roadmap planning.
 ---
 
 # vibe:issue
@@ -11,11 +11,11 @@ description: Skill-backed workflow that routes repo issue intake to the vibe-iss
 
 - `vibe:issue` 是一个 `skill-backed workflow`。
 - 它只负责 issue intake 入口，不直接承载模板检查、查重和创建细节。
-- `repo issue` 是来源层对象，不是本地执行 task，也不是 flow runtime 的主语。
+- `GitHub issue` 是来源层对象，不是本地执行 task，也不是 flow runtime 的主语。
 
 ## Steps
 
-1. 回复用户：`我会先把当前请求解释为 repo issue intake，再委托 vibe-issue skill 处理查重、模板和创建。`
+1. 回复用户：`我会先把当前请求解释为 GitHub issue intake，再委托 vibe-issue skill 处理查重、模板和创建。`
 2. 委托 `skills/vibe-issue/SKILL.md` 处理：
    - Template Gate
    - Duplication Gate

--- a/.agent/workflows/vibe:start.md
+++ b/.agent/workflows/vibe:start.md
@@ -12,7 +12,7 @@ tags: [workflow, vibe, execution, orchestration]
 ## 定位
 
 - `vibe:start` 是 workflow 层执行入口，只负责判断当前 flow 是否具备可执行 task，并委托 `vibe-start` skill。
-- 它默认以 `repo issue -> flow` 作为用户执行主链视角。
+- 它默认以 `GitHub issue -> flow` 作为用户执行主链视角。
 - 它负责在当前 flow 中从 issue 落 task 作为 execution bridge，再把 execution spec 交给执行体系。
 - 具体 task 选择顺序、`auto` 模式、blocker 分类、handoff 写回，都下沉到 `vibe-start` skill。
 - `vibe3 handoff status` 输出只是 handoff 补充，不是执行图纸。

--- a/docs/references/alias-helper.md
+++ b/docs/references/alias-helper.md
@@ -234,7 +234,7 @@ Agent 选项：`claude`（默认）、`codex`、`opencode`
 
 | 命令 | 功能 |
 |------|------|
-| `vibe <subcommand>` | 动态 Vibe 执行器（自动检测 local → git root → 全局） |
+| `vibe <subcommand>` | 执行代理（自动检测 local → git root → 全局） |
 | `vibe -g <subcommand>` | 强制使用全局 vibe |
 | `vc` | `vibe chat` — 打开 Vibe Chat |
 | `vsign` | `vibe sign` — 签名任务或文档 |

--- a/skills/vibe-done/SKILL.md
+++ b/skills/vibe-done/SKILL.md
@@ -218,7 +218,7 @@ uv run python src/vibe3/cli.py handoff append "vibe-done: flow closed" --actor v
 
 注意：handoff 没有单独的清理 / 删除命令；若需要纠正旧记录，应通过追加更正或终态说明来覆盖语义，而不是假设存在 cleanup 入口。
 
-若当前 PR 已 merged，对应旧 plan 已进入 terminal state。此阶段只允许补记交付证据、审计说明、handoff 更正与 follow-up 链接；若出现新需求，必须创建或挂接新的 `repo issue`，不得继续塞回旧 plan。
+若当前 PR 已 merged，对应旧 plan 已进入 terminal state。此阶段只允许补记交付证据、审计说明、handoff 更正与 follow-up 链接；若出现新需求，必须创建或挂接新的 `GitHub issue`，不得继续塞回旧 plan。
 
 ## Restrictions
 

--- a/skills/vibe-integrate/SKILL.md
+++ b/skills/vibe-integrate/SKILL.md
@@ -312,7 +312,7 @@ Issue 内容模板：
 - 不得借机把下一个目标混进同一个 PR
 - 不得直接改 `.git/vibe/*.json`
 - 若当前 PR 已 merged，则旧 plan 视为 terminal state；此阶段只允许补交付证据或 follow-up 链接，不得把新需求写回旧 plan
-- merge 后出现的新目标必须重新进入 `repo issue` intake，而不是继续挂在已完成 plan 下
+- merge 后出现的新目标必须重新进入 `GitHub issue` intake，而不是继续挂在已完成 plan 下
 
 ### Step 4.5: 单文件 exception 容量约束
 


### PR DESCRIPTION
## Summary

Aligns deprecated terminology in 5 docs to glossary.md standards:
- **alias-helper.md**: \"动态 Vibe 执行器\" → \"执行代理\" (glossary §5.3)
- **vibe:start.md**: \"repo issue\" → \"GitHub issue\" (glossary §3.1)
- **vibe:issue.md**: \"repo issue\" → \"GitHub issue\" (3 occurrences, glossary §3.1)
- **vibe-done/SKILL.md**: \"repo issue\" → \"GitHub issue\" (glossary §3.1)
- **vibe-integrate/SKILL.md**: \"repo issue\" → \"GitHub issue\" (glossary §3.1)

Closes #693

## Test Plan

- [x] Verified all 7 deprecated terminology occurrences are replaced
- [x] No existing "GitHub issue" usages were broken (verified context)
- [x] No scope expansion beyond the listed 5 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)