### PR TITLE
fix(docs): align 2 orchestra docs to current implementation

### DIFF
--- a/docs/v3/orchestra/README.md
+++ b/docs/v3/orchestra/README.md
@@ -14,6 +14,8 @@ related_docs:
   - docs/standards/glossary.md
   - src/vibe3/models/orchestration.py
   - src/vibe3/services/label_service.py
+  - src/vibe3/orchestra/global_dispatch_coordinator.py
+  - src/vibe3/orchestra/flow_dispatch.py
 ---
 
 # Task: Orchestra 调度器（MVP）
@@ -42,9 +44,9 @@ related_docs:
 - 心跳兜底：`polling_interval` 默认 900 秒。
 
 代码参考：
-- `src/vibe3/orchestra/serve.py`
-- `src/vibe3/orchestra/heartbeat.py`
-- `src/vibe3/orchestra/webhook_handler.py`
+- `docs/standards/vibe3-orchestra-runtime-standard.md` — runtime semantics
+- `docs/v3/orchestra/runtime-modes.md` — deployment modes
+- `src/vibe3/orchestra/global_dispatch_coordinator.py` — heartbeat tick driver
 
 ### 2) Issue assignee 触发 manager 执行
 
@@ -58,22 +60,23 @@ related_docs:
 - 心跳会对当前已分配 issue 做重检（依赖/flow 存在性），避免漏调度。
 
 代码参考：
-- `src/vibe3/orchestra/services/assignee_dispatch.py`
-- `src/vibe3/orchestra/dependency_checker.py`
-- `src/vibe3/orchestra/dispatcher.py`
+- `src/vibe3/orchestra/global_dispatch_coordinator.py` — frozen queue coordinator
+- `src/vibe3/orchestra/flow_dispatch.py` — flow/manager dispatch
+- `src/vibe3/orchestra/issue_loader.py` — issue loading utilities
+- `src/vibe3/domain/handlers/issue_state_dispatch.py` — ManagerDispatchIntent handler
 
 ### 3) PR reviewer 触发 review
 
 - 触发事件：`pull_request/review_requested`、`pull_request/ready_for_review`。
 - 触发条件：requested reviewer 命中 `manager_usernames`。
-- 执行动作：调度 `vibe3 review pr <pr_number>`。
+- 执行动作：通过 `GlobalDispatchCoordinator` 冻结队列派发 reviewer 角色执行。
 - 默认策略：优先复用 PR 对应已有 worktree（按 `head_branch` 匹配），不新建 worktree。
-- 可选：`pr_review_dispatch.use_worktree=true` 时改为 `vibe3 review pr <pr_number> --worktree`。
-- 可选异步：`pr_review_dispatch.async_mode=true` 时，调度为 `vibe3 review pr <pr_number> --async`（tmux 后台执行，不阻塞当前进程）。
+- 可选：配置中使用 worktree 参数时改为 `vibe3 review pr <pr_number> --worktree`。
+- 可选异步：配置异步模式时，调度为 `vibe3 review pr <pr_number> --async`（tmux 后台执行，不阻塞当前进程）。
 
 代码参考：
-- `src/vibe3/orchestra/services/pr_review_dispatch.py`
-- `src/vibe3/orchestra/dispatcher.py`
+- `src/vibe3/orchestra/global_dispatch_coordinator.py` — frozen queue coordinator（含 reviewer 派发）
+- `src/vibe3/orchestra/flow_dispatch.py` — flow 管理
 
 ## 事件到执行链路（当前真源）
 

--- a/docs/v3/orchestra/release-handoff.md
+++ b/docs/v3/orchestra/release-handoff.md
@@ -14,8 +14,8 @@ Orchestra 采用**主动轮询 + 被动 webhook 混合架构**：
 - 通过 `vibe3 serve start` 启动的 heartbeat 驱动
 
 ### 被动响应（辅助）
-- **CommentReplyService**：监听 `issue_comment` events，自动回复 @vibe-manager-agent 提及
-- **WorktreeCleanupService**：监听 `pull_request` closed events，清理临时 worktrees
+- Webhook 事件处理：通过 `POST /webhook/github` 接收 GitHub 事件，验签后由 driver 进程直接路由到对应 handler
+- 所有角色（manager / planner / executor / reviewer）均通过 `GlobalDispatchCoordinator` 冻结队列统一派发，无独立的 service 模块
 
 ### 关键配置（`config/settings.yaml`）
 - `orchestra.enabled: true`
@@ -71,7 +71,7 @@ uv run python src/vibe3/cli.py serve start -v --dry-run --port 8080
 ## 4. 已知 follow-up
 
 1. 临时 worktree 回收
-   - WorktreeCleanupService 已实现 PR 关闭后自动清理
+   - PR 关闭后的 worktree 自动清理待实现
    - 追踪 issue：[#366](https://github.com/jacobcy/vibe-coding-control-center/issues/366)
 
 ## 5. 发布 agent 交付清单


### PR DESCRIPTION
## Summary
- Align `docs/v3/orchestra/README.md` code references to actual orchestra files (replaced 7 non-existent file refs with `global_dispatch_coordinator.py`, `flow_dispatch.py`, `issue_loader.py`, `issue_state_dispatch.py`, runtime standard/modes docs)
- Align `docs/v3/orchestra/release-handoff.md` architecture description: removed `CommentReplyService` and `WorktreeCleanupService` references (these services do not exist), updated to describe actual unified dispatch via `GlobalDispatchCoordinator`

## Test plan
- [ ] Verify all referenced files exist in current codebase
- [ ] Verify no other stale references remain in these 2 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)