### PR TITLE
docs: sync 2 docs to current CLI semantics after PR #892

### DIFF
--- a/docs/references/flow-dependency.md
+++ b/docs/references/flow-dependency.md
@@ -118,7 +118,7 @@ UPDATE flow_state SET
   blocked_by = '等待依赖 issue #218'  -- 或自定义 reason
 WHERE branch = 'task/my-feature';
 
--- 2. 建立依赖关系（如果指定 --by）
+-- 2. 建立依赖关系
 INSERT INTO flow_issue_links
   (branch, issue_number, issue_role, created_at)
 VALUES

--- a/docs/standards/v3/command-standard.md
+++ b/docs/standards/v3/command-standard.md
@@ -251,7 +251,7 @@ vibe3 flow blocked [--branch <branch>] [--reason <text>] [--task <issue>]
 约束：
 
 - 目标 flow 必须已存在
-- `--branch` 与 `--pr` 互斥
+- 通过 `--branch` 指定目标 flow 分支（可选，默认当前分支）
 
 ### 7.4 `flow show`
 


### PR DESCRIPTION
## Summary
- Remove `--pr` reference from `docs/standards/v3/command-standard.md` (line 254)
- Remove `--by` reference from `docs/references/flow-dependency.md` (line 121)

## Verification
- 2 of 4 scoped docs needed fixes; the other 2 (`handoff/README.md`, `08-command-quick-ref.md`) were already clean
- No remaining `--pr`/`--by` references in the 4 scoped docs
- Remaining references elsewhere are in analysis/spec docs that discuss the parameter removal historically

## Test plan
- [ ] Verify no broken references in the updated docs
- [ ] Confirm CLI `flow blocked --help` matches updated docs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>