### PR TITLE
fix(profiles): align skills_manifest path with install.sh

### DIFF
--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -50,7 +50,7 @@ PROFILE_MINIMAL=(
     "conventions.agents.manager_name:none"
     "paths.policies_root:\${HOME}/.vibe/assets/policies"
     "paths.prompts_root:\${HOME}/.vibe/assets/prompts"
-    "paths.skills_manifest:\${HOME}/.vibe/manifests/skills.json"
+    "paths.skills_manifest:\${HOME}/.vibe/skills.json"
 )
 
 # GitHub-flow profile - GitHub issue/PR/label orchestration
@@ -70,7 +70,7 @@ PROFILE_GITHUB_FLOW=(
     "conventions.agents.manager_name:none"
     "paths.policies_root:\${HOME}/.vibe/assets/policies"
     "paths.prompts_root:\${HOME}/.vibe/assets/prompts"
-    "paths.skills_manifest:\${HOME}/.vibe/manifests/skills.json"
+    "paths.skills_manifest:\${HOME}/.vibe/skills.json"
 )
 
 # Vibe-center profile - Full Vibe Center distribution


### PR DESCRIPTION
## Summary
- Fix `lib/profiles.sh` MINIMAL and GITHUB_FLOW profile `skills_manifest` paths
- Changed from `~/.vibe/manifests/skills.json` (dead path) to `~/.vibe/skills.json` (actual install location)
- Matches `scripts/install.sh:211` which copies to `$INSTALL_DIR/skills.json`

## Changes
- `lib/profiles.sh:53` — MINIMAL profile skills_manifest path
- `lib/profiles.sh:73` — GITHUB_FLOW profile skills_manifest path

## Verification
- `zsh -n lib/profiles.sh` syntax check passed
- Zero remaining `manifests/skills` references confirmed via rg
- All pre-push checks passed (lint, type, tests, LOC)

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)