### PR TITLE
fix(orchestra): improve manager capacity defer error handling

### DIFF
--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -8,6 +8,7 @@ from vibe3.clients.store_context import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.flow_lifecycle import ManagerDispatchIntent
 from vibe3.domain.handler_registry import register_handler
+from vibe3.exceptions import CapacityDeferredError
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.roles.manager import build_manager_request
 from vibe3.services.issue_failure_service import block_manager_noop_issue
@@ -98,12 +99,24 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
 
         from vibe3.agents.backends.codeagent import CodeagentBackend
         from vibe3.environment.session_registry import SessionRegistryService
+        from vibe3.execution.capacity_service import CapacityService
         from vibe3.execution.coordinator import ExecutionCoordinator
 
         with get_store() as store:
             backend = CodeagentBackend()
             registry = SessionRegistryService(store=store, backend=backend)
             coordinator = ExecutionCoordinator(config, store)
+
+            # Early capacity check to avoid wasteful request preparation
+            # and prevent misleading "Failed to prepare role execution request" errors
+            capacity = CapacityService(config, store, backend)
+            if not capacity.can_dispatch("manager"):
+                logger.bind(
+                    domain="issue_state_dispatch_handler",
+                    role="manager",
+                    issue_number=event.issue_number,
+                ).info("Manager dispatch queued: Capacity full")
+                return
 
             try:
                 request = await loop.run_in_executor(
@@ -116,10 +129,20 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
                     ),
                 )
 
-                if request is None:
-                    _block_for_noop("Failed to prepare role execution request")
-                    return
+            except CapacityDeferredError as exc:
+                # Capacity defer is normal — just log and return (don't block)
+                logger.bind(
+                    domain="issue_state_dispatch_handler",
+                    role="manager",
+                    issue_number=event.issue_number,
+                ).info(f"Manager dispatch deferred: {exc.message}")
+                return
 
+            if request is None:
+                _block_for_noop("Failed to prepare role execution request")
+                return
+
+            try:
                 result = await loop.run_in_executor(
                     None, lambda: coordinator.dispatch_execution(request)
                 )

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -57,66 +57,62 @@ def handle_manager_dispatch_intent(event: ManagerDispatchIntent) -> None:
         loop = asyncio.get_running_loop()
         config = load_orchestra_config()
 
-        target_state = (
-            IssueState.READY
-            if event.trigger_state == IssueState.READY.value
-            else IssueState.HANDOFF
-        )
-
-        if event.issue_title is not None:
-            issue_info: IssueInfo | None = IssueInfo(
-                number=event.issue_number,
-                title=event.issue_title,
-                state=target_state,
-            )
-        else:
-            from vibe3.clients.github_client import GitHubClient
-
-            github_client = GitHubClient()
-            issue_data = await loop.run_in_executor(
-                None, lambda: github_client.view_issue(event.issue_number)
-            )
-
-            if issue_data is None or isinstance(issue_data, str):
-                _block_for_noop(
-                    "Failed to fetch issue details from GitHub for manager dispatch"
-                )
-                return
-
-            issue_info = IssueInfo.from_github_payload(issue_data)
-            if issue_info is None:
-                _block_for_noop(
-                    "Failed to parse issue data from GitHub"
-                    " response for manager dispatch"
-                )
-                return
-
-            issue_info.state = target_state
-
-        if issue_info is None:
-            _block_for_noop("Issue info is None, cannot dispatch manager role")
-            return
-
+        # Early capacity check BEFORE expensive work (GitHub fetch, coordinator setup)
+        # to avoid wasteful network/DB operations when system is at capacity
         from vibe3.agents.backends.codeagent import CodeagentBackend
-        from vibe3.environment.session_registry import SessionRegistryService
         from vibe3.execution.capacity_service import CapacityService
-        from vibe3.execution.coordinator import ExecutionCoordinator
 
         with get_store() as store:
             backend = CodeagentBackend()
-            registry = SessionRegistryService(store=store, backend=backend)
-            coordinator = ExecutionCoordinator(config, store)
-
-            # Early capacity check to avoid wasteful request preparation
-            # and prevent misleading "Failed to prepare role execution request" errors
             capacity = CapacityService(config, store, backend)
             if not capacity.can_dispatch("manager"):
-                logger.bind(
-                    domain="issue_state_dispatch_handler",
-                    role="manager",
-                    issue_number=event.issue_number,
-                ).info("Manager dispatch queued: Capacity full")
+                return  # CapacityService.can_dispatch already logs INFO
+
+            target_state = (
+                IssueState.READY
+                if event.trigger_state == IssueState.READY.value
+                else IssueState.HANDOFF
+            )
+
+            if event.issue_title is not None:
+                issue_info: IssueInfo | None = IssueInfo(
+                    number=event.issue_number,
+                    title=event.issue_title,
+                    state=target_state,
+                )
+            else:
+                from vibe3.clients.github_client import GitHubClient
+
+                github_client = GitHubClient()
+                issue_data = await loop.run_in_executor(
+                    None, lambda: github_client.view_issue(event.issue_number)
+                )
+
+                if issue_data is None or isinstance(issue_data, str):
+                    _block_for_noop(
+                        "Failed to fetch issue details from GitHub for manager dispatch"
+                    )
+                    return
+
+                issue_info = IssueInfo.from_github_payload(issue_data)
+                if issue_info is None:
+                    _block_for_noop(
+                        "Failed to parse issue data from GitHub"
+                        " response for manager dispatch"
+                    )
+                    return
+
+                issue_info.state = target_state
+
+            if issue_info is None:
+                _block_for_noop("Issue info is None, cannot dispatch manager role")
                 return
+
+            from vibe3.environment.session_registry import SessionRegistryService
+            from vibe3.execution.coordinator import ExecutionCoordinator
+
+            registry = SessionRegistryService(store=store, backend=backend)
+            coordinator = ExecutionCoordinator(config, store, backend=backend)
 
             try:
                 request = await loop.run_in_executor(

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -193,6 +193,18 @@ class PRNotFoundError(VibeError):
 # ========== Orchestration Errors ==========
 
 
+class CapacityDeferredError(VibeError):
+    """Dispatch deferred due to capacity limits.
+
+    This is not a failure — it signals that the dispatch should be
+    retried later when capacity becomes available. Handlers should
+    treat this as a skip/defer, not a blocking failure.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, recoverable=True)
+
+
 class InvalidTransitionError(UserError):
     """Invalid state transition in orchestration state machine."""
 

--- a/src/vibe3/orchestra/flow_dispatch.py
+++ b/src/vibe3/orchestra/flow_dispatch.py
@@ -183,7 +183,9 @@ class FlowManager:
         active_count = self._registry.count_live_worker_sessions(role="manager")
         if active_count >= self.config.max_concurrent_flows:
             limit = self.config.max_concurrent_flows
-            raise RuntimeError(
+            from vibe3.exceptions import CapacityDeferredError
+
+            raise CapacityDeferredError(
                 f"Manager capacity reached ({active_count}/{limit}). "
                 f"Deferred flow creation."
             )

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -142,18 +142,9 @@ def build_manager_request(
     flow_manager = FlowManager(config, registry=registry)
     try:
         flow = flow_manager.create_flow_for_issue(issue)
-    except RuntimeError as exc:
-        # Check if this is a capacity defer (not a blocking failure)
-        exc_msg = str(exc)
-        if "capacity reached" in exc_msg.lower() and "deferred" in exc_msg.lower():
-            # Raise as typed exception so handler can defer properly
-            raise CapacityDeferredError(exc_msg) from exc
-        # Other errors are genuine failures
-        logger.bind(
-            domain="manager",
-            issue_number=issue.number,
-        ).warning(f"create_flow_for_issue failed: {exc}")
-        return None
+    except CapacityDeferredError:
+        # Re-raise capacity defer so handler can defer properly
+        raise
     except Exception as exc:
         logger.bind(
             domain="manager",

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from vibe3.environment.session_naming import get_manager_session_name
 from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.exceptions import CapacityDeferredError
 from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.execution.issue_role_support import (
@@ -141,6 +142,18 @@ def build_manager_request(
     flow_manager = FlowManager(config, registry=registry)
     try:
         flow = flow_manager.create_flow_for_issue(issue)
+    except RuntimeError as exc:
+        # Check if this is a capacity defer (not a blocking failure)
+        exc_msg = str(exc)
+        if "capacity reached" in exc_msg.lower() and "deferred" in exc_msg.lower():
+            # Raise as typed exception so handler can defer properly
+            raise CapacityDeferredError(exc_msg) from exc
+        # Other errors are genuine failures
+        logger.bind(
+            domain="manager",
+            issue_number=issue.number,
+        ).warning(f"create_flow_for_issue failed: {exc}")
+        return None
     except Exception as exc:
         logger.bind(
             domain="manager",

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -34,6 +34,7 @@ class TestIssueStateDispatchHandler:
         mock_build_request.assert_not_called()
         mock_coordinator_cls.assert_not_called()
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
@@ -44,6 +45,7 @@ class TestIssueStateDispatchHandler:
         mock_config_cls: MagicMock,
         mock_coordinator_cls: MagicMock,
         mock_registry_cls: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
@@ -51,6 +53,7 @@ class TestIssueStateDispatchHandler:
         from vibe3.execution.contracts import ExecutionLaunchResult
 
         mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
         mock_config_cls.return_value = mock_config
 
         mock_request = MagicMock()
@@ -62,6 +65,11 @@ class TestIssueStateDispatchHandler:
             launched=True,
         )
         mock_coordinator_cls.return_value = mock_coordinator
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         handle_manager_dispatch_intent(
             ManagerDispatchIntent(
@@ -74,6 +82,7 @@ class TestIssueStateDispatchHandler:
 
         mock_build_request.assert_called_once()
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
@@ -84,6 +93,7 @@ class TestIssueStateDispatchHandler:
         mock_config_cls: MagicMock,
         mock_coordinator_cls: MagicMock,
         mock_registry_cls: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
@@ -91,6 +101,7 @@ class TestIssueStateDispatchHandler:
         from vibe3.execution.contracts import ExecutionLaunchResult
 
         mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
         mock_config_cls.return_value = mock_config
 
         mock_request = MagicMock()
@@ -102,6 +113,11 @@ class TestIssueStateDispatchHandler:
             launched=True,
         )
         mock_coordinator_cls.return_value = mock_coordinator
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         handle_manager_dispatch_intent(
             ManagerDispatchIntent(
@@ -214,6 +230,7 @@ class TestIssueStateDispatchHandler:
             actor="agent:manager",
         )
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
@@ -226,6 +243,7 @@ class TestIssueStateDispatchHandler:
         mock_coordinator_cls: MagicMock,
         mock_registry_cls: MagicMock,
         mock_block_issue: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
@@ -233,6 +251,11 @@ class TestIssueStateDispatchHandler:
 
         mock_config = MagicMock()
         mock_config_cls.return_value = mock_config
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         mock_build_request.return_value = None
 
@@ -256,3 +279,104 @@ class TestIssueStateDispatchHandler:
             reason="Failed to prepare role execution request",
             actor="agent:manager",
         )
+
+    @patch("vibe3.execution.capacity_service.CapacityService")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
+    @patch("vibe3.environment.session_registry.SessionRegistryService")
+    @patch("vibe3.execution.coordinator.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    def test_capacity_full_defers_without_blocking(
+        self,
+        mock_build_request: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_registry_cls: MagicMock,
+        mock_block_issue: MagicMock,
+        mock_capacity_cls: MagicMock,
+    ) -> None:
+        """Test that capacity full defers dispatch without blocking the issue."""
+        from vibe3.domain.handlers.issue_state_dispatch import (
+            handle_manager_dispatch_intent,
+        )
+
+        mock_config = MagicMock()
+        mock_config_cls.return_value = mock_config
+
+        # Mock capacity service to deny dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = False
+        mock_capacity_cls.return_value = mock_capacity
+
+        mock_build_request.return_value = None
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        # Provide issue_title to skip GitHub API call
+        handle_manager_dispatch_intent(
+            ManagerDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="ready",
+                issue_title="Test Issue",
+            )
+        )
+
+        # Capacity full should NOT call build_request or block_issue
+        # It should just return early (defer)
+        mock_build_request.assert_not_called()
+        mock_coordinator.dispatch_execution.assert_not_called()
+        mock_block_issue.assert_not_called()
+
+    @patch("vibe3.execution.capacity_service.CapacityService")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
+    @patch("vibe3.environment.session_registry.SessionRegistryService")
+    @patch("vibe3.execution.coordinator.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
+    @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
+    def test_capacity_deferred_error_defers_without_blocking(
+        self,
+        mock_build_request: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_registry_cls: MagicMock,
+        mock_block_issue: MagicMock,
+        mock_capacity_cls: MagicMock,
+    ) -> None:
+        """Test CapacityDeferredError from build_request defers without blocking."""
+        from vibe3.domain.handlers.issue_state_dispatch import (
+            handle_manager_dispatch_intent,
+        )
+        from vibe3.exceptions import CapacityDeferredError
+
+        mock_config = MagicMock()
+        mock_config_cls.return_value = mock_config
+
+        # Mock capacity service to allow dispatch initially
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
+
+        # Mock build_request to raise CapacityDeferredError (race condition case)
+        mock_build_request.side_effect = CapacityDeferredError(
+            "Manager capacity reached (3/3). Deferred flow creation."
+        )
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        # Provide issue_title to skip GitHub API call
+        handle_manager_dispatch_intent(
+            ManagerDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="ready",
+                issue_title="Test Issue",
+            )
+        )
+
+        # CapacityDeferredError should NOT block the issue
+        # It should just return early (defer)
+        mock_coordinator.dispatch_execution.assert_not_called()
+        mock_block_issue.assert_not_called()

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -143,6 +143,7 @@ class TestIssueStateDispatchHandler:
             )
         )
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
@@ -157,16 +158,23 @@ class TestIssueStateDispatchHandler:
         mock_registry_cls: MagicMock,
         mock_github_client_cls: MagicMock,
         mock_block_issue: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
         )
 
         mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
         mock_config_cls.return_value = mock_config
         mock_github_client = MagicMock()
         mock_github_client.view_issue.return_value = None
         mock_github_client_cls.return_value = mock_github_client
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         handle_manager_dispatch_intent(
             ManagerDispatchIntent(
@@ -185,6 +193,7 @@ class TestIssueStateDispatchHandler:
             actor="agent:manager",
         )
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
@@ -199,16 +208,23 @@ class TestIssueStateDispatchHandler:
         mock_registry_cls: MagicMock,
         mock_github_client_cls: MagicMock,
         mock_block_issue: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         from vibe3.domain.handlers.issue_state_dispatch import (
             handle_manager_dispatch_intent,
         )
 
         mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
         mock_config_cls.return_value = mock_config
         mock_github_client = MagicMock()
         mock_github_client.view_issue.return_value = {"id": "invalid_payload"}
         mock_github_client_cls.return_value = mock_github_client
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         handle_manager_dispatch_intent(
             ManagerDispatchIntent(

--- a/tests/vibe3/domain/handlers/test_manager.py
+++ b/tests/vibe3/domain/handlers/test_manager.py
@@ -166,6 +166,7 @@ class TestManagerHandlerIssueFetching:
 class TestManagerHandlerDispatch:
     """Test manager role service dispatch via fast path (issue_title present)."""
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
@@ -174,9 +175,11 @@ class TestManagerHandlerDispatch:
         mock_config_cls: MagicMock,
         mock_build_request: MagicMock,
         mock_coordinator_cls: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         """Handler should dispatch manager with correct IssueInfo via fast path."""
         mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
         mock_config_cls.return_value = mock_config
 
         mock_request = MagicMock()
@@ -188,6 +191,11 @@ class TestManagerHandlerDispatch:
             launched=True, reason=None
         )
         mock_coordinator_cls.return_value = mock_coordinator
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         # Provide issue_title to use the fast path
         event = _make_event(issue_title="Test issue")

--- a/tests/vibe3/domain/handlers/test_manager.py
+++ b/tests/vibe3/domain/handlers/test_manager.py
@@ -83,6 +83,7 @@ class TestManagerHandlerIssueFetching:
     (i.e., events that don't carry the title).
     """
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
@@ -93,13 +94,21 @@ class TestManagerHandlerIssueFetching:
         mock_github_cls: MagicMock,
         mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         """Handler should skip dispatch when GitHub returns None (slow path)."""
-        mock_config_cls.return_value = MagicMock()
+        mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
+        mock_config_cls.return_value = mock_config
 
         mock_github = MagicMock()
         mock_github.view_issue.return_value = None
         mock_github_cls.return_value = mock_github
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         # No issue_title triggers slow path
         event = _make_event(issue_title=None)
@@ -109,6 +118,7 @@ class TestManagerHandlerIssueFetching:
         mock_build_request.assert_not_called()
         mock_block_noop.assert_called_once()
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
@@ -119,13 +129,21 @@ class TestManagerHandlerIssueFetching:
         mock_github_cls: MagicMock,
         mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         """Handler should skip dispatch when GitHub returns network error."""
-        mock_config_cls.return_value = MagicMock()
+        mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
+        mock_config_cls.return_value = mock_config
 
         mock_github = MagicMock()
         mock_github.view_issue.return_value = "network_error"
         mock_github_cls.return_value = mock_github
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         event = _make_event(issue_title=None)
         handle_manager_dispatch_intent(event)
@@ -133,6 +151,7 @@ class TestManagerHandlerIssueFetching:
         mock_build_request.assert_not_called()
         mock_block_noop.assert_called_once()
 
+    @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.domain.handlers.issue_state_dispatch.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
     @patch("vibe3.clients.github_client.GitHubClient")
@@ -143,13 +162,21 @@ class TestManagerHandlerIssueFetching:
         mock_github_cls: MagicMock,
         mock_block_noop: MagicMock,
         mock_build_request: MagicMock,
+        mock_capacity_cls: MagicMock,
     ) -> None:
         """Handler should skip dispatch when from_github_payload returns None."""
-        mock_config_cls.return_value = MagicMock()
+        mock_config = MagicMock()
+        mock_config.max_concurrent_flows = 3
+        mock_config_cls.return_value = mock_config
 
         mock_github = MagicMock()
         mock_github.view_issue.return_value = _make_github_response()
         mock_github_cls.return_value = mock_github
+
+        # Mock capacity service to allow dispatch
+        mock_capacity = MagicMock()
+        mock_capacity.can_dispatch.return_value = True
+        mock_capacity_cls.return_value = mock_capacity
 
         event = _make_event(issue_title=None)
 


### PR DESCRIPTION
## Summary

- Adds early capacity check in `handle_manager_dispatch_intent` to avoid wasteful request preparation
- Introduces `CapacityDeferredError` for typed capacity defer signaling
- Updates `build_manager_request` to raise `CapacityDeferredError` when inner capacity check fires
- Handler now logs "Manager dispatch queued: Capacity full" at INFO level instead of blocking with generic error

This aligns manager dispatch behavior with other roles (planner/executor/reviewer) which already check capacity early and defer gracefully.

## Before

When manager dispatch was deferred due to capacity limits:
- Error message: "Failed to prepare role execution request" (misleading)
- Flow was blocked with generic error
- Operators couldn't distinguish capacity defer from real failures

## After

- Early capacity check → log "Manager dispatch queued: Capacity full" at INFO level
- Inner capacity check (race condition) → raise `CapacityDeferredError` → log at INFO level
- No blocking for capacity issues — defer and retry later

## Test plan

- [x] `test_capacity_full_defers_without_blocking` - early check triggers defer
- [x] `test_capacity_deferred_error_defers_without_blocking` - inner check triggers defer
- [x] All existing tests pass

Fixes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)