### PR TITLE
[codex] align review verdict semantics

### DIFF
--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -626,18 +626,20 @@ review:
   # Unlike plan/run output shape guidance, this is a hard behavioral contract.
   output_format: |
     The first line must be exactly:
-    VERDICT: PASS | MAJOR | BLOCK
+    VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE
 
     Each finding should follow this format:
     path/to/file.py:42 [MAJOR] concise issue description
 
     The final line must repeat the same `VERDICT:`:
-    VERDICT: PASS | MAJOR | BLOCK
+    VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE
 
     Where:
     - PASS: No significant issues found
+    - MINOR: Review passes; please consider a follow-up issue for improvements
     - MAJOR: Issues found that should be addressed before merge
     - BLOCK: Critical issues that must be fixed before merge
+    - REFUSE: Reviewer cannot responsibly provide a normal review verdict
 
   # Static: reviewer exit contract plus default review guidance.
   # Target recipe section name: review.exit_contract
@@ -652,11 +654,12 @@ review:
     Prioritize actionable findings with clear severity.
     Follow the repository review contract.
     You must directly output the review result in stdout.
-    The first line must be exactly `VERDICT: PASS | MAJOR | BLOCK`.
+    The first line must be exactly `VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE`.
     The final line must repeat the same `VERDICT:` line.
     Keep `VERDICT` and `audit_ref` separate: verdict is the conclusion, audit_ref is the detailed report.
+    `PASS` and `REFUSE` may omit `audit_ref`; `MINOR`, `MAJOR`, and `BLOCK` require `audit_ref`.
     You must explicitly record your final conclusion with
-    `uv run python src/vibe3/cli.py handoff verdict <PASS|MAJOR|BLOCK>`.
+    `uv run python src/vibe3/cli.py handoff verdict <PASS|MINOR|MAJOR|BLOCK|REFUSE>`.
     You should write a canonical audit report under `docs/reports/` in the current worktree
     and register it with `uv run python src/vibe3/cli.py handoff audit <path-to-audit-md>`.
     Use a repository-relative path such as `docs/reports/issue-123-audit-report.md`.

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -171,8 +171,8 @@ code_limits:
         limit: 480
         reason: "执行协调器聚合，包含容量控制、执行生命周期、worktree 解析错误捕获、dispatch_execution 核心流程等紧密耦合逻辑"
       - path: "src/vibe3/execution/noop_gate.py"
-        limit: 480
-        reason: "No-op gate 聚合，包含单步转换限制检查（transition_history pair count）、全局转换计数检查、state 验证、ref 检查、GitHub API 错误处理等多层防御机制，职责单一但紧密耦合"
+        limit: 540
+        reason: "No-op gate 聚合，包含 verdict-aware ref 检查（PASS 可省略 audit_ref，MINOR/MAJOR/BLOCK 仍需）、单步转换限制检查、全局转换计数检查、state 验证、GitHub API 错误处理等多层防御机制，职责单一但紧密耦合"
       - path: "src/vibe3/execution/codeagent_runner.py"
         limit: 480
         reason: "Sync execution runner 聚合，包含 supervisor label cleanup、context preparation、finalize 等紧密耦合的执行生命周期逻辑"

--- a/config/v3/settings.yaml
+++ b/config/v3/settings.yaml
@@ -121,7 +121,10 @@ pr_scoring:
 
     # Always block if codex returns these verdicts
     block_on_verdict:
+      - "MAJOR"
       - "BLOCK"
+      - "REFUSE"
+      - "UNKNOWN"
 
 # Review 配置
 # Review Configuration

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -139,20 +139,20 @@ def build_review_task_section(task_text: str | None) -> str:
     # Default: findings-first task guidance
     return """## Review Task
 
-    **Prioritize**: correctness → regression risk → API breaks → missing tests
+**Prioritize**: correctness → regression risk → API breaks → missing tests
 
-    **Focus on**:
-    - Run `git diff <base>...HEAD` to see file changes
-    - Review only changed code, not the entire codebase
-    - Use AST analysis to understand function-level impact
-    - Give findings first, then verdict with brief rationale
-    - Verdict meaning: PASS/REFUSE may omit `audit_ref`; MINOR means merge is
-      acceptable with follow-up; MAJOR/BLOCK require fixes and `audit_ref`
+**Focus on**:
+- Run `git diff <base>...HEAD` to see file changes
+- Review only changed code, not the entire codebase
+- Use AST analysis to understand function-level impact
+- Give findings first, then verdict with brief rationale
+- Verdict meaning: PASS/REFUSE may omit `audit_ref`; MINOR means merge is
+  acceptable with follow-up; MAJOR/BLOCK require fixes and `audit_ref`
 
-    **Skip**:
-    - Generic architecture commentary unrelated to this diff
-    - Praise/description paragraphs
-    - Style suggestions unless they affect correctness"""
+**Skip**:
+- Generic architecture commentary unrelated to this diff
+- Praise/description paragraphs
+- Style suggestions unless they affect correctness"""
 
 
 def build_output_contract_section(output_format: str | None) -> str:
@@ -173,25 +173,25 @@ def build_output_contract_section(output_format: str | None) -> str:
     # Default: findings-first output format
     return """## Output format requirements
 
-    **FINDINGS FIRST — No praise, no generic commentary.**
+**FINDINGS FIRST — No praise, no generic commentary.**
 
-    The first line must be exactly:
-    VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE
+The first line must be exactly:
+VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE
 
-    If findings exist, list them concisely:
-    path/to/file.py:42 [BLOCK] <specific issue with code evidence>
-    path/to/file.py:100 [MAJOR] <specific issue with code evidence>
+If findings exist, list them concisely:
+path/to/file.py:42 [BLOCK] <specific issue with code evidence>
+path/to/file.py:100 [MAJOR] <specific issue with code evidence>
 
-    Then provide a brief rationale (1-2 sentences):
-    - PASS: "Why no blocking/major issue was found for this diff"
-    - MINOR: "Summary of the accepted follow-up issue"
-    - MAJOR: "Summary of what should be addressed before merge"
-    - BLOCK: "Summary of critical issues that must be fixed"
-    - REFUSE: "Why a normal review verdict cannot be provided"
+Then provide a brief rationale (1-2 sentences):
+- PASS: "Why no blocking/major issue was found for this diff"
+- MINOR: "Summary of the accepted follow-up issue"
+- MAJOR: "Summary of what should be addressed before merge"
+- BLOCK: "Summary of critical issues that must be fixed"
+- REFUSE: "Why a normal review verdict cannot be provided"
 
-    The final line must repeat the same VERDICT.
+The final line must repeat the same VERDICT.
 
-    **DO NOT**:
+**DO NOT**:
 - Write lengthy summary before findings
 - Include "Strength" / "Positive" / "Praise" paragraphs
 - Give generic architecture commentary unrelated to the diff"""

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -139,18 +139,20 @@ def build_review_task_section(task_text: str | None) -> str:
     # Default: findings-first task guidance
     return """## Review Task
 
-**Prioritize**: correctness → regression risk → API breaks → missing tests
+    **Prioritize**: correctness → regression risk → API breaks → missing tests
 
-**Focus on**:
-- Run `git diff <base>...HEAD` to see file changes
-- Review only changed code, not the entire codebase
-- Use AST analysis to understand function-level impact
-- Give findings first, then verdict with brief rationale
+    **Focus on**:
+    - Run `git diff <base>...HEAD` to see file changes
+    - Review only changed code, not the entire codebase
+    - Use AST analysis to understand function-level impact
+    - Give findings first, then verdict with brief rationale
+    - Verdict meaning: PASS/REFUSE may omit `audit_ref`; MINOR means merge is
+      acceptable with follow-up; MAJOR/BLOCK require fixes and `audit_ref`
 
-**Skip**:
-- Generic architecture commentary unrelated to this diff
-- Praise/description paragraphs
-- Style suggestions unless they affect correctness"""
+    **Skip**:
+    - Generic architecture commentary unrelated to this diff
+    - Praise/description paragraphs
+    - Style suggestions unless they affect correctness"""
 
 
 def build_output_contract_section(output_format: str | None) -> str:
@@ -171,23 +173,25 @@ def build_output_contract_section(output_format: str | None) -> str:
     # Default: findings-first output format
     return """## Output format requirements
 
-**FINDINGS FIRST — No praise, no generic commentary.**
+    **FINDINGS FIRST — No praise, no generic commentary.**
 
-The first line must be exactly:
-VERDICT: PASS | MAJOR | BLOCK
+    The first line must be exactly:
+    VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE
 
-If findings exist, list them concisely:
-path/to/file.py:42 [BLOCK] <specific issue with code evidence>
-path/to/file.py:100 [MAJOR] <specific issue with code evidence>
+    If findings exist, list them concisely:
+    path/to/file.py:42 [BLOCK] <specific issue with code evidence>
+    path/to/file.py:100 [MAJOR] <specific issue with code evidence>
 
-Then provide a brief rationale (1-2 sentences):
-- PASS: "Why no blocking/major issue was found for this diff"
-- MAJOR: "Summary of what should be addressed before merge"
-- BLOCK: "Summary of critical issues that must be fixed"
+    Then provide a brief rationale (1-2 sentences):
+    - PASS: "Why no blocking/major issue was found for this diff"
+    - MINOR: "Summary of the accepted follow-up issue"
+    - MAJOR: "Summary of what should be addressed before merge"
+    - BLOCK: "Summary of critical issues that must be fixed"
+    - REFUSE: "Why a normal review verdict cannot be provided"
 
-The final line must repeat the same VERDICT.
+    The final line must repeat the same VERDICT.
 
-**DO NOT**:
+    **DO NOT**:
 - Write lengthy summary before findings
 - Include "Strength" / "Positive" / "Praise" paragraphs
 - Give generic architecture commentary unrelated to the diff"""

--- a/src/vibe3/commands/handoff_write.py
+++ b/src/vibe3/commands/handoff_write.py
@@ -322,8 +322,10 @@ def verdict(
 
     Verdict values:
     - PASS: No issues, ready to merge
+    - MINOR: Minor issues, merge acceptable with follow-up
     - MAJOR: Issues found, needs fix before merge
     - BLOCK: Critical issues, blocks merge
+    - REFUSE: Cannot perform normal review (ethical/legal concerns)
     - UNKNOWN: Cannot determine
 
     Examples:

--- a/src/vibe3/commands/handoff_write.py
+++ b/src/vibe3/commands/handoff_write.py
@@ -1,12 +1,13 @@
 """Handoff write commands - Modify handoff state and record events."""
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 import typer
 from loguru import logger
 
 from vibe3.commands.common import trace_scope
 from vibe3.services.handoff_service import HandoffService
+from vibe3.services.verdict_policy import VerdictValue
 from vibe3.services.verdict_service import VerdictService
 from vibe3.ui.console import console
 from vibe3.utils.branch_arg import resolve_branch_arg
@@ -296,8 +297,10 @@ def next_step(
 
 def verdict(
     verdict_value: Annotated[
-        Literal["PASS", "MAJOR", "BLOCK", "UNKNOWN"],
-        typer.Argument(help="Verdict value (PASS, MAJOR, BLOCK, UNKNOWN)"),
+        VerdictValue,
+        typer.Argument(
+            help="Verdict value (PASS, MINOR, MAJOR, BLOCK, REFUSE, UNKNOWN)"
+        ),
     ],
     reason: Annotated[
         str | None, typer.Option("--reason", "-r", help="Verdict reason")

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -211,5 +211,5 @@ def base(
             branch=current_branch,
         )
     _emit_review_result(result.verdict, result.handoff_file)
-    if result.verdict in {"BLOCK", "ERROR"}:
+    if result.verdict in {"MAJOR", "BLOCK", "REFUSE", "ERROR"}:
         raise typer.Exit(1)

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -211,5 +211,5 @@ def base(
             branch=current_branch,
         )
     _emit_review_result(result.verdict, result.handoff_file)
-    if result.verdict in {"MAJOR", "BLOCK", "REFUSE", "ERROR"}:
+    if result.verdict in {"MAJOR", "BLOCK", "REFUSE", "UNKNOWN", "ERROR"}:
         raise typer.Exit(1)

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -89,8 +89,10 @@ def _render_task_item_details(
         v = flow.latest_verdict
         color = {
             "PASS": "green",
+            "MINOR": "cyan",
             "MAJOR": "yellow",
             "BLOCK": "red",
+            "REFUSE": "magenta",
         }.get(v.verdict, "cyan")
         console.print(
             f"             [dim]verdict:[/] "

--- a/src/vibe3/config/role_policy.py
+++ b/src/vibe3/config/role_policy.py
@@ -32,7 +32,7 @@ def get_role_section(
 ROLE_TO_REQUIRED_REF_KEY: dict[str, str | None] = {
     "planner": "plan_ref",
     "executor": "report_ref",
-    "reviewer": "audit_ref",
+    "reviewer": None,
     "manager": None,  # manager 不受 ref 检查约束
 }
 

--- a/src/vibe3/config/settings_pr.py
+++ b/src/vibe3/config/settings_pr.py
@@ -53,7 +53,9 @@ class MergeGateConfig(BaseModel):
     """Merge gate configuration."""
 
     block_on_score_at_or_above: int = Field(default=9)
-    block_on_verdict: list[str] = Field(default_factory=lambda: ["BLOCK"])
+    block_on_verdict: list[str] = Field(
+        default_factory=lambda: ["MAJOR", "BLOCK", "REFUSE", "UNKNOWN"]
+    )
 
 
 class SizeThreshold(BaseModel):

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -1,10 +1,15 @@
 """Unified no-op gate: blocks when agent fails to change issue state."""
 
+import json
+from typing import cast
+
 from loguru import logger
 
 from vibe3.agents.models import ExecutionRole
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.role_policy import get_role_block_function
+from vibe3.models.verdict import VerdictRecord
+from vibe3.services.verdict_policy import VerdictValue, requires_audit_ref
 
 # Loop prevention constants
 SINGLE_STEP_LIMIT = 3  # Max occurrences of same transition pair
@@ -23,6 +28,28 @@ def extract_state_label(issue_payload: dict[str, object]) -> str | None:
         name = label.get("name")
         if isinstance(name, str) and name.startswith("state/"):
             return name
+    return None
+
+
+def _extract_latest_verdict(flow_state: dict | None) -> VerdictValue | None:
+    if not flow_state:
+        return None
+
+    raw_verdict = flow_state.get("latest_verdict")
+    if raw_verdict is None:
+        return None
+    if isinstance(raw_verdict, VerdictRecord):
+        return cast(VerdictValue, raw_verdict.verdict)
+    if isinstance(raw_verdict, dict):
+        try:
+            return cast(VerdictValue, VerdictRecord(**raw_verdict).verdict)
+        except Exception:
+            return None
+    if isinstance(raw_verdict, str):
+        try:
+            return cast(VerdictValue, VerdictRecord(**json.loads(raw_verdict)).verdict)
+        except Exception:
+            return None
     return None
 
 
@@ -273,10 +300,76 @@ def apply_unified_noop_gate(
             )
             return
 
-    # --- NEW: required_ref check ---
-    # Only check ref for worker roles (planner/executor/reviewer).
-    # Manager skips this check (required_ref_key is None).
-    if required_ref_key is not None and flow_state is not None:
+    # --- NEW: reviewer verdict-aware checks ---
+    if role == "reviewer":
+        latest_verdict = _extract_latest_verdict(flow_state)
+        if latest_verdict is None:
+            logger.bind(
+                domain="codeagent",
+                role=role,
+                issue_number=issue_number,
+                branch=branch,
+            ).warning("No-op gate BLOCK: latest verdict missing after reviewer")
+            store.add_event(
+                branch,
+                EVENT_REQUIRED_REF_MISSING,
+                actor,
+                detail=(
+                    f"Latest verdict missing after {role}: "
+                    f"state was {before_state_label}"
+                ),
+                refs={
+                    "before_state": str(before_state_label or ""),
+                    "issue": str(issue_number),
+                    "required_ref": "latest_verdict",
+                },
+            )
+            _block_fn(
+                issue_number=issue_number,
+                repo=repo,
+                reason="latest verdict missing after reviewer",
+                actor=actor,
+            )
+            return
+
+        if requires_audit_ref(latest_verdict):
+            ref_value = flow_state.get("audit_ref") if flow_state else None
+            if not ref_value:
+                logger.bind(
+                    domain="codeagent",
+                    role=role,
+                    issue_number=issue_number,
+                    branch=branch,
+                ).warning(
+                    f"No-op gate BLOCK: required ref audit_ref missing after {role} "
+                    f"for verdict {latest_verdict}"
+                )
+                store.add_event(
+                    branch,
+                    EVENT_REQUIRED_REF_MISSING,
+                    actor,
+                    detail=(
+                        f"Required ref audit_ref missing after {role} "
+                        f"for verdict {latest_verdict}: state was {before_state_label}"
+                    ),
+                    refs={
+                        "before_state": str(before_state_label or ""),
+                        "issue": str(issue_number),
+                        "required_ref": "audit_ref",
+                        "verdict": latest_verdict,
+                    },
+                )
+                _block_fn(
+                    issue_number=issue_number,
+                    repo=repo,
+                    reason=(
+                        f"required ref missing for verdict {latest_verdict}: "
+                        "audit_ref"
+                    ),
+                    actor=actor,
+                )
+                return
+    elif required_ref_key is not None and flow_state is not None:
         ref_value = flow_state.get(required_ref_key)
         if not ref_value:
             logger.bind(

--- a/src/vibe3/models/verdict.py
+++ b/src/vibe3/models/verdict.py
@@ -1,9 +1,10 @@
 """Verdict data model for handoff chain."""
 
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel
+
+from vibe3.services.verdict_policy import VerdictValue
 
 
 class VerdictRecord(BaseModel):
@@ -18,7 +19,7 @@ class VerdictRecord(BaseModel):
     - The agent layer (prompts) makes decisions based on the verdict data
     """
 
-    verdict: Literal["PASS", "MAJOR", "BLOCK", "UNKNOWN"]
+    verdict: VerdictValue
     actor: str  # e.g., "claude/claude-sonnet-4-6"
     role: str  # e.g., "reviewer" | "manager"
     timestamp: datetime

--- a/src/vibe3/services/flow_resume_resolver.py
+++ b/src/vibe3/services/flow_resume_resolver.py
@@ -6,7 +6,7 @@ on its local reference states (pr_ref, audit_ref, plan_ref, report_ref).
 
 from vibe3.models.flow import FlowState
 from vibe3.models.orchestration import IssueState
-from vibe3.services.verdict_policy import VerdictValue, blocks_merge, passes_review
+from vibe3.services.verdict_policy import VerdictValue, passes_review
 
 
 def infer_resume_label(flow_state: FlowState) -> IssueState:
@@ -37,11 +37,24 @@ def infer_resume_label(flow_state: FlowState) -> IssueState:
         verdict: VerdictValue = flow_state.latest_verdict.verdict
         # Verdict is the primary signal for review completion.
         if passes_review(verdict):
-            return IssueState.MERGE_READY
-        if blocks_merge(verdict):
+            # PASS -> merge-ready immediately
+            if verdict == "PASS":
+                return IssueState.MERGE_READY
+            # MINOR requires audit_ref
+            if verdict == "MINOR":
+                if flow_state.audit_ref:
+                    return IssueState.MERGE_READY
+                # Missing audit_ref -> back to review
+                return IssueState.REVIEW
+        else:
+            # blocks_merge(verdict) is True for these
             if verdict in {"MAJOR", "BLOCK"}:
-                return IssueState.IN_PROGRESS  # Needs revision before merge
-            return IssueState.HANDOFF  # REFUSE / UNKNOWN -> manager takes over
+                if flow_state.audit_ref:
+                    return IssueState.IN_PROGRESS
+                # Missing audit_ref -> back to review
+                return IssueState.REVIEW
+            # REFUSE / UNKNOWN -> manager takes over
+            return IssueState.HANDOFF
 
     if flow_state.plan_ref and flow_state.report_ref:
         # Code has been written (report exists) but no review yet

--- a/src/vibe3/services/flow_resume_resolver.py
+++ b/src/vibe3/services/flow_resume_resolver.py
@@ -6,6 +6,7 @@ on its local reference states (pr_ref, audit_ref, plan_ref, report_ref).
 
 from vibe3.models.flow import FlowState
 from vibe3.models.orchestration import IssueState
+from vibe3.services.verdict_policy import VerdictValue, blocks_merge, passes_review
 
 
 def infer_resume_label(flow_state: FlowState) -> IssueState:
@@ -17,7 +18,7 @@ def infer_resume_label(flow_state: FlowState) -> IssueState:
 
     Priority Rules (High to Low):
     1. pr_ref exists -> HANDOFF (Code is ready for delivery)
-    2. audit_ref exists -> IN_PROGRESS or HANDOFF (Based on verdict)
+    2. latest_verdict exists -> MERGE_READY / IN_PROGRESS / HANDOFF (Based on verdict)
     3. report_ref exists -> REVIEW (Code is written, needs review)
     4. plan_ref exists -> IN_PROGRESS (Plan exists, needs execution)
     5. default -> CLAIMED (Start fresh)
@@ -32,13 +33,15 @@ def infer_resume_label(flow_state: FlowState) -> IssueState:
         # PR already exists -> Manager should take over
         return IssueState.HANDOFF
 
-    if flow_state.audit_ref and flow_state.latest_verdict:
-        verdict = flow_state.latest_verdict.verdict.lower()
-        # Review has been completed
-        if verdict in {"pass", "major"}:
-            return IssueState.IN_PROGRESS  # Need to modify code based on review
-        if verdict == "unknown":
-            return IssueState.HANDOFF  # Cannot decide -> Manager takes over
+    if flow_state.latest_verdict:
+        verdict: VerdictValue = flow_state.latest_verdict.verdict
+        # Verdict is the primary signal for review completion.
+        if passes_review(verdict):
+            return IssueState.MERGE_READY
+        if blocks_merge(verdict):
+            if verdict in {"MAJOR", "BLOCK"}:
+                return IssueState.IN_PROGRESS  # Needs revision before merge
+            return IssueState.HANDOFF  # REFUSE / UNKNOWN -> manager takes over
 
     if flow_state.plan_ref and flow_state.report_ref:
         # Code has been written (report exists) but no review yet

--- a/src/vibe3/services/pr_scoring_service.py
+++ b/src/vibe3/services/pr_scoring_service.py
@@ -71,6 +71,10 @@ def _build_reason(score: RiskScore, dimensions: PRDimensions) -> str:
         reasons.append("online review critical")
     elif dimensions.codex_verdict == "MAJOR":
         reasons.append("online review major")
+    elif dimensions.codex_verdict == "MINOR":
+        reasons.append("online review minor")
+    elif dimensions.codex_verdict == "REFUSE":
+        reasons.append("online review refused")
 
     if not reasons:
         reasons.append("变更范围较小")
@@ -93,6 +97,10 @@ def _build_recommendations(score: RiskScore, dimensions: PRDimensions) -> list[s
         recommendations.append("补充跨模块联动验证或说明影响范围")
     if dimensions.codex_verdict in {"MAJOR", "CRITICAL", "BLOCK"}:
         recommendations.append("先处理审查结论，再继续推进合并")
+    if dimensions.codex_verdict == "MINOR":
+        recommendations.append("可以合并，但建议补 follow-up issue")
+    if dimensions.codex_verdict == "REFUSE":
+        recommendations.append("先澄清审查拒绝原因，再继续推进")
 
     if not recommendations and score.level in {RiskLevel.LOW, RiskLevel.MEDIUM}:
         recommendations.append("保持当前粒度，继续按常规测试和审查推进")

--- a/src/vibe3/services/verdict_policy.py
+++ b/src/vibe3/services/verdict_policy.py
@@ -1,0 +1,34 @@
+"""Central verdict policy for review and merge behavior."""
+
+from typing import Final, Literal
+
+VerdictValue = Literal["PASS", "MINOR", "MAJOR", "BLOCK", "REFUSE", "UNKNOWN"]
+
+ALL_VERDICTS: Final[tuple[VerdictValue, ...]] = (
+    "PASS",
+    "MINOR",
+    "MAJOR",
+    "BLOCK",
+    "REFUSE",
+    "UNKNOWN",
+)
+
+PASSING_VERDICTS: Final[frozenset[VerdictValue]] = frozenset({"PASS", "MINOR"})
+AUDIT_REQUIRED_VERDICTS: Final[frozenset[VerdictValue]] = frozenset(
+    {"MINOR", "MAJOR", "BLOCK"}
+)
+MERGE_BLOCKING_VERDICTS: Final[frozenset[VerdictValue]] = frozenset(
+    {"MAJOR", "BLOCK", "REFUSE", "UNKNOWN"}
+)
+
+
+def passes_review(verdict: VerdictValue) -> bool:
+    return verdict in PASSING_VERDICTS
+
+
+def requires_audit_ref(verdict: VerdictValue) -> bool:
+    return verdict in AUDIT_REQUIRED_VERDICTS
+
+
+def blocks_merge(verdict: VerdictValue) -> bool:
+    return verdict in MERGE_BLOCKING_VERDICTS

--- a/src/vibe3/services/verdict_service.py
+++ b/src/vibe3/services/verdict_service.py
@@ -8,7 +8,6 @@ It follows the principle of "tools, not decisions":
 
 import json
 from datetime import UTC, datetime
-from typing import Literal
 
 from loguru import logger
 
@@ -19,6 +18,7 @@ from vibe3.services.actor_support import extract_role_from_actor
 from vibe3.services.flow_service import FlowService
 from vibe3.services.handoff_storage import HandoffStorage
 from vibe3.services.signature_service import SignatureService
+from vibe3.services.verdict_policy import VerdictValue
 from vibe3.utils.git_path_client import GitPathProtocol
 
 
@@ -63,7 +63,7 @@ class VerdictService:
 
     def write_verdict(
         self,
-        verdict: Literal["PASS", "MAJOR", "BLOCK", "UNKNOWN"],
+        verdict: VerdictValue,
         reason: str | None = None,
         issues: str | None = None,
         branch: str | None = None,

--- a/src/vibe3/services/verdict_service.py
+++ b/src/vibe3/services/verdict_service.py
@@ -79,7 +79,7 @@ class VerdictService:
         6. Updates flow state's latest_verdict (quick query)
 
         Args:
-            verdict: Verdict value (PASS, MAJOR, BLOCK, UNKNOWN)
+            verdict: Verdict value (PASS, MINOR, MAJOR, BLOCK, REFUSE, UNKNOWN)
             reason: Optional reason for the verdict
             issues: Optional issues description
             branch: Target branch (current if None)

--- a/src/vibe3/ui/flow_ui.py
+++ b/src/vibe3/ui/flow_ui.py
@@ -139,9 +139,13 @@ def render_flow_status(
     # Latest verdict — shown inline under review results
     if status.latest_verdict:
         v = status.latest_verdict
-        verdict_color = {"PASS": "green", "MAJOR": "yellow", "BLOCK": "red"}.get(
-            v.verdict, "cyan"
-        )
+        verdict_color = {
+            "PASS": "green",
+            "MINOR": "cyan",
+            "MAJOR": "yellow",
+            "BLOCK": "red",
+            "REFUSE": "magenta",
+        }.get(v.verdict, "cyan")
         console.print(
             f"  [dim]verdict:[/] [{verdict_color}]{v.verdict}[/]" f"  [dim]{v.actor}[/]"
         )

--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -340,8 +340,10 @@ def _render_state_summary(state: FlowStatusResponse) -> None:
     v = state.latest_verdict
     color = {
         "PASS": "green",
+        "MINOR": "cyan",
         "MAJOR": "yellow",
         "BLOCK": "red",
+        "REFUSE": "magenta",
     }.get(v.verdict, "cyan")
     console.print(f"  [dim]verdict[/]     [{color}]{v.verdict}[/] [dim]({v.actor})[/]")
 

--- a/tests/vibe3/agents/test_review_prompt.py
+++ b/tests/vibe3/agents/test_review_prompt.py
@@ -136,7 +136,7 @@ class TestBuildOutputContractSection:
         """Should use default format if None."""
         result = build_output_contract_section(None)
         assert "## Output format requirements" in result
-        assert "VERDICT: PASS | MAJOR | BLOCK" in result
+        assert "VERDICT: PASS | MINOR | MAJOR | BLOCK | REFUSE" in result
 
 
 class TestBuildReviewPromptBody:
@@ -168,7 +168,11 @@ class TestBuildReviewPromptBody:
             context = build_review_prompt_body(request)
 
         assert "VERDICT:" in context
-        assert "PASS" in context or "MAJOR" in context or "BLOCK" in context
+        assert "PASS" in context
+        assert "MINOR" in context
+        assert "MAJOR" in context
+        assert "BLOCK" in context
+        assert "REFUSE" in context
 
     def test_build_review_prompt_body_minimal_without_ast(self) -> None:
         """Context should work without AST analysis (reviewer uses git diff)."""
@@ -228,3 +232,4 @@ class TestBuildReviewPromptBody:
         assert "The final line must repeat the same `VERDICT:`" in context
         assert "canonical audit report under `docs/reports/`" in context
         assert "handoff audit" in context
+        assert "PASS` and `REFUSE` may omit `audit_ref`" in context

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from typer.testing import CliRunner
+
+from vibe3.commands.review import app
+
+runner = CliRunner()
+
 
 class TestReviewContextBuilderUsesAssembler:
     """Assert review context builders go through PromptAssembler."""
@@ -43,3 +49,55 @@ class TestReviewContextBuilderUsesAssembler:
 
         assert hasattr(mod, "execute_manual_review_async")
         assert hasattr(mod, "execute_manual_review_sync")
+
+
+class TestReviewBaseExitCodes:
+    """Verify review base exit codes follow verdict semantics."""
+
+    def test_minor_verdict_does_not_exit_nonzero(self) -> None:
+        with (
+            patch("vibe3.commands.review.ensure_flow_for_current_branch") as mock_flow,
+            patch("vibe3.commands.review.build_base_resolution_usecase") as mock_base,
+            patch("vibe3.commands.review.build_base_review_request") as mock_request,
+            patch("vibe3.commands.review.execute_manual_review_sync") as mock_execute,
+        ):
+            mock_flow.return_value = (object(), "feature/test")
+            mock_base.return_value.resolve_review_base.return_value = type(
+                "ResolvedBase",
+                (),
+                {"base_branch": "main", "auto_detected": False},
+            )()
+            mock_request.return_value = (object(), 123, None)
+            mock_execute.return_value = type(
+                "Result",
+                (),
+                {"verdict": "MINOR", "handoff_file": None},
+            )()
+
+            result = runner.invoke(app, ["base", "main", "--no-async"])
+
+        assert result.exit_code == 0
+
+    def test_refuse_verdict_exits_nonzero(self) -> None:
+        with (
+            patch("vibe3.commands.review.ensure_flow_for_current_branch") as mock_flow,
+            patch("vibe3.commands.review.build_base_resolution_usecase") as mock_base,
+            patch("vibe3.commands.review.build_base_review_request") as mock_request,
+            patch("vibe3.commands.review.execute_manual_review_sync") as mock_execute,
+        ):
+            mock_flow.return_value = (object(), "feature/test")
+            mock_base.return_value.resolve_review_base.return_value = type(
+                "ResolvedBase",
+                (),
+                {"base_branch": "main", "auto_detected": False},
+            )()
+            mock_request.return_value = (object(), 123, None)
+            mock_execute.return_value = type(
+                "Result",
+                (),
+                {"verdict": "REFUSE", "handoff_file": None},
+            )()
+
+            result = runner.invoke(app, ["base", "main", "--no-async"])
+
+        assert result.exit_code == 1

--- a/tests/vibe3/execution/test_noop_gate_ref_check.py
+++ b/tests/vibe3/execution/test_noop_gate_ref_check.py
@@ -1,5 +1,6 @@
 """Unit tests for ref-check logic in no-op gate."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from vibe3.execution.noop_gate import apply_unified_noop_gate
@@ -103,7 +104,18 @@ class TestRefCheck:
                 role="reviewer",
                 before_state_label="state/review",
                 required_ref_key="audit_ref",
-                flow_state={"audit_ref": "path/to/audit.md"},
+                flow_state={
+                    "audit_ref": "path/to/audit.md",
+                    "latest_verdict": json.dumps(
+                        {
+                            "verdict": "PASS",
+                            "actor": "reviewer",
+                            "role": "reviewer",
+                            "timestamp": "2026-05-22T00:00:00+00:00",
+                            "flow_branch": "task/issue-55",
+                        }
+                    ),
+                },
             )
 
         mock_block.assert_called_once()
@@ -112,6 +124,112 @@ class TestRefCheck:
         store.add_event.assert_called_once()
         event_args = store.add_event.call_args
         assert event_args[0][1] == "state_unchanged"
+
+    def test_reviewer_pass_without_audit_ref_is_allowed(self) -> None:
+        """PASS verdict should not require audit_ref."""
+        store = _make_mock_store()
+        store.get_flow_state.return_value = {
+            "latest_verdict": json.dumps(
+                {
+                    "verdict": "PASS",
+                    "actor": "reviewer",
+                    "role": "reviewer",
+                    "timestamp": "2026-05-22T00:00:00+00:00",
+                    "flow_branch": "task/issue-55",
+                }
+            )
+        }
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_reviewer_noop_issue"
+            ) as mock_block,
+        ):
+            latest_verdict = store.get_flow_state.return_value["latest_verdict"]
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/handoff"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=55,
+                branch="task/issue-55",
+                actor="agent:review",
+                role="reviewer",
+                before_state_label="state/review",
+                required_ref_key="audit_ref",
+                flow_state={"latest_verdict": latest_verdict},
+            )
+
+        mock_block.assert_not_called()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "state_transitioned"
+
+    def test_reviewer_minor_without_audit_ref_blocks(self) -> None:
+        """MINOR verdict still requires audit_ref."""
+        store = _make_mock_store()
+        store.get_flow_state.return_value = {
+            "latest_verdict": json.dumps(
+                {
+                    "verdict": "MINOR",
+                    "actor": "reviewer",
+                    "role": "reviewer",
+                    "timestamp": "2026-05-22T00:00:00+00:00",
+                    "flow_branch": "task/issue-55",
+                }
+            )
+        }
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_reviewer_noop_issue"
+            ) as mock_block,
+        ):
+            latest_verdict = store.get_flow_state.return_value["latest_verdict"]
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/handoff"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=55,
+                branch="task/issue-55",
+                actor="agent:review",
+                role="reviewer",
+                before_state_label="state/review",
+                required_ref_key="audit_ref",
+                flow_state={"latest_verdict": latest_verdict},
+            )
+
+        mock_block.assert_called_once()
+        assert "audit_ref" in mock_block.call_args.kwargs["reason"]
+
+    def test_reviewer_missing_verdict_blocks_even_if_state_changed(self) -> None:
+        """Reviewer must persist a verdict before passing the gate."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_reviewer_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/handoff"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=55,
+                branch="task/issue-55",
+                actor="agent:review",
+                role="reviewer",
+                before_state_label="state/review",
+                required_ref_key="audit_ref",
+                flow_state={},
+            )
+
+        mock_block.assert_called_once()
+        assert "latest verdict missing" in mock_block.call_args.kwargs["reason"]
 
     def test_manager_skips_ref_check_state_changed_passes(self) -> None:
         """Manager role skips ref check; only state change matters."""

--- a/tests/vibe3/roles/test_review.py
+++ b/tests/vibe3/roles/test_review.py
@@ -42,11 +42,24 @@ class TestReviewerNoOpGate:
         self,
     ) -> None:
         """Reviewer state/review -> state/handoff -> pass"""
+        from datetime import datetime
         from unittest.mock import patch
 
         from vibe3.execution.noop_gate import apply_unified_noop_gate
+        from vibe3.models.verdict import VerdictRecord
 
         mock_store = MagicMock()
+        mock_verdict = VerdictRecord(
+            verdict="PASS",
+            timestamp=datetime.now(),
+            actor="agent:review",
+            role="reviewer",
+            flow_branch="task/issue-303",
+        )
+        flow_state = {
+            "latest_verdict": mock_verdict,
+            "audit_ref": "audit.md",
+        }
 
         with (
             patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
@@ -65,6 +78,7 @@ class TestReviewerNoOpGate:
                 actor="agent:review",
                 role="reviewer",
                 before_state_label="state/review",
+                flow_state=flow_state,
             )
 
         mock_block.assert_not_called()

--- a/tests/vibe3/services/test_pr_scoring_service.py
+++ b/tests/vibe3/services/test_pr_scoring_service.py
@@ -61,10 +61,20 @@ class TestCalculateRiskScore:
         assert result.breakdown.get("codex_critical", 0) == 5
 
     def test_block_verdict_blocks(self) -> None:
-        # block_on_verdict 配置为 ["BLOCK"]
+        # block_on_verdict should block severity verdicts
         dims = PRDimensions(changed_lines=10, codex_verdict="BLOCK")
         result = calculate_risk_score(dims)
         assert result.block is True
+
+    def test_refuse_verdict_blocks(self) -> None:
+        dims = PRDimensions(changed_lines=10, codex_verdict="REFUSE")
+        result = calculate_risk_score(dims)
+        assert result.block is True
+
+    def test_minor_verdict_does_not_block(self) -> None:
+        dims = PRDimensions(changed_lines=10, codex_verdict="MINOR")
+        result = calculate_risk_score(dims)
+        assert result.block is False
 
     def test_codex_major_adds_weight(self) -> None:
         base = PRDimensions(changed_lines=10)

--- a/tests/vibe3/services/test_verdict_policy.py
+++ b/tests/vibe3/services/test_verdict_policy.py
@@ -1,0 +1,34 @@
+"""Tests for review verdict policy helpers."""
+
+from vibe3.services.verdict_policy import (
+    ALL_VERDICTS,
+    blocks_merge,
+    passes_review,
+    requires_audit_ref,
+)
+
+
+def test_pass_and_minor_are_passing_verdicts() -> None:
+    assert passes_review("PASS") is True
+    assert passes_review("MINOR") is True
+    assert passes_review("MAJOR") is False
+
+
+def test_only_actionable_verdicts_require_audit_ref() -> None:
+    assert requires_audit_ref("MINOR") is True
+    assert requires_audit_ref("MAJOR") is True
+    assert requires_audit_ref("BLOCK") is True
+    assert requires_audit_ref("PASS") is False
+    assert requires_audit_ref("REFUSE") is False
+
+
+def test_refuse_blocks_merge_but_does_not_require_audit_ref() -> None:
+    assert blocks_merge("MAJOR") is True
+    assert blocks_merge("BLOCK") is True
+    assert blocks_merge("REFUSE") is True
+    assert blocks_merge("PASS") is False
+
+
+def test_verdict_policy_includes_new_values() -> None:
+    assert "MINOR" in ALL_VERDICTS
+    assert "REFUSE" in ALL_VERDICTS

--- a/tests/vibe3/test_flow_resume_resolver.py
+++ b/tests/vibe3/test_flow_resume_resolver.py
@@ -35,23 +35,45 @@ def test_infer_resume_label_pass() -> None:
 
 
 def test_infer_resume_label_minor() -> None:
-    """Minor review -> MERGE_READY."""
+    """Minor review -> MERGE_READY (requires audit_ref)."""
+    state = FlowState(
+        branch="task/issue-1",
+        flow_slug="test",
+        latest_verdict=_create_verdict("MINOR"),
+        audit_ref="audit.md",
+    )
+    assert infer_resume_label(state) == IssueState.MERGE_READY
+
+
+def test_infer_resume_label_minor_without_audit() -> None:
+    """Minor review without audit_ref -> REVIEW."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
         latest_verdict=_create_verdict("MINOR"),
     )
-    assert infer_resume_label(state) == IssueState.MERGE_READY
+    assert infer_resume_label(state) == IssueState.REVIEW
 
 
 def test_infer_resume_label_major() -> None:
-    """Major review issues -> IN_PROGRESS."""
+    """Major review issues -> IN_PROGRESS (requires audit_ref)."""
+    state = FlowState(
+        branch="task/issue-1",
+        flow_slug="test",
+        latest_verdict=_create_verdict("MAJOR"),
+        audit_ref="audit.md",
+    )
+    assert infer_resume_label(state) == IssueState.IN_PROGRESS
+
+
+def test_infer_resume_label_major_without_audit() -> None:
+    """Major review without audit_ref -> REVIEW."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
         latest_verdict=_create_verdict("MAJOR"),
     )
-    assert infer_resume_label(state) == IssueState.IN_PROGRESS
+    assert infer_resume_label(state) == IssueState.REVIEW
 
 
 def test_infer_resume_label_conflict_pr_vs_verdict() -> None:

--- a/tests/vibe3/test_flow_resume_resolver.py
+++ b/tests/vibe3/test_flow_resume_resolver.py
@@ -24,47 +24,53 @@ def test_infer_resume_label_with_pr() -> None:
     assert infer_resume_label(state) == IssueState.HANDOFF
 
 
-def test_infer_resume_label_audit_pass() -> None:
-    """Audit pass -> IN_PROGRESS."""
+def test_infer_resume_label_pass() -> None:
+    """Review pass -> MERGE_READY, even without audit_ref."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
-        audit_ref="audit.md",
         latest_verdict=_create_verdict("PASS"),
     )
-    assert infer_resume_label(state) == IssueState.IN_PROGRESS
+    assert infer_resume_label(state) == IssueState.MERGE_READY
 
 
-def test_infer_resume_label_audit_major() -> None:
-    """Audit major issues -> IN_PROGRESS."""
+def test_infer_resume_label_minor() -> None:
+    """Minor review -> MERGE_READY."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
-        audit_ref="audit.md",
+        latest_verdict=_create_verdict("MINOR"),
+    )
+    assert infer_resume_label(state) == IssueState.MERGE_READY
+
+
+def test_infer_resume_label_major() -> None:
+    """Major review issues -> IN_PROGRESS."""
+    state = FlowState(
+        branch="task/issue-1",
+        flow_slug="test",
         latest_verdict=_create_verdict("MAJOR"),
     )
     assert infer_resume_label(state) == IssueState.IN_PROGRESS
 
 
-def test_infer_resume_label_conflict_pr_vs_audit() -> None:
-    """Conflict: both PR and Audit exist -> HANDOFF (PR wins)."""
+def test_infer_resume_label_conflict_pr_vs_verdict() -> None:
+    """Conflict: PR always wins over verdict."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
         pr_ref="http://pr/1",
-        audit_ref="audit.md",
         latest_verdict=_create_verdict("PASS"),
     )
     assert infer_resume_label(state) == IssueState.HANDOFF
 
 
-def test_infer_resume_label_audit_unknown() -> None:
-    """Audit unknown -> HANDOFF."""
+def test_infer_resume_label_refuse() -> None:
+    """Refuse -> HANDOFF."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
-        audit_ref="audit.md",
-        latest_verdict=_create_verdict("UNKNOWN"),
+        latest_verdict=_create_verdict("REFUSE"),
     )
     assert infer_resume_label(state) == IssueState.HANDOFF
 

--- a/tests/vibe3/test_verdict_service.py
+++ b/tests/vibe3/test_verdict_service.py
@@ -119,6 +119,31 @@ class TestVerdictService:
         # Assert
         assert record.role == "manager"
 
+    def test_write_verdict_accepts_minor(
+        self,
+        verdict_service: VerdictService,
+        mock_store: MagicMock,
+        mock_handoff_storage: MagicMock,
+    ) -> None:
+        """Test writing a MINOR verdict successfully."""
+        mock_store.get_flow_state.return_value = {}
+
+        with patch(
+            "vibe3.services.verdict_service.SignatureService.resolve_for_branch"
+        ) as mock_resolve:
+            mock_resolve.return_value = "reviewer"
+
+            record = verdict_service.write_verdict(
+                verdict="MINOR",
+                reason="Acceptable with follow-up",
+                branch="test-branch",
+            )
+
+        assert record.verdict == "MINOR"
+        mock_handoff_storage.append_current_handoff.assert_called_once()
+        mock_store.update_flow_state.assert_called_once()
+        mock_store.add_event.assert_called_once()
+
     def test_get_latest_verdict_exists(
         self,
         verdict_service: VerdictService,

--- a/tests/vibe3/ui/test_flow_ui.py
+++ b/tests/vibe3/ui/test_flow_ui.py
@@ -1,9 +1,11 @@
 """Tests for flow timeline and flow show rendering."""
 
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 from vibe3.models.flow import FlowEvent, FlowStatusResponse
+from vibe3.models.verdict import VerdictRecord
 from vibe3.ui.flow_ui import render_flow_status, render_flow_timeline
 
 
@@ -151,3 +153,37 @@ def test_render_flow_status_shows_handoff_commands_for_artifacts(capsys) -> None
     assert "@report" in output
     # Should NOT show absolute path
     assert str(worktree_root) not in output
+
+
+def test_render_flow_status_shows_minor_and_refuse_verdicts(capsys) -> None:
+    status_minor = FlowStatusResponse(
+        branch="task/issue-401",
+        flow_slug="issue-401",
+        flow_status="active",
+        latest_verdict=VerdictRecord(
+            verdict="MINOR",
+            actor="reviewer",
+            role="reviewer",
+            timestamp=datetime.now(UTC),
+            flow_branch="task/issue-401",
+        ),
+    )
+    status_refuse = FlowStatusResponse(
+        branch="task/issue-402",
+        flow_slug="issue-402",
+        flow_status="active",
+        latest_verdict=VerdictRecord(
+            verdict="REFUSE",
+            actor="reviewer",
+            role="reviewer",
+            timestamp=datetime.now(UTC),
+            flow_branch="task/issue-402",
+        ),
+    )
+
+    render_flow_status(status_minor, worktree_root=None)
+    render_flow_status(status_refuse, worktree_root=None)
+
+    output = capsys.readouterr().out
+    assert "MINOR" in output
+    assert "REFUSE" in output


### PR DESCRIPTION
## What changed
- Introduce a central verdict policy and expand review verdicts to include MINOR and REFUSE.
- Make the reviewer no-op gate verdict-aware so PASS can succeed without audit_ref, while MINOR, MAJOR, and BLOCK still require it.
- Align resume, merge blocking, CLI exit codes, prompts, and UI rendering with the new verdict semantics.

## Why
The previous gate treated audit_ref as mandatory for reviewer completion, which incorrectly blocked valid PASS reviews that had nothing further to add. The review pipeline now uses verdict as the primary completion signal and only requires audit_ref for verdicts that imply actionable findings.

## Validation
- uv run pytest tests/vibe3/services/test_verdict_policy.py tests/vibe3/execution/test_noop_gate_ref_check.py tests/vibe3/execution/test_noop_gate_unit.py tests/vibe3/test_verdict_service.py tests/vibe3/test_flow_resume_resolver.py tests/vibe3/services/test_pr_scoring_service.py tests/vibe3/agents/test_review_prompt.py tests/vibe3/ui/test_flow_ui.py tests/vibe3/commands/test_review.py -v
- uv run ruff check src/vibe3/agents/review_prompt.py src/vibe3/execution/noop_gate.py src/vibe3/services/flow_resume_resolver.py tests/vibe3/execution/test_noop_gate_ref_check.py
- uv run mypy src/vibe3/services/flow_resume_resolver.py src/vibe3/execution/noop_gate.py
- git push -u origin review-verdict-semantics