### PR TITLE
docs: align documentation with V3 Python primary runtime semantics (#1199)

### DIFF
--- a/docs/standards/doc-quality-standards.md
+++ b/docs/standards/doc-quality-standards.md
@@ -54,7 +54,7 @@ related_docs:
 
 为避免 `vibe` 相关能力在文档中出现语义混淆，文档写作必须显式区分调用面：
 
-- `shell 命令`：`vibe <domain> <subcommand>`，例如 `vibe flow (shell)`
+- `shell 命令`：`vibe3 <subcommand>` (或 V2 `vibe <domain> <subcommand>`)，例如 `vibe3 flow (shell)`
 - `skill 命令`：`/<skill-name>`，例如 `/vibe-save (skill)`
 
 写作规则：

--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -384,7 +384,7 @@ related_docs:
 
 - 正式术语：`Shell 能力层`
 - 别称：`capability layer`
-- 定义：`vibe` shell 暴露的原子、可组合、可验证方法层，是 skill 与共享状态真源之间的唯一合法操作通道。
+- 定义：`vibe3` (Python) 和 `vibe` (V2 Shell) 暴露的原子、可组合、可验证方法层，是 skill 与共享状态真源之间的唯一合法操作通道。
 - 边界：
   - `Shell 能力层` 不是 workflow engine
   - `Shell 能力层` 不是调度器
@@ -393,12 +393,14 @@ related_docs:
   - 定义见 [python-capability-design.md](python-capability-design.md)
 - 使用规则：
   - 讨论命令设计、原子能力、shell 边界时使用 `Shell 能力层`
+  - **V3 Python (`vibe3`) 是当前主能力层**，负责 flow/handoff/orchestra 逻辑
+  - **V2 Shell (`vibe`) 是次要/兼容层**，负责环境初始化、密钥管理和 legacy 工具
 
 ### 5.6 `共享状态真源`
 
 - 正式术语：`共享状态真源`
 - 别称：无
-- 定义：项目共享状态的持久化数据真源集合，当前包括 `registry.json`、`roadmap.json`、`flow-history.json`，以及处于兼容清退期的 `worktrees.json`。
+- 定义：项目共享状态的持久化数据真源集合，当前主要由 `vibe3` 管理，包括 SQLite 数据库（`handoff.db`）以及处于兼容期的 `registry.json`、`roadmap.json` 等。
 - 边界：
   - `共享状态真源` 不是 shell
   - `共享状态真源` 不是 skill
@@ -413,13 +415,16 @@ related_docs:
 ### 5.7 `shell 命令`
 
 - 正式术语：`shell 命令`
-- 别称：`vibe shell`
-- 定义：通过 CLI 直接执行的 `vibe <domain> <subcommand>` 命令能力，例如 `vibe flow`、`vibe task`、`vibe roadmap`。
+- 别称：`vibe3 shell`, `vibe shell`
+- 定义：通过 CLI 直接执行的命令能力。
+  - **主命令 (V3)**：`uv run python src/vibe3/cli.py <subcommand>` (通常别名为 `vibe3`)
+  - **辅助命令 (V2)**：`vibe <domain> <subcommand>` (原 V2 shell 命令)
 - 边界：
   - `shell 命令` 不是 skill
   - `shell 命令` 不是 workflow 文案本身
 - 使用规则：
-  - 文档和沟通中首次提及时，建议显式写成 `vibe flow (shell)` 这类格式
+  - 文档和沟通中首次提及时，建议显式写成 `vibe3 flow (shell)` 这类格式
+  - 优先调用 V3 命令，仅在环境管理等特定场景使用 V2 命令
 
 ### 5.8 `skill 命令`
 

--- a/docs/standards/vibe3-execution-paths-standard.md
+++ b/docs/standards/vibe3-execution-paths-standard.md
@@ -166,7 +166,7 @@ store.add_event("tmux_*_started")  # checkpoint only
 ### 3.3 业务逻辑都在 execute_sync
 
 ```python
-# execute_sync
+# execute_sync (vibe3)
 record_handoff_unified(...)  # handoff
 persist_execution_lifecycle_event(...)  # lifecycle
 _apply_unified_noop_gate(...)  # gate
@@ -176,7 +176,7 @@ _apply_unified_noop_gate(...)  # gate
 - orchestration 层没有 gate/state 推进逻辑
 - `VIBE3_ASYNC_CHILD` 只服务 outer coordinator 的防重/容量判断
 - tmux wrapper 只保留容器 checkpoint，不承载业务 lifecycle
-- 真正的业务收口仍在 sync shell 内完成
+- 真正的业务收口仍在 `vibe3` 同步链内完成
 
 这说明当前主链已经大幅收敛，但不等于 Issue 476 已自动关闭；476 仍然负责验证是否要进一步收紧 async wrapper 与 sync shell 的边界表达。
 
@@ -186,7 +186,7 @@ _apply_unified_noop_gate(...)  # gate
 
 **用途**：
 - `coordinator.py` 通过此标记跳过 capacity/session check（避免 child 与 parent 冲突）
-- **不改变同步链行为**：child 内的 execute_sync 仍然执行完整的 gate/callback
+- **不改变同步链行为**：child 内的 `vibe3` execute_sync 仍然执行完整的 gate/callback
 
 **注意**：当前实现里，async child 与 orchestration sync 共享完全相同的 execute_sync 行为，包括 gate/callback。
 

--- a/docs/v3/architecture/dependency-handling.md
+++ b/docs/v3/architecture/dependency-handling.md
@@ -1,4 +1,4 @@
-# Dependency Handling Mechanism (V2)
+# Dependency Handling Mechanism (V3)
 
 ## Overview
 
@@ -46,7 +46,7 @@ Vibe Center 3.0 支持声明式依赖管理。当一个 flow 依赖其他 issue 
 
 ### 1. Qualify Gate (资格门)
 
-**Location**: `src/vibe3/orchestra/services/state_label_dispatch.py`
+**Location**: `src/vibe3/domain/qualify_gate.py`
 
 Orchestra 在发射派发意图前执行三步校验：
 - **Step 1 (Manual)**: 检查本地 `blocked_reason`。如果有值，则保持阻塞。

--- a/docs/v3/handoff/v3-rewrite-plan.md
+++ b/docs/v3/handoff/v3-rewrite-plan.md
@@ -1,6 +1,6 @@
-# Vibe 3.0 Execution Plan (Isolated Phase Logic)
+# Vibe 3.0 Execution Plan (Historical Archive)
 
-> **⚠️ Agent Instruction**: Focus ONLY on the current Phase. Do not attempt to optimize or understand the global roadmap. Your success is measured strictly by the Command-Line Acceptance Criteria below.
+> **⚠️ Status**: This document is preserved for historical reference only. The V3 Python primary runtime implementation is complete.
 
 > **数据真源**: [docs/standards/v3/handoff-store-standard.md](../../standards/v3/handoff-store-standard.md)
 > **GitHub 调用**: [docs/standards/v3/github-remote-call-standard.md](../../standards/v3/github-remote-call-standard.md)
@@ -9,8 +9,6 @@
 
 ## Technical Authority (Minimum Context)
 
-- ~~[Architecture Design](../implementation/02-architecture.md)~~ (已不存在)
-- ~~[Coding Standards](../implementation/03-coding-standards.md)~~ (已不存在)
 - [Data Standards](../../standards/v3/handoff-store-standard.md) (Authority on Database Schema)
 - [GitHub Standards](../../standards/v3/github-remote-call-standard.md) (Authority on Remote Calls)
 


### PR DESCRIPTION
Align 5 documents with V3 Python primary runtime reality as requested in #1199.