### PR TITLE
docs: clean up stale `vibe flow done` references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 ## [2.1.22] - 2026-03-12
 
 ### ✨ Changed
-- fix: gate vibe flow done on review evidence ...
+- fix: gate flow completion on review evidence ...
 
 ## [2.1.21] - 2026-03-12
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -257,10 +257,6 @@ bin/vibe flow pr       # 生成 PR
 
 ### Step 5：清理工作区
 
-```bash
-bin/vibe flow done     # 合并后清理 worktree
-```
-
 > V3: 使用 `git worktree remove` 手动清理，或由 orchestra 自动管理 worktree 生命周期。
 
 ---
@@ -322,7 +318,7 @@ tests/                 # bats-core 测试（≥20 个用例）
 bin/vibe flow start <feature>  # 创建 worktree + 分支
 bin/vibe flow review           # Pre-PR 检查
 bin/vibe flow pr               # 创建 PR
-bin/vibe flow done             # 清理 worktree
+# 注意：flow done 已弃用，V3 使用 git worktree remove
 
 # 质量验证（每次改代码后必跑）
 bash scripts/hooks/lint.sh           # 双层 lint

--- a/docs/references/vibe-engine-design.md
+++ b/docs/references/vibe-engine-design.md
@@ -72,7 +72,7 @@ related_docs:
    - **触发**: `vibe flow review --local` （调用底层大模型进行自动化逻辑与依赖检查）或者 `vibe flow pr` (推送至云端供人类复核)。
    - **状态**: 任务处于冻结待决状态，根据 Codex/Human 的反馈决定退回 *执行* 还是前进到 *完成*。
 4. **收尾 (Completed / Closed)**
-   - **触发**: `vibe flow done` (人类敲击或 AI 代办)。
+   - **触发**: PR 合并后自动触发或手动清理 worktree。
    - **状态**: 交付收口。当前特征分支被删除，flow 历史被保留；物理目录是否清理取决于 worktree 生命周期，而不是 flow 本体。
 5. **归档 (Archived)**
    - **触发**: `vibe check`。


### PR DESCRIPTION
## Summary
- Removed 4 outdated references to deprecated `vibe flow done` command across 3 documentation files
- Aligned docs with V3 command standard (docs/standards/v3/command-standard.md)
- Zero code changes - pure documentation cleanup

## Changes
- **CHANGELOG.md**: Updated historical entry to use generic description instead of deprecated command name
- **DEVELOPER.md**: Removed deprecated command examples from V2 workflow section, added notes about V3 alternatives
- **vibe-engine-design.md**: Updated flow completion trigger description to avoid deprecated command reference

## Verification
- `rg "vibe flow done"` confirms zero remaining references
- All lint hooks passed
- All pre-push checks passed

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)