### PR TITLE
fix(docs): align 5 stale V3 docs to current CLI semantics (#668)

### DIFF
--- a/docs/v3/PROMPTS.md
+++ b/docs/v3/PROMPTS.md
@@ -68,7 +68,7 @@ src/vibe3/
 **实施文档**：[trace/](trace/README.md)
 
 **验收标准**：
-- [ ] `vibe review pr 42 --trace` 输出调用链路
+- [ ] `vibe3 review pr 42 --trace` 输出调用链路
 - [ ] 追踪开销 < 20%
 - [ ] 不影响命令执行结果
 
@@ -95,7 +95,7 @@ src/vibe3/
 **验收标准**：
 - [ ] 每个操作记录到 SQLite handoff store
 - [ ] 每个 agent 署名（格式：`agent/model`）
-- [ ] `vibe flow status` 显示责任链
+- [ ] `vibe3 flow status` 显示责任链
 
 ---
 
@@ -244,14 +244,14 @@ src/vibe3/
 - [ ] 测试覆盖率 >= 80%
 
 ## Phase 2 验证
-- [ ] `vibe review pr 42 --trace` 输出调用链路
+- [ ] `vibe3 review pr 42 --trace` 输出调用链路
 - [ ] 追踪开销 < 20%
 - [ ] 不影响命令执行结果
 
 ## Phase 3 验证
 - [ ] 每个操作记录到 SQLite handoff store
 - [ ] 每个 agent 署名（格式：`agent/model`）
-- [ ] `vibe flow status` 显示责任链
+- [ ] `vibe3 flow status` 显示责任链
 
 ---
 

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -88,8 +88,8 @@ src/vibe3/
 - [phase3-automation.md](trace/phase3-automation.md) - Phase 3 自动化
 
 **验收标准**:
-- [ ] `vibe review pr 42 --trace` 输出调用链路
-- [ ] `vibe inspect pr 42 --trace` 输出调用链路
+- [ ] `vibe3 review pr 42 --trace` 输出调用链路
+- [ ] `vibe3 inspect pr 42 --trace` 输出调用链路
 - [ ] 追踪开销 < 20%
 - [ ] 不影响命令执行结果
 
@@ -115,7 +115,7 @@ src/vibe3/
 - [ ] 每个操作记录到 SQLite handoff store
 - [ ] 每个 agent 署名（格式：`agent/model`）
 - [ ] 产物引用不复制正文
-- [ ] `vibe flow status` 显示责任链
+- [ ] `vibe3 flow status` 显示责任链
 
 ---
 

--- a/docs/v3/ROADMAP.md
+++ b/docs/v3/ROADMAP.md
@@ -99,7 +99,7 @@ related_docs:
 
 ### 2.2 命令集成
 
-- [ ] **`vibe3 review --branch 42 --trace`**
+- [ ] **`vibe3 review pr 42 --trace`**
   - 输出调用链路
   - 显示执行步骤
   - **预估**: 3-4 小时
@@ -299,8 +299,8 @@ Orchestra ready queue 使用三级排序：
 
 ### Phase 2 验收
 
-- [ ] `vibe review pr 42 --trace` 输出调用链路
-- [ ] `vibe inspect pr 42 --trace` 输出调用链路
+- [ ] `vibe3 review pr 42 --trace` 输出调用链路
+- [ ] `vibe3 inspect pr 42 --trace` 输出调用链路
 - [ ] 追踪开销 < 20%
 - [ ] 不影响命令执行结果
 
@@ -309,7 +309,7 @@ Orchestra ready queue 使用三级排序：
 - [ ] 每个操作记录到 SQLite handoff store
 - [ ] 每个 agent 署名
 - [ ] 产物引用不复制正文
-- [ ] `vibe flow status` 显示责任链
+- [ ] `vibe3 flow status` 显示责任链
 
 ---
 

--- a/docs/v3/handoff/README.md
+++ b/docs/v3/handoff/README.md
@@ -51,7 +51,7 @@ related_docs:
 
 **Inputs**: `docs/v3/handoff/02-flow-task-foundation.md`, `src/vibe3/clients/sqlite_client.py`
 **Success Criteria**:
-- [ ] Execution of `vibe3 flow new test-flow --task 101` creates handoff record in SQLite.
+- [ ] Execution of `vibe3 flow update test-flow` creates handoff record in SQLite.
 - [ ] `vibe3 flow status --json` output contains `"flow_slug": "test-flow"` with handoff metadata.
 - [ ] Unit tests for `FlowService` pass with 100% success rate.
 

--- a/docs/v3/handoff/v3-rewrite-plan.md
+++ b/docs/v3/handoff/v3-rewrite-plan.md
@@ -47,7 +47,7 @@
 
 **Inputs**: `docs/v3/handoff/02-flow-task-foundation.md`, `src/vibe3/clients/sqlite_client.py`
 **Success Criteria**:
-- [ ] Execution of `vibe3 flow new test-flow --task 101` creates handoff record in SQLite.
+- [ ] Execution of `vibe3 flow update test-flow` creates handoff record in SQLite.
 - [ ] `vibe3 flow status --json` output contains `"flow_slug": "test-flow"` with handoff metadata.
 - [ ] Unit tests for `FlowManager` pass with 100% success rate.
 


### PR DESCRIPTION
## Summary
- Align 5 V3 docs to current CLI truth per `docs/standards/v3/command-standard.md`
- `vibe review pr` / `vibe inspect pr` → `vibe3 review pr` / `vibe3 inspect pr`
- `vibe flow status` → `vibe3 flow status`
- `vibe3 review --branch 42` → `vibe3 review pr 42`
- `vibe3 flow new` → `vibe3 flow update`

## Changed Files
- `docs/v3/PROMPTS.md` — 4 replacements
- `docs/v3/README.md` — 3 replacements
- `docs/v3/ROADMAP.md` — 4 replacements
- `docs/v3/handoff/README.md` — 1 replacement
- `docs/v3/handoff/v3-rewrite-plan.md` — 1 replacement

## Test plan
- [ ] `git diff` shows only the expected deprecated command replacements
- [ ] No stale `vibe review pr`, `vibe inspect pr`, `vibe flow status`, `vibe3 flow new` remain in scoped files

🤖 Generated with [Claude Code](https://claude.com/claude-code)