### PR TITLE
fix(sqlite): avoid row_factory on shared connection for thread safety

### DIFF
--- a/src/vibe3/clients/sqlite_context_cache_repo.py
+++ b/src/vibe3/clients/sqlite_context_cache_repo.py
@@ -1,7 +1,6 @@
 """SQLite repository methods for flow context cache persistence."""
 
 import datetime
-import sqlite3
 from typing import Any
 
 from loguru import logger
@@ -50,17 +49,19 @@ class SQLiteContextCacheRepo(_HasConnection):
 
     def get_flow_context_cache(self, branch: str) -> dict[str, Any] | None:
         conn = self._get_connection()
-        conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM flow_context_cache WHERE branch = ?", (branch,))
         row = cursor.fetchone()
         if row:
+            # Convert row to dict using cursor.description (thread-safe)
+            columns = [col[0] for col in cursor.description]
+            result = dict(zip(columns, row))
             logger.bind(
                 external="sqlite",
                 operation="get_flow_context_cache",
                 branch=branch,
             ).debug("Retrieved flow context cache")
-            return dict(row)
+            return result
         return None
 
     def delete_flow_context_cache(self, branch: str) -> None:


### PR DESCRIPTION
## Summary

- Fix `sqlite3.InterfaceError: bad parameter or other API misuse` in `SQLiteContextCacheRepo.get_flow_context_cache()`
- Replace `conn.row_factory = sqlite3.Row` with manual dict conversion using `cursor.description`
- Thread-safe approach for shared SQLite connections

## Problem

The error appeared in orchestra event logs:
```
sqlite3.InterfaceError: bad parameter or other API misuse
```

Root cause: `conn.row_factory` modifies the connection object, which is shared across threads in our SQLite connection pool. This creates a race condition when multiple threads access the same connection.

## Solution

Instead of modifying the connection with `row_factory`, we:
1. Execute the query normally
2. Use `cursor.description` to get column names
3. Manually convert the row tuple to a dict using `zip(columns, row)`

This approach is thread-safe because it only uses cursor-local data.

## Test Plan

- [x] Existing tests pass
- [x] Manual testing: no more InterfaceError in orchestra logs
- [x] Verified the returned dict structure matches original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)