### PR TITLE
fix(sqlite): complete Phase 2 FD exhaustion fix - migrate all repos to singleton

### DIFF
--- a/src/vibe3/clients/sqlite_context_cache_repo.py
+++ b/src/vibe3/clients/sqlite_context_cache_repo.py
@@ -21,25 +21,25 @@ class SQLiteContextCacheRepo:
         pr_title: str | None,
     ) -> None:
         updated_at = datetime.datetime.now().isoformat()
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO flow_context_cache
-                    (branch, task_issue_number, issue_title,
-                     pr_number, pr_title, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    branch,
-                    task_issue_number,
-                    issue_title,
-                    pr_number,
-                    pr_title,
-                    updated_at,
-                ),
-            )
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO flow_context_cache
+                (branch, task_issue_number, issue_title,
+                 pr_number, pr_title, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                branch,
+                task_issue_number,
+                issue_title,
+                pr_number,
+                pr_title,
+                updated_at,
+            ),
+        )
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="upsert_flow_context_cache",
@@ -47,27 +47,25 @@ class SQLiteContextCacheRepo:
         ).debug("Upserted flow context cache")
 
     def get_flow_context_cache(self, branch: str) -> dict[str, Any] | None:
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT * FROM flow_context_cache WHERE branch = ?", (branch,)
-            )
-            row = cursor.fetchone()
-            if row:
-                logger.bind(
-                    external="sqlite",
-                    operation="get_flow_context_cache",
-                    branch=branch,
-                ).debug("Retrieved flow context cache")
-                return dict(row)
-            return None
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM flow_context_cache WHERE branch = ?", (branch,))
+        row = cursor.fetchone()
+        if row:
+            logger.bind(
+                external="sqlite",
+                operation="get_flow_context_cache",
+                branch=branch,
+            ).debug("Retrieved flow context cache")
+            return dict(row)
+        return None
 
     def delete_flow_context_cache(self, branch: str) -> None:
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="delete_flow_context_cache",

--- a/src/vibe3/clients/sqlite_context_cache_repo.py
+++ b/src/vibe3/clients/sqlite_context_cache_repo.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from loguru import logger
 
+from vibe3.clients.sqlite_base import _HasConnection
 
-class SQLiteContextCacheRepo:
+
+class SQLiteContextCacheRepo(_HasConnection):
     """Flow context cache operations."""
 
     db_path: str
@@ -21,25 +23,25 @@ class SQLiteContextCacheRepo:
         pr_title: str | None,
     ) -> None:
         updated_at = datetime.datetime.now().isoformat()
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT OR REPLACE INTO flow_context_cache
-                (branch, task_issue_number, issue_title,
-                 pr_number, pr_title, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                branch,
-                task_issue_number,
-                issue_title,
-                pr_number,
-                pr_title,
-                updated_at,
-            ),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO flow_context_cache
+                    (branch, task_issue_number, issue_title,
+                     pr_number, pr_title, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    branch,
+                    task_issue_number,
+                    issue_title,
+                    pr_number,
+                    pr_title,
+                    updated_at,
+                ),
+            )
         logger.bind(
             external="sqlite",
             operation="upsert_flow_context_cache",
@@ -47,7 +49,7 @@ class SQLiteContextCacheRepo:
         ).debug("Upserted flow context cache")
 
     def get_flow_context_cache(self, branch: str) -> dict[str, Any] | None:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM flow_context_cache WHERE branch = ?", (branch,))
@@ -62,10 +64,10 @@ class SQLiteContextCacheRepo:
         return None
 
     def delete_flow_context_cache(self, branch: str) -> None:
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
         logger.bind(
             external="sqlite",
             operation="delete_flow_context_cache",

--- a/src/vibe3/clients/sqlite_event_repo.py
+++ b/src/vibe3/clients/sqlite_event_repo.py
@@ -7,8 +7,10 @@ from typing import Any
 
 from loguru import logger
 
+from vibe3.clients.sqlite_base import _HasConnection
 
-class SQLiteEventRepo:
+
+class SQLiteEventRepo(_HasConnection):
     """Flow event read/write operations."""
 
     db_path: str
@@ -23,15 +25,15 @@ class SQLiteEventRepo:
     ) -> None:
         now = datetime.datetime.now().isoformat()
         refs_json = json.dumps(refs) if refs else None
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            "INSERT INTO flow_events "
-            "(branch, event_type, actor, detail, refs, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (branch, event_type, actor, detail, refs_json, now),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT INTO flow_events "
+                "(branch, event_type, actor, detail, refs, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (branch, event_type, actor, detail, refs_json, now),
+            )
         logger.bind(
             external="sqlite",
             operation="add_event",
@@ -52,7 +54,7 @@ class SQLiteEventRepo:
         if isinstance(normalized_branch, str) and not normalized_branch.strip():
             normalized_branch = None
 
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         conditions: list[str] = []

--- a/src/vibe3/clients/sqlite_event_repo.py
+++ b/src/vibe3/clients/sqlite_event_repo.py
@@ -23,21 +23,21 @@ class SQLiteEventRepo:
     ) -> None:
         now = datetime.datetime.now().isoformat()
         refs_json = json.dumps(refs) if refs else None
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "INSERT INTO flow_events "
-                "(branch, event_type, actor, detail, refs, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (branch, event_type, actor, detail, refs_json, now),
-            )
-            conn.commit()
-            logger.bind(
-                external="sqlite",
-                operation="add_event",
-                branch=branch,
-                event_type=event_type,
-            ).debug("Added event")
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_events "
+            "(branch, event_type, actor, detail, refs, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (branch, event_type, actor, detail, refs_json, now),
+        )
+        conn.commit()
+        logger.bind(
+            external="sqlite",
+            operation="add_event",
+            branch=branch,
+            event_type=event_type,
+        ).debug("Added event")
 
     def get_events(
         self,
@@ -52,35 +52,35 @@ class SQLiteEventRepo:
         if isinstance(normalized_branch, str) and not normalized_branch.strip():
             normalized_branch = None
 
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            conditions: list[str] = []
-            params: list[Any] = []
-            if normalized_branch is not None:
-                conditions.append("branch = ?")
-                params.append(normalized_branch)
-            if event_type:
-                conditions.append("event_type = ?")
-                params.append(event_type)
-            if event_type_prefix:
-                conditions.append("event_type LIKE ?")
-                params.append(f"{event_type_prefix}%")
-            query = "SELECT * FROM flow_events"
-            if conditions:
-                query += " WHERE " + " AND ".join(conditions)
-            query += " ORDER BY created_at DESC"
-            if limit is not None:
-                query += " LIMIT ? OFFSET ?"
-                params.extend([limit, offset])
-            cursor.execute(query, params)
-            rows = [dict(row) for row in cursor.fetchall()]
-            for row in rows:
-                if row.get("refs"):
-                    try:
-                        row["refs"] = json.loads(row["refs"])
-                    except json.JSONDecodeError:
-                        row["refs"] = None
-                else:
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        conditions: list[str] = []
+        params: list[Any] = []
+        if normalized_branch is not None:
+            conditions.append("branch = ?")
+            params.append(normalized_branch)
+        if event_type:
+            conditions.append("event_type = ?")
+            params.append(event_type)
+        if event_type_prefix:
+            conditions.append("event_type LIKE ?")
+            params.append(f"{event_type_prefix}%")
+        query = "SELECT * FROM flow_events"
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+        query += " ORDER BY created_at DESC"
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        cursor.execute(query, params)
+        rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            if row.get("refs"):
+                try:
+                    row["refs"] = json.loads(row["refs"])
+                except json.JSONDecodeError:
                     row["refs"] = None
-            return rows
+            else:
+                row["refs"] = None
+        return rows

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -75,44 +75,44 @@ class SQLiteFlowStateRepo:
         values = [kwargs[f] for f in fields]
         set_clause = ", ".join([f"{f} = ?" for f in fields])
 
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            flow_slug = kwargs.get("flow_slug", branch.replace("/", "-"))
-            cursor.execute(
-                "INSERT OR IGNORE INTO flow_state (branch, flow_slug, updated_at) "
-                "VALUES (?, ?, ?)",
-                (branch, flow_slug, kwargs["updated_at"]),
-            )
-            cursor.execute(
-                f"UPDATE flow_state SET {set_clause} WHERE branch = ?",
-                values + [branch],
-            )
-            conn.commit()
-            logger.bind(
-                external="sqlite",
-                operation="update_flow_state",
-                branch=branch,
-                fields=fields,
-            ).debug("Updated flow state")
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        flow_slug = kwargs.get("flow_slug", branch.replace("/", "-"))
+        cursor.execute(
+            "INSERT OR IGNORE INTO flow_state (branch, flow_slug, updated_at) "
+            "VALUES (?, ?, ?)",
+            (branch, flow_slug, kwargs["updated_at"]),
+        )
+        cursor.execute(
+            f"UPDATE flow_state SET {set_clause} WHERE branch = ?",
+            values + [branch],
+        )
+        conn.commit()
+        logger.bind(
+            external="sqlite",
+            operation="update_flow_state",
+            branch=branch,
+            fields=fields,
+        ).debug("Updated flow state")
 
     def add_issue_link(self, branch: str, issue_number: int, role: str) -> None:
         now = datetime.datetime.now().isoformat()
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "INSERT OR REPLACE INTO flow_issue_links "
-                "(branch, issue_number, issue_role, created_at) "
-                "VALUES (?, ?, ?, ?)",
-                (branch, issue_number, role, now),
-            )
-            conn.commit()
-            logger.bind(
-                external="sqlite",
-                operation="add_issue_link",
-                branch=branch,
-                issue=issue_number,
-                role=role,
-            ).debug("Added issue link")
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR REPLACE INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (branch, issue_number, role, now),
+        )
+        conn.commit()
+        logger.bind(
+            external="sqlite",
+            operation="add_issue_link",
+            branch=branch,
+            issue=issue_number,
+            role=role,
+        ).debug("Added issue link")
 
     def update_issue_link_role(
         self,
@@ -121,25 +121,25 @@ class SQLiteFlowStateRepo:
         old_role: str,
         new_role: str,
     ) -> bool:
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "UPDATE flow_issue_links SET issue_role = ? "
-                "WHERE branch = ? AND issue_number = ? AND issue_role = ?",
-                (new_role, branch, issue_number, old_role),
-            )
-            conn.commit()
-            updated = cursor.rowcount > 0
-            logger.bind(
-                external="sqlite",
-                operation="update_issue_link_role",
-                branch=branch,
-                issue=issue_number,
-                old_role=old_role,
-                new_role=new_role,
-                updated=updated,
-            ).debug("Updated issue link role")
-            return updated
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE flow_issue_links SET issue_role = ? "
+            "WHERE branch = ? AND issue_number = ? AND issue_role = ?",
+            (new_role, branch, issue_number, old_role),
+        )
+        conn.commit()
+        updated = cursor.rowcount > 0
+        logger.bind(
+            external="sqlite",
+            operation="update_issue_link_role",
+            branch=branch,
+            issue=issue_number,
+            old_role=old_role,
+            new_role=new_role,
+            updated=updated,
+        ).debug("Updated issue link role")
+        return bool(updated)
 
     def get_issue_links(self, branch: str) -> list[dict[str, Any]]:
         conn = self._get_connection()  # type: ignore[attr-defined]
@@ -174,46 +174,46 @@ class SQLiteFlowStateRepo:
 
     def get_all_flows(self) -> list[dict[str, Any]]:
         """Get all flows (excludes soft-deleted flows)."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM flow_state WHERE deleted_at IS NULL")
-            flows = [dict(row) for row in cursor.fetchall()]
-            logger.bind(
-                external="sqlite", operation="get_all_flows", count=len(flows)
-            ).debug("Retrieved all flows")
-            return flows
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM flow_state WHERE deleted_at IS NULL")
+        flows = [dict(row) for row in cursor.fetchall()]
+        logger.bind(
+            external="sqlite", operation="get_all_flows", count=len(flows)
+        ).debug("Retrieved all flows")
+        return flows
 
     def get_active_flow_count(self) -> int:
         """Get count of active flows (excludes soft-deleted flows)."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT COUNT(*) FROM flow_state "
-                "WHERE flow_status = 'active' AND deleted_at IS NULL"
-            )
-            count = cursor.fetchone()[0]
-            logger.bind(
-                external="sqlite", operation="get_active_flow_count", count=count
-            ).debug("Retrieved active flow count")
-            return int(count)
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_state "
+            "WHERE flow_status = 'active' AND deleted_at IS NULL"
+        )
+        count = cursor.fetchone()[0]
+        logger.bind(
+            external="sqlite", operation="get_active_flow_count", count=count
+        ).debug("Retrieved active flow count")
+        return int(count)
 
     def get_active_auto_flow_count(self) -> int:
         """Get count of active auto flows (excludes soft-deleted flows)."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT COUNT(*) FROM flow_state "
-                "WHERE flow_status = 'active' AND branch LIKE 'task/issue-%' "
-                "AND deleted_at IS NULL"
-            )
-            count = cursor.fetchone()[0]
-            logger.bind(
-                external="sqlite",
-                operation="get_active_auto_flow_count",
-                count=count,
-            ).debug("Retrieved active auto flow count")
-            return int(count)
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_state "
+            "WHERE flow_status = 'active' AND branch LIKE 'task/issue-%' "
+            "AND deleted_at IS NULL"
+        )
+        count = cursor.fetchone()[0]
+        logger.bind(
+            external="sqlite",
+            operation="get_active_auto_flow_count",
+            count=count,
+        ).debug("Retrieved active auto flow count")
+        return int(count)
 
     def soft_delete_flow(self, branch: str) -> None:
         """Soft delete flow and normalize to tombstone state.
@@ -227,41 +227,41 @@ class SQLiteFlowStateRepo:
         distinguish tombstones from active flows in audits/debugging.
         """
         now = datetime.datetime.now().isoformat()
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            # Normalize to tombstone: clear refs/reasons/actors/worktree/execution-state
-            cursor.execute(
-                """UPDATE flow_state SET
-                    deleted_at = ?,
-                    flow_status = 'aborted',
-                    spec_ref = NULL,
-                    plan_ref = NULL,
-                    report_ref = NULL,
-                    audit_ref = NULL,
-                    indicate_ref = NULL,
-                    pr_ref = NULL,
-                    blocked_reason = NULL,
-                    failed_reason = NULL,
-                    blocked_by_issue = NULL,
-                    blocked_by = NULL,
-                    worktree_path = NULL,
-                    next_step = NULL,
-                    planner_actor = NULL,
-                    executor_actor = NULL,
-                    reviewer_actor = NULL,
-                    manager_actor = NULL,
-                    latest_actor = NULL,
-                    planner_status = NULL,
-                    executor_status = NULL,
-                    reviewer_status = NULL,
-                    execution_pid = NULL,
-                    execution_started_at = NULL,
-                    execution_completed_at = NULL,
-                    updated_at = ?
-                WHERE branch = ?""",
-                (now, now, branch),
-            )
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        # Normalize to tombstone: clear refs/reasons/actors/worktree/execution-state
+        cursor.execute(
+            """UPDATE flow_state SET
+                deleted_at = ?,
+                flow_status = 'aborted',
+                spec_ref = NULL,
+                plan_ref = NULL,
+                report_ref = NULL,
+                audit_ref = NULL,
+                indicate_ref = NULL,
+                pr_ref = NULL,
+                blocked_reason = NULL,
+                failed_reason = NULL,
+                blocked_by_issue = NULL,
+                blocked_by = NULL,
+                worktree_path = NULL,
+                next_step = NULL,
+                planner_actor = NULL,
+                executor_actor = NULL,
+                reviewer_actor = NULL,
+                manager_actor = NULL,
+                latest_actor = NULL,
+                planner_status = NULL,
+                executor_status = NULL,
+                reviewer_status = NULL,
+                execution_pid = NULL,
+                execution_started_at = NULL,
+                execution_completed_at = NULL,
+                updated_at = ?
+            WHERE branch = ?""",
+            (now, now, branch),
+        )
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="soft_delete_flow",
@@ -270,14 +270,14 @@ class SQLiteFlowStateRepo:
 
     def hard_delete_flow(self, branch: str) -> None:
         """Hard delete flow with cascade, removing all related records."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute("DELETE FROM runtime_session WHERE branch = ?", (branch,))
-            cursor.execute("DELETE FROM flow_events WHERE branch = ?", (branch,))
-            cursor.execute("DELETE FROM flow_issue_links WHERE branch = ?", (branch,))
-            cursor.execute("DELETE FROM flow_state WHERE branch = ?", (branch,))
-            cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM runtime_session WHERE branch = ?", (branch,))
+        cursor.execute("DELETE FROM flow_events WHERE branch = ?", (branch,))
+        cursor.execute("DELETE FROM flow_issue_links WHERE branch = ?", (branch,))
+        cursor.execute("DELETE FROM flow_state WHERE branch = ?", (branch,))
+        cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="hard_delete_flow",
@@ -298,13 +298,13 @@ class SQLiteFlowStateRepo:
         Restored flows will have flow_status='aborted' and cleared refs/actors/worktree.
         Use 'vibe flow update' to reset flow_status and re-establish metadata if needed.
         """
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "UPDATE flow_state SET deleted_at = NULL WHERE branch = ?",
-                (branch,),
-            )
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE flow_state SET deleted_at = NULL WHERE branch = ?",
+            (branch,),
+        )
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="restore_flow",
@@ -313,70 +313,70 @@ class SQLiteFlowStateRepo:
 
     def get_deleted_flows(self) -> list[dict[str, Any]]:
         """Get all soft-deleted flows."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT * FROM flow_state WHERE deleted_at IS NOT NULL "
-                "ORDER BY deleted_at DESC"
-            )
-            flows = [dict(row) for row in cursor.fetchall()]
-            logger.bind(
-                external="sqlite", operation="get_deleted_flows", count=len(flows)
-            ).debug("Retrieved deleted flows")
-            return flows
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM flow_state WHERE deleted_at IS NOT NULL "
+            "ORDER BY deleted_at DESC"
+        )
+        flows = [dict(row) for row in cursor.fetchall()]
+        logger.bind(
+            external="sqlite", operation="get_deleted_flows", count=len(flows)
+        ).debug("Retrieved deleted flows")
+        return flows
 
     def get_flow_state_include_deleted(self, branch: str) -> dict[str, Any] | None:
         """Get flow state including soft-deleted flows (for recovery check)."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM flow_state WHERE branch = ?", (branch,))
-            row = cursor.fetchone()
-            if row:
-                return dict(row)
-            return None
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM flow_state WHERE branch = ?", (branch,))
+        row = cursor.fetchone()
+        if row:
+            return dict(row)
+        return None
 
     def get_flows_by_issue(self, issue_number: int, role: str) -> list[dict[str, Any]]:
         """Get flows linked to an issue with specified role (excludes soft-deleted)."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT f.* FROM flow_state f "
-                "JOIN flow_issue_links l ON f.branch = l.branch "
-                "WHERE l.issue_number = ? AND l.issue_role = ? "
-                "AND f.deleted_at IS NULL "
-                "ORDER BY COALESCE(f.updated_at, '') DESC, f.branch ASC",
-                (issue_number, role),
-            )
-            flows = [dict(row) for row in cursor.fetchall()]
-            logger.bind(
-                external="sqlite",
-                operation="get_flows_by_issue",
-                issue_number=issue_number,
-                role=role,
-                count=len(flows),
-            ).debug("Retrieved flows by issue")
-            return flows
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT f.* FROM flow_state f "
+            "JOIN flow_issue_links l ON f.branch = l.branch "
+            "WHERE l.issue_number = ? AND l.issue_role = ? "
+            "AND f.deleted_at IS NULL "
+            "ORDER BY COALESCE(f.updated_at, '') DESC, f.branch ASC",
+            (issue_number, role),
+        )
+        flows = [dict(row) for row in cursor.fetchall()]
+        logger.bind(
+            external="sqlite",
+            operation="get_flows_by_issue",
+            issue_number=issue_number,
+            role=role,
+            count=len(flows),
+        ).debug("Retrieved flows by issue")
+        return flows
 
     def get_flow_dependents(self, branch: str) -> list[str]:
         """Get dependent flows (excludes soft-deleted flows)."""
         task_issue_number: int | None = None
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT issue_number
-                FROM flow_issue_links
-                WHERE branch = ? AND issue_role = 'task'
-                LIMIT 1
-                """,
-                (branch,),
-            )
-            row = cursor.fetchone()
-            if row and row[0] is not None:
-                task_issue_number = int(row[0])
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT issue_number
+            FROM flow_issue_links
+            WHERE branch = ? AND issue_role = 'task'
+            LIMIT 1
+            """,
+            (branch,),
+        )
+        row = cursor.fetchone()
+        if row and row[0] is not None:
+            task_issue_number = int(row[0])
 
         if task_issue_number is None:
             logger.bind(
@@ -387,26 +387,26 @@ class SQLiteFlowStateRepo:
             ).debug("No task issue bound; no dependents")
             return []
 
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT DISTINCT fil.branch
-                FROM flow_issue_links fil
-                JOIN flow_state fs ON fil.branch = fs.branch
-                WHERE fil.issue_number = ?
-                  AND fil.issue_role = 'dependency'
-                  AND fs.flow_status = 'active'
-                  AND fs.deleted_at IS NULL
-                ORDER BY fil.branch
-                """,
-                (task_issue_number,),
-            )
-            dependents = [row[0] for row in cursor.fetchall()]
-            logger.bind(
-                external="sqlite",
-                operation="get_flow_dependents",
-                branch=branch,
-                dependents_count=len(dependents),
-            ).debug("Retrieved flow dependents")
-            return dependents
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT DISTINCT fil.branch
+            FROM flow_issue_links fil
+            JOIN flow_state fs ON fil.branch = fs.branch
+            WHERE fil.issue_number = ?
+              AND fil.issue_role = 'dependency'
+              AND fs.flow_status = 'active'
+              AND fs.deleted_at IS NULL
+            ORDER BY fil.branch
+            """,
+            (task_issue_number,),
+        )
+        dependents = [row[0] for row in cursor.fetchall()]
+        logger.bind(
+            external="sqlite",
+            operation="get_flow_dependents",
+            branch=branch,
+            dependents_count=len(dependents),
+        ).debug("Retrieved flow dependents")
+        return dependents

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from loguru import logger
 
+from vibe3.clients.sqlite_base import _HasConnection
 
-class SQLiteFlowStateRepo:
+
+class SQLiteFlowStateRepo(_HasConnection):
     """Flow state, issue link, and dependent-scene operations."""
 
     db_path: str
@@ -47,7 +49,7 @@ class SQLiteFlowStateRepo:
 
     def get_flow_state(self, branch: str) -> dict[str, Any] | None:
         """Get flow state for branch (excludes soft-deleted flows)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
@@ -75,19 +77,19 @@ class SQLiteFlowStateRepo:
         values = [kwargs[f] for f in fields]
         set_clause = ", ".join([f"{f} = ?" for f in fields])
 
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        flow_slug = kwargs.get("flow_slug", branch.replace("/", "-"))
-        cursor.execute(
-            "INSERT OR IGNORE INTO flow_state (branch, flow_slug, updated_at) "
-            "VALUES (?, ?, ?)",
-            (branch, flow_slug, kwargs["updated_at"]),
-        )
-        cursor.execute(
-            f"UPDATE flow_state SET {set_clause} WHERE branch = ?",
-            values + [branch],
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            flow_slug = kwargs.get("flow_slug", branch.replace("/", "-"))
+            cursor.execute(
+                "INSERT OR IGNORE INTO flow_state (branch, flow_slug, updated_at) "
+                "VALUES (?, ?, ?)",
+                (branch, flow_slug, kwargs["updated_at"]),
+            )
+            cursor.execute(
+                f"UPDATE flow_state SET {set_clause} WHERE branch = ?",
+                values + [branch],
+            )
         logger.bind(
             external="sqlite",
             operation="update_flow_state",
@@ -97,15 +99,15 @@ class SQLiteFlowStateRepo:
 
     def add_issue_link(self, branch: str, issue_number: int, role: str) -> None:
         now = datetime.datetime.now().isoformat()
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            "INSERT OR REPLACE INTO flow_issue_links "
-            "(branch, issue_number, issue_role, created_at) "
-            "VALUES (?, ?, ?, ?)",
-            (branch, issue_number, role, now),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT OR REPLACE INTO flow_issue_links "
+                "(branch, issue_number, issue_role, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (branch, issue_number, role, now),
+            )
         logger.bind(
             external="sqlite",
             operation="add_issue_link",
@@ -121,15 +123,15 @@ class SQLiteFlowStateRepo:
         old_role: str,
         new_role: str,
     ) -> bool:
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE flow_issue_links SET issue_role = ? "
-            "WHERE branch = ? AND issue_number = ? AND issue_role = ?",
-            (new_role, branch, issue_number, old_role),
-        )
-        conn.commit()
-        updated = cursor.rowcount > 0
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE flow_issue_links SET issue_role = ? "
+                "WHERE branch = ? AND issue_number = ? AND issue_role = ?",
+                (new_role, branch, issue_number, old_role),
+            )
+            updated = cursor.rowcount > 0
         logger.bind(
             external="sqlite",
             operation="update_issue_link_role",
@@ -142,7 +144,7 @@ class SQLiteFlowStateRepo:
         return bool(updated)
 
     def get_issue_links(self, branch: str) -> list[dict[str, Any]]:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM flow_issue_links WHERE branch = ?", (branch,))
@@ -156,7 +158,7 @@ class SQLiteFlowStateRepo:
         return links
 
     def get_dependency_links(self, branch: str) -> list[int]:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             "SELECT issue_number FROM flow_issue_links "
@@ -174,7 +176,7 @@ class SQLiteFlowStateRepo:
 
     def get_all_flows(self) -> list[dict[str, Any]]:
         """Get all flows (excludes soft-deleted flows)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM flow_state WHERE deleted_at IS NULL")
@@ -186,7 +188,7 @@ class SQLiteFlowStateRepo:
 
     def get_active_flow_count(self) -> int:
         """Get count of active flows (excludes soft-deleted flows)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             "SELECT COUNT(*) FROM flow_state "
@@ -200,7 +202,7 @@ class SQLiteFlowStateRepo:
 
     def get_active_auto_flow_count(self) -> int:
         """Get count of active auto flows (excludes soft-deleted flows)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             "SELECT COUNT(*) FROM flow_state "
@@ -227,41 +229,40 @@ class SQLiteFlowStateRepo:
         distinguish tombstones from active flows in audits/debugging.
         """
         now = datetime.datetime.now().isoformat()
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        # Normalize to tombstone: clear refs/reasons/actors/worktree/execution-state
-        cursor.execute(
-            """UPDATE flow_state SET
-                deleted_at = ?,
-                flow_status = 'aborted',
-                spec_ref = NULL,
-                plan_ref = NULL,
-                report_ref = NULL,
-                audit_ref = NULL,
-                indicate_ref = NULL,
-                pr_ref = NULL,
-                blocked_reason = NULL,
-                failed_reason = NULL,
-                blocked_by_issue = NULL,
-                blocked_by = NULL,
-                worktree_path = NULL,
-                next_step = NULL,
-                planner_actor = NULL,
-                executor_actor = NULL,
-                reviewer_actor = NULL,
-                manager_actor = NULL,
-                latest_actor = NULL,
-                planner_status = NULL,
-                executor_status = NULL,
-                reviewer_status = NULL,
-                execution_pid = NULL,
-                execution_started_at = NULL,
-                execution_completed_at = NULL,
-                updated_at = ?
-            WHERE branch = ?""",
-            (now, now, branch),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """UPDATE flow_state SET
+                    deleted_at = ?,
+                    flow_status = 'aborted',
+                    spec_ref = NULL,
+                    plan_ref = NULL,
+                    report_ref = NULL,
+                    audit_ref = NULL,
+                    indicate_ref = NULL,
+                    pr_ref = NULL,
+                    blocked_reason = NULL,
+                    failed_reason = NULL,
+                    blocked_by_issue = NULL,
+                    blocked_by = NULL,
+                    worktree_path = NULL,
+                    next_step = NULL,
+                    planner_actor = NULL,
+                    executor_actor = NULL,
+                    reviewer_actor = NULL,
+                    manager_actor = NULL,
+                    latest_actor = NULL,
+                    planner_status = NULL,
+                    executor_status = NULL,
+                    reviewer_status = NULL,
+                    execution_pid = NULL,
+                    execution_started_at = NULL,
+                    execution_completed_at = NULL,
+                    updated_at = ?
+                WHERE branch = ?""",
+                (now, now, branch),
+            )
         logger.bind(
             external="sqlite",
             operation="soft_delete_flow",
@@ -270,14 +271,14 @@ class SQLiteFlowStateRepo:
 
     def hard_delete_flow(self, branch: str) -> None:
         """Hard delete flow with cascade, removing all related records."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute("DELETE FROM runtime_session WHERE branch = ?", (branch,))
-        cursor.execute("DELETE FROM flow_events WHERE branch = ?", (branch,))
-        cursor.execute("DELETE FROM flow_issue_links WHERE branch = ?", (branch,))
-        cursor.execute("DELETE FROM flow_state WHERE branch = ?", (branch,))
-        cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM runtime_session WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_events WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_issue_links WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_state WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
         logger.bind(
             external="sqlite",
             operation="hard_delete_flow",
@@ -298,13 +299,13 @@ class SQLiteFlowStateRepo:
         Restored flows will have flow_status='aborted' and cleared refs/actors/worktree.
         Use 'vibe flow update' to reset flow_status and re-establish metadata if needed.
         """
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE flow_state SET deleted_at = NULL WHERE branch = ?",
-            (branch,),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE flow_state SET deleted_at = NULL WHERE branch = ?",
+                (branch,),
+            )
         logger.bind(
             external="sqlite",
             operation="restore_flow",
@@ -313,7 +314,7 @@ class SQLiteFlowStateRepo:
 
     def get_deleted_flows(self) -> list[dict[str, Any]]:
         """Get all soft-deleted flows."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
@@ -328,7 +329,7 @@ class SQLiteFlowStateRepo:
 
     def get_flow_state_include_deleted(self, branch: str) -> dict[str, Any] | None:
         """Get flow state including soft-deleted flows (for recovery check)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM flow_state WHERE branch = ?", (branch,))
@@ -339,7 +340,7 @@ class SQLiteFlowStateRepo:
 
     def get_flows_by_issue(self, issue_number: int, role: str) -> list[dict[str, Any]]:
         """Get flows linked to an issue with specified role (excludes soft-deleted)."""
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
@@ -363,7 +364,7 @@ class SQLiteFlowStateRepo:
     def get_flow_dependents(self, branch: str) -> list[str]:
         """Get dependent flows (excludes soft-deleted flows)."""
         task_issue_number: int | None = None
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             """
@@ -387,7 +388,7 @@ class SQLiteFlowStateRepo:
             ).debug("No task issue bound; no dependents")
             return []
 
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             """

--- a/src/vibe3/clients/sqlite_queue_repo.py
+++ b/src/vibe3/clients/sqlite_queue_repo.py
@@ -2,8 +2,10 @@ import datetime
 import sqlite3
 from typing import Any
 
+from vibe3.clients.sqlite_base import _HasConnection
 
-class SQLiteQueueRepo:
+
+class SQLiteQueueRepo(_HasConnection):
     db_path: str
     _enqueued_at_cache: dict[str, bool] = {}  # db_path -> has_enqueued_at
 
@@ -29,42 +31,42 @@ class SQLiteQueueRepo:
         # Use last_attempted_at for enqueued_at if column exists (backward compat)
         timestamp = last_attempted_at or updated_at
 
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        if self._check_has_enqueued_at(conn):
-            conn.execute(
-                "INSERT OR REPLACE INTO orchestra_queue "
-                "(issue_number, collected_state, waiting_state, retry_count, "
-                "last_attempted_at, enqueued_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    issue_number,
-                    collected_state,
-                    waiting_state,
-                    retry_count,
-                    last_attempted_at,
-                    timestamp,
-                    updated_at,
-                ),
-            )
-        else:
-            conn.execute(
-                "INSERT OR REPLACE INTO orchestra_queue "
-                "(issue_number, collected_state, waiting_state, retry_count, "
-                "last_attempted_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (
-                    issue_number,
-                    collected_state,
-                    waiting_state,
-                    retry_count,
-                    last_attempted_at,
-                    updated_at,
-                ),
-            )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            if self._check_has_enqueued_at(conn):
+                conn.execute(
+                    "INSERT OR REPLACE INTO orchestra_queue "
+                    "(issue_number, collected_state, waiting_state, retry_count, "
+                    "last_attempted_at, enqueued_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        issue_number,
+                        collected_state,
+                        waiting_state,
+                        retry_count,
+                        last_attempted_at,
+                        timestamp,
+                        updated_at,
+                    ),
+                )
+            else:
+                conn.execute(
+                    "INSERT OR REPLACE INTO orchestra_queue "
+                    "(issue_number, collected_state, waiting_state, retry_count, "
+                    "last_attempted_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        issue_number,
+                        collected_state,
+                        waiting_state,
+                        retry_count,
+                        last_attempted_at,
+                        updated_at,
+                    ),
+                )
 
     def load_queue_entry(self, issue_number: int) -> dict[str, Any] | None:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
@@ -75,60 +77,60 @@ class SQLiteQueueRepo:
         return dict(row) if row else None
 
     def load_all_queue_entries(self) -> list[dict[str, Any]]:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM orchestra_queue ORDER BY updated_at")
         return [dict(row) for row in cursor.fetchall()]
 
     def remove_queue_entry(self, issue_number: int) -> None:
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        conn.execute(
-            "DELETE FROM orchestra_queue WHERE issue_number = ?",
-            (issue_number,),
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            conn.execute(
+                "DELETE FROM orchestra_queue WHERE issue_number = ?",
+                (issue_number,),
+            )
 
     def replace_all_queue_entries(self, entries: list[dict[str, Any]]) -> None:
         """DELETE all + INSERT batch in single transaction."""
         now = datetime.datetime.now().isoformat()
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        conn.execute("DELETE FROM orchestra_queue")
-        has_enqueued_at = self._check_has_enqueued_at(conn)
-        for entry in entries:
-            timestamp = entry.get("last_attempted_at") or now
-            if has_enqueued_at:
-                conn.execute(
-                    "INSERT OR REPLACE INTO orchestra_queue "
-                    "(issue_number, collected_state, waiting_state, retry_count, "
-                    "last_attempted_at, enqueued_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        entry["issue_number"],
-                        entry.get("collected_state"),
-                        entry.get("waiting_state"),
-                        entry.get("retry_count", 0),
-                        entry.get("last_attempted_at"),
-                        timestamp,
-                        now,
-                    ),
-                )
-            else:
-                conn.execute(
-                    "INSERT OR REPLACE INTO orchestra_queue "
-                    "(issue_number, collected_state, waiting_state, retry_count, "
-                    "last_attempted_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (
-                        entry["issue_number"],
-                        entry.get("collected_state"),
-                        entry.get("waiting_state"),
-                        entry.get("retry_count", 0),
-                        entry.get("last_attempted_at"),
-                        now,
-                    ),
-                )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            conn.execute("DELETE FROM orchestra_queue")
+            has_enqueued_at = self._check_has_enqueued_at(conn)
+            for entry in entries:
+                timestamp = entry.get("last_attempted_at") or now
+                if has_enqueued_at:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO orchestra_queue "
+                        "(issue_number, collected_state, waiting_state, retry_count, "
+                        "last_attempted_at, enqueued_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            entry["issue_number"],
+                            entry.get("collected_state"),
+                            entry.get("waiting_state"),
+                            entry.get("retry_count", 0),
+                            entry.get("last_attempted_at"),
+                            timestamp,
+                            now,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO orchestra_queue "
+                        "(issue_number, collected_state, waiting_state, retry_count, "
+                        "last_attempted_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (
+                            entry["issue_number"],
+                            entry.get("collected_state"),
+                            entry.get("waiting_state"),
+                            entry.get("retry_count", 0),
+                            entry.get("last_attempted_at"),
+                            now,
+                        ),
+                    )
 
     # Frozen queue compatibility methods (alias for orchestra_queue operations)
     def save_frozen_queue(self, entries: list[dict[str, Any]]) -> None:

--- a/src/vibe3/clients/sqlite_session_repo.py
+++ b/src/vibe3/clients/sqlite_session_repo.py
@@ -58,17 +58,17 @@ class SQLiteSessionRepo:
         columns = ", ".join(row.keys())
         placeholders = ", ".join(["?"] * len(row))
         values = list(row.values())
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                f"INSERT INTO runtime_session ({columns}) VALUES ({placeholders})",
-                values,
-            )
-            conn.commit()
-            last_id = cursor.lastrowid
-            if last_id is None:
-                raise RuntimeError("Failed to insert runtime_session: no lastrowid")
-            session_id = int(last_id)
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            f"INSERT INTO runtime_session ({columns}) VALUES ({placeholders})",
+            values,
+        )
+        conn.commit()
+        last_id = cursor.lastrowid
+        if last_id is None:
+            raise RuntimeError("Failed to insert runtime_session: no lastrowid")
+        session_id = int(last_id)
         logger.bind(
             external="sqlite",
             operation="create_runtime_session",
@@ -79,17 +79,17 @@ class SQLiteSessionRepo:
         return session_id
 
     def get_runtime_session(self, session_id: int) -> dict[str, Any] | None:
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT * FROM runtime_session WHERE id = ?",
-                (session_id,),
-            )
-            row = cursor.fetchone()
-            if row:
-                return dict(row)
-            return None
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM runtime_session WHERE id = ?",
+            (session_id,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return dict(row)
+        return None
 
     def update_runtime_session(self, session_id: int, **kwargs: Any) -> None:
         invalid = set(kwargs.keys()) - self.VALID_RUNTIME_SESSION_FIELDS
@@ -100,13 +100,13 @@ class SQLiteSessionRepo:
         kwargs["updated_at"] = datetime.datetime.now().isoformat()
         set_clause = ", ".join([f"{f} = ?" for f in kwargs])
         values = list(kwargs.values()) + [session_id]
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                f"UPDATE runtime_session SET {set_clause} WHERE id = ?",
-                values,
-            )
-            conn.commit()
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(
+            f"UPDATE runtime_session SET {set_clause} WHERE id = ?",
+            values,
+        )
+        conn.commit()
         logger.bind(
             external="sqlite",
             operation="update_runtime_session",
@@ -123,11 +123,11 @@ class SQLiteSessionRepo:
             query += " AND role = ?"
             params.append(role)
         query += " ORDER BY created_at DESC"
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute(query, params)
-            rows = [dict(row) for row in cursor.fetchall()]
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(query, params)
+        rows = [dict(row) for row in cursor.fetchall()]
         logger.bind(
             external="sqlite",
             operation="list_live_runtime_sessions",
@@ -158,14 +158,14 @@ class SQLiteSessionRepo:
         )
         params: list[Any] = [role] + target_strs + list(terminal_statuses)
         result: set[int] = set()
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(query, params)
-            for row in cursor.fetchall():
-                raw = row[0]
-                if raw is not None:
-                    try:
-                        result.add(int(raw))
-                    except (ValueError, TypeError):
-                        pass
+        conn = self._get_connection()  # type: ignore[attr-defined]
+        cursor = conn.cursor()
+        cursor.execute(query, params)
+        for row in cursor.fetchall():
+            raw = row[0]
+            if raw is not None:
+                try:
+                    result.add(int(raw))
+                except (ValueError, TypeError):
+                    pass
         return result

--- a/src/vibe3/clients/sqlite_session_repo.py
+++ b/src/vibe3/clients/sqlite_session_repo.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from loguru import logger
 
+from vibe3.clients.sqlite_base import _HasConnection
 
-class SQLiteSessionRepo:
+
+class SQLiteSessionRepo(_HasConnection):
     """Runtime session CRUD operations."""
 
     db_path: str
@@ -58,14 +60,14 @@ class SQLiteSessionRepo:
         columns = ", ".join(row.keys())
         placeholders = ", ".join(["?"] * len(row))
         values = list(row.values())
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            f"INSERT INTO runtime_session ({columns}) VALUES ({placeholders})",
-            values,
-        )
-        conn.commit()
-        last_id = cursor.lastrowid
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"INSERT INTO runtime_session ({columns}) VALUES ({placeholders})",
+                values,
+            )
+            last_id = cursor.lastrowid
         if last_id is None:
             raise RuntimeError("Failed to insert runtime_session: no lastrowid")
         session_id = int(last_id)
@@ -79,7 +81,7 @@ class SQLiteSessionRepo:
         return session_id
 
     def get_runtime_session(self, session_id: int) -> dict[str, Any] | None:
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
@@ -100,13 +102,13 @@ class SQLiteSessionRepo:
         kwargs["updated_at"] = datetime.datetime.now().isoformat()
         set_clause = ", ".join([f"{f} = ?" for f in kwargs])
         values = list(kwargs.values()) + [session_id]
-        conn = self._get_connection()  # type: ignore[attr-defined]
-        cursor = conn.cursor()
-        cursor.execute(
-            f"UPDATE runtime_session SET {set_clause} WHERE id = ?",
-            values,
-        )
-        conn.commit()
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"UPDATE runtime_session SET {set_clause} WHERE id = ?",
+                values,
+            )
         logger.bind(
             external="sqlite",
             operation="update_runtime_session",
@@ -123,7 +125,7 @@ class SQLiteSessionRepo:
             query += " AND role = ?"
             params.append(role)
         query += " ORDER BY created_at DESC"
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(query, params)
@@ -158,7 +160,7 @@ class SQLiteSessionRepo:
         )
         params: list[Any] = [role] + target_strs + list(terminal_statuses)
         result: set[int] = set()
-        conn = self._get_connection()  # type: ignore[attr-defined]
+        conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(query, params)
         for row in cursor.fetchall():

--- a/tests/vibe3/clients/test_sqlite_fd_exhaustion.py
+++ b/tests/vibe3/clients/test_sqlite_fd_exhaustion.py
@@ -16,10 +16,6 @@ except ImportError:
 
 
 @pytest.mark.skipif(not HAS_PSUTIL, reason="psutil not installed")
-@pytest.mark.skip(
-    reason="Requires complete repo migration (flow_state, event) "
-    "- currently only queue migrated"
-)
 def test_fd_not_exhausted_under_high_frequency(tmp_path: Path) -> None:
     """Verify FD count does not grow under high-frequency operations."""
     db_path = str(tmp_path / "test.db")
@@ -68,9 +64,6 @@ def test_fd_not_exhausted_queue_operations(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not HAS_PSUTIL, reason="psutil not installed")
-@pytest.mark.skip(
-    reason="Requires complete repo migration (event) - currently only queue migrated"
-)
 def test_fd_not_exhausted_event_operations(tmp_path: Path) -> None:
     """Verify event operations do not exhaust FDs."""
     db_path = str(tmp_path / "test.db")


### PR DESCRIPTION
## Summary
- 完成 Phase 2 迁移：所有 SQLite repo 现在使用单例连接模式
- 迁移方法统计：
  - SQLiteEventRepo (2 methods)
  - SQLiteContextCacheRepo (3 methods)
  - SQLiteSessionRepo (6 methods)
  - SQLiteFlowStateRepo (14 methods)
- 取消跳过 FD 回归测试，全部通过验证
- 修复类型安全：添加 bool() 类型转换

## Technical Details
所有 repo 方法从 `with sqlite3.connect(self.db_path) as conn:` 模式迁移到 `conn = self._get_connection()` 单例模式，防止 FD 耗尽问题。

### 验证结果
- ✅ 线程安全测试：100 并发操作通过
- ✅ FD 回归测试：高频率操作无 FD 增长
- ✅ 所有 SQLite 相关测试通过（31 passed, 2 unskipped）

## Test Plan
- [x] 本地测试：`uv run pytest tests/vibe3/clients/ -v -k "sqlite"`
- [x] 线程安全验证：`test_concurrent_connection_creation_no_thread_error`
- [x] FD 回归验证：`test_fd_not_exhausted_under_high_frequency`
- [x] FD 回归验证：`test_fd_not_exhausted_event_operations`

## Related
- Issue: #1143
- Phase 1 PR: #1156 (已合并)