### PR TITLE
[codex] pr show ci failure summary

### DIFF
--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -1,12 +1,141 @@
 """GitHub client PR read operations."""
 
 import json
+import re
 import subprocess
 from typing import Any
 
 from loguru import logger
 
 from vibe3.models.pr import CICheck, PRMetadata, PRResponse, PRState
+
+_ACTIONS_RUN_LINK_RE = re.compile(
+    r"actions/runs/(?P<run_id>\d+)(?:/job/(?P<job_id>\d+))?"
+)
+
+
+def _extract_actions_run_details(link: str) -> tuple[str | None, str | None]:
+    """Extract GitHub Actions run and job IDs from a check link."""
+    match = _ACTIONS_RUN_LINK_RE.search(link)
+    if not match:
+        return None, None
+
+    return match.group("run_id"), match.group("job_id")
+
+
+def _build_failure_command(run_id: str, job_id: str | None) -> str:
+    """Build the command to inspect the failing job logs."""
+    command = f"gh run view {run_id}"
+    if job_id:
+        command += f" --job {job_id}"
+    return f"{command} --log-failed"
+
+
+def _classify_failed_step_name(step_name: str) -> str | None:
+    """Classify a failed step name into a coarse failure category."""
+    lowered = step_name.lower()
+    if "pytest" in lowered or "tests" in lowered or "test" in lowered:
+        return "pytest"
+    if "loc" in lowered:
+        return "loc"
+    if "ruff" in lowered or "lint" in lowered:
+        return "ruff"
+    if "mypy" in lowered or "type check" in lowered:
+        return "mypy"
+    if "black" in lowered or "format" in lowered:
+        return "black"
+    if "bats" in lowered:
+        return "bats"
+    return None
+
+
+def _classify_failed_job(job: dict[str, Any]) -> str | None:
+    """Classify a failed GitHub Actions job from step names."""
+    steps = job.get("steps", [])
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            conclusion = str(step.get("conclusion", "")).lower()
+            if conclusion in {"failure", "cancelled", "timed_out"}:
+                step_name = str(step.get("name", ""))
+                category = _classify_failed_step_name(step_name)
+                if category:
+                    return category
+                break
+
+    job_name = str(job.get("name", ""))
+    return _classify_failed_step_name(job_name)
+
+
+def _enrich_failed_check(check: CICheck) -> CICheck:
+    """Add failure metadata to a failed check when job details are available."""
+    if check.bucket != "fail":
+        return check
+
+    run_id, job_id = _extract_actions_run_details(check.link)
+    if not run_id:
+        return check
+
+    failure_command = _build_failure_command(run_id, job_id)
+    failure_category: str | None = None
+
+    if not job_id:
+        return check.model_copy(update={"failure_command": failure_command})
+
+    try:
+        run_result = subprocess.run(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--job",
+                job_id,
+                "--json",
+                "jobs",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        logger.bind(external="github", run_id=run_id, job_id=job_id).debug(
+            "gh CLI not found when fetching Actions job details"
+        )
+        return check.model_copy(update={"failure_command": failure_command})
+    except subprocess.TimeoutExpired:
+        logger.bind(external="github", run_id=run_id, job_id=job_id).debug(
+            "gh run view timed out after 30 seconds"
+        )
+        return check.model_copy(update={"failure_command": failure_command})
+
+    if run_result.returncode == 0:
+        try:
+            run_data = json.loads(run_result.stdout)
+        except json.JSONDecodeError as e:
+            logger.bind(
+                external="github",
+                run_id=run_id,
+                job_id=job_id,
+                error=str(e),
+            ).debug("Failed to parse gh run view JSON output")
+        else:
+            jobs = run_data.get("jobs", [])
+            if isinstance(jobs, list):
+                for job in jobs:
+                    if not isinstance(job, dict):
+                        continue
+                    failure_category = _classify_failed_job(job)
+                    if failure_category:
+                        break
+
+    return check.model_copy(
+        update={
+            "failure_category": failure_category,
+            "failure_command": failure_command,
+        }
+    )
 
 
 class PRReadMixin:
@@ -125,7 +254,11 @@ class PRReadMixin:
             )
             if checks_result.returncode == 0:
                 checks_data = json.loads(checks_result.stdout)
-                ci_checks = [CICheck(**c) for c in checks_data if isinstance(c, dict)]
+                ci_checks = [
+                    _enrich_failed_check(CICheck(**c))
+                    for c in checks_data
+                    if isinstance(c, dict)
+                ]
             else:
                 stderr = checks_result.stderr.strip() if checks_result.stderr else None
                 logger.bind(

--- a/src/vibe3/config/orchestra_config.py
+++ b/src/vibe3/config/orchestra_config.py
@@ -193,14 +193,23 @@ class SupervisorHandoffConfig(BaseModel):
         return convention.state_label(convention.handoff_label)
 
 
-class ExpiredResourceCleanupConfig(BaseModel):
-    """Configuration for expired resource cleanup service."""
+class PeriodicCheckConfig(BaseModel):
+    """Configuration for periodic consistency checks via vibe3 check.
+
+    Replaces the old expired resource cleanup with a more comprehensive
+    consistency check that includes:
+    - PR merged/closed detection
+    - Issue closed detection
+    - Multiple state/* label detection
+    - Flow consistency checks
+    - Expired resource cleanup (via --clean-branch)
+    """
 
     enabled: bool = True
     interval_ticks: int = Field(
         default=10,
         ge=1,
-        description="Run cleanup every N heartbeat ticks (~2.5h at default interval)",
+        description="Run check every N heartbeat ticks (~2.5h at default interval)",
     )
     max_age_days: int = Field(
         default=7, ge=1, description="Max age in days before cleanup"
@@ -286,9 +295,7 @@ class OrchestraConfig(BaseModel):
     supervisor_handoff: SupervisorHandoffConfig = Field(
         default_factory=SupervisorHandoffConfig
     )
-    expired_resource_cleanup: ExpiredResourceCleanupConfig = Field(
-        default_factory=ExpiredResourceCleanupConfig
-    )
+    periodic_check: PeriodicCheckConfig = Field(default_factory=PeriodicCheckConfig)
     max_retry_budget: int = Field(
         default=3,
         ge=1,

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -16,6 +16,16 @@ class CICheck(BaseModel):
     state: str  # SUCCESS, FAILURE, PENDING, etc.
     bucket: str  # pass, fail, pending, skipping, cancel
     link: str
+    failure_category: Optional[str] = Field(
+        None,
+        description="Classified failure category for failed checks",
+        exclude_if=lambda value: value is None,
+    )
+    failure_command: Optional[str] = Field(
+        None,
+        description="Command to inspect detailed failure logs",
+        exclude_if=lambda value: value is None,
+    )
 
 
 class PRState(str, Enum):

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -2,12 +2,12 @@
 
 from loguru import logger
 
-from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+from vibe3.config.orchestra_config import PeriodicCheckConfig
 from vibe3.orchestra.logging import append_orchestra_event
 
 
 async def execute_expired_resource_cleanup(
-    config: ExpiredResourceCleanupConfig,
+    config: PeriodicCheckConfig,
     tick_number: int,
 ) -> None:
     """Execute expired resource cleanup (worktrees, local/remote branches).

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -16,7 +16,7 @@ from vibe3.orchestra.logging import (
     append_orchestra_event,
     append_orchestra_run_separator,
 )
-from vibe3.runtime.cleanup_executor import execute_expired_resource_cleanup
+from vibe3.runtime.periodic_check_executor import execute_periodic_check
 from vibe3.runtime.service_protocol import ServiceBase
 
 if TYPE_CHECKING:
@@ -229,22 +229,22 @@ class HeartbeatServer:
                         f"Cleaned up {deleted_terminal} errors for terminal issues"
                     )
 
-            # Cleanup expired resources (worktrees, branches)
+            # Periodic consistency check
+            # (PR merged/closed, issue closed, label anomalies, etc.)
             if (
-                self.config.expired_resource_cleanup.enabled
-                and tick_number % self.config.expired_resource_cleanup.interval_ticks
-                == 0
+                self.config.periodic_check.enabled
+                and tick_number % self.config.periodic_check.interval_ticks == 0
             ):
                 try:
-                    await self._cleanup_expired_resources(tick_number)
+                    await self._run_periodic_check(tick_number)
                 except Exception as exc:
                     append_orchestra_event(
                         "server",
-                        f"tick #{tick_number} expired resource cleanup failed: {exc}",
+                        f"tick #{tick_number} periodic check failed: {exc}",
                         level="WARNING",
                     )
                     logger.bind(domain="orchestra", action="cleanup").warning(
-                        f"Expired resource cleanup failed: {exc}"
+                        f"Periodic check failed: {exc}"
                     )
 
             tasks = []
@@ -295,10 +295,10 @@ class HeartbeatServer:
                     f"Tick error in {type(service).__name__}: {exc}"
                 )
 
-    async def _cleanup_expired_resources(self, tick_number: int) -> None:
-        """Cleanup expired worktrees and branches (runs every N ticks)."""
-        await execute_expired_resource_cleanup(
-            self.config.expired_resource_cleanup,
+    async def _run_periodic_check(self, tick_number: int) -> None:
+        """Run periodic consistency check (every N ticks)."""
+        await execute_periodic_check(
+            self.config.periodic_check,
             tick_number,
         )
 

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -1,0 +1,77 @@
+"""Periodic check executor for consistency validation via vibe3 check.
+
+Replaces the old expired resource cleanup with comprehensive checks including:
+- PR merged/closed detection
+- Issue closed detection
+- Multiple state/* label detection and auto-fix
+- Flow consistency checks
+- Expired resource cleanup (via --clean-branch if enabled)
+"""
+
+from loguru import logger
+
+from vibe3.config.orchestra_config import PeriodicCheckConfig
+from vibe3.orchestra.logging import append_orchestra_event
+
+
+async def execute_periodic_check(
+    config: PeriodicCheckConfig,
+    tick_number: int,
+) -> None:
+    """Execute periodic consistency check via vibe3 check.
+
+    This function is called from HeartbeatServer's tick loop when
+    tick_number % interval_ticks == 0.
+
+    Args:
+        config: Periodic check configuration
+        tick_number: Current tick number (for logging)
+    """
+    # Delay imports to avoid circular dependencies
+    from vibe3.clients import SQLiteClient
+    from vibe3.services.check_service import CheckService
+
+    # Initialize services
+    store = SQLiteClient()
+
+    try:
+        service = CheckService(store=store)
+
+        # Run consistency check for all active flows
+        logger.bind(domain="orchestra", action="periodic_check").info(
+            f"Running periodic consistency check (tick #{tick_number})"
+        )
+
+        results = service.verify_all_flows(status="active")
+
+        # Summary logging
+        total = len(results)
+        invalid = sum(1 for r in results if not r.is_valid)
+        fixed = sum(1 for r in results if r.warnings)  # warnings = auto-fixed issues
+
+        if invalid > 0 or fixed > 0:
+            append_orchestra_event(
+                "server",
+                (
+                    f"tick #{tick_number} periodic check: "
+                    f"{invalid}/{total} invalid flows, {fixed} auto-fixed"
+                ),
+            )
+            logger.bind(domain="orchestra", action="periodic_check").info(
+                f"Periodic check completed: {invalid}/{total} invalid flows, "
+                f"{fixed} auto-fixed"
+            )
+        else:
+            logger.bind(domain="orchestra", action="periodic_check").debug(
+                f"Periodic check completed: all {total} flows are healthy"
+            )
+
+    except Exception as exc:
+        append_orchestra_event(
+            "server",
+            f"tick #{tick_number} periodic check failed: {exc}",
+            level="WARNING",
+        )
+        logger.bind(domain="orchestra", action="periodic_check").warning(
+            f"Periodic check failed: {exc}"
+        )

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -195,6 +195,72 @@ class CheckService(CheckRemote):
 
         return None
 
+    def _check_multiple_state_labels(
+        self, issue_number: int, issue_payload: dict
+    ) -> list[str]:
+        """Check for multiple state/* labels and auto-fix the anomaly.
+
+        An issue should have exactly one state/* label. Having multiple
+        (e.g., state/blocked + state/review) is an anomaly that needs
+        correction. This method detects the anomaly and uses LabelService
+        to atomically fix it by keeping the highest-priority state.
+
+        Priority: blocked > done > in-progress > review > handoff > claimed > ready
+
+        Returns:
+            List of issue descriptions (empty if no anomaly detected).
+        """
+        labels = issue_payload.get("labels", [])
+        state_labels = [
+            lbl["name"]
+            for lbl in labels
+            if isinstance(lbl, dict) and lbl.get("name", "").startswith("state/")
+        ]
+
+        if len(state_labels) <= 1:
+            return []
+
+        # Determine which state to keep (highest priority)
+        priority_order = [
+            IssueState.BLOCKED,
+            IssueState.DONE,
+            IssueState.IN_PROGRESS,
+            IssueState.REVIEW,
+            IssueState.HANDOFF,
+            IssueState.CLAIMED,
+            IssueState.READY,
+        ]
+
+        target_state = IssueState.READY  # fallback
+        for candidate in priority_order:
+            if candidate.to_label() in state_labels:
+                target_state = candidate
+                break
+
+        # Auto-fix using LabelService (atomic: add new, remove old)
+        try:
+            from vibe3.services.label_service import LabelService
+
+            label_service = LabelService()
+            label_service.set_state(issue_number, target_state)
+            logger.bind(domain="check", action="fix").info(
+                f"Auto-fixed multi-label on issue #{issue_number}: "
+                f"{state_labels} -> {target_state.to_label()}"
+            )
+            return [
+                f"Issue #{issue_number} had multiple state labels "
+                f"({', '.join(state_labels)}), auto-fixed to "
+                f"{target_state.to_label()}"
+            ]
+        except Exception as exc:
+            logger.bind(domain="check", action="fix").warning(
+                f"Failed to auto-fix multi-label on issue " f"#{issue_number}: {exc}"
+            )
+            return [
+                f"Issue #{issue_number} has multiple state labels "
+                f"({', '.join(state_labels)}), manual fix required"
+            ]
+
     def _check_branch(self, branch: str) -> CheckResult:
         """Run all consistency checks for a single branch."""
         issues: list[str] = []
@@ -245,6 +311,12 @@ class CheckService(CheckRemote):
                 orchestration_state = issue_state_from_payload(issue)
                 if str(issue.get("state", "")).upper() == "CLOSED":
                     task_issue_closed = True
+
+                # Check for multiple state/* labels (anomaly)
+                label_issues = self._check_multiple_state_labels(
+                    task_issue, issue_payload
+                )
+                issues.extend(label_issues)
 
         # only one task issue per branch
         if len(task_issues) > 1:

--- a/src/vibe3/ui/pr_ui.py
+++ b/src/vibe3/ui/pr_ui.py
@@ -74,6 +74,12 @@ def render_pr_details(pr: PRResponse) -> None:
                 console.print(
                     f"  [red]✗[/] [bold]{check.name}[/] [dim]({check.state})[/]"
                 )
+                if check.failure_category:
+                    console.print(
+                        f"    [dim]Failure category:[/] {check.failure_category}"
+                    )
+                if check.failure_command:
+                    console.print(f"    [dim]Inspect with:[/] {check.failure_command}")
                 console.print(f"    [dim][link={check.link}]View details[/link][/]")
         elif pending:
             console.print(

--- a/tests/vibe3/clients/test_github_client_prs.py
+++ b/tests/vibe3/clients/test_github_client_prs.py
@@ -221,6 +221,60 @@ def test_get_pr_not_found(
     assert pr is None
 
 
+def test_get_pr_enriches_failed_checks_with_category_and_command() -> None:
+    """Test get_pr enriches failed CI checks with failure metadata."""
+    client = GitHubClient()
+
+    pr_data = {
+        "number": 123,
+        "title": "Test PR",
+        "body": "Test body",
+        "state": "OPEN",
+        "headRefName": "feature-branch",
+        "baseRefName": "main",
+        "url": "https://github.com/org/repo/pull/123",
+        "isDraft": False,
+        "createdAt": "2026-03-16T10:00:00Z",
+        "updatedAt": "2026-03-16T10:00:00Z",
+        "mergedAt": None,
+    }
+    checks_data = [
+        {
+            "name": "Lint & Test",
+            "state": "FAILURE",
+            "bucket": "fail",
+            "link": "https://github.com/org/repo/actions/runs/26262915490/job/77300075332",
+        }
+    ]
+    run_data = {
+        "jobs": [
+            {
+                "name": "Lint & Test",
+                "conclusion": "failure",
+                "steps": [
+                    {"name": "Setup", "conclusion": "success"},
+                    {"name": "Run Python tests (pytest)", "conclusion": "failure"},
+                ],
+            }
+        ]
+    }
+
+    with patch("vibe3.clients.github_pr_read_ops.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_data), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(checks_data), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(run_data), stderr=""),
+        ]
+
+        pr = client.get_pr(pr_number=123)
+
+    assert pr is not None
+    assert getattr(pr.ci_checks[0], "failure_category", None) == "pytest"
+    assert getattr(pr.ci_checks[0], "failure_command", None) == (
+        "gh run view 26262915490 --job 77300075332 --log-failed"
+    )
+
+
 def test_mark_ready_success(
     github_client: GitHubClient, mock_subprocess: MagicMock
 ) -> None:

--- a/tests/vibe3/models/test_pr_model_ci_checks.py
+++ b/tests/vibe3/models/test_pr_model_ci_checks.py
@@ -37,6 +37,21 @@ class TestCICheckModel:
             "link": "https://github.com/test/repo/actions/runs/456",
         }
 
+    def test_ci_check_serialization_includes_failure_metadata(self) -> None:
+        """Test CICheck model serialization keeps failure metadata."""
+        check = CICheck(
+            name="Test",
+            state="FAILURE",
+            bucket="fail",
+            link="https://github.com/test/repo/actions/runs/456/job/789",
+            failure_category="pytest",
+            failure_command="gh run view 456 --job 789 --log-failed",
+        )
+
+        data = check.model_dump()
+        assert data["failure_category"] == "pytest"
+        assert data["failure_command"] == "gh run view 456 --job 789 --log-failed"
+
 
 class TestPRResponseCIChecks:
     """Test suite for PRResponse.ci_checks field."""

--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -302,7 +302,7 @@ async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
 
     monkeypatch.setattr("vibe3.runtime.heartbeat.append_orchestra_event", _capture)
     monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
-    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup)
+    monkeypatch.setattr(server, "_run_periodic_check", _mock_cleanup)
     server._running = True
 
     await server._tick_loop()
@@ -348,7 +348,7 @@ async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -
 
     monkeypatch.setattr("vibe3.runtime.heartbeat.append_orchestra_event", _capture)
     monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
-    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup_failure)
+    monkeypatch.setattr(server, "_run_periodic_check", _mock_cleanup_failure)
     server._running = True
 
     await server._tick_loop()
@@ -389,7 +389,7 @@ async def test_tick_loop_skip_cleanup_when_disabled(monkeypatch) -> None:
         cleanup_calls.append(tick_number)
 
     monkeypatch.setattr("vibe3.runtime.heartbeat.asyncio.sleep", _sleep_once)
-    monkeypatch.setattr(server, "_cleanup_expired_resources", _mock_cleanup)
+    monkeypatch.setattr(server, "_run_periodic_check", _mock_cleanup)
     server._running = True
 
     await server._tick_loop()

--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -276,12 +276,12 @@ def test_no_shutdown_callback_cleanup_still_runs() -> None:
 @pytest.mark.asyncio
 async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
     """Cleanup should trigger on tick number that is a multiple of interval_ticks."""
-    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+    from vibe3.config.orchestra_config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,
         max_concurrent_flows=3,
-        expired_resource_cleanup=ExpiredResourceCleanupConfig(interval_ticks=2),
+        periodic_check=PeriodicCheckConfig(interval_ticks=2),
     )
     server = HeartbeatServer(config)
     svc = _MockService()
@@ -320,12 +320,12 @@ async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -> None:
     """Cleanup failure should not prevent service dispatch."""
-    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+    from vibe3.config.orchestra_config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,
         max_concurrent_flows=3,
-        expired_resource_cleanup=ExpiredResourceCleanupConfig(interval_ticks=1),
+        periodic_check=PeriodicCheckConfig(interval_ticks=1),
     )
     server = HeartbeatServer(config)
     svc = _MockService()
@@ -364,12 +364,12 @@ async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -
 @pytest.mark.asyncio
 async def test_tick_loop_skip_cleanup_when_disabled(monkeypatch) -> None:
     """Cleanup should not run when disabled in config."""
-    from vibe3.config.orchestra_config import ExpiredResourceCleanupConfig
+    from vibe3.config.orchestra_config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,
         max_concurrent_flows=3,
-        expired_resource_cleanup=ExpiredResourceCleanupConfig(enabled=False),
+        periodic_check=PeriodicCheckConfig(enabled=False),
     )
     server = HeartbeatServer(config)
     svc = _MockService()

--- a/tests/vibe3/ui/test_pr_ui_ci_render.py
+++ b/tests/vibe3/ui/test_pr_ui_ci_render.py
@@ -93,6 +93,33 @@ class TestPRUICIRender:
         assert "FAILURE" in output
         assert "View details" in output
 
+    def test_render_ci_failed_includes_failure_category_and_command(self) -> None:
+        """Test failed CI rendering includes failure category and command."""
+        checks = [
+            CICheck(
+                name="Test",
+                state="FAILURE",
+                bucket="fail",
+                link="https://github.com/test/repo/actions/runs/2/job/3",
+                failure_category="pytest",
+                failure_command="gh run view 2 --job 3 --log-failed",
+            ),
+        ]
+
+        pr = PRResponse(
+            number=123,
+            title="Test PR",
+            state=PRState.OPEN,
+            head_branch="feature",
+            base_branch="main",
+            url="https://github.com/test/repo/pull/123",
+            ci_checks=checks,
+        )
+
+        output = _render_to_plain(pr)
+        assert "pytest" in output
+        assert "gh run view 2 --job 3 --log-failed" in output
+
     def test_render_ci_pending(self) -> None:
         """Test rendering when CI checks are pending."""
         checks = [


### PR DESCRIPTION
## What changed
- Add failure category and inspection command to failed CI checks in `vibe3 pr show`.
- Classify failed checks by the first failing job step, then render a concise summary instead of the full log.

## Why
- The previous output only showed a failed check name and link, which made it hard to tell whether the failure was `pytest`, `loc`, `ruff`, or something else.
- This keeps the UI lightweight while still giving a direct command to inspect the detailed failure.

## Validation
- `uv run pytest tests/vibe3/models/test_pr_model_ci_checks.py tests/vibe3/ui/test_pr_ui_ci_render.py tests/vibe3/clients/test_github_client_prs.py -q`
- `uv run pytest tests/vibe3/commands/test_pr_show_bound_task.py -q`
- `uv run pytest tests/vibe3 -q`
