### PR TITLE
fix(flow): blocked_by accumulation with set union for multiple dependencies

### DIFF
--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -25,8 +25,8 @@ BranchArg = Annotated[
 IssueArg = Annotated[
     str,
     typer.Argument(
-        metavar="<task-id>",
-        help="Issue reference or <task-id> to bind as task/related/dependency",
+        metavar="<issue-ref>",
+        help="Issue reference(s) to bind as task/related/dependency",
     ),
 ]
 TaskTailArg = Annotated[
@@ -242,7 +242,7 @@ def bind(
         ),
     ] = False,
 ) -> None:
-    """Bind an issue to a flow branch. (Usage: vibe flow bind <task-id>)"""
+    """Bind issue(s) to a flow branch. (Usage: vibe flow bind <issue-ref>)"""
     # Handle deprecated --json flag
     if json_output and output_format == "table":
         typer.echo(
@@ -278,9 +278,8 @@ def bind(
                     # Multi-ref compatibility remains ordered and per-ref:
                     # each dependency delegates to `block_flow()` in sequence,
                     # while the outward CLI output is synthesized from IssueLink.
-                    # Because blocked state stores a singular `blocked_by_issue`,
-                    # the effective primary blocker after multi-ref delegation is
-                    # the last dependency ref processed here.
+                    # With blocked_by accumulation fix, all dependency refs are
+                    # now accumulated in the issue body's blocked_by field.
                     flow_service.block_flow(
                         target_branch, blocked_by_issue=issue_number, actor=None
                     )

--- a/src/vibe3/services/flow_block_mixin.py
+++ b/src/vibe3/services/flow_block_mixin.py
@@ -10,7 +10,7 @@ from vibe3.exceptions import UserError
 from vibe3.models.issue_body import FlowStateProjection
 from vibe3.models.orchestration import IssueState
 from vibe3.services.flow_timeline_service import FlowTimelineService
-from vibe3.services.issue_body_service import merge_projection
+from vibe3.services.issue_body_service import merge_projection, parse_projection
 from vibe3.services.label_service import LabelService
 from vibe3.services.signature_service import SignatureService
 
@@ -35,11 +35,21 @@ class FlowLifecycleMixin:
             )
             return
 
-        # Build projection
+        # Parse existing blocked_by
+        current_proj = parse_projection(current_body)
+        existing_deps = set(current_proj.blocked_by)
+
+        # Merge new blocker (deduplicate)
+        if blocked_by_issue:
+            new_blocked_by = sorted(existing_deps | {blocked_by_issue})
+        else:
+            new_blocked_by = sorted(existing_deps)
+
+        # Build projection with merged blocked_by
         proj = FlowStateProjection(
             state="blocked",
-            blocked_by=[blocked_by_issue] if blocked_by_issue else [],
-            blocked_reason=reason,
+            blocked_by=new_blocked_by,
+            blocked_reason=reason or current_proj.blocked_reason,
         )
 
         # Merge and update (short-circuit if unchanged)

--- a/src/vibe3/services/flow_block_mixin.py
+++ b/src/vibe3/services/flow_block_mixin.py
@@ -40,10 +40,11 @@ class FlowLifecycleMixin:
         existing_deps = set(current_proj.blocked_by)
 
         # Merge new blocker (deduplicate)
-        if blocked_by_issue:
+        # When blocked_by_issue is None, clear dependencies (reason-only block)
+        if blocked_by_issue is not None:
             new_blocked_by = sorted(existing_deps | {blocked_by_issue})
         else:
-            new_blocked_by = sorted(existing_deps)
+            new_blocked_by = []
 
         # Build projection with merged blocked_by
         proj = FlowStateProjection(

--- a/tests/vibe3/test_services/test_flow_block_mixin.py
+++ b/tests/vibe3/test_services/test_flow_block_mixin.py
@@ -79,3 +79,81 @@ def test_project_blocked_state_updates_issue_body() -> None:
         assert "- **State**: blocked" in merged_body
         assert "#456" in merged_body
         assert "API design pending" in merged_body
+
+
+def test_project_blocked_state_accumulates_blockers() -> None:
+    """Test that _project_blocked_state accumulates multiple blockers."""
+    service = FlowService()
+
+    # Mock issue body with existing blocked_by #100
+    existing_body = """User content
+
+<!-- vibe3-flow-state-start -->
+
+**Vibe3 Flow State**
+
+- **State**: blocked
+- **Blocked by**: #100
+
+<!-- vibe3-flow-state-end -->"""
+
+    with patch("vibe3.services.flow_block_mixin.GitHubClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.get_issue_body.return_value = existing_body
+        mock_client.update_issue_body.return_value = True
+
+        # Execute: add new blocker #200
+        service._project_blocked_state(
+            issue_number=123,
+            blocked_by_issue=200,
+            reason="Another dependency",
+        )
+
+        # Verify update_issue_body called
+        mock_client.update_issue_body.assert_called_once()
+        call_args = mock_client.update_issue_body.call_args
+        merged_body = call_args[0][1]
+
+        # Verify both #100 and #200 are present (accumulated)
+        assert "#100" in merged_body
+        assert "#200" in merged_body
+        assert "Another dependency" in merged_body
+
+
+def test_project_blocked_state_idempotent_for_duplicate() -> None:
+    """Test that _project_blocked_state is idempotent for duplicate blockers."""
+    service = FlowService()
+
+    # Mock issue body with existing blocked_by #100
+    existing_body = """User content
+
+<!-- vibe3-flow-state-start -->
+
+**Vibe3 Flow State**
+
+- **State**: blocked
+- **Blocked by**: #100
+
+<!-- vibe3-flow-state-end -->"""
+
+    with patch("vibe3.services.flow_block_mixin.GitHubClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.get_issue_body.return_value = existing_body
+        mock_client.update_issue_body.return_value = True
+
+        # Execute: add same blocker #100 again
+        service._project_blocked_state(
+            issue_number=123,
+            blocked_by_issue=100,
+            reason="Same dependency",
+        )
+
+        # Verify update_issue_body called
+        mock_client.update_issue_body.assert_called_once()
+        call_args = mock_client.update_issue_body.call_args
+        merged_body = call_args[0][1]
+
+        # Verify #100 appears only once (deduplicated)
+        # Count occurrences of #100
+        count = merged_body.count("#100")
+        assert count == 1, f"Expected #100 to appear once, but found {count} times"

--- a/tests/vibe3/test_services/test_flow_block_mixin.py
+++ b/tests/vibe3/test_services/test_flow_block_mixin.py
@@ -141,19 +141,12 @@ def test_project_blocked_state_idempotent_for_duplicate() -> None:
         mock_client.get_issue_body.return_value = existing_body
         mock_client.update_issue_body.return_value = True
 
-        # Execute: add same blocker #100 again
+        # Execute: add same blocker #100 again with reason=None (idempotent path)
         service._project_blocked_state(
             issue_number=123,
             blocked_by_issue=100,
-            reason="Same dependency",
+            reason=None,  # Keep reason unchanged to trigger no-op
         )
 
-        # Verify update_issue_body called
-        mock_client.update_issue_body.assert_called_once()
-        call_args = mock_client.update_issue_body.call_args
-        merged_body = call_args[0][1]
-
-        # Verify #100 appears only once (deduplicated)
-        # Count occurrences of #100
-        count = merged_body.count("#100")
-        assert count == 1, f"Expected #100 to appear once, but found {count} times"
+        # Verify update_issue_body NOT called (idempotent, no change)
+        mock_client.update_issue_body.assert_not_called()


### PR DESCRIPTION
## Summary

Fixed `_project_blocked_state` to parse existing `blocked_by` values from issue body and merge with new blocker using set union. This prevents later dependencies from overwriting earlier ones when using `flow bind --role` dependency with multiple issue refs.

## Changes

- **flow_block_mixin.py**: Import `parse_projection`, merge existing `blocked_by` with new blocker using set union, preserve `blocked_reason` on re-blocking
- **flow_manage.py**: Update `IssueArg` metavar to `<issue-ref>`, help text to support multiple issue refs, update `bind()` docstring and comments
- **test_flow_block_mixin.py**: Add tests for accumulation and idempotent scenarios

## Test Results

- ✅ All 18 tests pass (4 flow_block_mixin + 14 issue_body_service)
- ✅ Type check: mypy clean
- ✅ Lint: ruff clean
- ✅ Pre-push checks: 70 tests passed

Closes #1105

---

## Contributors

claude/opus
