### PR TITLE
fix: check_pane_exists now searches all tmux sessions

### DIFF
--- a/skills/vibe-review-pr/scripts/lib.sh
+++ b/skills/vibe-review-pr/scripts/lib.sh
@@ -95,24 +95,26 @@ print_agent_table_header() {
 
 check_pane_exists() {
   local agent_name="$1"
-  local agent_type current_session
-  agent_type="$(agent_type_for "$agent_name")"
+  local agent_type
 
-  # 获取当前 tmux session（如果不在 tmux 中，返回失败）
-  if ! current_session=$(tmux display-message -p "#{session_name}" 2>/dev/null); then
+  if ! agent_type="$(agent_type_for "$agent_name")"; then
+    # Agent not defined in AGENTS array
     return 1
   fi
 
-  # 只在当前 session 中检查 tmux pane 标题是否包含 agent_type 或 agent_name
-  if tmux list-panes -t "$current_session" -F "#{pane_title} #{pane_current_command}" 2>/dev/null | \
-     grep -qE "(^|✳ |⠐ |⠂ )${agent_type}.*claude"; then
-    return 0
-  elif tmux list-panes -t "$current_session" -F "#{pane_title} #{pane_current_command}" 2>/dev/null | \
-       grep -qE "(^|✳ |⠐ |⠂ )${agent_name}.*claude"; then
-    return 0
-  else
-    return 1
-  fi
+  # Search all tmux sessions for one matching the agent pattern.
+  # Session naming convention: vibe3-{agent_type}-* or vibe3-{agent_name}-*
+  local session
+  for session in $(tmux list-sessions -F '#{session_name}' 2>/dev/null); do
+    if [[ "$session" == *"${agent_type}"* ]] || [[ "$session" == *"${agent_name}"* ]]; then
+      # Session found — verify it's alive (has at least one pane with a running command)
+      if tmux list-panes -t "$session" -F '#{pane_current_command}' 2>/dev/null | grep -q .; then
+        return 0
+      fi
+    fi
+  done
+
+  return 1
 }
 
 check_last_alive() {

--- a/skills/vibe-review-pr/scripts/lib.sh
+++ b/skills/vibe-review-pr/scripts/lib.sh
@@ -105,14 +105,14 @@ check_pane_exists() {
   # Search all tmux sessions for one matching the agent pattern.
   # Session naming convention: vibe3-{agent_type}-* or vibe3-{agent_name}-*
   local session
-  for session in $(tmux list-sessions -F '#{session_name}' 2>/dev/null); do
-    if [[ "$session" == *"${agent_type}"* ]] || [[ "$session" == *"${agent_name}"* ]]; then
+  while IFS= read -r session; do
+    if [[ "$session" == vibe3-"${agent_type}"-* ]] || [[ "$session" == vibe3-"${agent_name}"-* ]]; then
       # Session found — verify it's alive (has at least one pane with a running command)
       if tmux list-panes -t "$session" -F '#{pane_current_command}' 2>/dev/null | grep -q .; then
         return 0
       fi
     fi
-  done
+  done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null)
 
   return 1
 }


### PR DESCRIPTION
## Summary

Fixed `check_pane_exists` function in `skills/vibe-review-pr/scripts/lib.sh` to search across ALL tmux sessions instead of only the current session, and corrected the match logic to identify agent sessions by session name pattern.

## Root Cause

The function had two bugs:
1. **Wrong session scope**: Used `tmux display-message -p "#{session_name}"` which returns the script's current session, not the agent's session
2. **Wrong match pattern**: Grepped for `agent_type.*claude` in pane title/command, but agent panes have hostname titles and `uv` commands

## Changes

- **`skills/vibe-review-pr/scripts/lib.sh` (lines 96-115)**: Rewrote `check_pane_exists` to:
  - Use `tmux list-sessions` to search ALL sessions
  - Match by session name pattern (`vibe3-{agent_type}-*` or `vibe3-{agent_name}-*`)
  - Verify session aliveness via non-empty `pane_current_command`
  - Added error handling for `agent_type_for` failure to prevent false positives

## Tests

- Manual verification: Existing sessions detected correctly, non-existent agents return `missing`
- Python tests: 120 passed (2 pre-existing failures unrelated to this change)
- MyPy: No issues in 323 source files
- Ruff: No new lint errors

Closes #899

---

## Contributors

claude/opus
