### PR TITLE
fix(status): include blocked flows in default status query

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -194,6 +194,7 @@ def status(
         flows = service.list_flows(status=None if all_flows else "active")
         if not all_flows:
             flows.extend(service.list_flows(status="done"))
+            flows.extend(service.list_flows(status="blocked"))
 
         stale_flows = service.list_flows(status="stale") if not all_flows else []
 


### PR DESCRIPTION
## Summary
- Fix blocked issues displaying '(no flow scene)' when they have valid flow scenes
- Add `blocked` flows to default status query (previously only included `active` + `done`)

## Problem
Blocked issues showed '(no flow scene)' even when they had:
- Valid worktrees
- Valid flow_state records  
- Valid flow_issue_links

## Root Cause
`status.py` only queried `active` + `done` flows by default, missing `blocked` flows.

This caused the `issue_to_flow` mapping to have no entries for blocked issues,
so they couldn't find their corresponding flow during rendering.

## Fix
Add one line in `src/vibe3/commands/status.py`:
```python
flows.extend(service.list_flows(status="blocked"))
```

## Test Plan
- [x] Verified blocked issues now show their flow branch
- [x] Checked `vibe3 task status` output
- [x] Confirmed no regression for active/done flows

## Impact
Blocked issues now correctly display:
```
  # 908  BLOCKED  ...
         flow: task/issue-908
```

Instead of:
```
  # 908  BLOCKED  ...
         flow: (no flow scene)
```

Fixes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)