### PR TITLE
fix(docs): align supervisor/vibe-orchestrator SKILL.md stale CLI ref to V3 semantics

### DIFF
--- a/supervisor/vibe-orchestrator/SKILL.md
+++ b/supervisor/vibe-orchestrator/SKILL.md
@@ -106,7 +106,7 @@ input_examples:
 
 - **任务负载检查（Task Load Validation）：**
   - 在创建新任务前，先检查当前分支的任务数量
-  - 运行 `vibe task count-by-branch $(git branch --show-current)` 获取当前分支任务数
+  - 运行 `vibe3 flow status` 获取当前分支 flow 列表
   - 如果任务数 > 3，**立即阻断**并提示用户：
 
     ```


### PR DESCRIPTION
## Summary

Supervisor apply result for issue #660. On-site verification found that 4 of 5 documents claimed stale were already aligned to V3 CLI:

- `supervisor/manager.md` — already correct V3 CLI throughout
- `supervisor/vibe-scope-gate/SKILL.md` — already uses `vibe3 flow update + bind`
- `supervisor/vibe-boundary-check/SKILL.md` — static analysis doc, no CLI refs
- `skills/vibe-onboard/SKILL.md` — already clean

The automated scan missed 1 genuinely stale reference:
- `supervisor/vibe-orchestrator/SKILL.md` line 109: `vibe task count-by-branch` → `vibe3 flow status`

## Changes

- `supervisor/vibe-orchestrator/SKILL.md`: Replaced non-existent `vibe task count-by-branch` with `vibe3 flow status`

Closes #660

## Test plan

- [ ] File content verified: only the targeted line was changed
- [ ] No code changes — docs-only fix within supervisor/apply scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)