### PR TITLE
fix(execution): preserve issue worktree resolution on sync retries

### DIFF
--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -198,7 +198,9 @@ def build_issue_sync_prompt_request(
         execution_name=execution_name,
         prompt=prompt,
         options=options,
-        cwd=str(Path.cwd()) if session_id else None,
+        # Keep sync issue-role requests worktree-agnostic so the coordinator can
+        # resolve the correct permanent worktree from target_branch.
+        cwd=None,
         repo_path=str(root),
         refs=refs,
         actor=actor,

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -306,7 +306,7 @@ def build_manager_sync_request(
         "and stop when the current state rule requires exit."
     )
 
-    repo_root = Path.cwd() if session_id else Path(resolve_orchestra_repo_root())
+    repo_root = Path(resolve_orchestra_repo_root())
     return build_issue_sync_prompt_request(
         role="manager",
         issue=issue,

--- a/tests/vibe3/execution/test_issue_role_support.py
+++ b/tests/vibe3/execution/test_issue_role_support.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
+    build_issue_sync_prompt_request,
     resolve_async_cli_project_root,
     resolve_orchestra_repo_root,
 )
@@ -86,3 +87,25 @@ def test_build_issue_async_cli_request_uses_debug_code_root_override(
     assert request.cmd[6] == str(WORKTREE_REPO / "src/vibe3/cli.py")
     # Worktree creation / shared state still anchor to main repo root.
     assert request.repo_path == str(MAIN_REPO)
+
+
+def test_build_issue_sync_prompt_request_with_session_does_not_pin_cwd() -> None:
+    """Retry sync requests should still let coordinator resolve the worktree cwd."""
+    issue = IssueInfo(number=431, title="Test issue", labels=[])
+
+    request = build_issue_sync_prompt_request(
+        role="manager",
+        issue=issue,
+        target_branch="task/issue-431",
+        prompt="test prompt",
+        task="test task",
+        options=object(),
+        actor="agent:manager",
+        execution_name="vibe3-manager-issue-431",
+        worktree_requirement=WorktreeRequirement.PERMANENT,
+        session_id="session-431",
+        repo_path=MAIN_REPO,
+    )
+
+    assert request.refs["session_id"] == "session-431"
+    assert request.cwd is None

--- a/tests/vibe3/roles/test_manager.py
+++ b/tests/vibe3/roles/test_manager.py
@@ -9,6 +9,7 @@ Note: Dispatch queue filtering tests moved to test_global_dispatch_coordinator.p
 after StateLabelDispatchService deletion in issue-462 refactoring.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -146,6 +147,64 @@ manager:
         )
 
         assert "SUPERVISOR CONTENT" not in (request.prompt or "")
+
+    def test_retry_resume_uses_main_repo_root_not_current_cwd(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Retry manager requests should keep orchestration anchored to main repo."""
+        from vibe3.prompts import manifest
+
+        recipes_path = tmp_path / "prompt-recipes.yaml"
+        recipes_path.write_text(
+            """
+recipes:
+  manager.default:
+    kind: section_recipe
+    variants:
+      first.bootstrap:
+        sections:
+          - key: manager.target
+      retry.resume:
+        sections:
+          - manager.retry_task
+""",
+            encoding="utf-8",
+        )
+
+        prompts_path = tmp_path / "prompts.yaml"
+        prompts_path.write_text(
+            """
+manager:
+  target: "target section"
+  retry_task: "retry task"
+""",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(manifest, "DEFAULT_PROMPT_RECIPES_PATH", recipes_path)
+        monkeypatch.setattr(
+            "vibe3.roles.manager._resolve_prompts_path", lambda: prompts_path
+        )
+        monkeypatch.setattr(
+            "vibe3.roles.manager.resolve_orchestra_repo_root",
+            lambda: Path("/test/repos/vibe-center/main"),
+        )
+
+        config = OrchestraConfig(assignee_dispatch=AssigneeDispatchConfig())
+
+        request = build_manager_sync_request(
+            config=config,
+            issue=IssueInfo(number=661, title="Config cleanup"),
+            branch="task/issue-661",
+            flow_state=None,
+            session_id="session-1",
+            options=object(),
+            actor="test",
+            dry_run=False,
+            show_prompt=False,
+        )
+
+        assert request.repo_path == "/test/repos/vibe-center/main"
 
 
 class TestManagerBlockedToHandoffTransitionBlocked:


### PR DESCRIPTION
## Summary
- stop sync issue-role retry requests from pinning execution `cwd` to the current directory
- keep manager retry requests anchored to the main repo root so coordinator can resolve the correct issue worktree
- add regression tests for sync request construction and manager retry repo-root behavior

## Verification
- `uv run pytest tests/vibe3/execution/test_issue_role_support.py -q`
- `uv run pytest tests/vibe3/roles/test_manager.py -q`
- `uv run pytest tests/vibe3/execution/test_coordinator.py -q -k permanent_worktree`
- pre-push incremental checks passed

## Contributors
- Yi Chen
- OpenAI Codex
