### PR TITLE
fix(loader): add UV_PROJECT_ENVIRONMENT fallback to prevent .venv pollution

### DIFF
--- a/config/shell/loader.sh
+++ b/config/shell/loader.sh
@@ -37,3 +37,9 @@ _keys_load() {
     return 0
 }
 _keys_load "${HOME}/.vibe/config/keys.env"
+
+# ---------- UV_PROJECT_ENVIRONMENT ----------
+# Fallback so `uv run` from external project dirs doesn't create .venv in $PWD.
+if [[ -z "$UV_PROJECT_ENVIRONMENT" && -d "$HOME/.venvs/vibe-center" ]]; then
+    export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/vibe-center"
+fi


### PR DESCRIPTION
## Summary

- Add guarded export of `UV_PROJECT_ENVIRONMENT` in `config/shell/loader.sh`
- Prevents `uv run` from creating `.venv` in external project directories when loader.sh is sourced without a full rc init
- Single 6-line addition: sets fallback to `~/.venvs/vibe-center` only when variable is unset and target directory exists

## Test plan

- [x] All 49 config tests pass
- [x] Shell syntax validation passes (`zsh -n`)
- [x] Pre-commit hooks pass (black, ruff, shellcheck, LOC)
- [x] Pre-push checks pass (smoke tests, type check)

Fixes #1095

---

## Contributors

claude/opus
