### PR TITLE
fix(manager.md): blocked 指引补充 --task 依赖关系登记 (#1097)

### DIFF
--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -133,6 +133,16 @@ This command performs three actions atomically:
 
 Note: If you also need to leave a handoff note for downstream agents, use `vibe3 handoff append` separately. But this does NOT replace the `flow blocked --reason` command.
 
+When blocking due to an **unresolved dependency**, use:
+
+```bash
+vibe3 flow blocked --task <dependency_issue_number>
+```
+
+This performs the same three actions as `--reason`, plus:
+4. Adds the dependency issue to `flow_issue_links` with role=`dependency`
+5. Enables Orchestra auto-patrol to detect when the dependency is resolved and auto-resume the flow
+
 ## Architecture Contract
 - **最小系统原则**：行为判断与推进决策由 agent 自己负责；Orchestra / flow / handoff 只负责观测、记录、展示和最小兜底。系统可以验证是否产生了预期 refs/artifacts，并在没有任何可观察进展时执行 no-op 防守（如进入 `blocked`），但系统不是业务结论的 owner，不替你决定应该 `retry`、`merge-ready` 还是 `blocked`
 - **循环保护原则**：关闭、退回、blocked 都是合法结论。**唯一不可接受的是无 PR 产出的工作循环**。如果同一 issue 已经历 3 轮以上 plan/run/review 仍未进入 merge-ready，你有责任做出终局判断：要么降级为 blocked 等人类介入，要么关闭 issue 说明无法完成。不得继续无意义地重试。
@@ -398,7 +408,9 @@ Steps:
    - 对每个被依赖的 issue，检查其状态是否已关闭或处于 `state/done`
    - 如果存在未解除的依赖：
      - comment 当前 issue，列出未解除的依赖项
-     - 将 issue 调整为 `state/blocked`
+     - 调用 `vibe3 flow blocked --task <被依赖的 issue 号>` 建立 flow 依赖关系
+       - 这会自动：写入 `blocked_reason`、转换 label、在 `flow_issue_links` 表中记录 `dependency` 角色
+     - 多个依赖时，对每个依赖分别调用一次
      - `exit()`
 
 5. 如果 scene 不健康：


### PR DESCRIPTION
Closes #1097

## Summary
补充 `supervisor/manager.md` 中 `vibe3 flow blocked --task` 的使用指引，完善依赖 issue 登记机制。

## Changes
1. **Section 4.5 (dependency check)**: 添加 `vibe3 flow blocked --task` 命令示例
2. **Setting Blocked State**: 新增 --task variant 文档，说明自动登记依赖关系

## Verification
- Command accuracy verified via --help
- Implementation consistency verified in flow_block_mixin.py
- Cross-layer consistency checked via grep
- Markdown formatting matches existing style

## Related
- Issue: #1097
- Review audit: docs/reports/issue-1097-review-audit.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
