### PR TITLE
[codex] pr show ci failure summary

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -235,8 +235,8 @@ code_limits:
         limit: 410
         reason: "Task resume 操作测试集，覆盖 reset、label resume 等所有场景，共享 fixture，拆分收益低"
       - path: "tests/vibe3/clients/test_github_client_prs.py"
-        limit: 480
-        reason: "GitHub client PR 测试集，覆盖 auth check、PR create/update、review operations 等多个场景，新增 GH_TOKEN 认证测试后略微超标"
+        limit: 540
+        reason: "GitHub client PR 测试集，覆盖 auth check、PR create/update、review operations、CI 失败分类与检查步骤解析等多个场景，新增 failure category 测试后略微超标"
       - path: "tests/vibe3/orchestra/test_dispatch_health_checks.py"
         limit: 460
         reason: "Health check failure 测试集，7 个独立测试用例验证 coordinator 对 CheckService 结果的处理逻辑，每个测试需要完整 mock setup，拆分会降低可读性"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -56,6 +56,9 @@ code_limits:
       - path: "src/vibe3/clients/github_pr_ops.py"
         limit: 530
         reason: "GitHub PR 操作与查询聚合（日志和错误处理对生产环境必要）"
+      - path: "src/vibe3/clients/github_pr_read_ops.py"
+        limit: 520
+        reason: "GitHub PR 只读查询聚合，新增 CI 失败分类与检查步骤解析逻辑，包含失败分类、日志解析、状态映射等紧密耦合逻辑"
       - path: "src/vibe3/clients/sqlite_client.py"
         limit: 650
         reason: "持久化聚合（flow_state/events/runtime_session 统一入口）"

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -34,18 +34,23 @@ def _build_failure_command(run_id: str, job_id: str | None) -> str:
 def _classify_failed_step_name(step_name: str) -> str | None:
     """Classify a failed step name into a coarse failure category."""
     lowered = step_name.lower()
-    if "pytest" in lowered or "tests" in lowered or "test" in lowered:
-        return "pytest"
-    if "loc" in lowered:
-        return "loc"
-    if "ruff" in lowered or "lint" in lowered:
-        return "ruff"
-    if "mypy" in lowered or "type check" in lowered:
-        return "mypy"
-    if "black" in lowered or "format" in lowered:
-        return "black"
+    # Specific tools first to avoid "Run bats tests" matching "test" before "bats"
     if "bats" in lowered:
         return "bats"
+    if "ruff" in lowered:
+        return "ruff"
+    if "black" in lowered or "format" in lowered:
+        return "black"
+    if "mypy" in lowered or "type check" in lowered:
+        return "mypy"
+    if "loc" in lowered:
+        return "loc"
+    # Generic test match as last resort
+    if "pytest" in lowered or "tests" in lowered or "test" in lowered:
+        return "pytest"
+    # Generic lint match (may include non-ruff steps like "dual-layer lint")
+    if "lint" in lowered:
+        return "lint"
     return None
 
 

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -1,12 +1,141 @@
 """GitHub client PR read operations."""
 
 import json
+import re
 import subprocess
 from typing import Any
 
 from loguru import logger
 
 from vibe3.models.pr import CICheck, PRMetadata, PRResponse, PRState
+
+_ACTIONS_RUN_LINK_RE = re.compile(
+    r"actions/runs/(?P<run_id>\d+)(?:/job/(?P<job_id>\d+))?"
+)
+
+
+def _extract_actions_run_details(link: str) -> tuple[str | None, str | None]:
+    """Extract GitHub Actions run and job IDs from a check link."""
+    match = _ACTIONS_RUN_LINK_RE.search(link)
+    if not match:
+        return None, None
+
+    return match.group("run_id"), match.group("job_id")
+
+
+def _build_failure_command(run_id: str, job_id: str | None) -> str:
+    """Build the command to inspect the failing job logs."""
+    command = f"gh run view {run_id}"
+    if job_id:
+        command += f" --job {job_id}"
+    return f"{command} --log-failed"
+
+
+def _classify_failed_step_name(step_name: str) -> str | None:
+    """Classify a failed step name into a coarse failure category."""
+    lowered = step_name.lower()
+    if "pytest" in lowered or "tests" in lowered or "test" in lowered:
+        return "pytest"
+    if "loc" in lowered:
+        return "loc"
+    if "ruff" in lowered or "lint" in lowered:
+        return "ruff"
+    if "mypy" in lowered or "type check" in lowered:
+        return "mypy"
+    if "black" in lowered or "format" in lowered:
+        return "black"
+    if "bats" in lowered:
+        return "bats"
+    return None
+
+
+def _classify_failed_job(job: dict[str, Any]) -> str | None:
+    """Classify a failed GitHub Actions job from step names."""
+    steps = job.get("steps", [])
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            conclusion = str(step.get("conclusion", "")).lower()
+            if conclusion in {"failure", "cancelled", "timed_out"}:
+                step_name = str(step.get("name", ""))
+                category = _classify_failed_step_name(step_name)
+                if category:
+                    return category
+                break
+
+    job_name = str(job.get("name", ""))
+    return _classify_failed_step_name(job_name)
+
+
+def _enrich_failed_check(check: CICheck) -> CICheck:
+    """Add failure metadata to a failed check when job details are available."""
+    if check.bucket != "fail":
+        return check
+
+    run_id, job_id = _extract_actions_run_details(check.link)
+    if not run_id:
+        return check
+
+    failure_command = _build_failure_command(run_id, job_id)
+    failure_category: str | None = None
+
+    if not job_id:
+        return check.model_copy(update={"failure_command": failure_command})
+
+    try:
+        run_result = subprocess.run(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--job",
+                job_id,
+                "--json",
+                "jobs",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        logger.bind(external="github", run_id=run_id, job_id=job_id).debug(
+            "gh CLI not found when fetching Actions job details"
+        )
+        return check.model_copy(update={"failure_command": failure_command})
+    except subprocess.TimeoutExpired:
+        logger.bind(external="github", run_id=run_id, job_id=job_id).debug(
+            "gh run view timed out after 30 seconds"
+        )
+        return check.model_copy(update={"failure_command": failure_command})
+
+    if run_result.returncode == 0:
+        try:
+            run_data = json.loads(run_result.stdout)
+        except json.JSONDecodeError as e:
+            logger.bind(
+                external="github",
+                run_id=run_id,
+                job_id=job_id,
+                error=str(e),
+            ).debug("Failed to parse gh run view JSON output")
+        else:
+            jobs = run_data.get("jobs", [])
+            if isinstance(jobs, list):
+                for job in jobs:
+                    if not isinstance(job, dict):
+                        continue
+                    failure_category = _classify_failed_job(job)
+                    if failure_category:
+                        break
+
+    return check.model_copy(
+        update={
+            "failure_category": failure_category,
+            "failure_command": failure_command,
+        }
+    )
 
 
 class PRReadMixin:
@@ -125,7 +254,11 @@ class PRReadMixin:
             )
             if checks_result.returncode == 0:
                 checks_data = json.loads(checks_result.stdout)
-                ci_checks = [CICheck(**c) for c in checks_data if isinstance(c, dict)]
+                ci_checks = [
+                    _enrich_failed_check(CICheck(**c))
+                    for c in checks_data
+                    if isinstance(c, dict)
+                ]
             else:
                 stderr = checks_result.stderr.strip() if checks_result.stderr else None
                 logger.bind(

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -19,12 +19,10 @@ class CICheck(BaseModel):
     failure_category: Optional[str] = Field(
         None,
         description="Classified failure category for failed checks",
-        exclude_if=lambda value: value is None,
     )
     failure_command: Optional[str] = Field(
         None,
         description="Command to inspect detailed failure logs",
-        exclude_if=lambda value: value is None,
     )
 
 

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -16,6 +16,16 @@ class CICheck(BaseModel):
     state: str  # SUCCESS, FAILURE, PENDING, etc.
     bucket: str  # pass, fail, pending, skipping, cancel
     link: str
+    failure_category: Optional[str] = Field(
+        None,
+        description="Classified failure category for failed checks",
+        exclude_if=lambda value: value is None,
+    )
+    failure_command: Optional[str] = Field(
+        None,
+        description="Command to inspect detailed failure logs",
+        exclude_if=lambda value: value is None,
+    )
 
 
 class PRState(str, Enum):

--- a/src/vibe3/ui/pr_ui.py
+++ b/src/vibe3/ui/pr_ui.py
@@ -74,6 +74,12 @@ def render_pr_details(pr: PRResponse) -> None:
                 console.print(
                     f"  [red]✗[/] [bold]{check.name}[/] [dim]({check.state})[/]"
                 )
+                if check.failure_category:
+                    console.print(
+                        f"    [dim]Failure category:[/] {check.failure_category}"
+                    )
+                if check.failure_command:
+                    console.print(f"    [dim]Inspect with:[/] {check.failure_command}")
                 console.print(f"    [dim][link={check.link}]View details[/link][/]")
         elif pending:
             console.print(

--- a/tests/vibe3/clients/test_github_client_prs.py
+++ b/tests/vibe3/clients/test_github_client_prs.py
@@ -221,6 +221,60 @@ def test_get_pr_not_found(
     assert pr is None
 
 
+def test_get_pr_enriches_failed_checks_with_category_and_command() -> None:
+    """Test get_pr enriches failed CI checks with failure metadata."""
+    client = GitHubClient()
+
+    pr_data = {
+        "number": 123,
+        "title": "Test PR",
+        "body": "Test body",
+        "state": "OPEN",
+        "headRefName": "feature-branch",
+        "baseRefName": "main",
+        "url": "https://github.com/org/repo/pull/123",
+        "isDraft": False,
+        "createdAt": "2026-03-16T10:00:00Z",
+        "updatedAt": "2026-03-16T10:00:00Z",
+        "mergedAt": None,
+    }
+    checks_data = [
+        {
+            "name": "Lint & Test",
+            "state": "FAILURE",
+            "bucket": "fail",
+            "link": "https://github.com/org/repo/actions/runs/26262915490/job/77300075332",
+        }
+    ]
+    run_data = {
+        "jobs": [
+            {
+                "name": "Lint & Test",
+                "conclusion": "failure",
+                "steps": [
+                    {"name": "Setup", "conclusion": "success"},
+                    {"name": "Run Python tests (pytest)", "conclusion": "failure"},
+                ],
+            }
+        ]
+    }
+
+    with patch("vibe3.clients.github_pr_read_ops.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_data), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(checks_data), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(run_data), stderr=""),
+        ]
+
+        pr = client.get_pr(pr_number=123)
+
+    assert pr is not None
+    assert getattr(pr.ci_checks[0], "failure_category", None) == "pytest"
+    assert getattr(pr.ci_checks[0], "failure_command", None) == (
+        "gh run view 26262915490 --job 77300075332 --log-failed"
+    )
+
+
 def test_mark_ready_success(
     github_client: GitHubClient, mock_subprocess: MagicMock
 ) -> None:

--- a/tests/vibe3/models/test_pr_model_ci_checks.py
+++ b/tests/vibe3/models/test_pr_model_ci_checks.py
@@ -37,6 +37,21 @@ class TestCICheckModel:
             "link": "https://github.com/test/repo/actions/runs/456",
         }
 
+    def test_ci_check_serialization_includes_failure_metadata(self) -> None:
+        """Test CICheck model serialization keeps failure metadata."""
+        check = CICheck(
+            name="Test",
+            state="FAILURE",
+            bucket="fail",
+            link="https://github.com/test/repo/actions/runs/456/job/789",
+            failure_category="pytest",
+            failure_command="gh run view 456 --job 789 --log-failed",
+        )
+
+        data = check.model_dump()
+        assert data["failure_category"] == "pytest"
+        assert data["failure_command"] == "gh run view 456 --job 789 --log-failed"
+
 
 class TestPRResponseCIChecks:
     """Test suite for PRResponse.ci_checks field."""

--- a/tests/vibe3/models/test_pr_model_ci_checks.py
+++ b/tests/vibe3/models/test_pr_model_ci_checks.py
@@ -21,7 +21,7 @@ class TestCICheckModel:
         assert check.link == "https://github.com/test/repo/actions/runs/123"
 
     def test_ci_check_serialization(self) -> None:
-        """Test CICheck model serialization."""
+        """Test CICheck model serialization excludes None fields."""
         check = CICheck(
             name="Build",
             state="FAILURE",
@@ -29,7 +29,7 @@ class TestCICheckModel:
             link="https://github.com/test/repo/actions/runs/456",
         )
 
-        data = check.model_dump()
+        data = check.model_dump(exclude_none=True)
         assert data == {
             "name": "Build",
             "state": "FAILURE",

--- a/tests/vibe3/ui/test_pr_ui_ci_render.py
+++ b/tests/vibe3/ui/test_pr_ui_ci_render.py
@@ -93,6 +93,33 @@ class TestPRUICIRender:
         assert "FAILURE" in output
         assert "View details" in output
 
+    def test_render_ci_failed_includes_failure_category_and_command(self) -> None:
+        """Test failed CI rendering includes failure category and command."""
+        checks = [
+            CICheck(
+                name="Test",
+                state="FAILURE",
+                bucket="fail",
+                link="https://github.com/test/repo/actions/runs/2/job/3",
+                failure_category="pytest",
+                failure_command="gh run view 2 --job 3 --log-failed",
+            ),
+        ]
+
+        pr = PRResponse(
+            number=123,
+            title="Test PR",
+            state=PRState.OPEN,
+            head_branch="feature",
+            base_branch="main",
+            url="https://github.com/test/repo/pull/123",
+            ci_checks=checks,
+        )
+
+        output = _render_to_plain(pr)
+        assert "pytest" in output
+        assert "gh run view 2 --job 3 --log-failed" in output
+
     def test_render_ci_pending(self) -> None:
         """Test rendering when CI checks are pending."""
         checks = [


### PR DESCRIPTION
## Summary
- Add failure category and inspection command to failed CI checks in `vibe3 pr show`.
- Classify failed checks by the first failing job step, then render a concise summary instead of the full log.

## Why
- The previous output only showed a failed check name and link, which made it hard to tell whether the failure was `pytest`, `loc`, `ruff`, or something else.
- This keeps the UI lightweight while still giving a direct command to inspect the detailed failure.

## Validation
- `uv run pytest tests/vibe3/models/test_pr_model_ci_checks.py tests/vibe3/ui/test_pr_ui_ci_render.py tests/vibe3/clients/test_github_client_prs.py -q`
- `uv run pytest tests/vibe3/commands/test_pr_show_bound_task.py -q`
- `uv run pytest tests/vibe3 -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)