### PR TITLE
test: add bats test for vibe init no-remote / SKIP_LABELS path

### DIFF
--- a/tests/vibe2/integration/test_init_no_remote.bats
+++ b/tests/vibe2/integration/test_init_no_remote.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# Tests for vibe init no-remote / SKIP_LABELS path (Issue #1152)
+
+setup() {
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  export VIBE_ROOT="$REPO_ROOT"
+  export VIBE_LIB="$REPO_ROOT/lib"
+}
+
+@test "vibe init warns and skips labels when no GitHub remote exists" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile github-flow --yes 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No GitHub remote found" ]]
+  [[ "$output" =~ "GitHub labels creation will be skipped" ]]
+  [[ "$output" =~ "git remote add origin" ]]
+  [[ ! "$output" =~ "Created label:" ]]
+}
+
+@test "gh is not invoked in no-remote path" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  # Create mock gh that logs when called
+  local mock_bin
+  mock_bin="$(mktemp -d)"
+  cat > "$mock_bin/gh" <<'SCRIPT'
+#!/bin/bash
+echo "gh was called with: $@" >> "$GHCALL_LOG"
+exit 0
+SCRIPT
+  chmod +x "$mock_bin/gh"
+
+  local ghcall_log
+  ghcall_log="$(mktemp)"
+
+  run zsh -c "
+    export PATH='$mock_bin:'\"\$PATH\"
+    export GHCALL_LOG='$ghcall_log'
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile github-flow --yes 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No GitHub remote found" ]]
+  # The log file should NOT exist (gh was never called)
+  [ ! -s "$ghcall_log" ]
+}
+
+@test "vibe init fails gracefully in non-git directory" {
+  local fixture
+  fixture="$(mktemp -d)"
+  # No git init here
+
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile github-flow --yes 2>&1
+  "
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Not in a git repository" ]]
+  [[ "$output" =~ "Please run this command in a git repository" ]]
+}


### PR DESCRIPTION
## Summary

Add test coverage for the no-GitHub-remote pre-check added in PR #1138 (lib/init.sh lines 143-148). The test verifies that when no GitHub remote exists, vibe init automatically sets SKIP_LABELS and emits appropriate warnings without invoking gh label create.

**Changes**:
- Created `tests/vibe2/integration/test_init_no_remote.bats` with 3 test cases (86 lines)

**Test cases**:
1. **vibe init warns and skips labels when no GitHub remote exists**
   - Verifies warning messages and remediation hints
   - Confirms label creation is skipped (no "Created label:" output)

2. **gh is not invoked in no-remote path**
   - Uses mock gh wrapper to prove gh is never called
   - Even with gh available on PATH, label creation block is skipped

3. **vibe init fails gracefully in non-git directory**
   - Covers earlier guard at lib/init.sh:108-112
   - Verifies error messages for non-git environment

## Test plan

- [x] All 3 new tests pass ✅
- [x] All init-related tests pass (10/10) ✅
- [x] Code follows existing test patterns
- [x] Proper mock strategy for gh command

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
