### PR TITLE
refactor(sqlite): remove unused save_queue_entry/load_queue_entry methods

### DIFF
--- a/src/vibe3/clients/sqlite_queue_repo.py
+++ b/src/vibe3/clients/sqlite_queue_repo.py
@@ -18,64 +18,6 @@ class SQLiteQueueRepo(_HasConnection):
             self._enqueued_at_cache[self.db_path] = "enqueued_at" in columns
         return self._enqueued_at_cache[self.db_path]
 
-    def save_queue_entry(
-        self,
-        issue_number: int,
-        collected_state: str | None = None,
-        waiting_state: str | None = None,
-        retry_count: int = 0,
-        last_attempted_at: str | None = None,
-    ) -> None:
-        """INSERT OR REPLACE a single queue entry."""
-        updated_at = datetime.datetime.now().isoformat()
-        # Use last_attempted_at for enqueued_at if column exists (backward compat)
-        timestamp = last_attempted_at or updated_at
-
-        conn = self._get_connection()
-        with conn:
-            if self._check_has_enqueued_at(conn):
-                conn.execute(
-                    "INSERT OR REPLACE INTO orchestra_queue "
-                    "(issue_number, collected_state, waiting_state, retry_count, "
-                    "last_attempted_at, enqueued_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        issue_number,
-                        collected_state,
-                        waiting_state,
-                        retry_count,
-                        last_attempted_at,
-                        timestamp,
-                        updated_at,
-                    ),
-                )
-            else:
-                conn.execute(
-                    "INSERT OR REPLACE INTO orchestra_queue "
-                    "(issue_number, collected_state, waiting_state, retry_count, "
-                    "last_attempted_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (
-                        issue_number,
-                        collected_state,
-                        waiting_state,
-                        retry_count,
-                        last_attempted_at,
-                        updated_at,
-                    ),
-                )
-
-    def load_queue_entry(self, issue_number: int) -> dict[str, Any] | None:
-        conn = self._get_connection()
-        conn.row_factory = sqlite3.Row
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
-            (issue_number,),
-        )
-        row = cursor.fetchone()
-        return dict(row) if row else None
-
     def load_all_queue_entries(self) -> list[dict[str, Any]]:
         conn = self._get_connection()
         conn.row_factory = sqlite3.Row

--- a/tests/vibe3/clients/test_sqlite_fd_exhaustion.py
+++ b/tests/vibe3/clients/test_sqlite_fd_exhaustion.py
@@ -51,11 +51,19 @@ def test_fd_not_exhausted_queue_operations(tmp_path: Path) -> None:
     proc = psutil.Process(os.getpid())
     before = proc.num_fds()
 
-    # Perform 1000 queue operations (heartbeat pattern)
+    # Perform 1000 queue operations using singleton connection (heartbeat pattern)
     for i in range(1000):
-        client.save_queue_entry(i % 100, collected_state=f"state-{i}")
-        entry = client.load_queue_entry(i % 100)
-        assert entry is not None
+        client.replace_all_queue_entries(
+            [
+                {
+                    "issue_number": i % 100,
+                    "collected_state": f"state-{i}",
+                    "retry_count": 0,
+                }
+            ]
+        )
+        entries = client.load_all_queue_entries()
+        assert len(entries) > 0
 
     after = proc.num_fds()
     fd_growth = after - before

--- a/tests/vibe3/clients/test_sqlite_queue_repo.py
+++ b/tests/vibe3/clients/test_sqlite_queue_repo.py
@@ -1,7 +1,6 @@
 """Tests for SQLiteQueueRepo CRUD operations."""
 
 import sqlite3
-import time
 
 from vibe3.clients.sqlite_client import SQLiteClient
 
@@ -24,53 +23,28 @@ def test_fresh_db_has_orchestra_queue_table(tmp_path):
     assert columns["updated_at"] == "TEXT"
 
 
-def test_save_and_load_single_entry(tmp_path):
-    """Save one entry, load it back — fields match."""
-    db_path = tmp_path / "test.db"
-    client = SQLiteClient(db_path=str(db_path))
-
-    client.save_queue_entry(
-        issue_number=123,
-        collected_state="state_collected",
-        waiting_state="state_waiting",
-    )
-
-    entry = client.load_queue_entry(123)
-    assert entry["issue_number"] == 123
-    assert entry["collected_state"] == "state_collected"
-    assert entry["waiting_state"] == "state_waiting"
-    assert entry["updated_at"] is not None
-
-
-def test_save_overwrites_existing_entry(tmp_path):
-    """Save twice — second write wins."""
-    db_path = tmp_path / "test.db"
-    client = SQLiteClient(db_path=str(db_path))
-
-    client.save_queue_entry(456, collected_state="first")
-    client.save_queue_entry(456, collected_state="second")
-
-    entry = client.load_queue_entry(456)
-    assert entry["collected_state"] == "second"
-
-
-def test_load_missing_returns_none(tmp_path):
-    """Load non-existent issue_number returns None."""
-    db_path = tmp_path / "test.db"
-    client = SQLiteClient(db_path=str(db_path))
-
-    assert client.load_queue_entry(999) is None
-
-
 def test_remove_entry(tmp_path):
     """Save then remove — load returns None."""
     db_path = tmp_path / "test.db"
     client = SQLiteClient(db_path=str(db_path))
 
-    client.save_queue_entry(789, collected_state="to_remove")
+    # Setup: insert entry using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (789, "to_remove"),
+        )
+
     client.remove_queue_entry(789)
 
-    assert client.load_queue_entry(789) is None
+    # Verify: check entry is gone using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (789,),
+        ).fetchone()
+    assert row is None
 
 
 def test_remove_missing_is_noop(tmp_path):
@@ -86,9 +60,23 @@ def test_load_all_returns_all_entries(tmp_path):
     db_path = tmp_path / "test.db"
     client = SQLiteClient(db_path=str(db_path))
 
-    client.save_queue_entry(101, collected_state="a")
-    client.save_queue_entry(102, collected_state="b")
-    client.save_queue_entry(103, collected_state="c")
+    # Setup: insert 3 entries using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (101, "a"),
+        )
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (102, "b"),
+        )
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (103, "c"),
+        )
 
     entries = client.load_all_queue_entries()
     assert len(entries) == 3
@@ -100,8 +88,18 @@ def test_replace_all_entries(tmp_path):
     db_path = tmp_path / "test.db"
     client = SQLiteClient(db_path=str(db_path))
 
-    client.save_queue_entry(201, collected_state="old1")
-    client.save_queue_entry(202, collected_state="old2")
+    # Setup: insert 2 old entries using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (201, "old1"),
+        )
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (202, "old2"),
+        )
 
     new_entries = [
         {"issue_number": 301, "collected_state": "new1"},
@@ -113,33 +111,19 @@ def test_replace_all_entries(tmp_path):
     entries = client.load_all_queue_entries()
     assert len(entries) == 3
     assert {e["issue_number"] for e in entries} == {301, 302, 303}
-    assert client.load_queue_entry(201) is None
-    assert client.load_queue_entry(202) is None
 
-
-def test_updated_at_auto_set_on_save(tmp_path):
-    """Save entry, updated_at is non-null."""
-    db_path = tmp_path / "test.db"
-    client = SQLiteClient(db_path=str(db_path))
-
-    client.save_queue_entry(401, collected_state="test")
-    assert client.load_queue_entry(401)["updated_at"] is not None
-
-
-def test_updated_at_updates_on_second_save(tmp_path):
-    """Save, wait, save again — updated_at changes."""
-    db_path = tmp_path / "test.db"
-    client = SQLiteClient(db_path=str(db_path))
-
-    client.save_queue_entry(501, collected_state="first")
-    first_updated = client.load_queue_entry(501)["updated_at"]
-
-    time.sleep(0.01)
-
-    client.save_queue_entry(501, collected_state="second")
-    second_updated = client.load_queue_entry(501)["updated_at"]
-
-    assert second_updated != first_updated
+    # Verify old entries are gone using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        row_201 = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (201,),
+        ).fetchone()
+        row_202 = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (202,),
+        ).fetchone()
+    assert row_201 is None
+    assert row_202 is None
 
 
 def test_replace_all_handles_duplicate_issue_numbers(tmp_path):
@@ -156,7 +140,8 @@ def test_replace_all_handles_duplicate_issue_numbers(tmp_path):
 
     all_entries = client.load_all_queue_entries()
     assert len(all_entries) == 2
-    entry_601 = client.load_queue_entry(601)
+    # Find entry 601 and verify it has the second value
+    entry_601 = next((e for e in all_entries if e["issue_number"] == 601), None)
     assert entry_601 is not None
     assert entry_601["collected_state"] == "second"
 
@@ -187,7 +172,7 @@ def test_legacy_enqueued_at_migration(tmp_path):
         )
 
     # Step 2: Run init_schema (triggers migration)
-    client = SQLiteClient(db_path=str(db_path))
+    SQLiteClient(db_path=str(db_path))
 
     # Step 3: Verify migration added last_attempted_at
     with sqlite3.connect(str(db_path)) as conn:
@@ -198,19 +183,32 @@ def test_legacy_enqueued_at_migration(tmp_path):
         assert "last_attempted_at" in columns
 
     # Step 4: Verify legacy row has last_attempted_at migrated from enqueued_at
-    legacy_entry = client.load_queue_entry(100)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (100,),
+        ).fetchone()
+        legacy_entry = dict(row) if row else None
     assert legacy_entry["last_attempted_at"] == "2026-05-16T10:00:00"
 
     # Step 5: Verify new inserts succeed (NOT NULL constraint satisfied)
-    client.save_queue_entry(
-        issue_number=200,
-        collected_state="blocked",
-        waiting_state="review",
-        retry_count=2,
-        last_attempted_at="2026-05-17T09:00:00",
-    )
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO orchestra_queue "
+            "(issue_number, collected_state, waiting_state, retry_count, "
+            "last_attempted_at, enqueued_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            (200, "blocked", "review", 2, "2026-05-17T09:00:00", "2026-05-17T09:00:00"),
+        )
 
-    new_entry = client.load_queue_entry(200)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (200,),
+        ).fetchone()
+        new_entry = dict(row) if row else None
     assert new_entry["issue_number"] == 200
     assert new_entry["retry_count"] == 2
     assert new_entry["last_attempted_at"] == "2026-05-17T09:00:00"
@@ -248,7 +246,13 @@ def test_replace_all_with_legacy_enqueued_at(tmp_path):
     ]
     client.replace_all_queue_entries(entries)
 
-    loaded = client.load_queue_entry(300)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM orchestra_queue WHERE issue_number = ?",
+            (300,),
+        ).fetchone()
+        loaded = dict(row) if row else None
     assert loaded["retry_count"] == 1
     assert loaded["last_attempted_at"] == "2026-05-17T08:00:00"
     assert loaded["enqueued_at"] == "2026-05-17T08:00:00"
@@ -259,7 +263,9 @@ def test_queue_entry_persists_across_connections(tmp_path):
     db_path = tmp_path / "persist.db"
     client = SQLiteClient(db_path=str(db_path))
 
-    client.save_queue_entry(777, collected_state="persisted")
+    client.replace_all_queue_entries(
+        [{"issue_number": 777, "collected_state": "persisted", "retry_count": 0}]
+    )
 
     with sqlite3.connect(str(db_path)) as conn:
         row = conn.execute(
@@ -276,8 +282,19 @@ def test_queue_operations_persist_across_connections(tmp_path):
     db_path = tmp_path / "persist_ops.db"
     client = SQLiteClient(db_path=str(db_path))
 
-    client.save_queue_entry(1, collected_state="one")
-    client.save_queue_entry(2, collected_state="two")
+    # Setup: insert 2 entries using raw SQL
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (1, "one"),
+        )
+        conn.execute(
+            "INSERT INTO orchestra_queue (issue_number, collected_state, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (2, "two"),
+        )
+
     client.remove_queue_entry(1)
     client.replace_all_queue_entries(
         [{"issue_number": 3, "collected_state": "three", "retry_count": 0}]

--- a/tests/vibe3/clients/test_sqlite_queue_repo.py
+++ b/tests/vibe3/clients/test_sqlite_queue_repo.py
@@ -148,7 +148,8 @@ def test_replace_all_handles_duplicate_issue_numbers(tmp_path):
 
 def test_legacy_enqueued_at_migration(tmp_path):
     """Simulate a legacy DB with enqueued_at NOT NULL, run init_schema,
-    then verify save_queue_entry succeeds and both columns are populated."""
+    verify last_attempted_at column is added, legacy data is migrated,
+    and new inserts succeed."""
     db_path = tmp_path / "legacy.db"
 
     # Step 1: Create a legacy-style orchestra_queue with enqueued_at NOT NULL


### PR DESCRIPTION
## Summary
Delete unused single-entry queue methods and migrate tests to use bulk operations or raw SQL.

Changes:
- Remove `save_queue_entry` and `load_queue_entry` from `SQLiteQueueRepo` (-58 lines)
- Delete 5 tests that only validated the removed methods
- Migrate 8 tests to use raw SQL for setup/verification
- Update FD exhaustion test (already using bulk operations)

The removed methods had no production callers - all references were in test files. Tests now use `replace_all_queue_entries`/`load_all_queue_entries` or raw SQL, maintaining the same test coverage.

## Test plan
- [x] 13/13 tests pass
- [x] MyPy type check clean
- [x] Pre-push checks passed
- [x] Review verdict: PASS

Closes #1208

---

## Contributors

claude/opus
