### PR TITLE
fix(serve): read runtime tick interval from events.log in status display

### DIFF
--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from rich.console import Console
 from rich.table import Table
@@ -12,6 +11,7 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.exceptions.error_tracking import ErrorTrackingService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import FailedGate
+from vibe3.orchestra.logging import orchestra_events_log_path
 from vibe3.utils.error_message_cleaner import (
     CODEAGENT_WRAPPER_RE,
     clean_error_message,
@@ -113,7 +113,7 @@ class ServeStatusService:
         Returns:
             The tick interval in seconds.
         """
-        events_log = Path("temp/logs/orchestra/events.log")
+        events_log = orchestra_events_log_path()
         if events_log.exists():
             try:
                 log_content = events_log.read_text()
@@ -124,13 +124,15 @@ class ServeStatusService:
                 )
                 if matches:
                     return int(matches[-1])
-            except Exception:
-                pass
+            except (OSError, UnicodeDecodeError, ValueError) as exc:
+                self.console.print(
+                    f"[yellow]Warning: Could not parse events.log: {exc}[/yellow]\n"
+                )
         return self.config.polling_interval
 
     def _display_recent_activity(self) -> None:
         """Display recent tick activity from events.log."""
-        events_log = Path("temp/logs/orchestra/events.log")
+        events_log = orchestra_events_log_path()
         if not events_log.exists():
             return
 

--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -99,8 +99,34 @@ class ServeStatusService:
 
     def _display_config(self) -> None:
         """Display configuration summary."""
-        self.console.print(f"  - Tick interval: {self.config.polling_interval}s")
+        tick_interval = self._resolve_tick_interval()
+        self.console.print(f"  - Tick interval: {tick_interval}s")
         self.console.print(f"  - Max concurrent: {self.config.max_concurrent_flows}\n")
+
+    def _resolve_tick_interval(self) -> int:
+        """Resolve the runtime tick interval from events.log, falling back to config.
+
+        The server writes its actual tick_interval to events.log on startup.
+        This method extracts the most recent value from that log, falling back
+        to the static config value when the log is unavailable.
+
+        Returns:
+            The tick interval in seconds.
+        """
+        events_log = Path("temp/logs/orchestra/events.log")
+        if events_log.exists():
+            try:
+                log_content = events_log.read_text()
+                matches = re.findall(
+                    r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] "
+                    r"\[server\] start tick_interval=(\d+)s",
+                    log_content,
+                )
+                if matches:
+                    return int(matches[-1])
+            except Exception:
+                pass
+        return self.config.polling_interval
 
     def _display_recent_activity(self) -> None:
         """Display recent tick activity from events.log."""

--- a/tests/vibe3/services/test_serve_status_service.py
+++ b/tests/vibe3/services/test_serve_status_service.py
@@ -82,37 +82,40 @@ class TestResolveTickInterval:
 
     def test_reads_runtime_interval_from_log(self, tmp_path, monkeypatch):
         """When events.log contains [server] start tick_interval, it is used."""
-        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir = tmp_path / "orchestra"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "events.log"
         log_file.write_text("[2026-05-19T10:00:00] [server] start tick_interval=30s\n")
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE3_ASYNC_LOG_DIR", str(tmp_path))
 
         service = self._make_service(polling_interval=900)
         assert service._resolve_tick_interval() == 30
 
-    def test_falls_back_when_no_log(self):
+    def test_falls_back_when_no_log(self, tmp_path, monkeypatch):
         """When events.log does not exist, config default is used."""
+        # Set empty log dir to avoid reading real events.log
+        monkeypatch.setenv("VIBE3_ASYNC_LOG_DIR", str(tmp_path))
+
         service = self._make_service(polling_interval=900)
         assert service._resolve_tick_interval() == 900
 
     def test_falls_back_when_no_start_entry(self, tmp_path, monkeypatch):
         """When events.log exists but no [server] start line, config is used."""
-        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir = tmp_path / "orchestra"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "events.log"
         log_file.write_text(
             "[2026-05-19T10:00:00] [server] tick #1 start\n"
             "[2026-05-19T10:00:00] [dispatcher] something\n"
         )
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE3_ASYNC_LOG_DIR", str(tmp_path))
 
         service = self._make_service(polling_interval=600)
         assert service._resolve_tick_interval() == 600
 
     def test_uses_most_recent_start(self, tmp_path, monkeypatch):
         """When multiple [server] start entries exist, the last one is used."""
-        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir = tmp_path / "orchestra"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "events.log"
         log_file.write_text(
@@ -120,18 +123,18 @@ class TestResolveTickInterval:
             "[2026-05-19T09:00:00] [server] tick #1 completed\n"
             "[2026-05-19T10:00:00] [server] start tick_interval=30s\n"
         )
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE3_ASYNC_LOG_DIR", str(tmp_path))
 
         service = self._make_service(polling_interval=900)
         assert service._resolve_tick_interval() == 30
 
     def test_display_config_shows_runtime_interval(self, tmp_path, monkeypatch):
         """Integration: _display_config outputs runtime interval from log."""
-        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir = tmp_path / "orchestra"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "events.log"
         log_file.write_text("[2026-05-19T10:00:00] [server] start tick_interval=45s\n")
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE3_ASYNC_LOG_DIR", str(tmp_path))
 
         service = self._make_service(polling_interval=900)
 

--- a/tests/vibe3/services/test_serve_status_service.py
+++ b/tests/vibe3/services/test_serve_status_service.py
@@ -1,5 +1,10 @@
 """Tests for ServeStatusService."""
 
+from io import StringIO
+
+from rich.console import Console
+
+from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.services.serve_status_service import ServeStatusService
 
 
@@ -66,3 +71,74 @@ class TestCleanErrorMessage:
             "CLAUDE_CODE_TMPDIR: /tmp/path | === Recent Errors ==="
         )
         assert result == "actual error"
+
+
+class TestResolveTickInterval:
+    """Test cases for _resolve_tick_interval method."""
+
+    def _make_service(self, polling_interval: int = 900) -> ServeStatusService:
+        config = OrchestraConfig(polling_interval=polling_interval)
+        return ServeStatusService(config=config)
+
+    def test_reads_runtime_interval_from_log(self, tmp_path, monkeypatch):
+        """When events.log contains [server] start tick_interval, it is used."""
+        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "events.log"
+        log_file.write_text("[2026-05-19T10:00:00] [server] start tick_interval=30s\n")
+        monkeypatch.chdir(tmp_path)
+
+        service = self._make_service(polling_interval=900)
+        assert service._resolve_tick_interval() == 30
+
+    def test_falls_back_when_no_log(self):
+        """When events.log does not exist, config default is used."""
+        service = self._make_service(polling_interval=900)
+        assert service._resolve_tick_interval() == 900
+
+    def test_falls_back_when_no_start_entry(self, tmp_path, monkeypatch):
+        """When events.log exists but no [server] start line, config is used."""
+        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "events.log"
+        log_file.write_text(
+            "[2026-05-19T10:00:00] [server] tick #1 start\n"
+            "[2026-05-19T10:00:00] [dispatcher] something\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        service = self._make_service(polling_interval=600)
+        assert service._resolve_tick_interval() == 600
+
+    def test_uses_most_recent_start(self, tmp_path, monkeypatch):
+        """When multiple [server] start entries exist, the last one is used."""
+        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "events.log"
+        log_file.write_text(
+            "[2026-05-19T08:00:00] [server] start tick_interval=60s\n"
+            "[2026-05-19T09:00:00] [server] tick #1 completed\n"
+            "[2026-05-19T10:00:00] [server] start tick_interval=30s\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        service = self._make_service(polling_interval=900)
+        assert service._resolve_tick_interval() == 30
+
+    def test_display_config_shows_runtime_interval(self, tmp_path, monkeypatch):
+        """Integration: _display_config outputs runtime interval from log."""
+        log_dir = tmp_path / "temp" / "logs" / "orchestra"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "events.log"
+        log_file.write_text("[2026-05-19T10:00:00] [server] start tick_interval=45s\n")
+        monkeypatch.chdir(tmp_path)
+
+        service = self._make_service(polling_interval=900)
+
+        # Capture console output
+        string_io = StringIO()
+        service.console = Console(file=string_io, force_terminal=True, width=80)
+        service._display_config()
+
+        output = string_io.getvalue()
+        assert "Tick interval: 45s" in output


### PR DESCRIPTION
Display the actual runtime tick interval instead of the static config value. `_display_config` now parses the most recent `[server] start tick_interval=<N>s` entry from events.log, falling back to the config default when the log is unavailable.

Fixes #1073

---

## Contributors

claude/opus
