### PR TITLE
fix(dispatch): bypass qualify gate for BLOCKED issue collection

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -38,7 +38,11 @@ from vibe3.orchestra.queue_persistence_mixin import (
 from vibe3.roles.registry import build_label_dispatch_event
 from vibe3.services.check_service import CheckService
 from vibe3.services.flow_service import FlowService
-from vibe3.utils.label_utils import clean_old_state_labels, should_skip_from_queue
+from vibe3.utils.label_utils import (
+    clean_old_state_labels,
+    normalize_labels,
+    should_skip_from_queue,
+)
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
@@ -94,6 +98,33 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
                 label=state.to_label(),
             ),
         )
+
+        # BLOCKED bypass: skip qualify gate so falsely-unblocked issues
+        # enter the queue.  Qualification is deferred to
+        # qualify_blocked_issue() at dispatch time (coordinate()).
+        if state == IssueState.BLOCKED:
+            selected: list[IssueInfo] = []
+            for item in raw_issues:
+                labels = normalize_labels(item.get("labels"))
+                if not any(lbl.startswith("state/") for lbl in labels):
+                    continue
+                issue = IssueInfo.from_github_payload(item)
+                if issue is None:
+                    continue
+                if should_skip_from_queue(
+                    issue,
+                    supervisor_label=self._supervisor_label,
+                    manager_usernames=self._config.get_manager_usernames(),
+                    require_manager_assignee=True,
+                ):
+                    continue
+                selected.append(issue)
+            append_orchestra_event(
+                "dispatcher",
+                f"poll_issues_by_state({state.value}): "
+                f"{len(selected)} ready issues (bypassed qualify gate)",
+            )
+            return selected
 
         ready = select_ready_issues(
             raw_issues,

--- a/tests/vibe3/orchestra/test_dispatch_queue_operations.py
+++ b/tests/vibe3/orchestra/test_dispatch_queue_operations.py
@@ -337,3 +337,100 @@ class TestQueueOperations:
         await coordinator.coordinate()
 
         assert len(emit_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_blocked_issues_collected_without_qualify_gate(
+        self, make_capacity, make_coordinator, make_issue_info
+    ) -> None:
+        """BLOCKED issues bypass qualify gate during collection (#1125)."""
+        capacity = make_capacity(remaining=2)
+
+        coordinator = make_coordinator(
+            "manager",
+            [],  # No issues from standard poll path
+            capacity=capacity,
+            mock_health_check=True,
+        )
+
+        # Create raw GitHub payloads for BLOCKED issues
+        raw_payloads = [
+            {
+                "number": 100,
+                "title": "Issue 100",
+                "labels": [{"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "html_url": "https://github.com/owner/repo/issues/100",
+            },
+            {
+                "number": 101,
+                "title": "Issue 101",
+                "labels": [{"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "html_url": "https://github.com/owner/repo/issues/101",
+            },
+            # Supervisor-labeled issue should be filtered out
+            {
+                "number": 102,
+                "title": "Issue 102",
+                "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "html_url": "https://github.com/owner/repo/issues/102",
+            },
+        ]
+
+        # Mock GitHub API to return raw payloads for BLOCKED state
+        def mock_list_issues(**kwargs):
+            if kwargs.get("label") == "state/blocked":
+                return raw_payloads
+            return []
+
+        coordinator._github.list_issues = mock_list_issues
+
+        # Directly test _poll_issues_by_state for BLOCKED state
+        blocked_issues = await coordinator._poll_issues_by_state(IssueState.BLOCKED)
+
+        # Should return 2 issues (100 and 101), filtering out supervisor-labeled 102
+        assert len(blocked_issues) == 2
+        assert {issue.number for issue in blocked_issues} == {100, 101}
+
+        # Verify both issues have BLOCKED state
+        for issue in blocked_issues:
+            assert issue.state == IssueState.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_blocked_supervisor_issues_excluded_from_collection(
+        self, make_capacity, make_coordinator, make_issue_info
+    ) -> None:
+        """Supervisor-labeled BLOCKED issues are excluded during collection."""
+        capacity = make_capacity(remaining=1)
+
+        coordinator = make_coordinator(
+            "manager",
+            [],
+            capacity=capacity,
+            mock_health_check=True,
+        )
+
+        # Create raw payload with supervisor label
+        raw_payloads = [
+            {
+                "number": 102,
+                "title": "Issue 102",
+                "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "html_url": "https://github.com/owner/repo/issues/102",
+            }
+        ]
+
+        def mock_list_issues(**kwargs):
+            if kwargs.get("label") == "state/blocked":
+                return raw_payloads
+            return []
+
+        coordinator._github.list_issues = mock_list_issues
+
+        # Directly test _poll_issues_by_state for BLOCKED state
+        blocked_issues = await coordinator._poll_issues_by_state(IssueState.BLOCKED)
+
+        # Supervisor issue should be filtered out during collection
+        assert len(blocked_issues) == 0

--- a/tests/vibe3/orchestra/test_dispatch_queue_operations.py
+++ b/tests/vibe3/orchestra/test_dispatch_queue_operations.py
@@ -50,88 +50,61 @@ class TestQueueOperations:
         assert len(emit_calls) == 2
 
     @pytest.mark.asyncio
-    async def test_supervisor_issue_removed_from_existing_frozen_queue(
-        self, make_issue, make_capacity, make_coordinator, make_issue_info
+    @pytest.mark.parametrize(
+        "issue_num,role,collected_state,issue_state,labels,assignees",
+        [
+            (
+                467,
+                "handoff-manager",
+                "handoff",
+                IssueState.HANDOFF,
+                ["supervisor", "state/handoff"],
+                ["manager-bot"],
+            ),
+            (468, "manager", "ready", IssueState.READY, ["state/ready"], []),
+            (
+                469,
+                "handoff-manager",
+                "handoff",
+                IssueState.HANDOFF,
+                ["state/handoff"],
+                [],
+            ),
+        ],
+    )
+    async def test_invalid_issues_removed_from_frozen_queue(
+        self,
+        make_issue,
+        make_capacity,
+        make_coordinator,
+        make_issue_info,
+        issue_num,
+        role,
+        collected_state,
+        issue_state,
+        labels,
+        assignees,
     ) -> None:
-        issue = make_issue(467)
+        """Issues violating queue criteria are removed (supervisor, no assignee)."""
+        issue = make_issue(issue_num)
         capacity = make_capacity(remaining=1)
 
         coordinator = make_coordinator(
-            "handoff-manager", [issue], capacity=capacity, mock_health_check=True
+            role, [issue], capacity=capacity, mock_health_check=True
         )
         coordinator._frozen_queue = [
-            QueueEntry(issue_number=467, collected_state="handoff", waiting_state=None)
+            QueueEntry(
+                issue_number=issue_num,
+                collected_state=collected_state,
+                waiting_state=None,
+            )
         ]
-        coordinator._load_issue = lambda issue_number: make_issue_info(
-            issue_number,
-            IssueState.HANDOFF,
-            labels=["supervisor", IssueState.HANDOFF.to_label()],
-            assignees=["manager-bot"],
+        coordinator._load_issue = lambda n: make_issue_info(
+            n, issue_state, labels=labels, assignees=assignees
         )
 
         emit_calls = []
-        coordinator._emit_dispatch_intent = (
-            lambda role, issue, tick_id: emit_calls.append((role, issue))
-        )
-
-        await coordinator.coordinate()
-
-        assert len(emit_calls) == 0
-        assert coordinator._frozen_queue == []
-
-    @pytest.mark.asyncio
-    async def test_ready_issue_no_manager_assignee_removed_from_frozen_queue(
-        self, make_issue, make_capacity, make_coordinator, make_issue_info
-    ) -> None:
-        issue = make_issue(468)
-        capacity = make_capacity(remaining=1)
-
-        coordinator = make_coordinator(
-            "manager", [issue], capacity=capacity, mock_health_check=True
-        )
-        coordinator._frozen_queue = [
-            QueueEntry(issue_number=468, collected_state="ready", waiting_state=None)
-        ]
-        coordinator._load_issue = lambda issue_number: make_issue_info(
-            issue_number,
-            IssueState.READY,
-            assignees=[],
-        )
-
-        emit_calls = []
-        coordinator._emit_dispatch_intent = (
-            lambda role, issue, tick_id: emit_calls.append((role, issue))
-        )
-
-        await coordinator.coordinate()
-
-        assert len(emit_calls) == 0
-        assert coordinator._frozen_queue == []
-
-    @pytest.mark.asyncio
-    async def test_unassigned_handoff_issue_removed_from_frozen_queue(
-        self, make_issue, make_capacity, make_coordinator, make_issue_info
-    ) -> None:
-        """Unassigned issues are now removed from queue at all stages (fix for #305)."""
-        issue = make_issue(469)
-        capacity = make_capacity(remaining=1)
-
-        coordinator = make_coordinator(
-            "handoff-manager", [issue], capacity=capacity, mock_health_check=True
-        )
-        coordinator._frozen_queue = [
-            QueueEntry(issue_number=469, collected_state="handoff", waiting_state=None)
-        ]
-        coordinator._load_issue = lambda issue_number: make_issue_info(
-            issue_number,
-            IssueState.HANDOFF,
-            assignees=[],
-        )
-
-        emit_calls = []
-        coordinator._emit_dispatch_intent = (
-            lambda role, issue, tick_id: emit_calls.append((role, issue))
-        )
+        coordinator._emit_dispatch_intent = lambda r, i, t: emit_calls.append((r, i))
 
         await coordinator.coordinate()
 
@@ -339,44 +312,67 @@ class TestQueueOperations:
         assert len(emit_calls) == 0
 
     @pytest.mark.asyncio
-    async def test_blocked_issues_collected_without_qualify_gate(
-        self, make_capacity, make_coordinator, make_issue_info
+    @pytest.mark.parametrize(
+        "test_case,expected_count,expected_numbers",
+        [
+            ("normal", 2, {100, 101}),
+            ("supervisor_only", 0, set()),
+        ],
+    )
+    async def test_blocked_issues_collection_filtering(
+        self,
+        make_capacity,
+        make_coordinator,
+        test_case,
+        expected_count,
+        expected_numbers,
     ) -> None:
-        """BLOCKED issues bypass qualify gate during collection (#1125)."""
+        """BLOCKED issues bypass qualify gate; supervisor-labeled issues excluded."""
         capacity = make_capacity(remaining=2)
 
         coordinator = make_coordinator(
             "manager",
-            [],  # No issues from standard poll path
+            [],
             capacity=capacity,
             mock_health_check=True,
         )
 
-        # Create raw GitHub payloads for BLOCKED issues
-        raw_payloads = [
-            {
-                "number": 100,
-                "title": "Issue 100",
-                "labels": [{"name": "state/blocked"}],
-                "assignees": [{"login": "manager-bot"}],
-                "html_url": "https://github.com/owner/repo/issues/100",
-            },
-            {
-                "number": 101,
-                "title": "Issue 101",
-                "labels": [{"name": "state/blocked"}],
-                "assignees": [{"login": "manager-bot"}],
-                "html_url": "https://github.com/owner/repo/issues/101",
-            },
-            # Supervisor-labeled issue should be filtered out
-            {
-                "number": 102,
-                "title": "Issue 102",
-                "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
-                "assignees": [{"login": "manager-bot"}],
-                "html_url": "https://github.com/owner/repo/issues/102",
-            },
-        ]
+        # Create raw payloads based on test case
+        if test_case == "normal":
+            raw_payloads = [
+                {
+                    "number": 100,
+                    "title": "Issue 100",
+                    "labels": [{"name": "state/blocked"}],
+                    "assignees": [{"login": "manager-bot"}],
+                    "html_url": "https://github.com/owner/repo/issues/100",
+                },
+                {
+                    "number": 101,
+                    "title": "Issue 101",
+                    "labels": [{"name": "state/blocked"}],
+                    "assignees": [{"login": "manager-bot"}],
+                    "html_url": "https://github.com/owner/repo/issues/101",
+                },
+                # Supervisor-labeled issue should be filtered out
+                {
+                    "number": 102,
+                    "title": "Issue 102",
+                    "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
+                    "assignees": [{"login": "manager-bot"}],
+                    "html_url": "https://github.com/owner/repo/issues/102",
+                },
+            ]
+        else:  # supervisor_only
+            raw_payloads = [
+                {
+                    "number": 102,
+                    "title": "Issue 102",
+                    "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
+                    "assignees": [{"login": "manager-bot"}],
+                    "html_url": "https://github.com/owner/repo/issues/102",
+                }
+            ]
 
         # Mock GitHub API to return raw payloads for BLOCKED state
         def mock_list_issues(**kwargs):
@@ -389,48 +385,10 @@ class TestQueueOperations:
         # Directly test _poll_issues_by_state for BLOCKED state
         blocked_issues = await coordinator._poll_issues_by_state(IssueState.BLOCKED)
 
-        # Should return 2 issues (100 and 101), filtering out supervisor-labeled 102
-        assert len(blocked_issues) == 2
-        assert {issue.number for issue in blocked_issues} == {100, 101}
+        # Verify filtering behavior
+        assert len(blocked_issues) == expected_count
+        assert {issue.number for issue in blocked_issues} == expected_numbers
 
-        # Verify both issues have BLOCKED state
+        # Verify all returned issues have BLOCKED state
         for issue in blocked_issues:
             assert issue.state == IssueState.BLOCKED
-
-    @pytest.mark.asyncio
-    async def test_blocked_supervisor_issues_excluded_from_collection(
-        self, make_capacity, make_coordinator, make_issue_info
-    ) -> None:
-        """Supervisor-labeled BLOCKED issues are excluded during collection."""
-        capacity = make_capacity(remaining=1)
-
-        coordinator = make_coordinator(
-            "manager",
-            [],
-            capacity=capacity,
-            mock_health_check=True,
-        )
-
-        # Create raw payload with supervisor label
-        raw_payloads = [
-            {
-                "number": 102,
-                "title": "Issue 102",
-                "labels": [{"name": "supervisor"}, {"name": "state/blocked"}],
-                "assignees": [{"login": "manager-bot"}],
-                "html_url": "https://github.com/owner/repo/issues/102",
-            }
-        ]
-
-        def mock_list_issues(**kwargs):
-            if kwargs.get("label") == "state/blocked":
-                return raw_payloads
-            return []
-
-        coordinator._github.list_issues = mock_list_issues
-
-        # Directly test _poll_issues_by_state for BLOCKED state
-        blocked_issues = await coordinator._poll_issues_by_state(IssueState.BLOCKED)
-
-        # Supervisor issue should be filtered out during collection
-        assert len(blocked_issues) == 0

--- a/tests/vibe3/orchestra/test_dispatch_state_transitions.py
+++ b/tests/vibe3/orchestra/test_dispatch_state_transitions.py
@@ -211,6 +211,66 @@ class TestStateTransitions:
 
         assert len(emit_calls) == 1
 
+    @pytest.mark.asyncio
+    async def test_falsely_blocked_issue_dispatches_after_qualify(
+        self,
+        make_capacity,
+        make_coordinator,
+        make_issue_info,
+    ) -> None:
+        """Falsely-blocked issue is dispatched after qualify_blocked_issue (#1125)."""
+        capacity = make_capacity(remaining=1)
+
+        coordinator = make_coordinator(
+            "manager",
+            [],
+            capacity=capacity,
+            mock_health_check=True,
+        )
+
+        # Create raw payload for falsely-blocked issue
+        # (label says blocked, but qualify gate determines it should be ready)
+        raw_payload = {
+            "number": 100,
+            "title": "Falsely Blocked Issue",
+            "labels": [{"name": "state/blocked"}],
+            "assignees": [{"login": "manager-bot"}],
+            "html_url": "https://github.com/owner/repo/issues/100",
+        }
+
+        def mock_list_issues(**kwargs):
+            if kwargs.get("label") == "state/blocked":
+                return [raw_payload]
+            return []
+
+        coordinator._github.list_issues = mock_list_issues
+
+        # Mock qualify_blocked_issue to return READY (unblocked)
+        def mock_qualify(issue) -> IssueState | None:
+            assert issue.number == 100
+            return IssueState.READY
+
+        coordinator._qualify_gate.qualify_blocked_issue = mock_qualify
+
+        # Mock _load_issue to return the issue with BLOCKED label
+        coordinator._load_issue = lambda issue_number: make_issue_info(
+            issue_number,
+            IssueState.BLOCKED,
+            labels=["state/blocked"],
+        )
+
+        emit_calls = []
+        coordinator._emit_dispatch_intent = (
+            lambda role, issue, tick_id=0: emit_calls.append((role, issue))
+        )
+
+        await coordinator.coordinate()
+
+        # Falsely-blocked issue should be dispatched to manager role
+        assert len(emit_calls) == 1
+        assert emit_calls[0][1].number == 100
+        assert emit_calls[0][0].registry_role == "manager"
+
 
 class TestLoggingBehavior:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix BLOCKED issue polling gap where `_poll_issues_by_state` filtered out
  falsely-unblocked issues via `run_qualify_gate`, causing them to never be
  rediscovered or rescheduled
- Add BLOCKED bypass path in `_poll_issues_by_state` to collect BLOCKED issues
  directly and use `qualify_blocked_issue` for dispatch-time qualification
- Add 3 new tests: collection bypass, dispatch behavior, and blocked-to-ready
  requalification

Closes #1125

## Test plan

- [x] All 127 orchestra tests pass
- [x] 3 new BLOCKED bypass tests pass
- [x] mypy type check passes
- [x] ruff lint passes
- [x] pre-commit hooks pass

---

## Contributors

claude/opus
