### PR TITLE
chore: remove redundant agent entries from skills config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,8 +72,6 @@
     "commit-commands@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "linear@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
   }
 }

--- a/config/v3/skills.json
+++ b/config/v3/skills.json
@@ -4,9 +4,7 @@
   "global": {
     "_comment": "Global third-party skills for non-Claude agents",
     "agents": [
-      "antigravity",
-      "codex",
-      "kiro-cli"
+      "codex"
     ],
     "packages": [
       {
@@ -32,10 +30,8 @@
   "project": {
     "_comment": "Project-visible local skills are linked by scripts/init.sh",
     "agents": [
-      "antigravity",
       "codex",
-      "claude-code",
-      "kiro"
+      "claude-code"
     ],
     "packages": []
   }


### PR DESCRIPTION
## Summary

清理 skills 配置中的冗余 agent 条目和未使用的插件配置。

### Changes

1. **global.agents**: 移除 `antigravity` 和 `kiro-cli`，仅保留 `codex`
2. **project.agents**: 移除 `antigravity` 和 `kiro`，仅保留 `codex` 和 `claude-code`
3. **settings.json**: 移除未使用的 `frontend-design` 和 `linear` 插件

### Context

通过调研发现：
- `.agents/skills` 是跨工具行业标准，原生支持于 **Codex CLI** 和 **Gemini CLI**
- **Claude Code** 不识别 `.agents/skills`，只读取 `.claude/skills`
- Vibe Center 的 `lib/skills_sync.sh` 已实现正确的 symlink 分发机制，将 `skills/vibe-*` 链接到各 agent 专属目录

因此，保留未使用的 agent 条目（antigravity、kiro）是冗余的，且可能造成误导。

## Test Plan

- [ ] 确认 `scripts/init.sh` 同步逻辑不受影响
- [ ] 确认 `lib/skills_sync.sh` 状态检查通过
- [ ] 验证 skills 发现机制正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)