### PR TITLE
refactor(utils): extract shared error message cleaner utility

### DIFF
--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -7,6 +7,7 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState
 from vibe3.services.task_status_classifier import TaskStatusBucket
 from vibe3.ui.console import console
+from vibe3.utils.error_message_cleaner import clean_error_message
 
 
 def _extract_blocked_reason_summary(blocked_reason: str) -> str:
@@ -26,11 +27,7 @@ def _extract_blocked_reason_summary(blocked_reason: str) -> str:
     if len(first_line) <= 60 and "CLAUDE_CODE_TMPDIR" not in first_line:
         return first_line
 
-    import re
-
-    cleaned = re.split(r"\s*CLAUDE_CODE_TMPDIR:", first_line)[0].strip()
-    cleaned = re.split(r"\s*\|\s*=== Recent Errors ===", cleaned)[0].strip()
-    cleaned = re.sub(r"\s*\|\s*$", "", cleaned).strip()
+    cleaned = clean_error_message(first_line)
 
     if len(cleaned) <= 80:
         return cleaned

--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -12,6 +12,10 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.exceptions.error_tracking import ErrorTrackingService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import FailedGate
+from vibe3.utils.error_message_cleaner import (
+    CODEAGENT_WRAPPER_RE,
+    clean_error_message,
+)
 from vibe3.utils.time_format import format_age_aware_time
 
 
@@ -57,18 +61,9 @@ class ServeStatusService:
         Returns:
             Cleaned and truncated error message
         """
-        # Remove codeagent-wrapper prefix
-        pattern = r"^codeagent-wrapper failed \(code \d+\):\s*"
-        cleaned = re.sub(pattern, "", error_message)
-
-        # Remove CLAUDE_CODE_TMPDIR and everything after it
-        cleaned = re.split(r"\s*CLAUDE_CODE_TMPDIR:", cleaned)[0].strip()
-
-        # Remove " | === Recent Errors ===" suffix
-        cleaned = re.split(r"\s*\|\s*=== Recent Errors ===", cleaned)[0].strip()
-
-        # Remove trailing pipe separators
-        cleaned = re.sub(r"\s*\|\s*$", "", cleaned).strip()
+        # Remove codeagent-wrapper prefix, then delegate shared cleaning
+        cleaned = CODEAGENT_WRAPPER_RE.sub("", error_message)
+        cleaned = clean_error_message(cleaned)
 
         # Truncate to max_length
         return cleaned[:max_length] if len(cleaned) > max_length else cleaned

--- a/src/vibe3/utils/error_message_cleaner.py
+++ b/src/vibe3/utils/error_message_cleaner.py
@@ -1,0 +1,38 @@
+"""Shared error message cleaning utilities.
+
+Provides precompiled regex patterns and a single clean_error_message()
+function that extracts duplicated cleaning logic from status_render.py
+and serve_status_service.py.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Precompiled regex patterns for shared cleaning steps
+_TMPDIR_RE = re.compile(r"\s*CLAUDE_CODE_TMPDIR:")
+_RECENT_ERRORS_RE = re.compile(r"\s*\|\s*=== Recent Errors ===")
+_TRAILING_PIPE_RE = re.compile(r"\s*\|\s*$")
+
+# Precompiled constant for codeagent-wrapper prefix (used by callers before delegation)
+CODEAGENT_WRAPPER_RE = re.compile(r"^codeagent-wrapper failed \(code \d+\):\s*")
+
+
+def clean_error_message(message: str) -> str:
+    """Remove common noise patterns from error messages.
+
+    Applies three cleaning steps in order:
+    1. Remove CLAUDE_CODE_TMPDIR and everything after it
+    2. Remove ' | === Recent Errors ===' suffix
+    3. Remove trailing pipe separators
+
+    Args:
+        message: Error message after any caller-specific prefix removal
+
+    Returns:
+        Cleaned error message
+    """
+    cleaned = _TMPDIR_RE.split(message)[0].strip()
+    cleaned = _RECENT_ERRORS_RE.split(cleaned)[0].strip()
+    cleaned = _TRAILING_PIPE_RE.sub("", cleaned).strip()
+    return cleaned

--- a/tests/vibe3/utils/test_error_message_cleaner.py
+++ b/tests/vibe3/utils/test_error_message_cleaner.py
@@ -1,0 +1,106 @@
+"""Tests for error_message_cleaner utility."""
+
+from vibe3.utils.error_message_cleaner import (
+    CODEAGENT_WRAPPER_RE,
+    clean_error_message,
+)
+
+
+class TestCleanErrorMessage:
+    """Test cases for clean_error_message function."""
+
+    def test_strips_tmpdir_noise(self):
+        """CLAUDE_CODE_TMPDIR and everything after is removed."""
+        result = clean_error_message(
+            "error message CLAUDE_CODE_TMPDIR: /tmp/path other"
+        )
+        assert result == "error message"
+
+    def test_strips_tmpdir_with_leading_space(self):
+        """TMPDIR preceded by pipe and space is handled."""
+        result = clean_error_message("error | CLAUDE_CODE_TMPDIR: /tmp")
+        assert result == "error"
+
+    def test_strips_recent_errors_suffix(self):
+        """'=== Recent Errors ===' suffix is removed."""
+        result = clean_error_message("error message | === Recent Errors ===")
+        assert result == "error message"
+
+    def test_strips_trailing_pipe(self):
+        """Trailing pipe separator is removed."""
+        result = clean_error_message("error message | ")
+        assert result == "error message"
+
+    def test_combined_cleaning_tmpdir_and_recent_errors(self):
+        """TMPDIR and Recent Errors removed together."""
+        result = clean_error_message(
+            "error CLAUDE_CODE_TMPDIR: /tmp | === Recent Errors ==="
+        )
+        assert result == "error"
+
+    def test_combined_cleaning_all_patterns(self):
+        """All three cleaning patterns applied."""
+        result = clean_error_message(
+            "actual error | CLAUDE_CODE_TMPDIR: /tmp/path | === Recent Errors ==="
+        )
+        assert result == "actual error"
+
+    def test_messages_without_noise_pass_through(self):
+        """Clean messages are unchanged."""
+        result = clean_error_message("short error message")
+        assert result == "short error message"
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        result = clean_error_message("")
+        assert result == ""
+
+    def test_whitespace_only(self):
+        """Whitespace-only input returns empty string."""
+        result = clean_error_message("   ")
+        assert result == ""
+
+    def test_tmpdir_at_start(self):
+        """TMPDIR at the start removes everything."""
+        result = clean_error_message("CLAUDE_CODE_TMPDIR: /tmp path")
+        assert result == ""
+
+    def test_codeagent_wrapper_re_constant(self):
+        """CODEAGENT_WRAPPER_RE matches the expected prefix pattern."""
+        assert (
+            CODEAGENT_WRAPPER_RE.sub("", "codeagent-wrapper failed (code 1):\nerror")
+            == "error"
+        )
+        assert (
+            CODEAGENT_WRAPPER_RE.sub("", "codeagent-wrapper failed (code 2): something")
+            == "something"
+        )
+        assert CODEAGENT_WRAPPER_RE.sub("", "no prefix here") == "no prefix here"
+
+
+class TestCleanErrorMessageCallerDelegation:
+    """Verify the shared function produces the same output as inline patterns."""
+
+    def test_equivalent_to_inline_tmpdir_split(self):
+        """clean_error_message matches inline re.split for TMPDIR."""
+        import re
+
+        message = "some error CLAUDE_CODE_TMPDIR: /tmp"
+        expected = re.split(r"\s*CLAUDE_CODE_TMPDIR:", message)[0].strip()
+        assert clean_error_message(message) == expected
+
+    def test_equivalent_to_inline_recent_errors_split(self):
+        """clean_error_message matches inline re.split for Recent Errors."""
+        import re
+
+        message = "some error | === Recent Errors ==="
+        expected = re.split(r"\s*\|\s*=== Recent Errors ===", message)[0].strip()
+        assert clean_error_message(message) == expected
+
+    def test_equivalent_to_inline_trailing_pipe_sub(self):
+        """clean_error_message matches inline re.sub for trailing pipe."""
+        import re
+
+        message = "some error | "
+        expected = re.sub(r"\s*\|\s*$", "", message).strip()
+        assert clean_error_message(message) == expected


### PR DESCRIPTION
Closes #939

## Summary

Extract the duplicated error message cleaner logic (CLAUDE_CODE_TMPDIR, Recent Errors, trailing pipe patterns) into a shared utility function, reducing code duplication across multiple callers.

## Changes

- Extracted `clean_error_message()` utility with shared regex patterns
- Updated all callers to use the shared utility
- Added comprehensive test coverage for the extracted function
- No behavioral changes — all original patterns preserved identically

## Related

- Issue: #939

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

## Contributors

claude/opus
