### PR TITLE
fix(docs): align vibe:done.md deprecated 'vibe flow done' to V3 standard

### DIFF
--- a/.agent/workflows/vibe:done.md
+++ b/.agent/workflows/vibe:done.md
@@ -12,7 +12,7 @@ tags: [workflow, vibe, completion, archive]
 ## 定位
 
 - `vibe:done` 是一个 `skill-backed workflow`。
-- 它用于在 PR 已 merged，或已满足 review gate、准备由 `vibe flow done` merge + closeout 时，把结算逻辑委托给 `vibe-done` skill。
+- 它用于在 PR 已 merged，或已满足 review gate、准备收口时，把结算逻辑委托给 `vibe-done` skill。
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- Verified all 5 docs listed in issue #648 governance findings via direct inspection
- 4 of 5 files already aligned (no changes needed):
  - docs/references/github-labels-implementation.md: file deleted in PR #893 docs cleanup
  - vibe:new-flow.md: already uses vibe3 flow update/bind
  - vibe:commit.md: already aligned with V3 patterns
  - vibe:new.md: already uses vibe3 flow update
- 1 fix applied: vibe:done.md removed the deprecated 'vibe flow done' reference (V2 pattern deprecated per command-standard.md)

## Verification
- The V3 command-standard.md lists valid subcommands as: update, bind, blocked, show, status
- 'flow done' is explicitly listed as deprecated in section 3.1
- vibe:done.md delegates to vibe-done skill for closure; no CLI command replacement needed

Closes #648

🤖 Generated with Claude Code