### PR TITLE
fix(handoff): include next_step_set in success events and status display

### DIFF
--- a/src/vibe3/commands/handoff_render.py
+++ b/src/vibe3/commands/handoff_render.py
@@ -44,6 +44,7 @@ def _render_handoff_events(
         "handoff_audit": "Audit Handoff",
         "handoff_indicate": "Manager Handoff",
         "handoff_verdict": "Verdict Handoff",
+        "next_step_set": "Next Step",
     }
 
     # Filter out recorded events if handoff events exist for same kind

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -73,6 +73,7 @@ class HandoffService:
         "handoff_verdict",
         "handoff_ci_status",
         "handoff_pr_comment",
+        "next_step_set",
     }
 
     @staticmethod

--- a/tests/vibe3/services/test_handoff_service.py
+++ b/tests/vibe3/services/test_handoff_service.py
@@ -388,12 +388,7 @@ def test_success_events_includes_next_step_set(tmp_path: Path) -> None:
         git_client=_StubGitClient(tmp_path / "wt", tmp_path / ".git", branch),
     )
 
-    store.add_event(
-        branch,
-        "next_step_set",
-        "executor",
-        detail="Next Step: Add test coverage for edge cases",
-    )
+    store.add_event(branch, "next_step_set", "executor", detail="Next step test")
     store.add_event(branch, "handoff_report", "executor", detail="report ready")
 
     events = service.get_success_handoff_events(branch)

--- a/tests/vibe3/services/test_handoff_service.py
+++ b/tests/vibe3/services/test_handoff_service.py
@@ -377,3 +377,26 @@ class TestHandoffFailureDetection:
         assert "handoff_report" in event_types
         assert "state_unchanged" not in event_types
         assert "transition_count_exceeded" not in event_types
+
+
+def test_success_events_includes_next_step_set(tmp_path: Path) -> None:
+    """Verify next_step_set events appear in get_success_handoff_events."""
+    store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+    branch = "task/issue-894"
+    service = HandoffService(
+        store=store,
+        git_client=_StubGitClient(tmp_path / "wt", tmp_path / ".git", branch),
+    )
+
+    store.add_event(
+        branch,
+        "next_step_set",
+        "executor",
+        detail="Next Step: Add test coverage for edge cases",
+    )
+    store.add_event(branch, "handoff_report", "executor", detail="report ready")
+
+    events = service.get_success_handoff_events(branch)
+    event_types = [e.event_type for e in events]
+    assert "next_step_set" in event_types
+    assert "handoff_report" in event_types


### PR DESCRIPTION
Closes #894

## Summary

- Add `next_step_set` to `_SUCCESS_HANDOFF_EVENT_TYPES` so it appears in handoff status output
- Add friendly display name in the renderer for `next_step_set` events
- Add tests to verify the new event type is properly included

## Test plan

- [x] 19/19 tests pass
- [x] mypy clean
- [x] ruff clean
- [x] Pre-push checks passed

---

## Contributors

claude/opus
