### PR TITLE
fix(manager): propagate tick_id through manager dispatch call chain

### DIFF
--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -133,6 +133,7 @@ def build_issue_async_cli_request(
     refs: dict[str, str] | None,
     worktree_requirement: WorktreeRequirement,
     repo_path: Path | None = None,
+    tick_id: int = 0,
 ) -> ExecutionRequest:
     """Build a generic async self-invocation request for an issue role."""
     root = (repo_path or resolve_orchestra_repo_root()).resolve()
@@ -160,6 +161,7 @@ def build_issue_async_cli_request(
         actor=actor,
         mode="async",
         worktree_requirement=worktree_requirement,
+        tick_id=tick_id,
     )
 
 
@@ -183,6 +185,7 @@ def build_issue_sync_prompt_request(
     fallback_include_global_notice: bool = True,
     extra_refs: dict[str, str] | None = None,
     dry_run_summary: dict[str, Any] | None = None,
+    tick_id: int = 0,
 ) -> ExecutionRequest:
     """Build a generic sync prompt-based request for an issue role."""
     root = (repo_path or resolve_orchestra_repo_root()).resolve()
@@ -210,6 +213,7 @@ def build_issue_sync_prompt_request(
         fallback_include_global_notice=fallback_include_global_notice,
         dry_run_summary=dry_run_summary or {},
         worktree_requirement=worktree_requirement,
+        tick_id=tick_id,
     )
 
 

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -205,6 +205,7 @@ def build_manager_request(
             actor=actor,
             dry_run=False,
             show_prompt=False,
+            tick_id=tick_id,
         )
         if request.env is None:
             request.env = env
@@ -223,6 +224,7 @@ def build_manager_request(
         refs=refs,
         worktree_requirement=MANAGER_ROLE.worktree,
         repo_path=repo_path,
+        tick_id=tick_id,
     )
     if request.env is None:
         request.env = env
@@ -241,6 +243,7 @@ def build_manager_sync_request(
     actor: str,
     dry_run: bool,
     show_prompt: bool,
+    tick_id: int = 0,
 ) -> ExecutionRequest:
     """Build the manager sync execution request using recipe-based prompt assembly."""
     _ = flow_state
@@ -321,6 +324,7 @@ def build_manager_sync_request(
         dry_run=dry_run,
         show_prompt=show_prompt,
         worktree_requirement=MANAGER_ROLE.worktree,
+        tick_id=tick_id,
     )
 
 


### PR DESCRIPTION
## Summary

- Add `tick_id` parameter propagation through `build_issue_async_cli_request`, `build_issue_sync_prompt_request`, and `build_manager_sync_request`
- Fixes `serve status` showing tick 0 for API errors that occur during normal heartbeat ticks
- Root cause: tick_id was received by `build_manager_request()` but not passed down the sync/async dispatch paths

## Test Plan

- [ ] Verify `vibe3 serve status` shows actual heartbeat tick number for new API errors instead of 0
- [ ] Run existing tests: 10 passed, mypy clean, ruff clean
- [ ] Confirm backward compatibility: all defaults preserved

Closes #1083

---

## Contributors

claude/opus
