### PR TITLE
fix: task resume --label auto 正确清除 issue body blocked_reason

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -63,13 +63,14 @@ code_limits:
         limit: 650
         reason: "持久化聚合（flow_state/events/runtime_session 统一入口）"
       - path: "src/vibe3/clients/sqlite_flow_state_repo.py"
-        limit: 420
+        limit: 450
         reason: |
           Repo 层职责内聚，包含：
           - 基础 CRUD 操作（10 个 get 方法）
           - Soft-delete 扩展（4 个方法）
           - Cascade delete 逻辑
           - Query 过滤逻辑（WHERE deleted_at IS NULL）
+          - get_task_issue_number 方法（从 flow_issue_links 查询 task issue）
 
           拆分会破坏：
           - 数据访问层完整性

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -174,6 +174,32 @@ class SQLiteFlowStateRepo(_HasConnection):
         ).debug("Retrieved dependency links")
         return deps
 
+    def get_task_issue_number(self, branch: str) -> int | None:
+        """Get task issue number for a branch from flow_issue_links.
+
+        Args:
+            branch: Branch name to query
+
+        Returns:
+            Task issue number if found, None otherwise
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT issue_number FROM flow_issue_links "
+            "WHERE branch = ? AND issue_role = 'task' LIMIT 1",
+            (branch,),
+        )
+        row = cursor.fetchone()
+        result = int(row[0]) if row and row[0] is not None else None
+        logger.bind(
+            external="sqlite",
+            operation="get_task_issue_number",
+            branch=branch,
+            issue_number=result,
+        ).debug("Retrieved task issue number")
+        return result
+
     def get_all_flows(self) -> list[dict[str, Any]]:
         """Get all flows (excludes soft-deleted flows)."""
         conn = self._get_connection()

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -396,11 +396,9 @@ class TaskResumeOperations:
             )
 
             # Clear blocked state from issue body projection
-            flow_data = self.flow_service.store.get_flow_state(branch)
-            if flow_data:
-                issue_number = flow_data.get("task_issue_number")
-                if issue_number:
-                    self._clear_blocked_projection(issue_number)
+            issue_number = self.flow_service.store.get_task_issue_number(branch)
+            if issue_number:
+                self._clear_blocked_projection(issue_number)
 
         except Exception as exc:
             # Non-blocking: reason clearing failure should not affect resume

--- a/tests/vibe3/clients/test_sqlite_flow_state_repo.py
+++ b/tests/vibe3/clients/test_sqlite_flow_state_repo.py
@@ -105,3 +105,60 @@ def test_soft_delete_flow_clears_refs_from_active_flow() -> None:
         assert deleted["plan_ref"] is None
         assert deleted["report_ref"] is None
         assert deleted["audit_ref"] is None
+
+
+def test_get_task_issue_number_returns_int_when_link_exists() -> None:
+    """Test get_task_issue_number returns int when flow_issue_links has task."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("task/issue-123", flow_slug="issue_123")
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-123", 123, "task"),
+        )
+        conn.commit()
+
+        result = store.get_task_issue_number("task/issue-123")
+        assert result == 123
+        assert isinstance(result, int)
+
+
+def test_get_task_issue_number_returns_none_when_missing() -> None:
+    """Test that get_task_issue_number returns None when no matching row."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("dev/issue-456", flow_slug="issue_456")
+
+        result = store.get_task_issue_number("dev/issue-456")
+        assert result is None
+
+
+def test_get_task_issue_number_ignores_non_task_roles() -> None:
+    """Test that get_task_issue_number only returns task role, not others."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("dev/issue-789", flow_slug="issue_789")
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("dev/issue-789", 789, "spec"),
+        )
+        conn.commit()
+
+        result = store.get_task_issue_number("dev/issue-789")
+        assert result is None

--- a/tests/vibe3/services/test_task_resume_operations.py
+++ b/tests/vibe3/services/test_task_resume_operations.py
@@ -407,15 +407,12 @@ def test_clear_flow_reasons_clears_blocked_projection() -> None:
 
     with (
         patch.object(operations.flow_service.store, "update_flow_state"),
-        patch.object(operations.flow_service.store, "get_flow_state") as mock_get,
+        patch.object(
+            operations.flow_service.store, "get_task_issue_number"
+        ) as mock_get_issue,
         patch.object(operations, "_clear_blocked_projection") as mock_clear,
     ):
-        # Setup flow state with issue number
-        mock_get.return_value = {
-            "branch": "task/issue-123",
-            "task_issue_number": 123,
-            "blocked_reason": "API design pending",
-        }
+        mock_get_issue.return_value = 123
 
         # Execute
         operations._clear_flow_reasons("task/issue-123", "blocked")


### PR DESCRIPTION
## Summary

修复 `task resume --label auto` 不清除 GitHub issue body `blocked_reason` 的 bug。

## Problem

`task resume --label auto` 只清除了 SQLite 的 `blocked_reason`，但没有清除 GitHub issue body 中的 `blocked_reason`。

下次 `qualify_gate` 运行时，会从 issue body 读取 `blocked_reason` 并同步回 SQLite，导致 blocked 状态恢复。

## Root Cause

`task_resume_operations.py:398-403` 中的代码有 bug：

```python
flow_data = self.flow_service.store.get_flow_state(branch)
if flow_data:
    issue_number = flow_data.get("task_issue_number")  # ❌ 永远返回 None
    if issue_number:
        self._clear_blocked_projection(issue_number)  # ❌ 永远不会调用
```

问题：
- `flow_state` 表**没有** `task_issue_number` 列
- `task_issue_number` 存在 `flow_issue_links` 表里
- `flow_data.get("task_issue_number")` 永远返回 `None`
- `_clear_blocked_projection` **永远不会被调用**

## Solution

1. 在 `sqlite_flow_state_repo.py` 添加 `get_task_issue_number()` 方法，从 `flow_issue_links` 表查询
2. 修改 `task_resume_operations.py` 使用新方法

## Verification

手动验证 `task resume 1035 --label auto`：

| 位置 | 修复前 | 修复后 |
|------|--------|--------|
| SQLite | 空 | 空 ✅ |
| Issue body | 有 blocked_reason | **已清除** ✅ |

## Test Plan

- [x] 所有单元测试通过 (15/15)
- [x] Pre-push checks 通过
- [x] 手动验证 issue body 被正确清除

Fixes #1284