### PR TITLE
test(config): add empty-string boundary test for prompts_root

### DIFF
--- a/tests/vibe3/config/test_settings.py
+++ b/tests/vibe3/config/test_settings.py
@@ -119,3 +119,16 @@ class TestLoadSupplementaryPromptsRoot:
         result = VibeConfig._load_supplementary(data)
 
         assert "agent_prompt" not in result
+
+    def test_empty_prompts_root_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty string paths.prompts_root is treated as falsy and falls back."""
+        # Run from tmp_path so repo-local prompts paths do not exist
+        monkeypatch.chdir(tmp_path)
+        data: dict = {"paths": {"prompts_root": ""}}
+
+        result = VibeConfig._load_supplementary(data)
+
+        # Empty string should be treated as falsy and not attempt path resolution
+        assert "agent_prompt" not in result


### PR DESCRIPTION
## Summary
- Added `test_empty_prompts_root_falls_back` to `TestLoadSupplementaryPromptsRoot` class
- Verifies that `paths.prompts_root: ""` (empty string) is treated as falsy and falls through to repo-local fallback paths

## Context
Follow-up from #1129 code review. PR #1129 fixed the prompts_root config resolution with a three-step fallback chain. The current check `if prompts_root_str:` correctly treats empty string as falsy, but this boundary was not explicitly covered by tests.

## Test Plan
- [x] All 4 tests in `TestLoadSupplementaryPromptsRoot` pass
- [x] Type checking clean (mypy)
- [x] Linting clean (ruff)

## Related
Closes #1158

---

## Contributors

claude/opus
