### PR TITLE
fix(dispatch): tmux session exists 被错误标记为 launch_failed 导致 issue blocked

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -37,8 +37,8 @@ code_limits:
         reason: "Task resume 操作聚合，包含 reset、label resume 等内聚操作；_clear_blocked_projection 改进后增加显式字段清除逻辑"
       # Exceptions 聚合 —— 允许 510
       - path: "src/vibe3/exceptions/error_tracking.py"
-        limit: 520
-        reason: "Error tracking 核心服务，新增 severity-aware 计数、critical 检查、windowed status 统计，错误分类逻辑紧密耦合"
+        limit: 540
+        reason: "Error tracking 核心服务，新增 get_critical_error_codes() 用于 severity-based CRITICAL 检查（替代硬编码前缀），severity-aware 计数、windowed status 统计，错误分类逻辑紧密耦合"
       - path: "src/vibe3/domain/qualify_gate.py"
         limit: 480
         reason: "Qualify gate 域服务，包含 truth-first 决策流程、blocked 对齐、auto-resume、worktree 健康检查、依赖检查等紧密耦合逻辑"

--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -231,6 +231,7 @@ class ErrorTrackingService:
                 """
                 SELECT DISTINCT error_code FROM error_log
                 WHERE severity = ?
+                ORDER BY error_code
                 """,
                 (ErrorSeverity.CRITICAL.value,),
             ).fetchall()

--- a/src/vibe3/exceptions/error_tracking.py
+++ b/src/vibe3/exceptions/error_tracking.py
@@ -220,6 +220,23 @@ class ErrorTrackingService:
 
         return rows[0] > 0 if rows else False
 
+    def get_critical_error_codes(self) -> list[str]:
+        """Get error codes of CRITICAL severity errors.
+
+        Returns:
+            List of error codes with CRITICAL severity.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT error_code FROM error_log
+                WHERE severity = ?
+                """,
+                (ErrorSeverity.CRITICAL.value,),
+            ).fetchall()
+
+        return [row[0] for row in rows]
+
     def has_model_config_error(self) -> bool:
         """Check if there are any model configuration errors.
 

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -382,7 +382,7 @@ class ExecutionCoordinator:
                 return ExecutionLaunchResult(
                     launched=False,
                     reason=formatted_msg,
-                    reason_code="launch_failed",
+                    reason_code="duplicate_dispatch",
                 )
 
             # Generic error handling for other exceptions

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -375,7 +375,8 @@ class ExecutionCoordinator:
                     target_id=request.target_id,
                 ).warning(f"Execution launch skipped: {formatted_msg}")
 
-                # Still mark as launch_failed (test expectation), but with WARNING level
+                # Mark session failed to release capacity,
+                # but use duplicate_dispatch reason
                 if request.mode == "async" and runtime_session_id is not None:
                     self.registry.mark_failed(runtime_session_id)
 

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -138,7 +138,7 @@ def run_issue_role_sync(
 
     if not sync_result.launched:
         # Soft-skip reason codes: coordinator intentionally declined, not a failure
-        _skip_codes = {"capacity_full"}
+        _skip_codes = {"capacity_full", "duplicate_dispatch"}
         if sync_result.reason_code in _skip_codes:
             typer.echo(
                 f"{spec.role_name} dispatch queued/throttled: {sync_result.reason}"

--- a/src/vibe3/orchestra/failed_gate.py
+++ b/src/vibe3/orchestra/failed_gate.py
@@ -157,10 +157,7 @@ class FailedGate:
         # Check for CRITICAL errors (immediate block)
         # Use has_model_config_error() for backward compatibility with pre-migration DBs
         if error_tracking.has_model_config_error():
-            error_counts = error_tracking.get_error_counts()
-            critical_errors = [
-                code for code in error_counts.keys() if code.startswith("E_MODEL_")
-            ]
+            critical_errors = error_tracking.get_critical_error_codes()
             log.error(f"CRITICAL errors detected: {critical_errors}")
             return GateResult(
                 blocked=True,

--- a/src/vibe3/orchestra/failed_gate.py
+++ b/src/vibe3/orchestra/failed_gate.py
@@ -155,13 +155,23 @@ class FailedGate:
         error_tracking = ErrorTrackingService.get_instance(store=self.store)
 
         # Check for CRITICAL errors (immediate block)
-        # Use has_model_config_error() for backward compatibility with pre-migration DBs
-        if error_tracking.has_model_config_error():
+        # Two-stage check for backward compatibility with pre-migration DBs:
+        # 1. If CRITICAL-severity rows exist → use get_critical_error_codes()
+        # 2. If only legacy E_MODEL_% prefix rows exist → use descriptive message
+        if error_tracking.has_critical_error():
             critical_errors = error_tracking.get_critical_error_codes()
             log.error(f"CRITICAL errors detected: {critical_errors}")
             return GateResult(
                 blocked=True,
                 reason=f"CRITICAL errors: {', '.join(critical_errors)}",
+            )
+        elif error_tracking.has_model_config_error():
+            # Legacy path: E_MODEL_% prefix without CRITICAL severity rows
+            log.error("Legacy model config errors detected (no severity metadata)")
+            return GateResult(
+                blocked=True,
+                reason="Model configuration errors "
+                "(legacy, severity migration pending)",
             )
 
         # Check for frequent ERROR-severity errors (threshold: 2+ in window)

--- a/tests/vibe3/execution/test_coordinator.py
+++ b/tests/vibe3/execution/test_coordinator.py
@@ -468,7 +468,7 @@ def test_coordinator_dispatch_launch_failed_duplicate_tmux_gets_context(
         result = coordinator.dispatch_execution(request)
 
         assert result.launched is False
-        assert result.reason_code == "launch_failed"
+        assert result.reason_code == "duplicate_dispatch"
         assert "previous session still alive" in result.reason
         assert "vibe3-planner-issue-303" in result.reason
         assert "previous session still alive" in mock_event.call_args.args[1]

--- a/tests/vibe3/test_dispatch_error_propagation.py
+++ b/tests/vibe3/test_dispatch_error_propagation.py
@@ -153,6 +153,7 @@ class TestFailedGateExecThreshold:
         # so we must patch the source module, not failed_gate.
         with patch("vibe3.exceptions.error_tracking.ErrorTrackingService") as mock_ets:
             mock_instance = MagicMock()
+            mock_instance.has_critical_error.return_value = False
             mock_instance.has_model_config_error.return_value = False
             mock_instance.get_threshold_error_count.return_value = 2
             mock_ets.get_instance.return_value = mock_instance
@@ -172,6 +173,7 @@ class TestFailedGateExecThreshold:
 
         with patch("vibe3.exceptions.error_tracking.ErrorTrackingService") as mock_ets:
             mock_instance = MagicMock()
+            mock_instance.has_critical_error.return_value = False
             mock_instance.has_model_config_error.return_value = False
             mock_instance.get_threshold_error_count.return_value = 1
             mock_ets.get_instance.return_value = mock_instance


### PR DESCRIPTION
## 问题

在 dispatch handler 中，当 tmux session 已存在时（典型的重试/心跳重复派发场景），coordinator 返回 `reason_code="launch_failed"`，导致 handler 调用 `block_flow()`，issue 被错误标记为 `state/blocked`。

## 根因

**coordinator.py** 有两条 tmux session exists 检测路径：

1. **路径 A（正常跳过）**：dispatch dedup 检查（第 184 行）→ 返回 `duplicate_dispatch` → ✅ 正确
2. **路径 B（错误 block）**：launch 失败（async_launcher 抛出 RuntimeError）→ 返回 `launch_failed` → ❌ 被 block

路径 B 中，虽然 coordinator 在日志中标注"expected skip"，但 `reason_code` 仍是 `"launch_failed"`，handler 无法区分这是"tmux 已存在（正常）"还是"真正的启动失败"。

## 修复内容

1. **coordinator.py**: 将 tmux session exists 的 `reason_code` 从 `"launch_failed"` 改为 `"duplicate_dispatch"`
2. **issue_role_sync_runner.py**: 将 `duplicate_dispatch` 加入 `_skip_codes`，避免触发失败处理
3. **failed_gate.py**: 使用基于 severity 的 `get_critical_error_codes()`，而不是硬编码前缀检查
4. **error_tracking.py**: 新增 `get_critical_error_codes()` 方法

## 额外修复：遗留旧模式

**failed_gate.py** 使用 `startswith("E_MODEL_")` 检查 CRITICAL errors，这是重构前的遗留模式。现已改为使用 severity 字段查询，符合 error severity 系统设计。

## 影响范围

- 影响所有通过 async_launcher 启动的 agent（manager/planner/executor/reviewer）
- 修复后，tmux session 冲突不再导致 issue blocked
- 现有错误 blocked 的 issues (#1009, #1010, #1011) 需要手动恢复

## 测试

- ✅ coordinator 测试通过（更新测试期望值）
- ✅ failed_gate 测试通过
- ✅ error_tracking 测试通过

Fixes #1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)