### PR TITLE
refactor(cli): add --branch option to flow show/update/restore and handoff status

### DIFF
--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -135,7 +135,10 @@ def _ensure_branch_worktree_ownership(flow_service: FlowService, branch: str) ->
 
 
 def update(
-    branch: BranchArg = None,
+    branch_arg: BranchArg = None,
+    branch_opt: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
+    ] = None,
     name: NameOption = None,
     actor: ActorOption = None,
     spec: SpecOption = None,
@@ -151,6 +154,7 @@ def update(
     ] = False,
 ) -> None:
     """Update flow metadata (idempotent add/update)."""
+    branch = branch_opt or branch_arg
     # Handle deprecated --json flag
     if json_output and output_format == "table":
         typer.echo(
@@ -389,10 +393,21 @@ def list_deleted(
 
 
 def restore_flow(
-    branch: str,
+    branch_arg: Annotated[
+        str | None,
+        typer.Argument(help="Branch name"),
+    ] = None,
+    branch_opt: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
+    ] = None,
     trace: TraceOption = False,
 ) -> None:
     """Restore a soft-deleted flow."""
+    branch = branch_opt or branch_arg
+    if branch is None:
+        typer.echo("Error: Branch is required for flow restore", err=True)
+        raise typer.Exit(1)
+
     from vibe3.utils.branch_arg import resolve_branch_arg
 
     target_branch = resolve_branch_arg(branch)

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -47,9 +47,12 @@ StatusOption = Annotated[bool, typer.Option("--snapshot", help="静态快照模�
 
 
 def show(
-    branch: Annotated[
+    branch_arg: Annotated[
         str | None,
         typer.Argument(help="Branch name"),
+    ] = None,
+    branch_opt: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
     ] = None,
     snapshot: StatusOption = False,
     trace: TraceOption = False,
@@ -69,6 +72,7 @@ def show(
     ] = False,
 ) -> None:
     """Show flow details with source-aware reads."""
+    branch = branch_opt or branch_arg
     # Handle deprecated --json flag
     if json_output and output_format == "table":
         typer.echo(

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -135,7 +135,10 @@ def show(
 
 
 def status(
-    branch: Annotated[str | None, typer.Argument(help="Branch name")] = None,
+    branch_arg: Annotated[str | None, typer.Argument(help="Branch name")] = None,
+    branch_opt: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
+    ] = None,
     show_all: Annotated[bool, typer.Option("--all", help="显示全部历史")] = False,
     trace: Annotated[
         bool, typer.Option("--trace", help="启用调用链路追踪 + DEBUG 日志")
@@ -152,6 +155,7 @@ def status(
     ] = False,
 ) -> None:
     """Show current flow handoff status and recent records."""
+    branch = branch_opt or branch_arg
     # Handle deprecated --json flag
     if json_output and output_format == "table":
         typer.echo(

--- a/tests/vibe3/commands/test_flow_update_spec.py
+++ b/tests/vibe3/commands/test_flow_update_spec.py
@@ -21,7 +21,7 @@ def test_update_clear_spec_ref_with_empty_string() -> None:
         "vibe3.commands.flow_manage.FlowService", return_value=mock_flow_service
     ):
         with patch("vibe3.commands.flow_manage.trace_scope"):
-            update(branch="test/branch", spec="")
+            update(branch_arg="test/branch", spec="")
 
     # Verify: spec_ref cleared with None
     mock_flow_service.store.update_flow_state.assert_called_once_with(
@@ -42,7 +42,7 @@ def test_update_with_issue_number_rejected() -> None:
     ):
         with patch("vibe3.commands.flow_manage.trace_scope"):
             with pytest.raises(typer.Exit) as exc_info:
-                update(branch="test/branch", spec="123")
+                update(branch_arg="test/branch", spec="123")
 
     # Verify: exit code 1
     assert exc_info.value.exit_code == 1
@@ -64,7 +64,7 @@ def test_update_with_valid_file_path() -> None:
                     with patch.object(
                         Path, "resolve", return_value=Path("/abs/docs/spec.md")
                     ):
-                        update(branch="test/branch", spec="docs/spec.md")
+                        update(branch_arg="test/branch", spec="docs/spec.md")
 
     # Verify: bind_spec called with absolute path
     mock_flow_service.bind_spec.assert_called_once()
@@ -83,7 +83,7 @@ def test_update_with_invalid_file_path_raises_error() -> None:
         with patch("vibe3.commands.flow_manage.trace_scope"):
             with patch.object(Path, "exists", return_value=False):
                 with pytest.raises(typer.Exit) as exc_info:
-                    update(branch="test/branch", spec="nonexistent.md")
+                    update(branch_arg="test/branch", spec="nonexistent.md")
 
     # Verify: exit code 1
     assert exc_info.value.exit_code == 1
@@ -100,7 +100,7 @@ def test_update_without_spec_does_not_modify() -> None:
         "vibe3.commands.flow_manage.FlowService", return_value=mock_flow_service
     ):
         with patch("vibe3.commands.flow_manage.trace_scope"):
-            update(branch="test/branch", spec=None)
+            update(branch_arg="test/branch", spec=None)
 
     # Verify: bind_spec NOT called, update_flow_state NOT called for spec_ref
     mock_flow_service.bind_spec.assert_not_called()


### PR DESCRIPTION
Closes #1029

## Summary

- Added `--branch` option to 4 CLI commands: `flow show`, `flow update`, `flow restore`, `handoff status`
- Maintains backward compatibility with existing positional argument usage
- `branch_opt or branch_arg` merge pattern: `--branch` takes priority over positional

## Changes

- `src/vibe3/commands/flow_status.py` — flow show command
- `src/vibe3/commands/flow_manage.py` — flow update, restore commands
- `src/vibe3/commands/handoff_read.py` — handoff status command
- `tests/vibe3/commands/test_flow_update_spec.py` — updated tests for keyword param renames

## Verification

- All 57 tests pass
- mypy clean, ruff clean
- CLI smoke tests: both positional and `--branch` forms produce identical output
- +23 LOC across 3 source files, no new dependencies

## Notes

- `restore_flow()`: required positional → optional dual-param with explicit None guard
- Audit report: `docs/reports/issue-1029-audit-report.md`

---

## Contributors

claude/opus
