### PR TITLE
fix(docs): align 5 stale docs to current architecture (#1126)

### DIFF
--- a/docs/standards/v3/skill-standard.md
+++ b/docs/standards/v3/skill-standard.md
@@ -18,7 +18,7 @@ related_docs:
   - docs/standards/glossary.md
   - docs/standards/action-verbs.md
   - docs/standards/v3/command-standard.md
-  - docs/standards/v3/development-flow-semantic-standard.md
+  - docs/standards/v3/ARCHIVED_development-flow-semantic-standard.md
   - docs/standards/v3/python-capability-design.md
   - docs/standards/v3/skill-trigger-standard.md
 ---

--- a/docs/v3/infrastructure/02-architecture.md
+++ b/docs/v3/infrastructure/02-architecture.md
@@ -26,14 +26,23 @@ src/vibe3/
 ├── cli.py                    # Typer 入口
 ├── commands/                 # 命令调度层
 ├── services/                 # 业务逻辑层
-├── engine/                   # DAG + flow + state machine
-├── runtime/                  # executor + scheduler + dispatcher
+├── domain/                   # 领域事件、业务逻辑编排、状态机
+├── execution/                # 执行控制面 (Capacity, Lifecycle, Session, Agent Launch)
+├── runtime/                  # 调度器 (Heartbeat, 事件路由, Observation 翻译)
 ├── clients/                  # 外部依赖封装 (Protocol 接口)
 ├── models/                   # Pydantic 数据模型
 ├── observability/            # logging + trace + audit
 ├── exceptions/               # 异常定义
+├── server/                   # HTTP/Webhook 暴露、进程级驱动装配
+├── environment/              # 资源原语 (Worktree, Tmux)
 ├── ui/                       # 展示层 (Rich)
-└── config/                   # 配置模块
+├── config/                   # 配置模块
+├── adapters/                 # 角色适配器
+├── agents/                   # Agent 定义与实现
+├── analysis/                 # 分析工具
+├── prompts/                  # Prompt 模板
+├── roles/                    # 角色定义
+└── utils/                    # 通用工具
 ```
 
 **代码规模限制**：见 **[03-coding-standards.md](03-coding-standards.md)**

--- a/docs/v3/orchestra/github-issue-draft.md
+++ b/docs/v3/orchestra/github-issue-draft.md
@@ -1,7 +1,8 @@
 # Orchestra Follow-up Issue Drafts
 
-> 用途：把“本版不做但必须做”的能力拆成可执行 issue。
+> 用途：把”本版不做但必须做”的能力拆成可执行 issue。
 > 标签建议：`orchestra`, `enhancement`, `priority/medium`（按实际调整）。
+> **Status Review (2026-05-20)**: 三个 draft 仍然有效。Phase A 的候选列表/优先级/依赖决策尚未完整实现；Phase B 的 manager 多阶段编排（plan/run/review 子 agent 协同）由 manager 材料定义但尚未落地；Phase C 的可观测性有部分基础设施（observability/）但缺少决策日志结构化和队列可视化。
 
 ## Draft 1: Orchestrator 决策循环（候选列表 + 优先级 + 依赖）
 

--- a/docs/v3/orchestra/prd-orchestra-integration.md
+++ b/docs/v3/orchestra/prd-orchestra-integration.md
@@ -7,10 +7,9 @@ created: "2026-03-16"
 last_updated: "2026-03-29"
 related_docs:
   - docs/v3/orchestra/README.md
-  - src/vibe3/orchestra/serve.py
-  - src/vibe3/orchestra/heartbeat.py
-  - src/vibe3/orchestra/services/assignee_dispatch.py
-  - src/vibe3/orchestra/services/pr_review_dispatch.py
+  - src/vibe3/orchestra/global_dispatch_coordinator.py
+  - src/vibe3/orchestra/flow_dispatch.py
+  - src/vibe3/orchestra/failed_gate.py
 status: active
 ---
 

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -1,32 +1,4 @@
 # Manager 自动化执行材料
-## Handoff Append Format Requirements
-
-When writing handoff append, follow these strict format requirements:
-
-**FORBIDDEN content**:
-- ❌ Complete pytest output (dozens of lines)
-- ❌ Complete error stack traces (dozens of lines)
-- ❌ Verbatim command outputs or logs
-
-**REQUIRED format**:
-- 📏 Each append ≤ 500 characters (≈ 10 lines)
-- 📝 Only write summary (what) + reference (where)
-- 🔗 Reference forms:
-  - Log file path: `temp/logs/issues/issue-XXX/run-YY.async.log`
-  - Reproduction command: `uv run pytest <test-file>::<test-name>`
-  - Issue link: `#123`
-
-**Example**:
-```markdown
-vibe-commit: BLOCKED - test failure in pre-push hook
-
-**Test**: test_repo_root_detection_works_from_subdirectory
-**Failure**: get_worktree_root() returns subdirectory path
-**Evidence**: temp/logs/issues/issue-608/run-10.async.log
-**Reproduction**: `uv run pytest tests/vibe3/integration/test_ci_parity.py::TestWorkingDirectoryIndependence::test_repo_root_detection_works_from_subdirectory`
-```
-
-
 
 ## Handoff Append Format Requirements
 


### PR DESCRIPTION
## Summary
- **02-architecture.md**: Replace non-existent `engine/` with current directory structure including `domain/`, `execution/`, `environment/`, `server/` etc.
- **prd-orchestra-integration.md**: Update `related_docs` from 4 non-existent files to 3 current orchestra files
- **github-issue-draft.md**: Add status review (2026-05-20) confirming all 3 drafts remain relevant
- **manager.md**: Remove duplicate "Handoff Append Format Requirements" section (~25 lines)
- **skill-standard.md**: Update reference to archived `development-flow-semantic-standard.md`

## Test plan
- [ ] Verify each doc's changes are scoped to reference/staleness fixes only (no semantic changes)
- [ ] Confirm no new stale references introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)