### PR TITLE
fix(install): add skills directory to install.sh sync list

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,7 +144,7 @@ mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/lib" "$INSTALL_DIR/config" "$INSTALL_D
 
 # 3. Sync core components (Copying to ensure global persistence)
 log_info "Syncing core modules..."
-for dir in bin lib lib3 config scripts alias src; do
+for dir in bin lib lib3 config scripts alias src skills; do
     [[ -d "$SOURCE_ROOT/$dir" ]] || continue
     mkdir -p "$INSTALL_DIR/$dir"
     # Copy directory contents portably so GNU/BSD cp do not create nested dir/dir trees.


### PR DESCRIPTION
Closes #1087

## Summary

- Single-line fix in `scripts/install.sh:147` adds `skills` to the directory sync loop
- Ensures `skills/vibe-*` directories are copied to `~/.vibe/skills/` during install

## Change

- `scripts/install.sh:147`: Added `skills` to `for dir in ...` loop

## Verification

- Audit: PASS (claude/opus)
- Pre-commit hooks: passed (ShellCheck, Custom Lint, Ruff, Black, MyPy)
- Pre-push checks: passed (smoke tests, type check, LOC)
- No structural changes (snapshot diff: +0 files, +0 modules, +0 deps, +0 LOC)
- Symlink safety: confirmed (skills/ contains only regular files)
- uninstall.sh compatibility: confirmed
- init.sh: no impact

## Risk

LOW — single-line addition to existing, well-tested loop.

---

## Contributors

claude/opus
