### PR TITLE
fix(orchestra): prevent infinite retry loop in manager dispatch

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -495,6 +495,7 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
             )
             self._emit_dispatch_intent(role, issue, tick_id)
             entry.waiting_state = entry.collected_state
+            entry.dispatched = True
             dispatched_count += 1
 
             logger.bind(

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -231,6 +231,20 @@ def promote_progressed_entries(
         # Blocked label alone is not a terminal fact.
         # Promote for re-evaluation — body truth alignment happens in qualify gate.
         if current_state == "blocked":
+            # Dispatch-failed issue that got blocked: don't re-promote for
+            # immediate re-dispatch (infinite loop guard).  It will be
+            # re-evaluated by the qualify gate on the next fresh collection.
+            if entry.get("collected_state") in ("ready", "handoff") and entry.get(
+                "dispatched", False
+            ):
+                removed.append(entry)
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: removed #{entry['issue_number']} "
+                    "from queue (dispatch-failed and blocked, infinite loop guard)",
+                )
+                continue
+
             retry_count = entry.get("retry_count", 0) + 1
             entry["retry_count"] = retry_count
             entry["last_attempted_at"] = datetime.now(timezone.utc).isoformat()

--- a/src/vibe3/orchestra/queue_persistence_mixin.py
+++ b/src/vibe3/orchestra/queue_persistence_mixin.py
@@ -32,6 +32,7 @@ class QueueEntry:
     waiting_state: str | None = None
     retry_count: int = 0
     last_attempted_at: str | None = None
+    dispatched: bool = False
 
 
 class QueuePersistenceMixin:
@@ -114,6 +115,7 @@ class QueuePersistenceMixin:
                     waiting_state=None,  # Reset to trigger re-dispatch
                     retry_count=entry.get("retry_count", 0),
                     last_attempted_at=entry.get("last_attempted_at"),
+                    dispatched=entry.get("dispatched", False),
                 )
             )
 
@@ -142,6 +144,7 @@ class QueuePersistenceMixin:
                 "waiting_state": e.waiting_state,
                 "retry_count": e.retry_count,
                 "last_attempted_at": e.last_attempted_at,
+                "dispatched": e.dispatched,
             }
             for e in frozen_queue
         ]
@@ -168,6 +171,7 @@ class QueuePersistenceMixin:
                 "waiting_state": e.waiting_state,
                 "retry_count": e.retry_count,
                 "last_attempted_at": e.last_attempted_at,
+                "dispatched": e.dispatched,
             }
             for e in frozen_queue
         ]
@@ -190,6 +194,7 @@ class QueuePersistenceMixin:
                 waiting_state=e.get("waiting_state"),
                 retry_count=e.get("retry_count", 0),
                 last_attempted_at=e.get("last_attempted_at"),
+                dispatched=e.get("dispatched", False),
             )
             for e in promoted
         ]
@@ -201,6 +206,7 @@ class QueuePersistenceMixin:
                 waiting_state=e.get("waiting_state"),
                 retry_count=e.get("retry_count", 0),
                 last_attempted_at=e.get("last_attempted_at"),
+                dispatched=e.get("dispatched", False),
             )
             for e in retained
         ]

--- a/tests/vibe3/orchestra/test_dispatch_queue_operations.py
+++ b/tests/vibe3/orchestra/test_dispatch_queue_operations.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from vibe3.models.orchestration import IssueState
 from vibe3.orchestra.global_dispatch_coordinator import QueueEntry
+from vibe3.orchestra.queue_operations import promote_progressed_entries
 
 
 class TestQueueOperations:
@@ -409,3 +412,119 @@ class TestQueueOperations:
         # Verify all returned issues have BLOCKED state
         for issue in blocked_issues:
             assert issue.state == IssueState.BLOCKED
+
+    def test_dispatch_failed_blocked_issue_not_promoted(self, make_issue_info) -> None:
+        """Verify dispatch-failed BLOCKED issues are removed (infinite loop guard)."""
+        config = MagicMock()
+        config.get_manager_usernames = MagicMock(return_value=["manager-bot"])
+
+        github = MagicMock()
+
+        # Entry that was dispatched (dispatched=True), collected as ready,
+        # and then transitioned to blocked (dispatch failed, got blocked)
+        entry = {
+            "issue_number": 123,
+            "collected_state": "ready",  # was collected as ready
+            "waiting_state": "ready",  # was dispatched
+            "retry_count": 0,
+            "last_attempted_at": None,
+            "dispatched": True,  # was dispatched
+        }
+
+        # Mock issue loader to return BLOCKED state
+        def mock_loader(issue_number: int):
+            return make_issue_info(123, IssueState.BLOCKED)
+
+        promoted, retained, removed = promote_progressed_entries(
+            [entry],
+            config,
+            github,
+            registry=None,
+            supervisor_label="supervisor",
+            load_issue_func=mock_loader,
+            max_retry_budget=3,
+        )
+
+        # Should be removed, not promoted
+        assert len(promoted) == 0
+        assert len(retained) == 0
+        assert len(removed) == 1
+        assert removed[0]["issue_number"] == 123
+
+    def test_collected_blocked_issue_still_promoted(self, make_issue_info) -> None:
+        """Verify collected-as-BLOCKED issues are retained.
+
+        (not removed by infinite loop guard)
+        """
+        config = MagicMock()
+        config.get_manager_usernames = MagicMock(return_value=["manager-bot"])
+
+        github = MagicMock()
+
+        # Entry that was collected as blocked (not dispatch-failed)
+        entry = {
+            "issue_number": 456,
+            "collected_state": "blocked",  # was collected as blocked
+            "waiting_state": "blocked",  # was waiting in blocked
+            "retry_count": 0,
+            "last_attempted_at": None,
+            "dispatched": False,  # was not dispatched
+        }
+
+        # Mock issue loader to return BLOCKED state
+        def mock_loader(issue_number: int):
+            return make_issue_info(456, IssueState.BLOCKED)
+
+        promoted, retained, removed = promote_progressed_entries(
+            [entry],
+            config,
+            github,
+            registry=None,
+            supervisor_label="supervisor",
+            load_issue_func=mock_loader,
+            max_retry_budget=3,
+        )
+
+        # Should be retained (waiting for state change), not removed
+        assert len(promoted) == 0
+        assert len(retained) == 1
+        assert len(removed) == 0
+        assert retained[0]["issue_number"] == 456
+
+    @pytest.mark.asyncio
+    async def test_dispatched_flag_set_after_dispatch(
+        self, make_issue, make_capacity, make_coordinator, install_issue_loader
+    ) -> None:
+        """Verify dispatched flag is set to True after dispatch."""
+        issue = make_issue(1)
+        capacity = make_capacity(remaining=1)
+
+        coordinator = make_coordinator(
+            "planner",
+            [issue],
+            capacity=capacity,
+            with_branches=True,
+            mock_health_check=True,
+        )
+
+        # Set _frozen_queue directly (new queue strategy collects lazily)
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="claimed")
+        ]
+
+        install_issue_loader(coordinator, {1: IssueState.CLAIMED})
+
+        emit_calls = []
+        coordinator._emit_dispatch_intent = (
+            lambda role, issue, tick_id: emit_calls.append((role, issue))
+        )
+
+        await coordinator.coordinate()
+
+        # Verify dispatch happened
+        assert len(emit_calls) == 1
+
+        # Verify dispatched flag is set
+        assert coordinator._frozen_queue is not None
+        assert len(coordinator._frozen_queue) == 1
+        assert coordinator._frozen_queue[0].dispatched is True


### PR DESCRIPTION
## Summary
- Add `dispatched` flag to QueueEntry to distinguish dispatch-failed BLOCKED issues from collected-as-BLOCKED issues
- Implement infinite loop guard: remove dispatch-failed BLOCKED issues instead of promoting them for immediate re-dispatch
- Fix FD exhaustion caused by infinite retry loop when manager dispatch fails

## Changes
1. **queue_persistence_mixin.py**: Add `dispatched` field to QueueEntry dataclass
2. **global_dispatch_coordinator.py**: Set `dispatched=True` after dispatch
3. **queue_operations.py**: Add infinite loop guard in BLOCKED branch of `promote_progressed_entries()`
4. **test_dispatch_queue_operations.py**: Add 3 new tests for dispatched flag behavior

## Test Results
- ✅ All 133 orchestra tests pass
- ✅ mypy type check passes
- ✅ ruff lint check passes
- ✅ Test updated for new queue collection strategy

## Verification
- Dispatch-failed BLOCKED issues are now removed instead of promoted
- Collected-as-BLOCKED issues are unaffected (normal flow continues)
- Backward compatible with old DB records (defaults to `dispatched=False`)

Fixes #1148

## Contributors
- Planning: claude/opus
- Execution: claude/sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)