### PR TITLE
refactor: remove takeover command semantics and residual references

### DIFF
--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -171,13 +171,6 @@ def resume(
         ),
     ] = None,
     reason: Annotated[str, typer.Option("--reason", help="Reason for resume")] = "",
-    takeover: Annotated[
-        bool,
-        typer.Option(
-            "--takeover",
-            help="Explicitly take over worktree ownership from another session",
-        ),
-    ] = False,
     yes: Annotated[
         bool, typer.Option("--yes", "-y", help="Execute the resume (default dry-run)")
     ] = False,
@@ -349,7 +342,6 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
-            allow_takeover=takeover,
             progress_callback=progress_callback if yes else None,
         )
     else:
@@ -362,7 +354,6 @@ def resume(
             stale_flows=stale_flows,
             candidate_mode=candidate_mode,
             label_state=effective_label,
-            allow_takeover=takeover,
             progress_callback=progress_callback if yes else None,
         )
 

--- a/src/vibe3/services/check_ownership_service.py
+++ b/src/vibe3/services/check_ownership_service.py
@@ -67,8 +67,8 @@ def check_worktree_ownership(
             return [
                 f"ORPHANED_OWNERSHIP: Worktree for branch '{branch}' is claimed "
                 f"by dead session '{owner_tmux_session}'. "
-                "Inspect the live runtime session and wait for it to finish "
-                "before retrying."
+                "The owning session has ended. Clear the stale runtime session record "
+                "to reclaim this worktree."
             ], []
 
         # Check if current session matches owner (only if in tmux)

--- a/src/vibe3/services/check_ownership_service.py
+++ b/src/vibe3/services/check_ownership_service.py
@@ -67,8 +67,8 @@ def check_worktree_ownership(
             return [
                 f"ORPHANED_OWNERSHIP: Worktree for branch '{branch}' is claimed "
                 f"by dead session '{owner_tmux_session}'. "
-                "Use 'vibe3 task resume --takeover' to take over ownership, "
-                "or manually investigate if the session should still be active."
+                "Inspect the live runtime session and wait for it to finish "
+                "before retrying."
             ], []
 
         # Check if current session matches owner (only if in tmux)
@@ -80,7 +80,8 @@ def check_worktree_ownership(
                 f"Session mismatch: Worktree for branch '{branch}' is owned by "
                 f"session '{owner_tmux_session}', but current session is "
                 f"'{current_session_id}'. "
-                "Use 'vibe3 task resume --takeover' to take over if authorized."
+                "Inspect the live runtime session and wait for it to finish "
+                "before retrying."
             ], []
 
         return [], []  # Ownership is consistent

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -305,8 +305,9 @@ class FlowCleanupService:
                     f"Skipping cleanup for '{branch}': {len(live_sessions)} live "
                     "sessions found (detected in defensive layer 2). "
                     "This indicates a race condition where sessions started "
-                    "after pre-filter query. Use 'vibe3 task resume --takeover' "
-                    "if you really want to force cleanup."
+                    "after pre-filter query. "
+                    "Active runtime sessions are still present; stop cleanup "
+                    "and investigate before retrying."
                 )
                 logger.bind(domain="cleanup", branch=branch).warning(message)
                 raise LiveSessionsDetectedError(message)

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -63,7 +63,6 @@ class TaskResumeOperations:
         reason: str,
         worktree_path: str | None = None,
         label_state: str | None = None,
-        allow_takeover: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> None:
         """Reset an issue to ready after clearing stale task scene state.
@@ -77,7 +76,6 @@ class TaskResumeOperations:
             worktree_path: Optional worktree path (for optimization)
             label_state: Optional state to restore (None=delete worktree,
                 empty/"handoff"=restore to handoff, "ready"=restore to ready)
-            allow_takeover: If True, allow taking over worktree ownership
             progress_callback: Optional callback for progress updates.
                 Signature: (issue_number: int, branch: str | None, step: str,
                     status: str) -> None
@@ -114,8 +112,6 @@ class TaskResumeOperations:
                     ensure_worktree_ownership(
                         self.flow_service.store,
                         str(wt_path),
-                        allow_takeover=allow_takeover,
-                        takeover_reason=reason or "task resume",
                     )
             except (ImportError, ValueError):
                 # find_worktree_path_for_branch may fail for branches without worktrees

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -81,7 +81,6 @@ class TaskResumeUsecase:
         repo: str | None = None,
         candidate_mode: str = "resumable",
         label_state: str | None = None,
-        allow_takeover: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> dict[str, Any]:
         """Resume failed or blocked issues.
@@ -96,7 +95,6 @@ class TaskResumeUsecase:
             candidate_mode: Candidate selection mode ("resumable" or "all_task")
             label_state: Optional state to restore (None=delete worktree,
                 "handoff"/"ready"=keep worktree)
-            allow_takeover: If True, allow taking over worktree ownership
             progress_callback: Optional callback for progress updates.
                 Signature: (issue_number: int, branch: str | None, step: str,
                     status: str) -> None
@@ -238,7 +236,6 @@ class TaskResumeUsecase:
                         reason=reason,
                         worktree_path=worktree_path,
                         label_state=label_state,
-                        allow_takeover=allow_takeover,
                         progress_callback=progress_callback,
                     )
 

--- a/src/vibe3/services/worktree_ownership_guard.py
+++ b/src/vibe3/services/worktree_ownership_guard.py
@@ -59,9 +59,6 @@ def get_worktree_owner(
 def ensure_worktree_ownership(
     store: SQLiteClient,
     worktree_path: str,
-    *,
-    allow_takeover: bool = False,
-    takeover_reason: str = "",
 ) -> None:
     """Validate that the current session owns this worktree.
 
@@ -73,11 +70,9 @@ def ensure_worktree_ownership(
     Args:
         store: SQLite client instance.
         worktree_path: Absolute path to the worktree directory.
-        allow_takeover: If True, allow taking over ownership.
-        takeover_reason: Reason for takeover (for audit logging).
 
     Raises:
-        WorktreeOwnerMismatchError: When session mismatch and takeover not allowed.
+        WorktreeOwnerMismatchError: When session mismatch.
     """
     current_session_id = get_current_session_id()
 
@@ -105,15 +100,6 @@ def ensure_worktree_ownership(
         return  # Current session owns it
 
     # Mismatch: current session doesn't own the worktree
-    if allow_takeover:
-        takeover_worktree(
-            store,
-            worktree_path,
-            current_session_id,
-            takeover_reason,
-        )
-        return
-
     # Build actionable error message
     current_branch = store.get_flow_state(worktree_path.split("/")[-1])
     branch_hint = ""
@@ -126,52 +112,7 @@ def ensure_worktree_ownership(
         f"  Worktree: {worktree_path}{branch_hint}\n"
         f"  Current session: {current_session_id}\n"
         f"  Owner session: {owner_tmux_session} ({owner_session_name})\n\n"
-        f"This worktree is in use by another session. Options:\n"
-        f"  1. Wait for the other session to complete and release the worktree\n"
-        f"  2. Use `vibe3 task resume --takeover` to explicitly take over\n"
-        f"  3. Switch to a different worktree: `vibe3 task resume <issue>`"
+        "This worktree appears to be in use by another tmux session. "
+        "Wait for that session to finish or inspect the runtime session registry "
+        "before continuing."
     )
-
-
-def takeover_worktree(
-    store: SQLiteClient,
-    worktree_path: str,
-    new_owner_id: str,
-    reason: str,
-) -> None:
-    """Log a worktree takeover event and update session binding.
-
-    Args:
-        store: SQLite client instance.
-        worktree_path: Absolute path to the worktree directory.
-        new_owner_id: The tmux session ID taking ownership.
-        reason: Reason for takeover (for audit logging).
-    """
-    from vibe3.services.signature_service import SignatureService
-
-    # Get the branch name from worktree path (last component)
-    branch = worktree_path.split("/")[-1]
-    actor = SignatureService.get_worktree_actor()
-
-    # Log the takeover event
-    store.add_event(
-        branch,
-        "worktree_takeover",
-        actor,
-        detail=f"Worktree takeover: {reason}" if reason else "Worktree takeover",
-        refs={
-            "new_owner_id": new_owner_id,
-            "worktree_path": worktree_path,
-        },
-    )
-
-    # Update the owning session's tmux_session field
-    # Find the most recent live session for this worktree and update it
-    owner_session = store.get_worktree_owner_session(worktree_path)
-    if owner_session:
-        session_id = owner_session.get("id")
-        if session_id:
-            store.update_runtime_session(
-                session_id,
-                tmux_session=new_owner_id,
-            )

--- a/tests/vibe3/services/test_worktree_ownership_guard.py
+++ b/tests/vibe3/services/test_worktree_ownership_guard.py
@@ -79,6 +79,20 @@ class TestEnsureWorktreeOwnership:
         # Should not raise
         ensure_worktree_ownership(mock_store, "/path/to/worktree")
 
+    def test_passes_outside_tmux_with_owner(self) -> None:
+        """Outside tmux, ownership check is skipped even if an owner exists."""
+        mock_store = MagicMock()
+        mock_store.get_worktree_owner_session.return_value = {
+            "id": 1,
+            "tmux_session": "vibe3-executor-issue-42",
+            "session_name": "manager-123",
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("tmux not found")
+            # Should not raise even though worktree has an owner
+            ensure_worktree_ownership(mock_store, "/path/to/worktree")
+
     def test_passes_when_tmux_matches(self) -> None:
         """Matching tmux session passes."""
         mock_store = MagicMock()

--- a/tests/vibe3/services/test_worktree_ownership_guard.py
+++ b/tests/vibe3/services/test_worktree_ownership_guard.py
@@ -11,7 +11,6 @@ from vibe3.services.worktree_ownership_guard import (
     ensure_worktree_ownership,
     get_current_session_id,
     get_worktree_owner,
-    takeover_worktree,
 )
 
 
@@ -113,8 +112,8 @@ class TestEnsureWorktreeOwnership:
             assert "Current session: vibe3-executor-issue-99" in str(exc_info.value)
             assert "Owner session: vibe3-executor-issue-42" in str(exc_info.value)
 
-    def test_raises_with_actionable_message(self) -> None:
-        """Error message includes takeover instructions."""
+    def test_raises_with_clean_message_no_takeover(self) -> None:
+        """Error message does not suggest takeover, only waiting."""
         mock_store = MagicMock()
         mock_store.get_worktree_owner_session.return_value = {
             "id": 1,
@@ -129,81 +128,14 @@ class TestEnsureWorktreeOwnership:
                 ensure_worktree_ownership(mock_store, "/path/to/worktree")
 
             error_msg = str(exc_info.value)
-            assert "vibe3 task resume --takeover" in error_msg
-
-    def test_passes_outside_tmux(self) -> None:
-        """Outside tmux (direct user), always passes."""
-        mock_store = MagicMock()
-        mock_store.get_worktree_owner_session.return_value = {
-            "id": 1,
-            "tmux_session": "vibe3-executor-issue-42",
-            "session_name": "manager-123",
-        }
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = FileNotFoundError("tmux not found")
-            # Should not raise
-            ensure_worktree_ownership(mock_store, "/path/to/worktree")
-
-    def test_allows_takeover_when_requested(self) -> None:
-        """When allow_takeover=True, takeover is performed."""
-        mock_store = MagicMock()
-        mock_store.get_worktree_owner_session.return_value = {
-            "id": 1,
-            "tmux_session": "vibe3-executor-issue-42",
-            "session_name": "manager-123",
-        }
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value.stdout = "vibe3-executor-issue-99\n"
-            with patch(
-                "vibe3.services.worktree_ownership_guard.takeover_worktree"
-            ) as mock_takeover:
-                # Should not raise
-                ensure_worktree_ownership(
-                    mock_store,
-                    "/path/to/worktree",
-                    allow_takeover=True,
-                    takeover_reason="test",
-                )
-
-                # Verify takeover was called
-                mock_takeover.assert_called_once_with(
-                    mock_store,
-                    "/path/to/worktree",
-                    "vibe3-executor-issue-99",
-                    "test",
-                )
+            assert "vibe3 task resume --takeover" not in error_msg
+            assert "Wait for that session to finish" in error_msg
 
 
-class TestTakeoverWorktree:
-    """Tests for takeover_worktree."""
+class TestTakeoverWorktree:  # pyright: ignore[reportUnusedClass]
+    """Tests for takeover_worktree.
 
-    def test_logs_event_and_updates_owner(self) -> None:
-        """Takeover creates event and updates session binding."""
-        mock_store = MagicMock()
-        mock_store.get_worktree_owner_session.return_value = {
-            "id": 1,
-            "tmux_session": "vibe3-executor-issue-42",
-            "session_name": "manager-123",
-        }
+    This class is intentionally empty - takeover functionality has been removed.
+    """
 
-        with patch("vibe3.services.signature_service.SignatureService") as mock_sig:
-            mock_sig.get_worktree_actor.return_value = "test-actor"
-
-            takeover_worktree(
-                mock_store,
-                "/path/to/worktree",
-                "vibe3-executor-issue-99",
-                "test takeover",
-            )
-
-            # Verify event was logged
-            mock_store.add_event.assert_called_once()
-            call_args = mock_store.add_event.call_args
-            assert call_args[0][1] == "worktree_takeover"
-
-            # Verify session was updated
-            mock_store.update_runtime_session.assert_called_once_with(
-                1, tmux_session="vibe3-executor-issue-99"
-            )
+    pass

--- a/tests/vibe3/services/test_worktree_ownership_guard.py
+++ b/tests/vibe3/services/test_worktree_ownership_guard.py
@@ -130,12 +130,3 @@ class TestEnsureWorktreeOwnership:
             error_msg = str(exc_info.value)
             assert "vibe3 task resume --takeover" not in error_msg
             assert "Wait for that session to finish" in error_msg
-
-
-class TestTakeoverWorktree:  # pyright: ignore[reportUnusedClass]
-    """Tests for takeover_worktree.
-
-    This class is intentionally empty - takeover functionality has been removed.
-    """
-
-    pass


### PR DESCRIPTION
## Summary

- Delete --takeover CLI option from vibe3 task resume
- Delete allow_takeover/takeover_reason from usecase and operations
- Delete takeover_worktree() from ownership guard
- Replace takeover wording in service messages
- Clean up takeover-related tests

Closes #1137