### PR TITLE
docs: secondary documentation semantic alignment (issue #1227)

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -1,3 +1,20 @@
+---
+document_type: core-entry
+title: AI Agent Workspace (.agent)
+status: approved
+scope: project-entry
+authority:
+  - agent-workspace-structure
+  - agent-interoperability-protocol
+author: Claude Sonnet 4.5
+created: 2024-01-15
+last_updated: 2026-05-22
+related_docs:
+  - AGENTS.md
+  - SOUL.md
+  - STRUCTURE.md
+---
+
 # AI Agent Workspace (.agent)
 
 **这是 AI Agent (Claude, OpenCode, Codex, Trae, etc.) 的指定工作环境。**
@@ -9,14 +26,15 @@
 - **[CLAUDE.md](../CLAUDE.md)**: 技术栈与上下文
 - **[SOUL.md](../SOUL.md)**: 核心原则与价值观 (Constitution & Principles)
 - **[docs/standards/glossary.md](../docs/standards/glossary.md)**: 项目术语真源
-- **[docs/standards/action-verbs.md](../docs/standards/action-verbs.md)**: 高频动作词真源
+- **[docs/standards/action-verbs.md](../docs/standards/action-verbs.md)**: 高频 动作词真源
 
 ## 📂 目录结构 (Directory Structure)
 
 - **`context/`**: 记忆与任务管理
-  - `memory.md`: 长期记忆，记录关键决策和架构选择。
-  - handoff：当前 flow 的交接记录（`vibe3 handoff status` 读取，`vibe3 handoff append` 写入）。
-- **`workflows/`**: **workflow 层入口**。只负责编排、委托和停点，不承载复杂业务逻辑。
+  - `memory.md`: 长期记忆，记录关键决策和架构选择（日常记忆优先使用 `claude-memory` MCP 工具）。
+  - `task.md`: **[UNTRACKED]** 由 `vibe3 handoff` 命令自动管理的短期上下文，不建议手动编辑。
+  - `handoff`: 由 `vibe3 handoff status` 读取，`vibe3 handoff append` 写入的当前 flow 交接事实。
+- **`workflows/`**: **workflow 层入口**。只负责编排、委托和停点，不承载复杂业务 逻辑。
 - **`rules/`**: 具体的编码标准和项目规则。
   - `coding-standards.md`: 实现、边界、工具与交付细则
   - `patterns.md`: 执行模式、报告模式与渐进披露模式

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,20 @@
+---
+document_type: core-entry
+title: AI Agent Guide
+status: approved
+scope: project-entry
+authority:
+  - agent-entry-navigation
+  - essential-reading-order
+author: Claude Sonnet 4.5
+created: 2024-01-15
+last_updated: 2026-05-22
+related_docs:
+  - SOUL.md
+  - STRUCTURE.md
+  - CLAUDE.md
+---
+
 # AI Agent Guide
 
 Welcome, AI Agent. This file serves as your entry point to Vibe Center 3.0.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,3 +1,20 @@
+---
+document_type: constitution
+title: VIBE Constitution
+status: approved
+scope: project-core
+authority:
+  - core-principles
+  - agent-behavior-standards
+author: Vibe Team
+created: 2024-01-15
+last_updated: 2026-05-22
+related_docs:
+  - AGENTS.md
+  - STRUCTURE.md
+  - CLAUDE.md
+---
+
 # VIBE Constitution
 
 Vibe Coding 的核心是：**认知优先，代码次之**。

--- a/docs/standards/action-verbs.md
+++ b/docs/standards/action-verbs.md
@@ -8,7 +8,7 @@ authority:
   - action-verb-reminders
 author: Codex GPT-5
 created: 2026-03-08
-last_updated: 2026-03-08
+last_updated: 2026-05-22
 related_docs:
   - SOUL.md
   - CLAUDE.md
@@ -111,3 +111,15 @@ related_docs:
 - 默认含义：执行检查、验证或审计
 - 前置提醒：确认检查对象、失败条件和输出格式明确
 - 不要隐含什么：不要把 `check` 做成修复命令，不要在失败时静默改数据
+
+### 2.14 `handoff`
+
+- 默认含义：在不同 agent 或不同 session 之间传递本地执行上下文与中间态产物
+- 前置提醒：确认 handoff 内容已持久化到共享 store（如 `.git/vibe3/handoff.db`），且关键 artifact 已登记
+- 不要隐含什么：不要把 `handoff` 理解为 GitHub PR 的合入或 issue 的关闭，它仅限于本地执行链的衔接
+
+### 2.15 `indicate`
+
+- 默认含义：由管理角色（如 manager）发布明确的指令、动作建议或停点要求，供后续执行角色消费
+- 前置提醒：确认 indicate 内容清晰、不具歧义，且已绑定到当前 flow 的 handoff 链路中
+- 不要隐含什么：不要借 `indicate` 隐式修改业务代码或外部状态，它仅作为执行层面的意图传达


### PR DESCRIPTION
Aligned AGENTS.md, .agent/README.md, SOUL.md, and docs/standards/action-verbs.md with V3 truth sources. Added standard frontmatter and updated last_updated to 2026-05. Fixes #1227.