### PR TITLE
fix(init): add GitHub remote check to prevent silent label creation failure

### DIFF
--- a/lib/init.sh
+++ b/lib/init.sh
@@ -139,6 +139,12 @@ vibe_init() {
             _log_warning "GitHub CLI (gh) not found"
             echo "   GitHub labels creation will be skipped."
             SKIP_LABELS=true
+        elif ! git remote get-url origin >/dev/null 2>&1; then
+            _log_warning "No GitHub remote found"
+            echo "   GitHub labels creation will be skipped."
+            _log_info "Add a remote with: git remote add origin <url>"
+            _log_info "Then re-run: vibe init --profile github-flow"
+            SKIP_LABELS=true
         fi
     fi
 


### PR DESCRIPTION
Closes #1094

## Summary
- Add git remote get-url origin check in pre-flight checks to detect missing GitHub remote
- Skip label creation when remote not found, preventing false success reports  
- Provide actionable guidance for users: add remote with git remote add and re-run vibe init

## Test plan
- [ ] Tested in local repo without GitHub remote - labels skipped, warning shown
- [ ] Tested in repo with GitHub remote - labels created successfully
- [ ] Pre-push checks passed (shellcheck, mypy, tests)
- [ ] Manual verification: SKIP_LABELS=true propagation verified at L169, L221, L356, L365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
