### PR TITLE
fix(orchestra): clean tombstone issue errors from failed gate

### DIFF
--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -307,6 +307,9 @@ class ErrorTrackingService:
         Uses flow_issue_links (issue_role='task') as SSOT to identify current
         task flow for each issue, avoiding false matches on superseded flows.
 
+        Also cleans up orphaned errors that still point at a terminal tombstone
+        branch after the current task flow link has already been removed.
+
         Terminal states: done, aborted, stale (per _is_reusable_auto_flow
         in flow_dispatch.py).
 
@@ -315,14 +318,35 @@ class ErrorTrackingService:
         """
         with sqlite3.connect(self.db_path) as conn:
             result = conn.execute("""
-                DELETE FROM error_log
-                WHERE issue_number IN (
-                    SELECT fil.issue_number
-                    FROM flow_issue_links fil
-                    INNER JOIN flow_state fs ON fs.branch = fil.branch
-                    WHERE fil.issue_role = 'task'
-                      AND fs.flow_status IN ('done', 'aborted', 'stale')
-                      AND fs.deleted_at IS NULL
+                DELETE FROM error_log AS el
+                WHERE el.issue_number IS NOT NULL
+                  AND (
+                    EXISTS (
+                        SELECT 1
+                        FROM flow_issue_links fil
+                        INNER JOIN flow_state fs ON fs.branch = fil.branch
+                        WHERE fil.issue_role = 'task'
+                          AND fil.issue_number = el.issue_number
+                          AND fs.flow_status IN ('done', 'aborted', 'stale')
+                          AND fs.deleted_at IS NULL
+                    )
+                    OR (
+                        NOT EXISTS (
+                            SELECT 1
+                            FROM flow_issue_links fil_current
+                            INNER JOIN flow_state fs_current
+                                ON fs_current.branch = fil_current.branch
+                            WHERE fil_current.issue_role = 'task'
+                              AND fil_current.issue_number = el.issue_number
+                              AND fs_current.deleted_at IS NULL
+                        )
+                        AND EXISTS (
+                            SELECT 1
+                            FROM flow_state fs_tomb
+                            WHERE fs_tomb.branch = el.branch
+                              AND fs_tomb.flow_status IN ('done', 'aborted', 'stale')
+                        )
+                    )
                 )
             """)
             conn.commit()

--- a/tests/vibe3/exceptions/test_error_tracking_terminal.py
+++ b/tests/vibe3/exceptions/test_error_tracking_terminal.py
@@ -282,3 +282,51 @@ def test_cleanup_terminal_preserves_issue_with_active_new_flow(
         rows = conn.execute("SELECT issue_number FROM error_log").fetchall()
         assert len(rows) == 1
         assert rows[0][0] == 100
+
+
+def test_cleanup_terminal_deletes_tombstone_issue_without_current_flow(
+    temp_store: SQLiteClient,
+) -> None:
+    """cleanup_terminal_issue_errors should delete errors for a tombstone flow
+    when the issue no longer has a current task flow link.
+
+    This matches the serve-status production scene where a soft-deleted aborted
+    flow remains in flow_state, flow_issue_links have already been cleared, and
+    old error_log rows would otherwise keep FailedGate blocked indefinitely.
+    """
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    with sqlite3.connect(temp_store.db_path) as conn:
+        conn.execute("""
+            INSERT INTO flow_state
+                (branch, flow_slug, flow_status, deleted_at, updated_at)
+            VALUES
+                (
+                    'task/issue-42',
+                    'task-issue-42',
+                    'aborted',
+                    datetime('now'),
+                    datetime('now')
+                )
+        """)
+        conn.execute("""
+            INSERT INTO error_log
+                (tick_id, error_code, error_message, issue_number, branch)
+            VALUES
+                (
+                    1,
+                    'E_EXEC_UNKNOWN',
+                    'MagicMock <= int',
+                    42,
+                    'task/issue-42'
+                )
+        """)
+        conn.commit()
+
+    deleted = ErrorTrackingService._instance.cleanup_terminal_issue_errors()
+
+    assert deleted == 1
+
+    with sqlite3.connect(temp_store.db_path) as conn:
+        rows = conn.execute("SELECT issue_number, branch FROM error_log").fetchall()
+        assert rows == []


### PR DESCRIPTION
## Summary
- clean `error_log` rows for terminal tombstone task flows after soft delete clears `flow_issue_links`
- preserve the existing guard that keeps errors when an issue has a newer active task flow
- add a regression test covering the serve-status production scene for `task/issue-42`

## Root Cause
Soft delete normalizes a flow into a tombstone in `flow_state` and clears `flow_issue_links`.
`cleanup_terminal_issue_errors()` previously only deleted errors for terminal flows that still had a current task link and were not soft-deleted, so stale `error_log` rows for tombstone branches could keep `FailedGate` blocked indefinitely.

## Testing
- `uv run pytest tests/vibe3/orchestra/test_failed_gate.py tests/vibe3/exceptions/test_error_tracking_terminal.py -q`
- pre-push incremental checks passed

## Contributors
- Yi Chen
- OpenAI Codex
