### PR TITLE
fix(docs): align 4 stale docs to current V3 CLI semantics (#663)

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -44,7 +44,7 @@
 
 ### 2.3 验证环境
 ```bash
-bin/vibe check       # 环境诊断
+bin/vibe check       # 环境诊断（V2）
 uv run python src/vibe3/cli.py check  # V3 一致性与共享状态审计
 bats tests/          # 运行所有测试（应看到 20 tests, 0 failures）
 bash scripts/hooks/lint.sh # 双层 lint 检查（0 errors）

--- a/docs/standards/agent-workflow-standard.md
+++ b/docs/standards/agent-workflow-standard.md
@@ -171,7 +171,7 @@ git checkout -b feature/api-v2
 vibe3 flow update
 
 # 2. 绑定 task issue（同时绑定为 spec）
-vibe flow bind <issue_number> --role task
+vibe3 flow bind <issue_number> --role task
 
 # 3. 创建 plan
 vibe plan --branch <issue_number>

--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -87,7 +87,7 @@ new → active → blocked → active (恢复)
 
 **清理机制**：
 
-- **被动清理**：`vibe check --clean-branch` 处理 aborted flows
+- **被动清理**：`vibe3 check --clean-branch` 处理 aborted flows
 - **主动清理**：`task resume` 人类重置权限
 - **自动清理**：FailedGate 检测并清理无效 FAILED 标签
 
@@ -95,7 +95,7 @@ new → active → blocked → active (恢复)
 
 Flow 进入终端状态（done/aborted）后：
 
-1. **等待 Check 清理**：`vibe check --clean-branch`
+1. **等待 Check 清理**：`vibe3 check --clean-branch`
 2. **物理资源回收**：删除 worktree/branch/handoff
 3. **Flow 记录处理**：
    - done: 保留记录（审计历史）
@@ -198,7 +198,7 @@ PR merged (GitHub webhook)
   ↓ Check 检测
 发现 flow.pr_ref == merged PR
   ├─ 标记 flow_status = "done"
-  └─ 等待 vibe check --clean-branch
+  └─ 等待 vibe3 check --clean-branch
 ```
 
 **清理策略**：
@@ -212,7 +212,7 @@ PR closed (GitHub webhook)
   ↓ Check 检测
 发现 flow.pr_ref == closed PR
   ├─ 标记 flow_status = "aborted"
-  └─ 等待 vibe check --clean-branch
+  └─ 等待 vibe3 check --clean-branch
 ```
 
 **清理策略**：
@@ -228,7 +228,7 @@ GitHub 原生关闭关键字（`closes #N`、`fixes #N` 在 PR body 中）与 vi
 | 机制 | 触发时机 | 控制方式 |
 |------|----------|----------|
 | GitHub 原生关键字 | PR merge 时自动触发 | PR body 中的关键字 |
-| vibe3 flow done | `vibe check` 检测到 merged PR | `close_issue_if_open` API 调用 |
+| vibe3 flow done（PR merge 后由 `vibe3 check` 触发） | `vibe3 check` 检测到 merged PR | `close_issue_if_open` API 调用 |
 
 两者**互不干扰**：
 - PR body 不会被 vibe3 修改以注入关闭关键字
@@ -276,7 +276,7 @@ Issue #123 绑定两个 flow:
 
 ### 6.1 统一清理入口
 
-所有终端状态的 flow 通过 `vibe check --clean-branch` 统一回收：
+所有终端状态的 flow 通过 `vibe3 check --clean-branch` 统一回收：
 
 ```python
 # CheckCleanupService.clean_residual_branches
@@ -342,11 +342,11 @@ get_deleted_flows()                      # 专门查询已删除记录
 **恢复流程**：
 
 ```bash
-# 查看已删除 flows
-vibe3 flow list-deleted
+# 查看已删除 flows（已废弃，不再作为公共 CLI 命令）
+# vibe3 flow list-deleted
 
-# 恢复软删除 flow
-vibe3 flow restore <branch>
+# 恢复软删除 flow（已废弃，不再作为公共 CLI 命令）
+# vibe3 flow restore <branch>
 
 # 创建新 flow 自动覆盖已删除记录
 vibe3 flow update <branch>  # 自动清除 deleted_at
@@ -404,7 +404,7 @@ if flow_status == "aborted":
 - 目的：允许 issue 重新开始，同时保留审计追踪
 - Issue 可能仍在 open，需要恢复 labels
 - deleted_at 设置为删除时间戳
-- 可通过 `vibe3 flow restore` 恢复
+- 可通过内部 `restore_flow()` API 恢复（CLI 命令已废弃）
 
 ## 7. 典型场景流程
 
@@ -425,7 +425,7 @@ Manager 提交 PR
 PR merged
   ├─ flow.flow_status: done
   └─ issue.state: closed
-  ↓ vibe check --clean-branch
+  ↓ vibe3 check --clean-branch
 清理物理资源
   ├─ worktree: deleted
   ├─ branch: deleted
@@ -461,7 +461,7 @@ Issue #789 (state/blocked)
   ↓ Flow 已被 aborted（可能是手动）
   ├─ flow.flow_status: aborted
   └─ flow 记录存在但无物理资源
-  ↓ vibe check --clean-branch
+  ↓ vibe3 check --clean-branch
 检测 aborted flow
   ├─ cleanup_flow_scene(keep_flow_record=False)
   └─ _resume_blocked_issue(task/issue-789)
@@ -473,16 +473,14 @@ Issue #789 (state/blocked)
 ```
 Issue #999 (state/blocked)
   ↓ Flow 被软删除
-vibe check --clean-branch
+vibe3 check --clean-branch
   ├─ cleanup_flow_scene(keep_flow_record=False)
   ├─ deleted_at: "2026-04-28T15:00:00"
   └─ issue label: state/blocked → state/ready
   ↓ 用户发现需要恢复
-vibe3 flow list-deleted
-  └─ 显示: task/issue-999 | deleted_at: 2026-04-28T15:00:00
-  ↓ 恢复软删除 flow
-vibe3 flow restore task/issue-999
-  ├─ deleted_at: NULL ✅
+# 通过 gh issue / flow status 确认已删除的 flow
+vibe3 flow update task/issue-999
+  ├─ deleted_at: NULL ✅（创建新 flow 自动清除 deleted_at）
   └─ flow 记录恢复可用
   ↓ 验证恢复结果
 vibe3 flow show task/issue-999

--- a/docs/v3/infrastructure/08-command-quick-ref.md
+++ b/docs/v3/infrastructure/08-command-quick-ref.md
@@ -19,7 +19,7 @@ related_docs:
 
 ```
 全局层     vibe3 -v/-vv [COMMAND]
-命令组层   vibe3 flow/inspect/review/... [-h]
+命令组层   vibe3 flow/handoff/... [-h]
 子命令层   vibe3 flow update [--trace] [--json] [-y]
 ```
 
@@ -36,7 +36,7 @@ related_docs:
 
 ```bash
 vibe3 -v flow status
-vibe3 -vv inspect pr 42
+vibe3 -vv flow show
 vibe3 -h
 vibe3 help
 ```
@@ -53,10 +53,10 @@ vibe3 help
 | `--help` | `-h` | 显示帮助 |
 
 ```bash
-vibe3 inspect pr 42 --trace
-vibe3 inspect pr 42 --json | jq '.score'
-vibe3 inspect pr 42 --trace --json
-vibe3 review pr 42 --help
+vibe3 flow show --trace
+vibe3 flow show --json | jq '.status'
+vibe3 flow show --trace --json
+vibe3 flow bind --help
 vibe3 flow show -h
 ```
 
@@ -134,7 +134,7 @@ vibe3 handoff audit docs/audits/security-check.md --actor "reviewer/sonnet-4.6"
 
 ## Verification Commands
 
-### `vibe check`
+### `vibe3 check`
 
 Verify handoff store consistency.
 
@@ -174,22 +174,20 @@ vibe3 check --branch task/issue-456
 # 查看帮助（任意层级）
 vibe3 -h
 vibe3 flow -h
-vibe3 inspect pr -h
-
-# 分析 PR
-vibe3 inspect pr 42
-vibe3 inspect pr 42 --json
-vibe3 inspect pr 42 --trace
-
-# 代码审核
-vibe3 review pr 42
-vibe3 review pr 42 --publish
-vibe3 -v review pr 42          # INFO 日志 + 审核
+vibe3 handoff -h
 
 # 查看流程
 vibe3 flow status
 vibe3 flow show
 vibe3 -vv flow update  # DEBUG 日志 + 更新
+
+# Handoff 协作
+vibe3 handoff show
+vibe3 handoff append "context update"
+
+# 共享状态审计
+vibe3 check
+vibe3 check --json
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Align 4 documentation files to current V3 CLI semantics per `docs/standards/v3/command-standard.md`
- **DEVELOPER.md**: Clarified `bin/vibe check` is V2, not V3
- **08-command-quick-ref.md**: Replaced deprecated `inspect`/`review` examples with current `flow`/`handoff`/`check` commands; renamed `vibe check` heading to `vibe3 check`
- **flow-lifecycle-standard.md**: Replaced all `vibe check` → `vibe3 check`; commented out deprecated `flow list-deleted`/`flow restore` CLI examples; updated soft-delete recovery flow diagram to use `flow update`
- **agent-workflow-standard.md**: Aligned `vibe flow bind` → `vibe3 flow bind`
- **vibe3-state-sync-standard.md**: No changes needed — already a deprecation stub (5 lines)

## Test plan
- [ ] Verify all 4 changed docs render correctly on GitHub
- [ ] Spot-check command references against `docs/standards/v3/command-standard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)