### PR TITLE
test: add bats test for profiles.sh skills_manifest path output

### DIFF
--- a/tests/vibe2/integration/test_profiles_skills_manifest.bats
+++ b/tests/vibe2/integration/test_profiles_skills_manifest.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# Tests for profiles.sh skills_manifest path output (Issue #1151)
+
+setup() {
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  export VIBE_ROOT="$REPO_ROOT"
+  export VIBE_LIB="$REPO_ROOT/lib"
+}
+
+@test "minimal profile skills_manifest path is ~/.vibe/skills.json" {
+  run zsh -c "
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    get_profile_config minimal
+    get_profile_path skills_manifest
+  "
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.vibe/skills.json" ]
+}
+
+@test "github-flow profile skills_manifest path is ~/.vibe/skills.json" {
+  run zsh -c "
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    get_profile_config github-flow
+    get_profile_path skills_manifest
+  "
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.vibe/skills.json" ]
+}
+
+@test "vibe-center profile skills_manifest path is repo-local config/v3/skills.json" {
+  run zsh -c "
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    get_profile_config vibe-center
+    get_profile_path skills_manifest
+  "
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "config/v3/skills.json" ]
+}
+
+@test "no hard-coded manifests/skills path in profiles.sh" {
+  # Regression guard against drift from PR #1130
+  run grep -c 'manifests/skills' "$REPO_ROOT/lib/profiles.sh"
+
+  # Exit code should be non-zero (no match found)
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
- Add bats test file to verify skills_manifest path generation across all profiles
- Test minimal, github-flow, and vibe-center profiles
- Add regression guard against hard-coded 'manifests/skills' path

## Changes
- `tests/vibe2/integration/test_profiles_skills_manifest.bats`: New test file with 4 test cases

## Test Results
```
1..4
ok 1 minimal profile skills_manifest path is ~/.vibe/skills.json
ok 2 github-flow profile skills_manifest path is ~/.vibe/skills.json
ok 3 vibe-center profile skills_manifest path is repo-local config/v3/skills.json
ok 4 no hard-coded manifests/skills path in profiles.sh
```

## Verification
- ✅ All 4 tests pass
- ✅ Follows existing bats test patterns
- ✅ Uses zsh -c sourcing pattern (profiles.sh is zsh)
- ✅ Regression guard prevents PR #1130 regression

Fixes #1151

## Contributors
- Planning: claude/opus
- Execution: claude/sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)