### PR TITLE
fix(task): improve error hint for positional PR number input

### DIFF
--- a/src/vibe3/utils/issue_branch_resolver.py
+++ b/src/vibe3/utils/issue_branch_resolver.py
@@ -71,7 +71,8 @@ def resolve_issue_branch_input(branch: str | None, flow_service: Any) -> str | N
     # Step 5: No flows at all
     raise UserError(
         f"No flow found for issue #{issue_number}. "
-        f"Use '/vibe-new issue {issue_number}' to create a flow."
+        f"Use '/vibe-new issue {issue_number}' to create a flow.\n"
+        f"提示：如果是 PR 号，请使用 --pr {issue_number}"
     )
 
 


### PR DESCRIPTION
## Summary

- 当用户将 PR 号作为位置参数传入 `vibe3 task show` 时，错误消息现在会提示使用 `--pr` 选项

## 修改内容

仅修改 `src/vibe3/utils/issue_branch_resolver.py` 的 Step 5 错误消息，添加一行提示：

```
No flow found for issue #1187. Use '/vibe-new issue 1187' to create a flow.
提示：如果是 PR 号，请使用 --pr 1187
```

## Test plan

- [x] `vibe3 task show 1187` 报错时显示 --pr 提示
- [x] `vibe3 task show --pr 1187` 正常工作
- [x] `vibe3 task show 1200` 通过 issue 号正常工作
- [x] `uv run mypy` 类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)