### PR TITLE
docs: align stale reference docs with current truth sources (#1115)

### DIFF
--- a/docs/references/codeagent-wrapper-guide.md
+++ b/docs/references/codeagent-wrapper-guide.md
@@ -35,7 +35,7 @@ related_docs:
 | 后端 | 最适用场景 | 默认模型 |
 |------|-----------|---------|
 | **Codex** | 深度代码分析、大规模重构、算法优化 | gpt-5.2 |
-| **Claude** | 快速功能实现、文档生成、Prompt 工程 | claude-sonnet-4.5 |
+| **Claude** | 快速功能实现、文档生成、Prompt 工程 | claude-sonnet-4-6 |
 | **Gemini** | UI 组件搭建、设计系统实现 | gemini-3-pro-preview |
 | **OpenCode** | 代码探索、快速原型 | opencode/grok-code |
 
@@ -113,8 +113,8 @@ cat /private/tmp/claude-501/<workdir>/<session_id>/tasks/<task_id>.output | tail
 > **说明**：Agent 预设通过 `config/v3/settings.yaml` 的 `agent_config` 字段配置，用户通过 `vibe3 run` 间接使用。
 
 **可用预设**（定义在 `~/.codeagent/models.json`）：
-- `oracle`: 深度推理（Claude Opus 4.5）
-- `librarian`: 文档管理（Claude Sonnet 4.5）
+- `oracle`: 深度推理（Claude Opus 4.7）
+- `librarian`: 文档管理（Claude Sonnet 4.6）
 - `explore`: 代码探索（OpenCode）
 - `develop`: 开发实现（Codex + 高推理）
 - `frontend-ui-ux-engineer`: 前端开发（Gemini Pro）
@@ -295,7 +295,7 @@ EOF
   "agents": {
     "oracle": {
       "backend": "claude",
-      "model": "claude-opus-4-5-20251101",
+      "model": "claude-opus-4-7",
       "yolo": true
     }
   }
@@ -383,5 +383,6 @@ export CODEAGENT_MAX_PARALLEL_WORKERS=8
 
 ## 更新历史
 
+- 2026-05-20：更新模型名称到当前版本（Claude Opus 4.7 / Sonnet 4.6）
 - 2026-05-15：重构为内部实现文档，更新为 `vibe3 run` 用法
 - 2026-03-17：初始版本，基于 codeagent-wrapper 当前功能编写

--- a/docs/references/flow-dependency.md
+++ b/docs/references/flow-dependency.md
@@ -81,7 +81,8 @@ vibe3 flow show task/reports-unified-storage
 CREATE TABLE flow_state (
     branch TEXT PRIMARY KEY,
     flow_status TEXT NOT NULL DEFAULT 'active',  -- 'active' | 'blocked' | 'done' | 'aborted'
-    blocked_by TEXT,  -- 阻塞原因描述
+    blocked_by_issue INTEGER,  -- dependency issue number (INT)
+    blocked_reason TEXT,       -- blocking reason description
     ...
 )
 ```
@@ -91,7 +92,7 @@ CREATE TABLE flow_state (
 | 命令 | 使用场景 | 数据影响 | 建立依赖关系 |
 |------|---------|---------|------------|
 | `flow blocked --task <issue>` | Flow 执行中遇到依赖阻塞 | `flow_issue_links` + `flow_state` | ✅ 是 |
-| `handoff next_step <text>` | Agent 交接时记录阻塞状态 | 仅 `flow_state` | ❌ 否 |
+| `handoff next <text>` | Agent 交接时记录阻塞状态 | 仅 `flow_state` | ❌ 否 |
 
 > **注意**：`--task` 是主要选项。
 
@@ -106,8 +107,11 @@ CREATE TABLE flow_state (
 # 使用 --task 建立依赖
 vibe3 flow blocked --task 218
 
-# 注意：--reason 和 --task 互斥，不能同时使用
+# 使用 --reason 描述阻塞原因
 vibe3 flow blocked --reason "等待外部反馈"
+
+# --task 和 --reason 可同时使用，分别记录依赖 issue 和原因描述
+vibe3 flow blocked --task 218 --reason "等待 API 完成"
 ```
 
 **数据库变更**：
@@ -115,7 +119,8 @@ vibe3 flow blocked --reason "等待外部反馈"
 -- 1. 更新 flow 状态
 UPDATE flow_state SET
   flow_status = 'blocked',
-  blocked_by = '等待依赖 issue #218'  -- 或自定义 reason
+  blocked_by_issue = 218,
+  blocked_reason = '等待依赖 issue #218'
 WHERE branch = 'task/my-feature';
 
 -- 2. 建立依赖关系
@@ -136,7 +141,7 @@ VALUES
 - 自动更新 `flow_status` 和 `blocked_by`
 - 避免遗漏依赖关系
 
-#### 2. `vibe3 handoff next_step <message>`
+#### 2. `vibe3 handoff next <message>`
 
 **使用场景**：Agent 交接时记录下一步或阻塞状态。
 
@@ -148,9 +153,9 @@ VALUES
 
 **命令示例**：
 ```bash
-vibe3 handoff next_step "等待外部反馈" --branch task/issue-218
+vibe3 handoff next "等待外部反馈" --branch task/issue-218
 
-vibe3 handoff next_step "开始实现 API 接口" --branch task/issue-218
+vibe3 handoff next "开始实现 API 接口" --branch task/issue-218
 ```
 
 **数据库变更**：
@@ -195,7 +200,8 @@ vibe3 flow show task/my-feature
 # Dependencies: #218
 # Related Issues: #219
 # Flow Status: blocked
-# Blocked By: 等待依赖 issue #218
+# Blocked By Issue: 218
+# Blocked Reason: 等待依赖 issue #218
 ```
 
 ### 解除阻塞
@@ -219,7 +225,7 @@ vibe3 task resume
 - 需要在数据库中建立依赖关系
 - 方便后续查询和分析
 
-**使用 `handoff next_step`**：
+**使用 `handoff next`**：
 - Agent 交接时记录下一步或阻塞状态
 - 阻塞原因不一定是具体的 issue
 - 阻塞原因可能是：外部反馈、资源等待、审批流程等
@@ -233,13 +239,13 @@ vibe3 task resume
 vibe3 handoff plan docs/plans/feature-a.md --actor "claude/sonnet-4.6"
 
 # Step 2: Agent 记录下一步（可选）
-vibe3 handoff next_step "需要等待 API 完成" --branch task/my-feature
+vibe3 handoff next "需要等待 API 完成" --branch task/my-feature
 
 # Step 3: 开发者补充依赖关系
 vibe3 flow blocked --task 218
 
 # 结果：
-# - flow_state.next_step 可能被更新（如果使用了 handoff next_step）
+# - flow_state.next_step 可能被更新（如果使用了 handoff next）
 # - flow_issue_links 新增 dependency 记录
 ```
 

--- a/docs/references/streaming-output-fix.md
+++ b/docs/references/streaming-output-fix.md
@@ -3,11 +3,16 @@ title: codeagent-wrapper 流式输出修复
 author: AI Agent
 created: 2026-04-21
 purpose: 修复 Vibe3 async_launcher 的流式输出问题，使 tmux 模式能看到实时输出
+document_type: reference
+status: historical-reference
+scope: streaming-fix-history
 related_docs:
   - codeagent-wrapper-guide.md
   - ../v3/architecture/async-execution.md
 tags: [streaming, tmux, buffering, realtime]
 ---
+
+> **历史免责声明**：本文档记录的是 2026-04-21 针对 `async_launcher.py` 流式输出缓冲问题的一次性修复方案。该修复方案可能已被后续代码变更集成、替代或取代。请勿将其作为现行实现的权威依据，仅供历史参考。当前 async_launcher 实现见 `src/vibe3/agents/backends/async_launcher.py`。
 
 # codeagent-wrapper 流式输出修复
 

--- a/docs/references/v3_suggestion_openai.md
+++ b/docs/references/v3_suggestion_openai.md
@@ -1,5 +1,15 @@
 
 
+---
+document_type: reference
+title: V3 Suggestion Design (OpenAI)
+status: historical-reference
+scope: v3-design-history
+author: Vibe Team
+---
+
+> **历史免责声明**：本文档是 V3 早期设计阶段的历史参考材料，记录的是 OpenAI 视角下的 suggestion 功能设计思路。当前 V3 实现已与本文描述存在差异，请勿将其作为现行实现的权威依据。现行规范见 `docs/standards/v3/` 目录。
+
 1. 系统目标
 
 该工具是一个 GitHub workflow wrapper CLI。


### PR DESCRIPTION
## Summary
- Align `flow-dependency.md` to current truth sources: fix `blocked_by` → `blocked_by_issue`/`blocked_reason`, `handoff next_step` → `handoff next`, correct `--reason`/`--task` mutual exclusivity claim
- Update `codeagent-wrapper-guide.md` model names to current Claude versions (Opus 4.7 / Sonnet 4.6)
- Add frontmatter and historical-reference status to `v3_suggestion_openai.md` with disclaimer
- Add historical-reference status and disclaimer to `streaming-output-fix.md`

## Test plan
- [ ] Verify all 4 docs render correctly
- [ ] Confirm no broken references or links

🤖 Generated with [Claude Code](https://claude.com/claude-code)