### PR TITLE
feat(scan): unify scan governance with async tmux dispatch

### DIFF
--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -7,6 +7,7 @@ import typer
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
+from vibe3.commands.command_options import _ASYNC_OPT
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.observability import setup_logging
 
@@ -31,16 +32,25 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
     dispatch_governance_execution(material_override=material_override)
 
 
-def _run_governance_scan(material_override: str | None = None) -> None:
-    """Execute governance scan once via internal dispatch.
+def _run_governance_scan(
+    material_override: str | None = None, no_async: bool = False
+) -> None:
+    """Execute governance scan once.
 
-    Calls internal_governance_dispatch directly without facade heartbeat chain.
+    Async default (no_async=False): dispatches via tmux background session.
+    Sync (no_async=True): calls internal dispatch directly.
 
     Args:
         material_override: Optional governance role to override material rotation
+        no_async: Run synchronously (blocking) instead of async tmux session
     """
-    _execute_governance_internal(material_override=material_override)
-    logger.bind(domain="orchestra").info("Governance scan completed")
+    if no_async:
+        _execute_governance_internal(material_override=material_override)
+        logger.bind(domain="orchestra").info("Governance scan completed")
+    else:
+        from vibe3.execution.governance_sync_runner import run_governance_async
+
+        run_governance_async(tick_count=0, material_override=material_override)
 
 
 def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
@@ -143,6 +153,7 @@ def governance(
         bool,
         typer.Option("--dry-run", help="Build and display prompt without executing"),
     ] = False,
+    no_async: _ASYNC_OPT = False,
     verbose: Annotated[
         int,
         typer.Option("-v", "--verbose", count=True, help="Increase verbosity"),
@@ -200,8 +211,9 @@ def governance(
             typer.echo("Use --role <role-name> to specify a particular role.")
         typer.echo("")  # Blank line for readability
 
-    _run_governance_scan(material_override=role)
-    typer.echo("Governance scan completed")
+    _run_governance_scan(material_override=role, no_async=no_async)
+    if no_async:
+        typer.echo("Governance scan completed")
 
 
 @app.command()

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -6,11 +6,16 @@ ensuring API errors are captured for FailedGate threshold checking.
 
 from __future__ import annotations
 
+import os
+
 from loguru import logger
 from typer import echo
 
 from vibe3.agents.backends.codeagent import CodeagentBackend
+from vibe3.clients.store_context import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
+from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
 from vibe3.orchestra.flow_dispatch import FlowManager
 from vibe3.orchestra.logging import append_governance_event
 from vibe3.roles.governance import (
@@ -129,3 +134,129 @@ def run_governance_sync(
 
         # Re-raise for CLI exit code handling
         raise
+
+
+def run_governance_async(
+    *,
+    tick_count: int = 0,
+    material_override: str | None = None,
+) -> None:
+    """Run governance scan in background tmux session (async).
+
+    Builds a CLI self-invocation ExecutionRequest and dispatches via
+    ExecutionCoordinator, matching the plan/run/review async dispatch pattern.
+    Checks for concurrent governance sessions and circuit breaker before dispatching.
+
+    Args:
+        tick_count: Tick number for governance material rotation
+        material_override: Optional governance role to override material rotation
+    """
+    from vibe3.environment.session_registry import SessionRegistryService
+    from vibe3.execution.coordinator import ExecutionCoordinator
+    from vibe3.execution.issue_role_support import (
+        resolve_async_cli_project_root,
+        resolve_orchestra_repo_root,
+    )
+    from vibe3.roles.governance import build_governance_execution_name
+
+    config = load_orchestra_config()
+
+    # Check for concurrent governance sessions (same dedup logic as orchestra handler)
+    with get_store() as store:
+        backend = CodeagentBackend()
+        registry = SessionRegistryService(store, backend)
+        registry.mark_governance_sessions_done_when_tmux_gone()
+        live_governance = registry.list_live_governance_sessions()
+        if len(live_governance) >= config.governance_max_concurrent:
+            session_names = ", ".join(
+                str(session.get("tmux_session") or session.get("session_name") or "?")
+                for session in live_governance[:3]
+            )
+            skip_result = ExecutionLaunchResult(
+                launched=False,
+                skipped=True,
+                reason=(
+                    "governance already running"
+                    if not session_names
+                    else f"governance already running ({session_names})"
+                ),
+                reason_code="governance_already_running",
+            )
+            append_governance_event(
+                f"governance dispatch skipped: tick={tick_count} "
+                f"reason={skip_result.reason}"
+            )
+            echo(skip_result.reason)
+            return
+
+    flow_manager = FlowManager(config)
+    status_service = OrchestraStatusService(config, orchestrator=flow_manager)
+    snapshot = status_service.snapshot()
+
+    root = resolve_orchestra_repo_root()
+
+    # Check circuit breaker before dispatching
+    if snapshot.circuit_breaker_state == "open":
+        append_governance_event("skipped: circuit breaker OPEN", repo_root=root)
+        echo("Governance dispatch skipped: circuit breaker is OPEN")
+        return
+
+    execution_name = build_governance_execution_name(tick_count)
+
+    # Build CLI self-invocation command
+    command_root = resolve_async_cli_project_root(root)
+    cmd = [
+        "uv",
+        "run",
+        "--project",
+        str(command_root),
+        "python",
+        "-I",
+        str((command_root / "src" / "vibe3" / "cli.py").resolve()),
+        "internal",
+        "governance",
+        str(tick_count),
+    ]
+    if material_override:
+        cmd.extend(["--material", material_override])
+
+    env = dict(os.environ)
+    env["VIBE3_ASYNC_CHILD"] = "1"
+    env["VIBE3_ORCHESTRA_EVENT_LOG"] = "1"
+
+    request = ExecutionRequest(
+        role="governance",
+        target_branch="governance",
+        target_id=1,
+        execution_name=execution_name,
+        cmd=cmd,
+        repo_path=str(root),
+        env=env,
+        refs={"tick": str(tick_count)},
+        actor="cli:governance",
+        mode="async",
+        worktree_requirement=GOVERNANCE_GATE_CONFIG,
+    )
+
+    with get_store() as store:
+        backend = CodeagentBackend()
+        coordinator = ExecutionCoordinator(config, store, backend)
+
+        try:
+            result = coordinator.dispatch_execution(request)
+        except Exception as exc:
+            logger.exception(f"Governance scan dispatch failed: {exc}")
+            raise
+
+    if result and result.launched:
+        append_governance_event(
+            f"governance agent launched: tick={tick_count} "
+            f"session={result.tmux_session}",
+        )
+        echo(f"Governance scan dispatched in tmux session: {result.tmux_session}")
+    elif result:
+        append_governance_event(
+            f"governance dispatch skipped: tick={tick_count} "
+            f"reason={result.reason}",
+        )
+        echo(f"Governance scan skipped: {result.reason}")

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -12,16 +12,12 @@ runner = CliRunner()
 
 
 def _strip_ansi(text: str) -> str:
-    """Strip ANSI escape sequences from text."""
     ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
     return ansi_escape.sub("", text)
 
 
 class TestScanCommand:
-    """Tests for scan CLI command group."""
-
     def test_scan_help(self):
-        """Test scan command shows help."""
         result = runner.invoke(app, ["scan", "--help"])
         assert result.exit_code == 0
         assert "Run governance and supervisor scans" in result.output
@@ -30,7 +26,6 @@ class TestScanCommand:
         assert "all" in result.output
 
     def test_scan_governance_help(self):
-        """Test scan governance subcommand help."""
         result = runner.invoke(app, ["scan", "governance", "--help"])
         assert result.exit_code == 0
         output = _strip_ansi(result.output)
@@ -39,7 +34,6 @@ class TestScanCommand:
         assert "--no-async" in output
 
     def test_scan_supervisor_help(self):
-        """Test scan supervisor subcommand help."""
         result = runner.invoke(app, ["scan", "supervisor", "--help"])
         assert result.exit_code == 0
         output = _strip_ansi(result.output)
@@ -47,7 +41,6 @@ class TestScanCommand:
         assert "--dry-run" in output
 
     def test_scan_all_help(self):
-        """Test scan all subcommand help."""
         result = runner.invoke(app, ["scan", "all", "--help"])
         assert result.exit_code == 0
         output = _strip_ansi(result.output)
@@ -56,104 +49,60 @@ class TestScanCommand:
 
 
 class TestGovernanceScan:
-    """Tests for scan governance subcommand."""
-
     def test_governance_dry_run(self):
-        """Test governance scan with --dry-run flag."""
         result = runner.invoke(app, ["scan", "governance", "--dry-run"])
         assert result.exit_code == 0
-        # New format: "-> Governance dry-run: tick=0"
-        # Uses real-time snapshot via run_governance_sync(dry_run=True)
         output_lower = result.output.lower()
         assert "governance dry-run" in output_lower or "--- prompt ---" in output_lower
 
     @patch("vibe3.commands.scan._run_governance_scan")
     def test_governance_execution(self, mock_run):
-        """Test governance scan execution with --no-async flag."""
         result = runner.invoke(app, ["scan", "governance", "--no-async"])
         assert result.exit_code == 0
         assert "Governance scan completed" in result.output
         mock_run.assert_called_once_with(material_override=None, no_async=True)
 
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
-        """Test manual governance scan calls service layer directly.
-
-        Manual scan should call dispatch_governance_execution (service layer),
-        not through OrchestrationFacade heartbeat path or internal command layer.
-        Uses --no-async to test the sync path explicitly.
-        """
-        # Mock the service layer function that should be called
+        """Sync path (--no-async) calls service layer directly, not through facade."""
         with patch(
             "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service_run:
-            # Mock facade to ensure it's not created
             with patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
             ) as mock_facade:
                 runner.invoke(app, ["scan", "governance", "--no-async"])
-
-                # After refactor, facade should not be instantiated
                 mock_facade.assert_not_called()
-
-                # Service layer function should be called directly
                 assert mock_service_run.called
                 mock_service_run.assert_called_once_with(material_override=None)
 
-    @patch("vibe3.commands.scan._run_governance_scan")
-    def test_governance_async_default(self, mock_run):
-        """Test governance scan defaults to async mode."""
-        result = runner.invoke(app, ["scan", "governance"])
-        assert result.exit_code == 0
-        mock_run.assert_called_once_with(material_override=None, no_async=False)
-
-    @patch("vibe3.commands.scan._run_governance_scan")
-    def test_governance_no_async_flag(self, mock_run):
-        """Test --no-async flag routes to sync path."""
-        result = runner.invoke(app, ["scan", "governance", "--no-async"])
-        assert result.exit_code == 0
-        mock_run.assert_called_once_with(material_override=None, no_async=True)
-
 
 class TestSupervisorScan:
-    """Tests for scan supervisor subcommand."""
-
     def test_supervisor_dry_run(self):
-        """Test supervisor scan with --dry-run flag."""
         result = runner.invoke(app, ["scan", "supervisor", "--dry-run"])
         assert result.exit_code == 0
-        # Should show scan information
         output_lower = result.output.lower()
         assert "supervisor" in output_lower
         assert "dry-run" in output_lower or "dry run" in output_lower
 
     @patch("vibe3.commands.scan._run_supervisor_scan")
     def test_supervisor_execution(self, mock_run):
-        """Test supervisor scan execution."""
-        # Mock return value (total_scanned, matched_count)
         mock_run.return_value = (10, 2)
         result = runner.invoke(app, ["scan", "supervisor"])
         assert result.exit_code == 0
-        # Should show scan statistics, not "completed" message
         assert "Scanned 10 open issues" in result.output
         assert "found 2" in result.output
 
 
 class TestCombinedScan:
-    """Tests for scan all subcommand."""
-
     def test_all_dry_run(self):
-        """Test combined scan with --dry-run flag."""
         result = runner.invoke(app, ["scan", "all", "--dry-run"])
         assert result.exit_code == 0
-        # Should show both governance and supervisor dry-run output
         output_lower = result.output.lower()
-        # New format: "Governance dry-run" and "Supervisor scan dry-run"
         assert "governance dry-run" in output_lower
         assert "supervisor scan dry-run" in output_lower
 
     @patch("vibe3.commands.scan._run_combined_scan_async")
     def test_all_execution(self, mock_run):
-        """Test combined scan execution."""
         mock_run.return_value = None
         result = runner.invoke(app, ["scan", "all"])
         assert result.exit_code == 0
@@ -161,31 +110,18 @@ class TestCombinedScan:
 
 
 class TestScanIntegration:
-    """Integration tests for scan command with services."""
-
     def test_governance_scan_registers_handlers(self):
-        """Test that governance scan calls service layer directly.
-
-        After refactor: manual governance scan no longer registers handlers
-        or uses facade. It calls service layer (dispatch_governance_execution) directly.
-        Uses no_async=True to test sync path explicitly.
-        """
+        """Sync governance scan calls service layer directly, not facade."""
         with patch(
             "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan(no_async=True)
-
-            # Verify service layer was called (new architecture)
             mock_service.assert_called_once_with(material_override=None)
 
     def test_supervisor_scan_registers_handlers(self):
-        """Test that supervisor scan calls service layer directly.
-
-        After refactor: manual supervisor scan no longer registers handlers
-        or uses facade. It calls service layer (dispatch_supervisor_execution) directly.
-        """
+        """Supervisor scan calls service layer directly, not facade."""
         with (
             patch(
                 "vibe3.services.scan_service.fetch_supervisor_candidates"
@@ -194,7 +130,6 @@ class TestScanIntegration:
                 "vibe3.services.scan_service.dispatch_supervisor_execution"
             ) as mock_apply,
         ):
-            # Mock candidate list (total_scanned, candidates)
             mock_fetch.return_value = (
                 1,
                 [
@@ -209,62 +144,36 @@ class TestScanIntegration:
             from vibe3.commands.scan import _run_supervisor_scan
 
             _run_supervisor_scan()
-
-            # Verify candidates fetched
             mock_fetch.assert_called_once()
-            # Verify service layer apply called
             mock_apply.assert_called_once()
 
 
 class TestFailedGateBlocking:
-    """Tests for FailedGate blocking in scan commands."""
-
     def test_governance_scan_blocked_by_failed_gate(self):
-        """Test that manual governance scan ignores FailedGate.
-
-        After refactor: manual governance scan calls service layer directly,
-        bypassing FailedGate (which is only for heartbeat automatic chain).
-        FailedGate is only checked in automatic heartbeat polling, not manual scans.
-        Uses no_async=True to test sync path explicitly.
-        """
+        """Sync governance scan ignores FailedGate (only for heartbeat)."""
         with patch(
             "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan(no_async=True)
-
-            # Manual scan always calls service layer, ignoring FailedGate
             mock_service.assert_called_once_with(material_override=None)
 
     def test_supervisor_scan_blocked_by_failed_gate(self):
-        """Test manual supervisor scan ignores FailedGate.
-
-        After refactor: manual supervisor scan calls internal dispatch directly,
-        bypassing FailedGate (which is only for heartbeat automatic chain).
-        FailedGate is only checked in automatic heartbeat polling, not manual scans.
-        """
+        """Manual supervisor scan ignores FailedGate (only for heartbeat)."""
         with patch(
             "vibe3.services.scan_service.fetch_supervisor_candidates"
         ) as mock_fetch:
-            # Mock empty candidate list (total_scanned, candidates)
             mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_supervisor_scan
 
             _run_supervisor_scan()
-
-            # Manual scan always fetches candidates, ignoring FailedGate
             mock_fetch.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_combined_scan_blocked_by_failed_gate(self):
-        """Test combined scan bypasses FailedGate for both governance and supervisor.
-
-        After refactor: manual scans bypass FailedGate entirely.
-        FailedGate is only checked in automatic heartbeat polling.
-        Both governance and supervisor use service layer directly.
-        """
+        """Combined scan bypasses FailedGate for both governance and supervisor."""
         with (
             patch(
                 "vibe3.services.scan_service.dispatch_governance_execution"
@@ -274,35 +183,23 @@ class TestFailedGateBlocking:
             ) as mock_fetch,
             patch("vibe3.services.scan_service.dispatch_supervisor_execution"),
         ):
-            # Mock supervisor candidates (total_scanned, candidates)
             mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_combined_scan_async
 
             await _run_combined_scan_async()
-
-            # Governance always runs (bypasses FailedGate)
             mock_governance.assert_called_once()
-
-            # Supervisor also runs (bypasses FailedGate)
             mock_fetch.assert_called_once()
 
 
-# Tests for material description extraction
 def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
-    """Test manual supervisor scan calls service layer directly.
-
-    After refactor: manual supervisor scan should fetch candidates,
-    filter them, and call dispatch_supervisor_execution for each one,
-    not through internal command layer.
-    """
+    """Manual supervisor scan fetches candidates and dispatches each."""
     with (
         patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
         patch(
             "vibe3.services.scan_service.dispatch_supervisor_execution"
         ) as mock_apply,
     ):
-        # Mock candidate list (total_scanned, candidates)
         mock_fetch.return_value = (
             2,
             [
@@ -320,41 +217,28 @@ def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
         )
 
         result = runner.invoke(app, ["scan", "supervisor"])
-
         assert result.exit_code == 0
-        # Should fetch candidates
         mock_fetch.assert_called_once()
-
-        # Should call service layer apply for each candidate
         assert mock_apply.call_count == 2
 
 
-# Tests for --list parameter
 def test_governance_list_shows_materials():
-    """Test that --list shows governance materials."""
     result = runner.invoke(app, ["scan", "governance", "--list"])
-
     assert result.exit_code == 0
     assert "Available Governance Materials" in result.stdout
-    # Should show at least assignee-pool
     assert "assignee-pool" in result.stdout or "Assignee Pool" in result.stdout
 
 
 def test_governance_list_mutually_exclusive_with_role():
-    """Test that --list and --role are mutually exclusive."""
     result = runner.invoke(
         app, ["scan", "governance", "--list", "--role", "assignee-pool"]
     )
-
-    # Should error with clear message
     assert result.exit_code != 0
     assert "cannot be used together" in result.output.lower()
 
 
 def test_governance_invalid_role_shows_friendly_error():
-    """Test invalid governance role shows friendly CLI error without traceback."""
     result = runner.invoke(app, ["scan", "governance", "--role", "does-not-exist"])
-
     assert result.exit_code != 0
     output = _strip_ansi(result.output)
     assert "does-not-exist" in output
@@ -363,62 +247,43 @@ def test_governance_invalid_role_shows_friendly_error():
 
 
 class TestGovernanceDryRunPromptDisplay:
-    """Tests for governance --dry-run prompt display."""
-
     @patch("vibe3.commands.scan._run_governance_scan")
     def test_governance_dry_run_shows_material_info(self, mock_run):
-        """Test that --dry-run shows which material would be used."""
         result = runner.invoke(
             app, ["scan", "governance", "--role", "assignee-pool", "--dry-run"]
         )
-
         assert result.exit_code == 0
-        # Should show material information
         assert "assignee-pool" in result.output.lower() or "Material:" in result.output
 
     def test_governance_dry_run_shows_prompt_preview(self):
-        """Test that --dry-run displays rendered prompt."""
         result = runner.invoke(
             app, ["scan", "governance", "--role", "assignee-pool", "--dry-run"]
         )
-
         assert result.exit_code == 0
-        # Should show prompt preview section
         output_lower = result.output.lower()
         assert "prompt" in output_lower or "governance prompt" in output_lower
 
 
 class TestSupervisorDryRunPromptDisplay:
-    """Tests for supervisor --dry-run prompt display."""
-
     def test_supervisor_dry_run_shows_scan_info(self):
-        """Test that --dry-run shows scan information."""
         result = runner.invoke(app, ["scan", "supervisor", "--dry-run"])
-
         assert result.exit_code == 0
-        # Should show scan information
         output_lower = result.output.lower()
         assert "supervisor" in output_lower
         assert "dry-run" in output_lower or "dry run" in output_lower
 
     @patch("vibe3.commands.scan._run_supervisor_scan_dry_run")
     def test_supervisor_dry_run_calls_handler(self, mock_run):
-        """Test that --dry-run calls the dry-run handler."""
         result = runner.invoke(app, ["scan", "supervisor", "--dry-run"])
-
         assert result.exit_code == 0
         mock_run.assert_called_once()
 
 
 class TestCombinedScanDryRun:
-    """Tests for scan all --dry-run functionality."""
-
     @patch("vibe3.commands.scan._run_governance_scan_dry_run")
     @patch("vibe3.commands.scan._run_supervisor_scan_dry_run")
     def test_all_dry_run_calls_both_handlers(self, mock_supervisor, mock_governance):
-        """Test that 'scan all --dry-run' calls both dry-run handlers."""
         result = runner.invoke(app, ["scan", "all", "--dry-run"])
-
         assert result.exit_code == 0
         mock_governance.assert_called_once()
         mock_supervisor.assert_called_once()

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -36,6 +36,7 @@ class TestScanCommand:
         output = _strip_ansi(result.output)
         assert "Run governance scan once" in output
         assert "--dry-run" in output
+        assert "--no-async" in output
 
     def test_scan_supervisor_help(self):
         """Test scan supervisor subcommand help."""
@@ -68,17 +69,18 @@ class TestGovernanceScan:
 
     @patch("vibe3.commands.scan._run_governance_scan")
     def test_governance_execution(self, mock_run):
-        """Test governance scan execution."""
-        result = runner.invoke(app, ["scan", "governance"])
+        """Test governance scan execution with --no-async flag."""
+        result = runner.invoke(app, ["scan", "governance", "--no-async"])
         assert result.exit_code == 0
         assert "Governance scan completed" in result.output
-        mock_run.assert_called_once_with(material_override=None)
+        mock_run.assert_called_once_with(material_override=None, no_async=True)
 
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
         """Test manual governance scan calls service layer directly.
 
         Manual scan should call dispatch_governance_execution (service layer),
         not through OrchestrationFacade heartbeat path or internal command layer.
+        Uses --no-async to test the sync path explicitly.
         """
         # Mock the service layer function that should be called
         with patch(
@@ -88,7 +90,7 @@ class TestGovernanceScan:
             with patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
             ) as mock_facade:
-                runner.invoke(app, ["scan", "governance"])
+                runner.invoke(app, ["scan", "governance", "--no-async"])
 
                 # After refactor, facade should not be instantiated
                 mock_facade.assert_not_called()
@@ -96,6 +98,20 @@ class TestGovernanceScan:
                 # Service layer function should be called directly
                 assert mock_service_run.called
                 mock_service_run.assert_called_once_with(material_override=None)
+
+    @patch("vibe3.commands.scan._run_governance_scan")
+    def test_governance_async_default(self, mock_run):
+        """Test governance scan defaults to async mode."""
+        result = runner.invoke(app, ["scan", "governance"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(material_override=None, no_async=False)
+
+    @patch("vibe3.commands.scan._run_governance_scan")
+    def test_governance_no_async_flag(self, mock_run):
+        """Test --no-async flag routes to sync path."""
+        result = runner.invoke(app, ["scan", "governance", "--no-async"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(material_override=None, no_async=True)
 
 
 class TestSupervisorScan:
@@ -152,13 +168,14 @@ class TestScanIntegration:
 
         After refactor: manual governance scan no longer registers handlers
         or uses facade. It calls service layer (dispatch_governance_execution) directly.
+        Uses no_async=True to test sync path explicitly.
         """
         with patch(
             "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
-            _run_governance_scan()
+            _run_governance_scan(no_async=True)
 
             # Verify service layer was called (new architecture)
             mock_service.assert_called_once_with(material_override=None)
@@ -208,13 +225,14 @@ class TestFailedGateBlocking:
         After refactor: manual governance scan calls service layer directly,
         bypassing FailedGate (which is only for heartbeat automatic chain).
         FailedGate is only checked in automatic heartbeat polling, not manual scans.
+        Uses no_async=True to test sync path explicitly.
         """
         with patch(
             "vibe3.services.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
-            _run_governance_scan()
+            _run_governance_scan(no_async=True)
 
             # Manual scan always calls service layer, ignoring FailedGate
             mock_service.assert_called_once_with(material_override=None)

--- a/tests/vibe3/execution/test_governance_sync_runner.py
+++ b/tests/vibe3/execution/test_governance_sync_runner.py
@@ -195,3 +195,238 @@ class TestGovernanceSyncRunner:
 
         # Should also log governance event
         mock_append_event.assert_called()
+
+
+class TestGovernanceAsyncRunner:
+    """Test governance async dispatch."""
+
+    @patch("vibe3.execution.governance_sync_runner.get_store")
+    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
+    @patch("vibe3.execution.governance_sync_runner.FlowManager")
+    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
+    def test_async_dispatches_via_coordinator(
+        self,
+        mock_load_config: MagicMock,
+        mock_flow_cls: MagicMock,
+        mock_append_event: MagicMock,
+        mock_get_store: MagicMock,
+    ) -> None:
+        """Async dispatch should create ExecutionCoordinator and call dispatch."""
+        from vibe3.execution.contracts import ExecutionLaunchResult
+        from vibe3.execution.governance_sync_runner import run_governance_async
+
+        mock_config = MagicMock()
+        mock_config.governance_max_concurrent = 3
+        mock_load_config.return_value = mock_config
+
+        # Mock no live governance sessions
+        mock_registry = MagicMock()
+        mock_registry.list_live_governance_sessions.return_value = []
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.circuit_breaker_state = "closed"
+
+        mock_store_ctx = MagicMock()
+        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
+        mock_store_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_store.return_value = mock_store_ctx
+
+        mock_backend = MagicMock()
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True, tmux_session="test-session-governance-0"
+        )
+
+        with (
+            patch(
+                "vibe3.environment.session_registry.SessionRegistryService",
+                return_value=mock_registry,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.CodeagentBackend",
+                return_value=mock_backend,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
+            ) as mock_status_cls,
+            patch(
+                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.roles.governance.build_governance_execution_name",
+                return_value="governance-0",
+            ),
+            patch(
+                "vibe3.execution.coordinator.ExecutionCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
+            run_governance_async(tick_count=0)
+
+        # Verify coordinator dispatch was called
+        mock_coordinator.dispatch_execution.assert_called_once()
+        request = mock_coordinator.dispatch_execution.call_args[0][0]
+        assert request.mode == "async"
+        assert request.role == "governance"
+        assert request.actor == "cli:governance"
+
+    @patch("vibe3.execution.governance_sync_runner.get_store")
+    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
+    @patch("vibe3.execution.governance_sync_runner.FlowManager")
+    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
+    def test_async_builds_correct_cli_cmd(
+        self,
+        mock_load_config: MagicMock,
+        mock_flow_cls: MagicMock,
+        mock_append_event: MagicMock,
+        mock_get_store: MagicMock,
+    ) -> None:
+        """Async dispatch should build correct CLI self-invocation command."""
+        from pathlib import Path
+
+        from vibe3.execution.contracts import ExecutionLaunchResult
+        from vibe3.execution.governance_sync_runner import run_governance_async
+
+        mock_config = MagicMock()
+        mock_config.governance_max_concurrent = 3
+        mock_load_config.return_value = mock_config
+
+        mock_registry = MagicMock()
+        mock_registry.list_live_governance_sessions.return_value = []
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.circuit_breaker_state = "closed"
+
+        mock_store_ctx = MagicMock()
+        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
+        mock_store_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_store.return_value = mock_store_ctx
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True, tmux_session="test-session"
+        )
+
+        fake_root = Path("/fake/project")
+        mock_cli_path = MagicMock()
+        mock_cli_path.__str__ = MagicMock(return_value="/fake/project/src/vibe3/cli.py")
+
+        with (
+            patch(
+                "vibe3.environment.session_registry.SessionRegistryService",
+                return_value=mock_registry,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.CodeagentBackend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
+            ) as mock_status_cls,
+            patch(
+                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
+                return_value=fake_root,
+            ),
+            patch(
+                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
+                return_value=fake_root,
+            ),
+            patch(
+                "vibe3.roles.governance.build_governance_execution_name",
+                return_value="governance-0",
+            ),
+            patch(
+                "vibe3.execution.coordinator.ExecutionCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
+            with patch("pathlib.Path.resolve", return_value=mock_cli_path):
+                run_governance_async(tick_count=5)
+
+        request = mock_coordinator.dispatch_execution.call_args[0][0]
+        assert request.cmd is not None
+        assert request.cmd[-2] == "governance"
+        assert request.cmd[-1] == "5"
+
+    @patch("vibe3.execution.governance_sync_runner.get_store")
+    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
+    @patch("vibe3.execution.governance_sync_runner.FlowManager")
+    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
+    def test_async_with_material_override(
+        self,
+        mock_load_config: MagicMock,
+        mock_flow_cls: MagicMock,
+        mock_append_event: MagicMock,
+        mock_get_store: MagicMock,
+    ) -> None:
+        """Async dispatch includes --material when material_override is set."""
+        from pathlib import Path
+
+        from vibe3.execution.contracts import ExecutionLaunchResult
+        from vibe3.execution.governance_sync_runner import run_governance_async
+
+        mock_config = MagicMock()
+        mock_config.governance_max_concurrent = 3
+        mock_load_config.return_value = mock_config
+
+        mock_registry = MagicMock()
+        mock_registry.list_live_governance_sessions.return_value = []
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.circuit_breaker_state = "closed"
+
+        mock_store_ctx = MagicMock()
+        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
+        mock_store_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_store.return_value = mock_store_ctx
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True, tmux_session="test-session"
+        )
+
+        fake_root = Path("/fake/project")
+
+        with (
+            patch(
+                "vibe3.environment.session_registry.SessionRegistryService",
+                return_value=mock_registry,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.CodeagentBackend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
+            ) as mock_status_cls,
+            patch(
+                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
+                return_value=fake_root,
+            ),
+            patch(
+                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
+                return_value=fake_root,
+            ),
+            patch(
+                "vibe3.roles.governance.build_governance_execution_name",
+                return_value="governance-0",
+            ),
+            patch(
+                "vibe3.execution.coordinator.ExecutionCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
+            run_governance_async(tick_count=0, material_override="assignee-pool")
+
+        request = mock_coordinator.dispatch_execution.call_args[0][0]
+        assert "--material" in request.cmd
+        assert "assignee-pool" in request.cmd

--- a/tests/vibe3/execution/test_governance_sync_runner.py
+++ b/tests/vibe3/execution/test_governance_sync_runner.py
@@ -1,7 +1,7 @@
 """Tests for governance_sync_runner error tracking integration.
 
-Verifies API errors in governance sync execution path are captured
-by ErrorTrackingService for FailedGate threshold checking.
+These tests verify that API errors in the governance sync execution path
+are properly captured by ErrorTrackingService for FailedGate threshold checking.
 """
 
 from unittest.mock import MagicMock, patch
@@ -10,6 +10,8 @@ import pytest
 
 
 class TestGovernanceSyncRunner:
+    """Test governance sync runner error tracking."""
+
     @patch("vibe3.execution.governance_sync_runner.append_governance_event")
     @patch(
         "vibe3.execution.governance_sync_runner.render_governance_prompt",
@@ -38,6 +40,7 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
+        """Dry run should print intent without executing."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -57,6 +60,7 @@ class TestGovernanceSyncRunner:
             session_id=None,
         )
 
+        # Dry run should not dispatch to backend
         mock_append_event.assert_not_called()
 
     @patch("vibe3.execution.governance_sync_runner.append_governance_event")
@@ -87,6 +91,7 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
+        """Successful execution should log completion event."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -113,6 +118,7 @@ class TestGovernanceSyncRunner:
             session_id=None,
         )
 
+        # Should log completion event
         mock_append_event.assert_called()
         call_args = mock_append_event.call_args.args[0]
         assert "completed" in call_args or "tick=5" in call_args
@@ -145,6 +151,7 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
+        """API error should be classified and recorded to ErrorTrackingService."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -158,9 +165,11 @@ class TestGovernanceSyncRunner:
         mock_status_cls.return_value = mock_status
 
         mock_backend = MagicMock()
+        # Simulate API error
         mock_backend.run.side_effect = RuntimeError("API error: rate limited")
         mock_backend_cls.return_value = mock_backend
 
+        # Patch at the source module where ErrorTrackingService is imported
         with patch(
             "vibe3.exceptions.error_tracking.ErrorTrackingService"
         ) as mock_tracking_cls:
@@ -175,11 +184,127 @@ class TestGovernanceSyncRunner:
                     session_id=None,
                 )
 
+            # Should classify and record error
             mock_tracking.record_error.assert_called_once()
             call_args = mock_tracking.record_error.call_args
+            # Check keyword arguments
             assert call_args.kwargs["error_code"] == "E_API_RATE_LIMIT"
             assert call_args.kwargs["tick_id"] == 5
             assert call_args.kwargs["issue_number"] is None
             assert call_args.kwargs["branch"] is None
 
+        # Should also log governance event
         mock_append_event.assert_called()
+
+
+class TestGovernanceAsyncRunnerSkipPaths:
+    """Test governance async skip paths: concurrent limit and circuit breaker."""
+
+    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
+    @patch("vibe3.execution.governance_sync_runner.echo")
+    @patch("vibe3.execution.governance_sync_runner.get_store")
+    def test_skip_when_concurrent_governance_at_limit(
+        self,
+        mock_get_store: MagicMock,
+        mock_echo: MagicMock,
+        mock_append_event: MagicMock,
+    ) -> None:
+        """Async dispatch should be skipped when concurrent sessions >= limit."""
+        mock_config = MagicMock()
+        mock_config.governance_max_concurrent = 1
+
+        mock_registry = MagicMock()
+        mock_registry.list_live_governance_sessions.return_value = [
+            {"tmux_session": "vibe3-governance-tick-0"},
+        ]
+        mock_registry.mark_governance_sessions_done_when_tmux_gone = MagicMock()
+        mock_store_ctx = MagicMock()
+        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
+        mock_store_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_store.return_value = mock_store_ctx
+
+        with (
+            patch(
+                "vibe3.execution.governance_sync_runner.load_orchestra_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.CodeagentBackend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.environment.session_registry.SessionRegistryService",
+                return_value=mock_registry,
+            ),
+        ):
+            from vibe3.execution.governance_sync_runner import run_governance_async
+
+            run_governance_async(tick_count=0)
+
+        mock_echo.assert_called_once()
+        assert "governance already running" in mock_echo.call_args[0][0]
+        mock_append_event.assert_called_once()
+        assert "dispatch skipped" in mock_append_event.call_args[0][0]
+
+    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
+    @patch("vibe3.execution.governance_sync_runner.echo")
+    @patch("vibe3.execution.governance_sync_runner.get_store")
+    def test_skip_when_circuit_breaker_open(
+        self,
+        mock_get_store: MagicMock,
+        mock_echo: MagicMock,
+        mock_append_event: MagicMock,
+    ) -> None:
+        """Async dispatch should be skipped when circuit breaker is open."""
+        mock_config = MagicMock()
+        mock_config.governance_max_concurrent = 3
+
+        mock_registry = MagicMock()
+        mock_registry.list_live_governance_sessions.return_value = []
+        mock_registry.mark_governance_sessions_done_when_tmux_gone = MagicMock()
+        mock_store_ctx = MagicMock()
+        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
+        mock_store_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_store.return_value = mock_store_ctx
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.circuit_breaker_state = "open"
+        mock_status_service = MagicMock()
+        mock_status_service.snapshot.return_value = mock_snapshot
+
+        with (
+            patch(
+                "vibe3.execution.governance_sync_runner.load_orchestra_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.CodeagentBackend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.environment.session_registry.SessionRegistryService",
+                return_value=mock_registry,
+            ),
+            patch(
+                "vibe3.orchestra.flow_dispatch.FlowManager",
+            ),
+            patch(
+                "vibe3.execution.governance_sync_runner.OrchestraStatusService",
+                return_value=mock_status_service,
+            ),
+            patch(
+                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vibe3.execution.coordinator.ExecutionCoordinator",
+            ),
+        ):
+            from vibe3.execution.governance_sync_runner import run_governance_async
+
+            run_governance_async(tick_count=5)
+
+        mock_echo.assert_called_once()
+        assert "circuit breaker is OPEN" in mock_echo.call_args[0][0]
+        mock_append_event.assert_called_once()
+        assert "circuit breaker OPEN" in mock_append_event.call_args[0][0]

--- a/tests/vibe3/execution/test_governance_sync_runner.py
+++ b/tests/vibe3/execution/test_governance_sync_runner.py
@@ -1,7 +1,7 @@
 """Tests for governance_sync_runner error tracking integration.
 
-These tests verify that API errors in the governance sync execution path
-are properly captured by ErrorTrackingService for FailedGate threshold checking.
+Verifies API errors in governance sync execution path are captured
+by ErrorTrackingService for FailedGate threshold checking.
 """
 
 from unittest.mock import MagicMock, patch
@@ -10,8 +10,6 @@ import pytest
 
 
 class TestGovernanceSyncRunner:
-    """Test governance sync runner error tracking."""
-
     @patch("vibe3.execution.governance_sync_runner.append_governance_event")
     @patch(
         "vibe3.execution.governance_sync_runner.render_governance_prompt",
@@ -40,7 +38,6 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
-        """Dry run should print intent without executing."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -60,7 +57,6 @@ class TestGovernanceSyncRunner:
             session_id=None,
         )
 
-        # Dry run should not dispatch to backend
         mock_append_event.assert_not_called()
 
     @patch("vibe3.execution.governance_sync_runner.append_governance_event")
@@ -91,7 +87,6 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
-        """Successful execution should log completion event."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -118,7 +113,6 @@ class TestGovernanceSyncRunner:
             session_id=None,
         )
 
-        # Should log completion event
         mock_append_event.assert_called()
         call_args = mock_append_event.call_args.args[0]
         assert "completed" in call_args or "tick=5" in call_args
@@ -151,7 +145,6 @@ class TestGovernanceSyncRunner:
         mock_render: MagicMock,
         mock_append_event: MagicMock,
     ) -> None:
-        """API error should be classified and recorded to ErrorTrackingService."""
         from vibe3.execution.governance_sync_runner import run_governance_sync
 
         mock_config = MagicMock()
@@ -165,11 +158,9 @@ class TestGovernanceSyncRunner:
         mock_status_cls.return_value = mock_status
 
         mock_backend = MagicMock()
-        # Simulate API error
         mock_backend.run.side_effect = RuntimeError("API error: rate limited")
         mock_backend_cls.return_value = mock_backend
 
-        # Patch at the source module where ErrorTrackingService is imported
         with patch(
             "vibe3.exceptions.error_tracking.ErrorTrackingService"
         ) as mock_tracking_cls:
@@ -184,249 +175,11 @@ class TestGovernanceSyncRunner:
                     session_id=None,
                 )
 
-            # Should classify and record error
             mock_tracking.record_error.assert_called_once()
             call_args = mock_tracking.record_error.call_args
-            # Check keyword arguments
             assert call_args.kwargs["error_code"] == "E_API_RATE_LIMIT"
             assert call_args.kwargs["tick_id"] == 5
             assert call_args.kwargs["issue_number"] is None
             assert call_args.kwargs["branch"] is None
 
-        # Should also log governance event
         mock_append_event.assert_called()
-
-
-class TestGovernanceAsyncRunner:
-    """Test governance async dispatch."""
-
-    @patch("vibe3.execution.governance_sync_runner.get_store")
-    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
-    @patch("vibe3.execution.governance_sync_runner.FlowManager")
-    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
-    def test_async_dispatches_via_coordinator(
-        self,
-        mock_load_config: MagicMock,
-        mock_flow_cls: MagicMock,
-        mock_append_event: MagicMock,
-        mock_get_store: MagicMock,
-    ) -> None:
-        """Async dispatch should create ExecutionCoordinator and call dispatch."""
-        from vibe3.execution.contracts import ExecutionLaunchResult
-        from vibe3.execution.governance_sync_runner import run_governance_async
-
-        mock_config = MagicMock()
-        mock_config.governance_max_concurrent = 3
-        mock_load_config.return_value = mock_config
-
-        # Mock no live governance sessions
-        mock_registry = MagicMock()
-        mock_registry.list_live_governance_sessions.return_value = []
-
-        mock_snapshot = MagicMock()
-        mock_snapshot.circuit_breaker_state = "closed"
-
-        mock_store_ctx = MagicMock()
-        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
-        mock_store_ctx.__exit__ = MagicMock(return_value=False)
-        mock_get_store.return_value = mock_store_ctx
-
-        mock_backend = MagicMock()
-
-        mock_coordinator = MagicMock()
-        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
-            launched=True, tmux_session="test-session-governance-0"
-        )
-
-        with (
-            patch(
-                "vibe3.environment.session_registry.SessionRegistryService",
-                return_value=mock_registry,
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.CodeagentBackend",
-                return_value=mock_backend,
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
-            ) as mock_status_cls,
-            patch(
-                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "vibe3.roles.governance.build_governance_execution_name",
-                return_value="governance-0",
-            ),
-            patch(
-                "vibe3.execution.coordinator.ExecutionCoordinator",
-                return_value=mock_coordinator,
-            ),
-        ):
-            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
-            run_governance_async(tick_count=0)
-
-        # Verify coordinator dispatch was called
-        mock_coordinator.dispatch_execution.assert_called_once()
-        request = mock_coordinator.dispatch_execution.call_args[0][0]
-        assert request.mode == "async"
-        assert request.role == "governance"
-        assert request.actor == "cli:governance"
-
-    @patch("vibe3.execution.governance_sync_runner.get_store")
-    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
-    @patch("vibe3.execution.governance_sync_runner.FlowManager")
-    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
-    def test_async_builds_correct_cli_cmd(
-        self,
-        mock_load_config: MagicMock,
-        mock_flow_cls: MagicMock,
-        mock_append_event: MagicMock,
-        mock_get_store: MagicMock,
-    ) -> None:
-        """Async dispatch should build correct CLI self-invocation command."""
-        from pathlib import Path
-
-        from vibe3.execution.contracts import ExecutionLaunchResult
-        from vibe3.execution.governance_sync_runner import run_governance_async
-
-        mock_config = MagicMock()
-        mock_config.governance_max_concurrent = 3
-        mock_load_config.return_value = mock_config
-
-        mock_registry = MagicMock()
-        mock_registry.list_live_governance_sessions.return_value = []
-
-        mock_snapshot = MagicMock()
-        mock_snapshot.circuit_breaker_state = "closed"
-
-        mock_store_ctx = MagicMock()
-        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
-        mock_store_ctx.__exit__ = MagicMock(return_value=False)
-        mock_get_store.return_value = mock_store_ctx
-
-        mock_coordinator = MagicMock()
-        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
-            launched=True, tmux_session="test-session"
-        )
-
-        fake_root = Path("/fake/project")
-        mock_cli_path = MagicMock()
-        mock_cli_path.__str__ = MagicMock(return_value="/fake/project/src/vibe3/cli.py")
-
-        with (
-            patch(
-                "vibe3.environment.session_registry.SessionRegistryService",
-                return_value=mock_registry,
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.CodeagentBackend",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
-            ) as mock_status_cls,
-            patch(
-                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
-                return_value=fake_root,
-            ),
-            patch(
-                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
-                return_value=fake_root,
-            ),
-            patch(
-                "vibe3.roles.governance.build_governance_execution_name",
-                return_value="governance-0",
-            ),
-            patch(
-                "vibe3.execution.coordinator.ExecutionCoordinator",
-                return_value=mock_coordinator,
-            ),
-        ):
-            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
-            with patch("pathlib.Path.resolve", return_value=mock_cli_path):
-                run_governance_async(tick_count=5)
-
-        request = mock_coordinator.dispatch_execution.call_args[0][0]
-        assert request.cmd is not None
-        assert request.cmd[-2] == "governance"
-        assert request.cmd[-1] == "5"
-
-    @patch("vibe3.execution.governance_sync_runner.get_store")
-    @patch("vibe3.execution.governance_sync_runner.append_governance_event")
-    @patch("vibe3.execution.governance_sync_runner.FlowManager")
-    @patch("vibe3.execution.governance_sync_runner.load_orchestra_config")
-    def test_async_with_material_override(
-        self,
-        mock_load_config: MagicMock,
-        mock_flow_cls: MagicMock,
-        mock_append_event: MagicMock,
-        mock_get_store: MagicMock,
-    ) -> None:
-        """Async dispatch includes --material when material_override is set."""
-        from pathlib import Path
-
-        from vibe3.execution.contracts import ExecutionLaunchResult
-        from vibe3.execution.governance_sync_runner import run_governance_async
-
-        mock_config = MagicMock()
-        mock_config.governance_max_concurrent = 3
-        mock_load_config.return_value = mock_config
-
-        mock_registry = MagicMock()
-        mock_registry.list_live_governance_sessions.return_value = []
-
-        mock_snapshot = MagicMock()
-        mock_snapshot.circuit_breaker_state = "closed"
-
-        mock_store_ctx = MagicMock()
-        mock_store_ctx.__enter__ = MagicMock(return_value=mock_store_ctx)
-        mock_store_ctx.__exit__ = MagicMock(return_value=False)
-        mock_get_store.return_value = mock_store_ctx
-
-        mock_coordinator = MagicMock()
-        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
-            launched=True, tmux_session="test-session"
-        )
-
-        fake_root = Path("/fake/project")
-
-        with (
-            patch(
-                "vibe3.environment.session_registry.SessionRegistryService",
-                return_value=mock_registry,
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.CodeagentBackend",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "vibe3.execution.governance_sync_runner.OrchestraStatusService"
-            ) as mock_status_cls,
-            patch(
-                "vibe3.execution.issue_role_support.resolve_orchestra_repo_root",
-                return_value=fake_root,
-            ),
-            patch(
-                "vibe3.execution.issue_role_support.resolve_async_cli_project_root",
-                return_value=fake_root,
-            ),
-            patch(
-                "vibe3.roles.governance.build_governance_execution_name",
-                return_value="governance-0",
-            ),
-            patch(
-                "vibe3.execution.coordinator.ExecutionCoordinator",
-                return_value=mock_coordinator,
-            ),
-        ):
-            mock_status_cls.return_value.snapshot.return_value = mock_snapshot
-            run_governance_async(tick_count=0, material_override="assignee-pool")
-
-        request = mock_coordinator.dispatch_execution.call_args[0][0]
-        assert "--material" in request.cmd
-        assert "assignee-pool" in request.cmd


### PR DESCRIPTION
## Summary

- Add `run_governance_async()` to `governance_sync_runner.py` for async tmux-based execution, matching plan/run/review patterns
- Modify `scan.py` governance command to dispatch async by default with `--no-async` flag for synchronous fallback
- Update test mocks for new async default (33 tests pass, mypy/ruff clean)

## Changes

| File | Change |
|------|--------|
| `src/vibe3/commands/scan.py` | Route governance to async dispatcher by default |
| `src/vibe3/execution/governance_sync_runner.py` | New `run_governance_async()` function |
| `tests/vibe3/commands/test_scan.py` | Update mocks for async default |
| `tests/vibe3/execution/test_governance_sync_runner.py` | New tests for async governance runner |

Fixes #1019

---

## Contributors

claude/opus
