### PR TITLE
feat(orchestra): add automatic expired resource cleanup on tick interval

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -97,8 +97,8 @@ code_limits:
         limit: 450
         reason: "Task 服务聚合，包含状态转换、查询、resume 候选筛选逻辑"
       - path: "src/vibe3/services/expired_resource_cleanup_service.py"
-        limit: 520
-        reason: "过期资源清理服务聚合，包含 agent worktree、远程分支、本地分支清理等三个紧密耦合的过期资源清理逻辑，新增颜色高亮输出后略微超标"
+        limit: 540
+        reason: "过期资源清理服务聚合，包含 agent worktree、远程分支、本地分支清理等三个紧密耦合的过期资源清理逻辑，新增 quiet 模式和颜色高亮输出后略微超标"
       - path: "src/vibe3/services/check_cleanup_service.py"
         limit: 540
         reason: "终端 flow 清理 + detached worktree 清理聚合，包含 done/aborted 处理、live session 过滤、issue resume、detached worktree 安全清理（worktree root 比较、flow-managed scope 检查）等紧密耦合逻辑"

--- a/src/vibe3/config/orchestra_config.py
+++ b/src/vibe3/config/orchestra_config.py
@@ -193,6 +193,23 @@ class SupervisorHandoffConfig(BaseModel):
         return convention.state_label(convention.handoff_label)
 
 
+class ExpiredResourceCleanupConfig(BaseModel):
+    """Configuration for expired resource cleanup service."""
+
+    enabled: bool = True
+    interval_ticks: int = Field(
+        default=10,
+        ge=1,
+        description="Run cleanup every N heartbeat ticks (~2.5h at default interval)",
+    )
+    max_age_days: int = Field(
+        default=7, ge=1, description="Max age in days before cleanup"
+    )
+    enable_worktree_cleanup: bool = True
+    enable_local_branch_cleanup: bool = True
+    enable_remote_branch_cleanup: bool = True
+
+
 class OrchestraConfig(BaseModel):
     """Orchestra daemon configuration.
 
@@ -258,6 +275,9 @@ class OrchestraConfig(BaseModel):
     governance: GovernanceConfig = Field(default_factory=GovernanceConfig)
     supervisor_handoff: SupervisorHandoffConfig = Field(
         default_factory=SupervisorHandoffConfig
+    )
+    expired_resource_cleanup: ExpiredResourceCleanupConfig = Field(
+        default_factory=ExpiredResourceCleanupConfig
     )
     max_retry_budget: int = Field(
         default=3,

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -1,7 +1,5 @@
 """Cleanup executor for expired resources (worktrees, branches)."""
 
-import asyncio
-
 from loguru import logger
 
 from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
@@ -53,9 +51,8 @@ async def execute_expired_resource_cleanup(
     # Cleanup worktrees
     if config.enable_worktree_cleanup:
         try:
-            result = await asyncio.to_thread(
-                service.clean_expired_agent_worktrees,
-                config.max_age_days,
+            result = service.clean_expired_agent_worktrees(
+                config.max_age_days, quiet=True
             )
             cleaned = result.get("cleaned", [])
             if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
@@ -82,9 +79,8 @@ async def execute_expired_resource_cleanup(
     # Cleanup local branches
     if config.enable_local_branch_cleanup:
         try:
-            result = await asyncio.to_thread(
-                service.clean_expired_local_branches,
-                config.max_age_days,
+            result = service.clean_expired_local_branches(
+                config.max_age_days, quiet=True
             )
             cleaned = result.get("cleaned", [])
             if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
@@ -111,9 +107,8 @@ async def execute_expired_resource_cleanup(
     # Cleanup remote branches (only if GitHub client available)
     if config.enable_remote_branch_cleanup and github_client is not None:
         try:
-            result = await asyncio.to_thread(
-                service.clean_expired_remote_branches,
-                config.max_age_days,
+            result = service.clean_expired_remote_branches(
+                config.max_age_days, quiet=True
             )
             cleaned = result.get("cleaned", [])
             if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -1,0 +1,138 @@
+"""Cleanup executor for expired resources (worktrees, branches)."""
+
+import asyncio
+
+from loguru import logger
+
+from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+from vibe3.orchestra.logging import append_orchestra_event
+
+
+async def execute_expired_resource_cleanup(
+    config: ExpiredResourceCleanupConfig,
+    tick_number: int,
+) -> None:
+    """Execute expired resource cleanup (worktrees, local/remote branches).
+
+    This function is called from HeartbeatServer's tick loop when
+    tick_number % interval_ticks == 0.
+
+    Args:
+        config: Cleanup configuration (enabled flags, max_age_days, etc.)
+        tick_number: Current tick number (for logging)
+    """
+    # Delay imports to avoid circular dependencies
+    from vibe3.clients.git_client import GitClient
+    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.expired_resource_cleanup_service import (
+        ExpiredResourceCleanupService,
+    )
+
+    # Initialize services
+    store = SQLiteClient()
+    git_client = GitClient()
+    github_client: GitHubClient | None = None
+
+    # Only initialize GitHub client if remote branch cleanup is enabled
+    if config.enable_remote_branch_cleanup:
+        try:
+            github_client = GitHubClient()
+        except Exception as exc:
+            logger.bind(domain="orchestra", action="cleanup").warning(
+                "Failed to initialize GitHub client, "
+                f"skipping remote branch cleanup: {exc}"
+            )
+
+    service = ExpiredResourceCleanupService(
+        store=store,
+        git_client=git_client,
+        github_client=github_client,
+    )
+
+    # Cleanup worktrees
+    if config.enable_worktree_cleanup:
+        try:
+            result = await asyncio.to_thread(
+                service.clean_expired_agent_worktrees,
+                config.max_age_days,
+            )
+            cleaned = result.get("cleaned", [])
+            if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                append_orchestra_event(
+                    "server",
+                    (
+                        f"tick #{tick_number} cleanup: cleaned "
+                        f"{len(cleaned)} expired worktrees"
+                    ),
+                )
+                logger.bind(domain="orchestra", action="cleanup").info(
+                    f"Cleaned {len(cleaned)} expired worktrees"
+                )
+        except Exception as exc:
+            append_orchestra_event(
+                "server",
+                f"tick #{tick_number} worktree cleanup failed: {exc}",
+                level="WARNING",
+            )
+            logger.bind(domain="orchestra", action="cleanup").warning(
+                f"Worktree cleanup failed: {exc}"
+            )
+
+    # Cleanup local branches
+    if config.enable_local_branch_cleanup:
+        try:
+            result = await asyncio.to_thread(
+                service.clean_expired_local_branches,
+                config.max_age_days,
+            )
+            cleaned = result.get("cleaned", [])
+            if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                append_orchestra_event(
+                    "server",
+                    (
+                        f"tick #{tick_number} cleanup: cleaned "
+                        f"{len(cleaned)} expired local branches"
+                    ),
+                )
+                logger.bind(domain="orchestra", action="cleanup").info(
+                    f"Cleaned {len(cleaned)} expired local branches"
+                )
+        except Exception as exc:
+            append_orchestra_event(
+                "server",
+                f"tick #{tick_number} local branch cleanup failed: {exc}",
+                level="WARNING",
+            )
+            logger.bind(domain="orchestra", action="cleanup").warning(
+                f"Local branch cleanup failed: {exc}"
+            )
+
+    # Cleanup remote branches (only if GitHub client available)
+    if config.enable_remote_branch_cleanup and github_client is not None:
+        try:
+            result = await asyncio.to_thread(
+                service.clean_expired_remote_branches,
+                config.max_age_days,
+            )
+            cleaned = result.get("cleaned", [])
+            if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                append_orchestra_event(
+                    "server",
+                    (
+                        f"tick #{tick_number} cleanup: cleaned "
+                        f"{len(cleaned)} expired remote branches"
+                    ),
+                )
+                logger.bind(domain="orchestra", action="cleanup").info(
+                    f"Cleaned {len(cleaned)} expired remote branches"
+                )
+        except Exception as exc:
+            append_orchestra_event(
+                "server",
+                f"tick #{tick_number} remote branch cleanup failed: {exc}",
+                level="WARNING",
+            )
+            logger.bind(domain="orchestra", action="cleanup").warning(
+                f"Remote branch cleanup failed: {exc}"
+            )

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -16,6 +16,7 @@ from vibe3.orchestra.logging import (
     append_orchestra_event,
     append_orchestra_run_separator,
 )
+from vibe3.runtime.cleanup_executor import execute_expired_resource_cleanup
 from vibe3.runtime.service_protocol import ServiceBase
 
 if TYPE_CHECKING:
@@ -298,123 +299,10 @@ class HeartbeatServer:
 
     async def _cleanup_expired_resources(self, tick_number: int) -> None:
         """Cleanup expired worktrees and branches (runs every N ticks)."""
-        # Delay imports to avoid circular dependencies
-        from vibe3.clients.git_client import GitClient
-        from vibe3.clients.github_client import GitHubClient
-        from vibe3.clients.sqlite_client import SQLiteClient
-        from vibe3.services.expired_resource_cleanup_service import (
-            ExpiredResourceCleanupService,
+        await execute_expired_resource_cleanup(
+            self.config.expired_resource_cleanup,
+            tick_number,
         )
-
-        config = self.config.expired_resource_cleanup
-
-        # Initialize services
-        store = SQLiteClient()
-        git_client = GitClient()
-        github_client: GitHubClient | None = None
-
-        # Only initialize GitHub client if remote branch cleanup is enabled
-        if config.enable_remote_branch_cleanup:
-            try:
-                github_client = GitHubClient()
-            except Exception as exc:
-                logger.bind(domain="orchestra", action="cleanup").warning(
-                    "Failed to initialize GitHub client, "
-                    f"skipping remote branch cleanup: {exc}"
-                )
-
-        service = ExpiredResourceCleanupService(
-            store=store,
-            git_client=git_client,
-            github_client=github_client,
-        )
-
-        # Cleanup worktrees
-        if config.enable_worktree_cleanup:
-            try:
-                result = await asyncio.to_thread(
-                    service.clean_expired_agent_worktrees,
-                    config.max_age_days,
-                )
-                cleaned = result.get("cleaned", [])
-                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
-                    append_orchestra_event(
-                        "server",
-                        (
-                            f"tick #{tick_number} cleanup: cleaned "
-                            f"{len(cleaned)} expired worktrees"
-                        ),
-                    )
-                    logger.bind(domain="orchestra", action="cleanup").info(
-                        f"Cleaned {len(cleaned)} expired worktrees"
-                    )
-            except Exception as exc:
-                append_orchestra_event(
-                    "server",
-                    f"tick #{tick_number} worktree cleanup failed: {exc}",
-                    level="WARNING",
-                )
-                logger.bind(domain="orchestra", action="cleanup").warning(
-                    f"Worktree cleanup failed: {exc}"
-                )
-
-        # Cleanup local branches
-        if config.enable_local_branch_cleanup:
-            try:
-                result = await asyncio.to_thread(
-                    service.clean_expired_local_branches,
-                    config.max_age_days,
-                )
-                cleaned = result.get("cleaned", [])
-                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
-                    append_orchestra_event(
-                        "server",
-                        (
-                            f"tick #{tick_number} cleanup: cleaned "
-                            f"{len(cleaned)} expired local branches"
-                        ),
-                    )
-                    logger.bind(domain="orchestra", action="cleanup").info(
-                        f"Cleaned {len(cleaned)} expired local branches"
-                    )
-            except Exception as exc:
-                append_orchestra_event(
-                    "server",
-                    f"tick #{tick_number} local branch cleanup failed: {exc}",
-                    level="WARNING",
-                )
-                logger.bind(domain="orchestra", action="cleanup").warning(
-                    f"Local branch cleanup failed: {exc}"
-                )
-
-        # Cleanup remote branches (only if GitHub client available)
-        if config.enable_remote_branch_cleanup and github_client is not None:
-            try:
-                result = await asyncio.to_thread(
-                    service.clean_expired_remote_branches,
-                    config.max_age_days,
-                )
-                cleaned = result.get("cleaned", [])
-                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
-                    append_orchestra_event(
-                        "server",
-                        (
-                            f"tick #{tick_number} cleanup: cleaned "
-                            f"{len(cleaned)} expired remote branches"
-                        ),
-                    )
-                    logger.bind(domain="orchestra", action="cleanup").info(
-                        f"Cleaned {len(cleaned)} expired remote branches"
-                    )
-            except Exception as exc:
-                append_orchestra_event(
-                    "server",
-                    f"tick #{tick_number} remote branch cleanup failed: {exc}",
-                    level="WARNING",
-                )
-                logger.bind(domain="orchestra", action="cleanup").warning(
-                    f"Remote branch cleanup failed: {exc}"
-                )
 
     async def _idle_loop(self) -> None:
         """Keep server running when polling is disabled (HTTP-only mode)."""

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -230,6 +230,24 @@ class HeartbeatServer:
                         f"Cleaned up {deleted_terminal} errors for terminal issues"
                     )
 
+            # Cleanup expired resources (worktrees, branches)
+            if (
+                self.config.expired_resource_cleanup.enabled
+                and tick_number % self.config.expired_resource_cleanup.interval_ticks
+                == 0
+            ):
+                try:
+                    await self._cleanup_expired_resources(tick_number)
+                except Exception as exc:
+                    append_orchestra_event(
+                        "server",
+                        f"tick #{tick_number} expired resource cleanup failed: {exc}",
+                        level="WARNING",
+                    )
+                    logger.bind(domain="orchestra", action="cleanup").warning(
+                        f"Expired resource cleanup failed: {exc}"
+                    )
+
             tasks = []
             tick_services: list[str] = []
             for svc in self._services:
@@ -276,6 +294,126 @@ class HeartbeatServer:
                 )
                 logger.bind(domain="orchestra").error(
                     f"Tick error in {type(service).__name__}: {exc}"
+                )
+
+    async def _cleanup_expired_resources(self, tick_number: int) -> None:
+        """Cleanup expired worktrees and branches (runs every N ticks)."""
+        # Delay imports to avoid circular dependencies
+        from vibe3.clients.git_client import GitClient
+        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients.sqlite_client import SQLiteClient
+        from vibe3.services.expired_resource_cleanup_service import (
+            ExpiredResourceCleanupService,
+        )
+
+        config = self.config.expired_resource_cleanup
+
+        # Initialize services
+        store = SQLiteClient()
+        git_client = GitClient()
+        github_client: GitHubClient | None = None
+
+        # Only initialize GitHub client if remote branch cleanup is enabled
+        if config.enable_remote_branch_cleanup:
+            try:
+                github_client = GitHubClient()
+            except Exception as exc:
+                logger.bind(domain="orchestra", action="cleanup").warning(
+                    "Failed to initialize GitHub client, "
+                    f"skipping remote branch cleanup: {exc}"
+                )
+
+        service = ExpiredResourceCleanupService(
+            store=store,
+            git_client=git_client,
+            github_client=github_client,
+        )
+
+        # Cleanup worktrees
+        if config.enable_worktree_cleanup:
+            try:
+                result = await asyncio.to_thread(
+                    service.clean_expired_agent_worktrees,
+                    config.max_age_days,
+                )
+                cleaned = result.get("cleaned", [])
+                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                    append_orchestra_event(
+                        "server",
+                        (
+                            f"tick #{tick_number} cleanup: cleaned "
+                            f"{len(cleaned)} expired worktrees"
+                        ),
+                    )
+                    logger.bind(domain="orchestra", action="cleanup").info(
+                        f"Cleaned {len(cleaned)} expired worktrees"
+                    )
+            except Exception as exc:
+                append_orchestra_event(
+                    "server",
+                    f"tick #{tick_number} worktree cleanup failed: {exc}",
+                    level="WARNING",
+                )
+                logger.bind(domain="orchestra", action="cleanup").warning(
+                    f"Worktree cleanup failed: {exc}"
+                )
+
+        # Cleanup local branches
+        if config.enable_local_branch_cleanup:
+            try:
+                result = await asyncio.to_thread(
+                    service.clean_expired_local_branches,
+                    config.max_age_days,
+                )
+                cleaned = result.get("cleaned", [])
+                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                    append_orchestra_event(
+                        "server",
+                        (
+                            f"tick #{tick_number} cleanup: cleaned "
+                            f"{len(cleaned)} expired local branches"
+                        ),
+                    )
+                    logger.bind(domain="orchestra", action="cleanup").info(
+                        f"Cleaned {len(cleaned)} expired local branches"
+                    )
+            except Exception as exc:
+                append_orchestra_event(
+                    "server",
+                    f"tick #{tick_number} local branch cleanup failed: {exc}",
+                    level="WARNING",
+                )
+                logger.bind(domain="orchestra", action="cleanup").warning(
+                    f"Local branch cleanup failed: {exc}"
+                )
+
+        # Cleanup remote branches (only if GitHub client available)
+        if config.enable_remote_branch_cleanup and github_client is not None:
+            try:
+                result = await asyncio.to_thread(
+                    service.clean_expired_remote_branches,
+                    config.max_age_days,
+                )
+                cleaned = result.get("cleaned", [])
+                if cleaned and isinstance(cleaned, list) and len(cleaned) > 0:
+                    append_orchestra_event(
+                        "server",
+                        (
+                            f"tick #{tick_number} cleanup: cleaned "
+                            f"{len(cleaned)} expired remote branches"
+                        ),
+                    )
+                    logger.bind(domain="orchestra", action="cleanup").info(
+                        f"Cleaned {len(cleaned)} expired remote branches"
+                    )
+            except Exception as exc:
+                append_orchestra_event(
+                    "server",
+                    f"tick #{tick_number} remote branch cleanup failed: {exc}",
+                    level="WARNING",
+                )
+                logger.bind(domain="orchestra", action="cleanup").warning(
+                    f"Remote branch cleanup failed: {exc}"
                 )
 
     async def _idle_loop(self) -> None:

--- a/src/vibe3/services/expired_resource_cleanup_service.py
+++ b/src/vibe3/services/expired_resource_cleanup_service.py
@@ -58,7 +58,9 @@ class ExpiredResourceCleanupService:
             )
         return self._pr_service
 
-    def clean_expired_agent_worktrees(self, max_age_days: int = 7) -> dict[str, object]:
+    def clean_expired_agent_worktrees(
+        self, max_age_days: int = 7, *, quiet: bool = False
+    ) -> dict[str, object]:
         """Clean expired agent worktrees older than max_age_days.
 
         Safety checks:
@@ -70,6 +72,7 @@ class ExpiredResourceCleanupService:
 
         Args:
             max_age_days: Max age in days before cleanup (default: 7)
+            quiet: If True, suppress terminal output (for daemon/heartbeat use)
 
         Returns:
             Dict with 'cleaned' list and 'skipped_live' list
@@ -79,9 +82,10 @@ class ExpiredResourceCleanupService:
         logger.bind(domain="check", action="clean_agent_worktrees").info(
             f"Checking agent worktrees older than {max_age_days} days"
         )
-        typer.echo(
-            f"  [dim]Checking agent worktrees older than {max_age_days} days...[/]"
-        )
+        if not quiet:
+            typer.echo(
+                f"  [dim]Checking agent worktrees older than {max_age_days} days...[/]"
+            )
 
         base = self._get_agent_worktree_base()
         if not base.exists():
@@ -122,33 +126,40 @@ class ExpiredResourceCleanupService:
                         worktree=worktree_name,
                         session_count=len(live_sessions),
                     ).info("Skipped agent worktree with live runtime sessions")
-                    typer.echo(
-                        f"    [cyan][skipped][/cyan] {worktree_name} "
-                        f"[dim](has {len(live_sessions)} live sessions)[/]"
-                    )
+                    if not quiet:
+                        typer.echo(
+                            f"    [cyan][skipped][/cyan] {worktree_name} "
+                            f"[dim](has {len(live_sessions)} live sessions)[/]"
+                        )
                     continue
 
                 # Properly remove worktree: cleans git metadata AND directory
-                typer.echo(f"    [yellow][cleaning][/yellow] {worktree_name}...")
+                if not quiet:
+                    typer.echo(f"    [yellow][cleaning][/yellow] {worktree_name}...")
                 remove_worktree(worktree_dir, force=True)
                 cleaned.append(worktree_name)
                 logger.bind(domain="check", worktree=worktree_name).info(
                     "Deleted expired agent worktree"
                 )
-                typer.echo(f"    [green][cleaned][/green]  {worktree_name}")
+                if not quiet:
+                    typer.echo(f"    [green][cleaned][/green]  {worktree_name}")
 
             except Exception as exc:
                 failed.append(f"{worktree_name}: {exc}")
                 logger.bind(domain="check", worktree=worktree_name).warning(
                     f"Failed to clean agent worktree: {exc}"
                 )
-                typer.echo(
-                    f"    [red][failed][/red]   {worktree_name}: {exc}", err=True
-                )
+                if not quiet:
+                    typer.echo(
+                        f"    [red][failed][/red]   {worktree_name}: {exc}",
+                        err=True,
+                    )
 
         return {"cleaned": cleaned, "skipped_live": skipped_live, "failed": failed}
 
-    def clean_expired_remote_branches(self, max_age_days: int = 7) -> dict[str, object]:
+    def clean_expired_remote_branches(
+        self, max_age_days: int = 7, *, quiet: bool = False
+    ) -> dict[str, object]:
         """Clean expired remote non-protected branches older than max_age_days.
 
         Safety checks:
@@ -158,6 +169,7 @@ class ExpiredResourceCleanupService:
 
         Args:
             max_age_days: Max age in days before cleanup (default: 7)
+            quiet: If True, suppress terminal output (for daemon/heartbeat use)
 
         Returns:
             Dict with 'cleaned', 'skipped_protected', 'skipped_pr', 'failed' lists
@@ -167,9 +179,10 @@ class ExpiredResourceCleanupService:
         logger.bind(domain="check", action="clean_remote_branches").info(
             f"Checking remote branches older than {max_age_days} days"
         )
-        typer.echo(
-            f"  [dim]Checking remote branches older than {max_age_days} days...[/]"
-        )
+        if not quiet:
+            typer.echo(
+                f"  [dim]Checking remote branches older than {max_age_days} days...[/]"
+            )
 
         # Load protected branches from config
         from vibe3.config.settings import VibeConfig
@@ -191,10 +204,11 @@ class ExpiredResourceCleanupService:
             )
         except Exception as exc:
             logger.bind(domain="check").error(f"Failed to get remote branches: {exc}")
-            typer.echo(
-                f"    [red][error][/red] Failed to get remote branches: {exc}",
-                err=True,
-            )
+            if not quiet:
+                typer.echo(
+                    f"    [red][error][/red] Failed to get remote branches: {exc}",
+                    err=True,
+                )
             return {
                 "cleaned": [],
                 "skipped_protected": [],
@@ -207,9 +221,11 @@ class ExpiredResourceCleanupService:
             pr_branches = set(self.pr_service.refresh_open_pr_cache())
         except Exception as exc:
             logger.bind(domain="check").error(f"Failed to get open PRs: {exc}")
-            typer.echo(
-                f"    [red][error][/red] Failed to get open PRs: {exc}", err=True
-            )
+            if not quiet:
+                typer.echo(
+                    f"    [red][error][/red] Failed to get open PRs: {exc}",
+                    err=True,
+                )
             return {
                 "cleaned": [],
                 "skipped_protected": [],
@@ -241,9 +257,11 @@ class ExpiredResourceCleanupService:
                     logger.bind(domain="check", branch=branch).info(
                         "Skipped remote branch with open PR"
                     )
-                    typer.echo(
-                        f"    [cyan][skipped][/cyan] {branch} [dim](has open PR)[/]"
-                    )
+                    if not quiet:
+                        typer.echo(
+                            f"    [cyan][skipped][/cyan] {branch} "
+                            "[dim](has open PR)[/]"
+                        )
                     continue
 
                 # Check age
@@ -251,20 +269,23 @@ class ExpiredResourceCleanupService:
                     continue
 
                 # Delete remote branch
-                typer.echo(f"    [yellow][cleaning][/yellow] {branch}...")
+                if not quiet:
+                    typer.echo(f"    [yellow][cleaning][/yellow] {branch}...")
                 self.git_client.delete_remote_branch(branch_name)
                 cleaned.append(branch)
                 logger.bind(domain="check", branch=branch).info(
                     "Deleted expired remote branch"
                 )
-                typer.echo(f"    [green][cleaned][/green]  {branch}")
+                if not quiet:
+                    typer.echo(f"    [green][cleaned][/green]  {branch}")
 
             except Exception as exc:
                 failed.append(f"{branch}: {exc}")
                 logger.bind(domain="check", branch=branch).warning(
                     f"Failed to clean remote branch: {exc}"
                 )
-                typer.echo(f"    [red][failed][/red]   {branch}: {exc}", err=True)
+                if not quiet:
+                    typer.echo(f"    [red][failed][/red]   {branch}: {exc}", err=True)
 
         return {
             "cleaned": cleaned,
@@ -273,7 +294,9 @@ class ExpiredResourceCleanupService:
             "failed": failed,
         }
 
-    def clean_expired_local_branches(self, max_age_days: int = 7) -> dict[str, object]:
+    def clean_expired_local_branches(
+        self, max_age_days: int = 7, *, quiet: bool = False
+    ) -> dict[str, object]:
         """Clean expired local non-protected branches older than max_age_days.
 
         Safety checks:
@@ -285,6 +308,7 @@ class ExpiredResourceCleanupService:
 
         Args:
             max_age_days: Max age in days before cleanup (default: 7)
+            quiet: If True, suppress terminal output (for daemon/heartbeat use)
 
         Returns:
             Dict with 'cleaned', 'skipped_protected', 'skipped_current',
@@ -295,9 +319,10 @@ class ExpiredResourceCleanupService:
         logger.bind(domain="check", action="clean_local_branches").info(
             f"Checking local branches older than {max_age_days} days"
         )
-        typer.echo(
-            f"  [dim]Checking local branches older than {max_age_days} days...[/]"
-        )
+        if not quiet:
+            typer.echo(
+                f"  [dim]Checking local branches older than {max_age_days} days...[/]"
+            )
 
         # Load protected branches from config
         from vibe3.config.settings import VibeConfig
@@ -319,10 +344,11 @@ class ExpiredResourceCleanupService:
             current_branch = self.git_client.get_current_branch()
         except Exception as exc:
             logger.bind(domain="check").error(f"Failed to get current branch: {exc}")
-            typer.echo(
-                f"    [red][error][/red] Failed to get current branch: {exc}",
-                err=True,
-            )
+            if not quiet:
+                typer.echo(
+                    f"    [red][error][/red] Failed to get current branch: {exc}",
+                    err=True,
+                )
             return {
                 "cleaned": [],
                 "skipped_protected": [],
@@ -339,10 +365,11 @@ class ExpiredResourceCleanupService:
             logger.bind(domain="check").error(
                 "Failed to get live sessions, skipping local branch cleanup"
             )
-            typer.echo(
-                "    [red][error][/red] Live session query failed, skipping",
-                err=True,
-            )
+            if not quiet:
+                typer.echo(
+                    "    [red][error][/red] Live session query failed, skipping",
+                    err=True,
+                )
             return {
                 "cleaned": [],
                 "skipped_protected": [],
@@ -359,10 +386,11 @@ class ExpiredResourceCleanupService:
             )
         except Exception as exc:
             logger.bind(domain="check").error(f"Failed to get local branches: {exc}")
-            typer.echo(
-                f"    [red][error][/red] Failed to get local branches: {exc}",
-                err=True,
-            )
+            if not quiet:
+                typer.echo(
+                    f"    [red][error][/red] Failed to get local branches: {exc}",
+                    err=True,
+                )
             return {
                 "cleaned": [],
                 "skipped_protected": [],
@@ -398,10 +426,11 @@ class ExpiredResourceCleanupService:
                     logger.bind(domain="check", branch=branch).info(
                         "Skipped local branch with live session"
                     )
-                    typer.echo(
-                        f"    [cyan][skipped][/cyan] {branch} "
-                        f"[dim](has live session)[/]"
-                    )
+                    if not quiet:
+                        typer.echo(
+                            f"    [cyan][skipped][/cyan] {branch} "
+                            f"[dim](has live session)[/]"
+                        )
                     continue
 
                 # Check age
@@ -419,34 +448,39 @@ class ExpiredResourceCleanupService:
                         branch
                     )
                     if worktree_path:
-                        typer.echo(
-                            f"    [yellow][cleaning][/yellow] worktree for {branch} "
-                            f"[dim]at {worktree_path}...[/]"
-                        )
+                        if not quiet:
+                            typer.echo(
+                                f"    [yellow][cleaning][/yellow] worktree for "
+                                f"{branch} [dim]at {worktree_path}...[/]"
+                            )
                         remove_worktree(worktree_path, force=True)
                         skipped_worktree.append(branch)
                         logger.bind(domain="check", branch=branch).info(
                             f"Deleted worktree at {worktree_path}"
                         )
-                        typer.echo(
-                            f"    [green][cleaned][/green]  worktree for {branch}"
-                        )
+                        if not quiet:
+                            typer.echo(
+                                f"    [green][cleaned][/green]  worktree for {branch}"
+                            )
 
                 # Delete local branch
-                typer.echo(f"    [yellow][cleaning][/yellow] {branch}...")
+                if not quiet:
+                    typer.echo(f"    [yellow][cleaning][/yellow] {branch}...")
                 self.git_client.delete_branch(branch, force=False)
                 cleaned.append(branch)
                 logger.bind(domain="check", branch=branch).info(
                     "Deleted expired local branch"
                 )
-                typer.echo(f"    [green][cleaned][/green]  {branch}")
+                if not quiet:
+                    typer.echo(f"    [green][cleaned][/green]  {branch}")
 
             except Exception as exc:
                 failed.append(f"{branch}: {exc}")
                 logger.bind(domain="check", branch=branch).warning(
                     f"Failed to clean local branch: {exc}"
                 )
-                typer.echo(f"    [red][failed][/red]   {branch}: {exc}", err=True)
+                if not quiet:
+                    typer.echo(f"    [red][failed][/red]   {branch}: {exc}", err=True)
 
         return {
             "cleaned": cleaned,

--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -377,8 +377,12 @@ async def test_tick_loop_skip_cleanup_when_disabled(monkeypatch) -> None:
 
     cleanup_calls: list[int] = []
 
+    tick_count = 0
+
     async def _sleep_once(_seconds: float) -> None:
-        if len(cleanup_calls) >= 2:
+        nonlocal tick_count
+        tick_count += 1
+        if tick_count >= 3:
             server.stop()
 
     async def _mock_cleanup(tick_number: int) -> None:

--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -271,3 +271,126 @@ def test_no_shutdown_callback_cleanup_still_runs() -> None:
     """_cleanup() without a registered callback should not raise."""
     server = HeartbeatServer(_config())
     server._cleanup()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
+    """Cleanup should trigger on tick number that is a multiple of interval_ticks."""
+    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+
+    config = OrchestraConfig(
+        polling_interval=1,
+        max_concurrent_flows=3,
+        expired_resource_cleanup=ExpiredResourceCleanupConfig(interval_ticks=2),
+    )
+    server = HeartbeatServer(config)
+    svc = _MockService()
+    server.register(svc)
+
+    events: list[str] = []
+    cleanup_calls: list[int] = []
+
+    def _capture(domain: str, message: str, **kwargs) -> None:
+        events.append(f"{domain}:{message}")
+
+    async def _sleep_once(_seconds: float) -> None:
+        if len(cleanup_calls) >= 3:  # Run at least 3 ticks
+            server.stop()
+
+    async def _mock_cleanup(tick_number: int) -> None:
+        cleanup_calls.append(tick_number)
+
+    monkeypatch.setattr("vibe3.runtime.heartbeat.append_orchestra_event", _capture)
+    monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
+    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup)
+    server._running = True
+
+    await server._tick_loop()
+
+    # Should trigger on tick #2 (2 % 2 == 0), not on #1 or #3
+    assert 2 in cleanup_calls, f"Expected cleanup on tick #2, got: {cleanup_calls}"
+    assert (
+        1 not in cleanup_calls
+    ), f"Should not cleanup on tick #1, got: {cleanup_calls}"
+    assert (
+        3 not in cleanup_calls
+    ), f"Should not cleanup on tick #3, got: {cleanup_calls}"
+
+
+@pytest.mark.asyncio
+async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -> None:
+    """Cleanup failure should not prevent service dispatch."""
+    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+
+    config = OrchestraConfig(
+        polling_interval=1,
+        max_concurrent_flows=3,
+        expired_resource_cleanup=ExpiredResourceCleanupConfig(interval_ticks=1),
+    )
+    server = HeartbeatServer(config)
+    svc = _MockService()
+    server.register(svc)
+
+    events: list[str] = []
+
+    def _capture(domain: str, message: str, **kwargs) -> None:
+        events.append(f"{domain}:{message}")
+
+    calls = {"count": 0}
+
+    async def _sleep_once(_seconds: float) -> None:
+        calls["count"] += 1
+        if calls["count"] >= 2:
+            server.stop()
+
+    async def _mock_cleanup_failure(tick_number: int) -> None:
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr("vibe3.runtime.heartbeat.append_orchestra_event", _capture)
+    monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
+    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup_failure)
+    server._running = True
+
+    await server._tick_loop()
+
+    # Service should still be ticked despite cleanup failure
+    assert svc.ticks == 1, f"Expected 1 tick, got: {svc.ticks}"
+    # Should have error event
+    assert any(
+        "cleanup failed" in item for item in events
+    ), f"Expected cleanup error, got: {events}"
+
+
+@pytest.mark.asyncio
+async def test_tick_loop_skip_cleanup_when_disabled(monkeypatch) -> None:
+    """Cleanup should not run when disabled in config."""
+    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+
+    config = OrchestraConfig(
+        polling_interval=1,
+        max_concurrent_flows=3,
+        expired_resource_cleanup=ExpiredResourceCleanupConfig(enabled=False),
+    )
+    server = HeartbeatServer(config)
+    svc = _MockService()
+    server.register(svc)
+
+    cleanup_calls: list[int] = []
+
+    async def _sleep_once(_seconds: float) -> None:
+        if len(cleanup_calls) >= 2:
+            server.stop()
+
+    async def _mock_cleanup(tick_number: int) -> None:
+        cleanup_calls.append(tick_number)
+
+    monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
+    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup)
+    server._running = True
+
+    await server._tick_loop()
+
+    # Should not call cleanup when disabled
+    assert (
+        len(cleanup_calls) == 0
+    ), f"Expected no cleanup calls when disabled, got: {cleanup_calls}"


### PR DESCRIPTION
Closes #1162

### Summary
- Integrate `ExpiredResourceCleanupService` into `HeartbeatServer` tick loop
- Cleanup runs every 10 ticks (configurable via `interval_ticks`)
- Exception isolation ensures cleanup failures don't affect heartbeat
- Configurable via `ExpiredResourceCleanupConfig` on `OrchestraConfig`
- Cleanup methods support `quiet` mode to suppress terminal output in daemon context
- Cleanup runs in main thread to avoid SQLite cross-thread concurrent access

### Test Plan
- ✅ `test_tick_loop_triggers_cleanup_on_interval_tick` — verifies cleanup trigger
- ✅ `test_tick_loop_cleanup_failure_does_not_affect_services` — verifies error isolation
- ✅ `test_tick_loop_skip_cleanup_when_disabled` — verifies config control
- ✅ All 14 heartbeat tests pass
- ✅ Type checks pass (mypy)
- ✅ Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus