### PR TITLE
fix(docs): align 5 stale docs to current V3 CLI semantics

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -198,8 +198,9 @@ bash scripts/tools/metrics.sh
 
 ---
 
-## 4. V2 标准开发流程
+## 4. V2 标准开发流程（V2 Legacy，仅供参考）
 
+> ⚠️ **此流程基于已不再扩展的 V2 Shell 入口（`bin/vibe`）。V3 用户请优先参考 §2.4 V3 开发入口。**
 > 小白入门：**每次开发功能，严格按这 5 步走。**
 > V3 用户请参考 §2.4 V3 开发入口中的 `uv run python src/vibe3/cli.py` 命令集，以及 `.agent/README.md` 中的 agent workflow 入口。
 
@@ -312,10 +313,12 @@ tests/                 # bats-core 测试（≥20 个用例）
 
 ## 7. 常用命令速查
 
-### V2 (Shell)
+### V2 (Shell) — Legacy，不再扩展
+
+> ⚠️ `bin/vibe` 是 V2 Shell 入口，已稳定不再扩展。V3 用户请使用下方 V3 (Python) 命令。
 
 ```bash
-# 开发工作流
+# 开发工作流（V2，仅供参考）
 bin/vibe flow start <feature>  # 创建 worktree + 分支
 bin/vibe flow review           # Pre-PR 检查
 bin/vibe flow pr               # 创建 PR

--- a/docs/references/codex-review.md
+++ b/docs/references/codex-review.md
@@ -1,7 +1,7 @@
 ---
 document_type: reference
 title: Codex Review 工程级使用体系
-status: current
+status: archived
 scope: code-review
 author: Vibe Team
 related_docs:
@@ -10,7 +10,15 @@ related_docs:
 
 # Codex Review 工程级使用体系
 
-> **当前用法说明**：在 Vibe Center 中，codex 作为外部 plugin 通过 `codex:rescue` skill 调用（见 `skills/vibe-review-pr/`）。本文档描述的 review policy 设计理念和与 Serena AST 的结合思路仍有参考价值。
+> ⚠️ **本文档已归档为历史设计参考。**
+> Vibe Center 当前采用 `vibe3 review` 命令和 `skills/vibe-review-pr/` skill 进行代码审查，不再使用 codex CLI。
+> 本文档中引用的以下文件和路径 **不存在于当前仓库**：
+> - `.codex/review-policy.md` — 不存在
+> - `.codex/impact-summary.md` — 不存在
+> - `scripts/review-with-serena.sh` — 不存在
+>
+> 文档中描述的 `codex review` CLI 工作流与当前 skill-based 方法不匹配，请勿直接执行文中的命令示例。
+> 审查标准请参考 `skills/vibe-review-pr/SKILL.md` 和 `docs/standards/github-code-review-standard.md`。
 
 ## 概述
 

--- a/docs/references/structure-snapshow.md
+++ b/docs/references/structure-snapshow.md
@@ -1,5 +1,13 @@
 # PRD: Structure Snapshot - 代码结构快照系统
 
+> ⚠️ **V3 语义更新**：本文档为 V2 时代的 PRD 设计稿，文件名的拼写（"snapshow" 而非 "snapshot"）也是历史遗留。
+> V3 中的实际命令入口为：
+> - `vibe3 snapshot` — 项目级结构快照追踪（对应本文档的 `structure build/show/diff` 概念）
+> - `vibe3 inspect structure` — 单文件/变更分析
+>
+> 本文档保留为历史设计参考，其中描述的 CLI 命令名（`structure build/show/diff`）并非 V3 实际命令。
+> 详见 `docs/v3/v3-next-steps.md` §4 "Structure Snapshot 的位置"。
+
 1. Goal
 
 Provide a stable, hierarchical code structure snapshot for:

--- a/docs/standards/v3/git-workflow-standard.md
+++ b/docs/standards/v3/git-workflow-standard.md
@@ -24,7 +24,7 @@ related_docs:
 本文档定义本项目的 Git 交付流程标准，重点回答：
 
 - 用户主视角 `GitHub issue -> flow -> plan/spec -> commit -> PR -> done` 应如何推进
-- 内部桥接链 `GitHub issue -> roadmap item -> task -> flow` 应如何配合
+- 内部桥接链 `GitHub issue -> roadmap item (deprecated, 仅作规划参考) -> task -> flow` 应如何配合
 - `flow`、`branch`、`worktree` 在交付中的职责如何分离
 - 何时继续当前 flow
 - 何时必须新开 branch / 新开 flow
@@ -106,14 +106,14 @@ related_docs:
 
 | 当前 Flow 状态 | 动作 | 说明 |
 |---------------|-------------------|------|
-| `active` | **拒绝新 flow** | 提示使用 `vibe3 wtnew` 创建新 worktree |
+| `active` | **拒绝新 flow** | 提示使用 `git worktree add` 创建新 worktree，或参见 [worktree-lifecycle-standard.md](worktree-lifecycle-standard.md) |
 | `blocked` | **允许切分支** | 从当前 branch 切出新 branch（下游修复流） |
 | `done/aborted/stale` | **允许新任务** | 从 `origin/main` 开始新目标 |
 | 无 flow | **允许新任务** | 从 `origin/main` 开始新目标 |
 
 ### 新 Feature 推荐路径
 
-1. **独立新 feature**: 使用 `vibe3 wtnew <name>` 创建新 worktree
+1. **独立新 feature**: 使用 `git worktree add` 创建新 worktree，或参见 [worktree-lifecycle-standard.md](worktree-lifecycle-standard.md)
 2. **下游修复流**: 先 `vibe3 flow blocked`，再切换分支并 `vibe3 flow update`
 3. **同 worktree 串行**: 使用 `/vibe-done` 收口后，通过 `/vibe-new` 开启新目标
 
@@ -265,7 +265,7 @@ closeout 约束：
 - 若该 PR 已完成且相关 follow-up 已收束，应进入 `vibe3-done` 或等价收口流程
 - 若当前 PR 已 merged，则该 PR 对应的 plan 进入 terminal state
 - merged 后只允许补记交付证据、审计说明、handoff 更正与 follow-up 链接，不允许把新需求继续写回旧 plan
-- merged 后若出现新的 feature、补丁或治理项，必须重新进入用户主链 `GitHub issue -> flow -> plan/spec -> commit -> PR -> done`，并按需重建内部桥接链 `GitHub issue -> roadmap item -> task -> flow`
+- merged 后若出现新的 feature、补丁或治理项，必须重新进入用户主链 `GitHub issue -> flow -> plan/spec -> commit -> PR -> done`；`roadmap item` 仅作规划参考，不作为执行必经关口
 
 ### 6.3 一个 `flow` 中做了不同 feature，想拆成多个 `pr`
 
@@ -318,7 +318,7 @@ closeout 约束：
   - 负责合并后的收口编排
   - 通过 `gh issue close` 等动作完成 task / issue / flow handoff
 
-`.agent/context/task.md` 只作为 skill 之间的短期 handoff 记录，不是共享真源。
+`.agent/context/task.md`（如存在）只作为 skill 之间的短期 handoff 记录，不是共享真源。V3 优先使用 `handoff` 命令与 SQLite 存储。
 
 ## 9. Branch Protection
 

--- a/docs/standards/v3/registry-json-standard.md
+++ b/docs/standards/v3/registry-json-standard.md
@@ -1,7 +1,7 @@
 ---
 document_type: standard
 title: Registry JSON Standard
-status: approved
+status: archived
 scope: shared-state
 authority:
   - registry-json-schema


### PR DESCRIPTION
## Summary
- Aligns 5 stale docs (identified in #1078) to current V3 CLI semantics
- DEVELOPER.md: marks V2 workflow/commands as legacy with clear V3 guidance
- git-workflow-standard.md: replaces non-existent `vibe3 wtnew`, clarifies deprecated `roadmap item`, updates `.agent/context/task.md` reference
- structure-snapshow.md: adds V3 alignment header noting actual `vibe3 snapshot`/`vibe3 inspect structure` commands and filename typo
- codex-review.md: status changed to `archived`, strong disclaimer about non-existent referenced files (`.codex/review-policy.md`, `.codex/impact-summary.md`, `scripts/review-with-serena.sh`)
- registry-json-standard.md: status changed from `approved` to `archived`

## Test plan
- [ ] Review diff of all 5 docs for accuracy of V3 command references
- [ ] Verify no code changes (docs only)
- [ ] Confirm issue #1078 scope not expanded

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>