### PR TITLE
fix(init): split features.skills into local_skills and global_skills flags

### DIFF
--- a/docs/validation/smoke-tests.md
+++ b/docs/validation/smoke-tests.md
@@ -51,7 +51,8 @@ vibe init --profile minimal --yes
 **Verify**:
 - [ ] `.vibe/config.yaml` exists and contains `profile: minimal`
 - [ ] `.vibe/config.yaml` has `features.agent: false`
-- [ ] `.vibe/config.yaml` has `features.skills: false`
+- [ ] `.vibe/config.yaml` has `features.local_skills: false`
+- [ ] `.vibe/config.yaml` has `features.global_skills: false`
 - [ ] `.vibe/config.yaml` has `features.github_labels: false`
 - [ ] `.vibe/config.yaml` has `paths.policies_root` pointing to `~/.vibe/assets/policies`
 - [ ] No `.agent/` directory created
@@ -86,7 +87,8 @@ vibe init --profile github-flow --yes --skip-labels
 **Verify**:
 - [ ] `.vibe/config.yaml` exists and contains `profile: github-flow`
 - [ ] `.vibe/config.yaml` has `features.agent: true`
-- [ ] `.vibe/config.yaml` has `features.skills: false`
+- [ ] `.vibe/config.yaml` has `features.local_skills: false`
+- [ ] `.vibe/config.yaml` has `features.global_skills: true`
 - [ ] `.vibe/config.yaml` has `features.github_labels: true`
 - [ ] `.vibe/config.yaml` has `paths.policies_root` pointing to `~/.vibe/assets/policies`
 - [ ] `.agent/` directory created

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -134,6 +134,20 @@ vibe_init() {
 
     _log_success "Git repository detected: $REPO_ROOT"
 
+    # 1b. Check for legacy features.skills in existing config (backward compat)
+    local LEGACY_CONFIG="$REPO_ROOT/.vibe/config.yaml"
+    if [[ -f "$LEGACY_CONFIG" ]]; then
+        local _has_skills _has_local _has_global
+        _has_skills=$(grep -c "^\s*skills:" "$LEGACY_CONFIG" 2>/dev/null || true)
+        _has_local=$(grep -c "local_skills:" "$LEGACY_CONFIG" 2>/dev/null || true)
+        _has_global=$(grep -c "global_skills:" "$LEGACY_CONFIG" 2>/dev/null || true)
+        if [[ "$_has_skills" -gt 0 && "$_has_local" -eq 0 && "$_has_global" -eq 0 ]]; then
+            _log_warning "Detected legacy config: features.skills is deprecated"
+            echo "   Use features.local_skills + features.global_skills instead."
+            echo "   Re-running init will migrate your config to the new format."
+        fi
+    fi
+
     # 2. Check GitHub CLI (only if profile requires labels)
     if [[ "$ENABLE_GITHUB_LABELS" == true && "$SKIP_LABELS" != true ]]; then
         if ! command -v gh >/dev/null 2>&1; then

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -16,7 +16,7 @@ vibe_init_help() {
     echo "  1. 检查 git 环境"
     echo "  2. 根据 profile 创建必要的目录结构"
     echo "  3. 根据 profile 创建 GitHub labels"
-    echo "  4. 根据 profile 复制 .claude/skills 符号链接"
+    echo "  4.根据 profile 分别创建 skills/ 目录和 .claude/skills 全局符号链接"
     echo "  5. 生成 .vibe/config.yaml 配置文件"
     echo "  6. 验证项目运行支持"
     echo ""
@@ -114,7 +114,8 @@ vibe_init() {
     # Get profile features (needed for both pre-flight checks and execution)
     local ENABLE_GITHUB_LABELS=$(get_profile_feature "github_labels")
     local ENABLE_AGENT=$(get_profile_feature "agent")
-    local ENABLE_SKILLS=$(get_profile_feature "skills")
+    local ENABLE_LOCAL_SKILLS=$(get_profile_feature "local_skills")
+    local ENABLE_GLOBAL_SKILLS=$(get_profile_feature "global_skills")
     local ENABLE_SUPERVISOR=$(get_profile_feature "supervisor")
 
     # 1. Check git environment
@@ -155,8 +156,11 @@ vibe_init() {
             echo "  - Create .agent/ directory structure"
         fi
 
-        if [[ "$ENABLE_SKILLS" == true ]]; then
+        if [[ "$ENABLE_LOCAL_SKILLS" == true ]]; then
             echo "  - Create skills/ structure"
+        fi
+
+        if [[ "$ENABLE_GLOBAL_SKILLS" == true ]]; then
             echo "  - Setup .claude/skills symlinks"
         fi
 
@@ -198,7 +202,7 @@ vibe_init() {
     fi
 
     # Create skills/ if profile requires
-    if [[ "$ENABLE_SKILLS" == true ]]; then
+    if [[ "$ENABLE_LOCAL_SKILLS" == true ]]; then
         mkdir -p "$REPO_ROOT/skills"
         _log_success "Created: skills/ directory"
     fi
@@ -258,7 +262,7 @@ vibe_init() {
     fi
 
     # 6. Setup .claude/skills symlinks (profile-dependent)
-    if [[ "$ENABLE_SKILLS" == true ]]; then
+    if [[ "$ENABLE_GLOBAL_SKILLS" == true ]]; then
         _log_info "Setting up .claude/skills symlinks..."
 
         local VIBE_SKILLS_DIR="$HOME/.vibe/skills"

--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -9,7 +9,8 @@
 # profile: <minimal|github-flow|vibe-center>
 # features:
 #   agent: <true|false>          # Whether to create .agent/ directory
-#   skills: <true|false>         # Whether to create skills/ structure
+#   local_skills: <true|false>   # Whether to create skills/ directory
+#   global_skills: <true|false>  # Whether to symlink ~/.vibe/skills → .claude/skills/
 #   supervisor: <true|false>     # Whether to enable supervisor orchestration
 #   github_labels: <true|false>  # Whether to create GitHub labels
 #   github_orchestration: <true|false>  # Whether to enable GitHub flow/PR/issue orchestration
@@ -37,7 +38,8 @@
 PROFILE_MINIMAL=(
     "profile:minimal"
     "features.agent:false"
-    "features.skills:false"
+    "features.local_skills:false"
+    "features.global_skills:false"
     "features.supervisor:false"
     "features.github_labels:false"
     "features.github_orchestration:false"
@@ -57,7 +59,8 @@ PROFILE_MINIMAL=(
 PROFILE_GITHUB_FLOW=(
     "profile:github-flow"
     "features.agent:true"
-    "features.skills:false"
+    "features.local_skills:false"
+    "features.global_skills:true"
     "features.supervisor:false"
     "features.github_labels:true"
     "features.github_orchestration:true"
@@ -77,7 +80,8 @@ PROFILE_GITHUB_FLOW=(
 PROFILE_VIBE_CENTER=(
     "profile:vibe-center"
     "features.agent:true"
-    "features.skills:true"
+    "features.local_skills:true"
+    "features.global_skills:true"
     "features.supervisor:true"
     "features.github_labels:true"
     "features.github_orchestration:true"
@@ -195,7 +199,8 @@ profile: $profile_name
 
 features:
   agent: $(get_profile_feature "agent")
-  skills: $(get_profile_feature "skills")
+  local_skills: $(get_profile_feature "local_skills")
+  global_skills: $(get_profile_feature "global_skills")
   supervisor: $(get_profile_feature "supervisor")
   github_labels: $(get_profile_feature "github_labels")
   github_orchestration: $(get_profile_feature "github_orchestration")
@@ -247,7 +252,7 @@ list_profiles() {
     echo "  ${GREEN}minimal${NC}"
     echo "    - Minimal runtime without GitHub orchestration"
     echo "    - No .agent/ directory"
-    echo "    - No skills/ structure"
+    echo "    - No local skills/ or global .claude/skills/ symlinks"
     echo "    - No GitHub labels"
     echo "    - Uses global policies/prompts from ~/.vibe/assets"
     echo ""
@@ -256,6 +261,7 @@ list_profiles() {
     echo "    - Creates .agent/ directory"
     echo "    - Creates GitHub labels (state/*)"
     echo "    - Enables GitHub flow conventions"
+    echo "    - Symlinks global ~/.vibe/skills → .claude/skills/ (no local skills/ directory)"
     echo "    - Uses global policies/prompts from ~/.vibe/assets"
     echo ""
     echo "  ${GREEN}vibe-center${NC}"

--- a/tests/vibe2/integration/test_init_legacy_fallback.bats
+++ b/tests/vibe2/integration/test_init_legacy_fallback.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# Tests for legacy features.skills → local_skills + global_skills migration
+
+setup() {
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  export VIBE_ROOT="$REPO_ROOT"
+  export VIBE_LIB="$REPO_ROOT/lib"
+}
+
+@test "init warns when existing config has legacy features.skills" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  # Create a legacy .vibe/config.yaml with old features.skills flag
+  mkdir -p "$fixture/.vibe"
+  cat > "$fixture/.vibe/config.yaml" <<'YAML'
+profile: vibe-center
+features:
+  agent: true
+  skills: true
+  supervisor: true
+  github_labels: true
+  github_orchestration: true
+YAML
+
+  # Run vibe init and capture output (use --yes and --skip-labels to avoid prompts)
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile vibe-center --yes --skip-labels 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "features.skills is deprecated" ]]
+}
+
+@test "init generates new format config with local_skills and global_skills" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile minimal --yes --skip-labels 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [ -f "$fixture/.vibe/config.yaml" ]
+
+  # New format must have local_skills and global_skills, not features.skills
+  run grep "local_skills:" "$fixture/.vibe/config.yaml"
+  [ "$status" -eq 0 ]
+
+  run grep "global_skills:" "$fixture/.vibe/config.yaml"
+  [ "$status" -eq 0 ]
+
+  # Must NOT have old features.skills key (only local_skills/global_skills)
+  run grep -E "^\s+skills:" "$fixture/.vibe/config.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "init does not warn when config already uses new format" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  # Create a new-format .vibe/config.yaml
+  mkdir -p "$fixture/.vibe"
+  cat > "$fixture/.vibe/config.yaml" <<'YAML'
+profile: minimal
+features:
+  agent: false
+  local_skills: false
+  global_skills: false
+  supervisor: false
+  github_labels: false
+  github_orchestration: false
+YAML
+
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile minimal --yes --skip-labels 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "features.skills is deprecated" ]]
+}


### PR DESCRIPTION
## Summary

- Fixes github-flow profile where `.claude/skills/` was always empty because `features.skills:false` blocked both local skills/ creation and global symlinking
- Splits the monolithic `features.skills` flag into two independent flags:
  - `local_skills`: controls whether to create local `skills/` directory
  - `global_skills`: controls whether to symlink `~/.vibe/skills` → `.claude/skills/`
- Updates all 3 profile definitions (minimal, github-flow, vibe-center) with correct flag combinations

## Changes

| Profile | local_skills | global_skills |
|---------|-------------|---------------|
| minimal | false | false |
| github-flow | false | true |
| vibe-center | true | true |

## Verification

- All 9 profile smoke tests pass
- Shell syntax verified (shellcheck + lint.sh)
- Zero stale references to old `ENABLE_SKILLS` variable

Fixes #1091

---

## Contributors

claude/opus
