### PR TITLE
fix: avoid orchestra status crash when failed gate is active

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -148,7 +148,10 @@ def status(
                 "Dispatch: [bold red]FROZEN[/] "
                 f"[dim]({orch_snapshot.blocked_reason})[/]"
             )
-            console.print(f"  [red]Issue:   #{orch_snapshot.blocked_issue_number}[/]")
+            if orch_snapshot.blocked_issue_number is not None:
+                console.print(
+                    f"  [red]Issue:   #{orch_snapshot.blocked_issue_number}[/]"
+                )
             console.print(f"  [red]Reason:  {orch_snapshot.blocked_issue_reason}[/]")
         elif not orch_snapshot.server_running:
             console.print("Dispatch: [dim]inactive (server stopped)[/]")

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -367,7 +367,6 @@ class OrchestraStatusService:
                 resolver = ConventionResolver.from_repo()
                 convention = resolver.resolve()
                 blocked_reason = convention.state_label(convention.blocked_label)
-                blocked_issue_number = gate_result.issue_number
                 blocked_issue_reason = gate_result.reason
 
         snapshot = OrchestraSnapshot(

--- a/tests/vibe3/commands/test_task_status_dashboard.py
+++ b/tests/vibe3/commands/test_task_status_dashboard.py
@@ -170,3 +170,48 @@ def test_task_status_shows_flows_with_prs(
     assert "Flows with PRs (Merge-Ready/Done):" in result.output
     assert "# 404" in result.output
     assert "PR: https://github.com/openai/vibe-center/pull/1" in result.output
+
+
+@patch("vibe3.commands.status.load_orchestra_config")
+@patch("vibe3.commands.status.OrchestraStatusService.fetch_live_snapshot")
+@patch("vibe3.commands.status.FlowService")
+@patch("vibe3.commands.status.StatusQueryService")
+def test_task_status_hides_missing_blocked_issue_number(
+    mock_status_service_cls,
+    mock_flow_service_cls,
+    mock_fetch_live_snapshot,
+    mock_load_orchestra_config,
+) -> None:
+    """task status should not render '#None' when failed gate has no issue number."""
+    config_mock = MagicMock()
+    config_mock.pid_file = "/tmp/vibe3.pid"
+    config_mock.repo = "openai/vibe-center"
+    config_mock.port = 1234
+    config_mock.supervisor_handoff = MagicMock(issue_label="supervisor")
+    config_mock.manager_usernames = ["manager-bot"]
+    config_mock.get_manager_usernames.return_value = ["manager-bot"]
+    mock_load_orchestra_config.return_value = config_mock
+    mock_fetch_live_snapshot.return_value = OrchestraSnapshot(
+        timestamp=1234567890.0,
+        server_running=True,
+        active_issues=tuple(),
+        active_flows=0,
+        active_worktrees=0,
+        dispatch_blocked=True,
+        blocked_reason="state/blocked",
+        blocked_issue_number=None,
+        blocked_issue_reason="API/Exec error threshold: 3 recent errors",
+    )
+
+    mock_flow_service_cls.return_value = MagicMock(list_flows=lambda status: [])
+    status_service = MagicMock()
+    status_service.fetch_worktree_map.return_value = {}
+    status_service.fetch_orchestrated_issues.return_value = []
+    mock_status_service_cls.return_value = status_service
+
+    result = runner.invoke(app, ["task", "status"])
+
+    assert result.exit_code == 0
+    assert "Dispatch: FROZEN" in result.output
+    assert "Reason:  API/Exec error threshold: 3 recent errors" in result.output
+    assert "#None" not in result.output

--- a/tests/vibe3/services/test_orchestra_status_snapshot.py
+++ b/tests/vibe3/services/test_orchestra_status_snapshot.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState
+from vibe3.orchestra.failed_gate import GateResult
 from vibe3.services.orchestra_status_service import OrchestraStatusService
 
 
@@ -124,3 +125,25 @@ class TestSnapshotIssuePoolBoundary:
         assert snapshot.active_issues[0].assignee == "manager-bot"
         assert snapshot.active_issues[0].queue_rank == 1
         assert snapshot.active_issues[1].queue_rank == 2
+
+    def test_snapshot_handles_failed_gate_without_issue_number(self):
+        """Failed gate snapshot should not require a nonexistent issue number."""
+        github = MagicMock()
+        github.list_issues.return_value = []
+        failed_gate = MagicMock()
+        failed_gate.check.return_value = GateResult(
+            blocked=True,
+            reason="API/Exec error threshold: 3 recent errors",
+            blocked_ticks=2,
+        )
+
+        service = self._make_service(github)
+        service._failed_gate = failed_gate
+
+        snapshot = service.snapshot()
+
+        assert snapshot.dispatch_blocked is True
+        assert snapshot.blocked_issue_number is None
+        assert (
+            snapshot.blocked_issue_reason == "API/Exec error threshold: 3 recent errors"
+        )


### PR DESCRIPTION
## Summary
- avoid reading nonexistent `GateResult.issue_number` in orchestra status snapshots
- keep task status output stable when failed gate has no issue number
- add regression coverage for failed gate snapshot and dashboard rendering

## Testing
- `uv run pytest tests/vibe3/services/test_orchestra_status_snapshot.py tests/vibe3/commands/test_task_status_dashboard.py -q`
- `uv run pre-commit run --files src/vibe3/commands/status.py src/vibe3/services/orchestra_status_service.py tests/vibe3/commands/test_task_status_dashboard.py tests/vibe3/services/test_orchestra_status_snapshot.py`
- `git push -u origin fix/issue-1107-failed-gate-status-crash` (pre-push passed: incremental 85 tests)

Closes #1107

## Contributors
- Logic author: codex
- Published by: codex
