### PR TITLE
docs: explain flow bind multi-dependency semantics (issue #896)

### DIFF
--- a/docs/references/flow-dependency.md
+++ b/docs/references/flow-dependency.md
@@ -187,6 +187,60 @@ VALUES
 
 ---
 
+## 多依赖语义
+
+当使用 `flow bind --role dependency` 同时绑定多个依赖时，系统表现出**双重语义**：
+
+### 行为描述
+
+```bash
+vibe3 flow bind --role dependency 100 101 102
+```
+
+执行流程：
+1. **按顺序调用**: 对每个依赖 issue 依次调用 `block_flow()`（100 → 101 → 102）
+2. **数据库字段**: `flow_state.blocked_by_issue` 被最后一次调用覆盖，最终值为 102
+3. **Issue Body 累积**: 所有依赖都累积到 issue body 的 `blocked_by` 字段（100, 101, 102 均保留）
+4. **链接记录**: 所有依赖都记录在 `flow_issue_links` 表中，角色为 `dependency`
+
+### 双重存储机制
+
+这种"双重语义"源于两层存储：
+
+| 存储层 | 字段 | 更新行为 | 最终值 |
+|--------|------|---------|--------|
+| **flow_state 表** | `blocked_by_issue` | 每次调用覆盖 | 102（最后一个） |
+| **issue body** | `blocked_by` | 通过 `_project_blocked_state()` 合并去重 | [100, 101, 102] |
+| **flow_issue_links 表** | `issue_role='dependency'` | 每次调用插入 | 三条记录 |
+
+代码位置：
+- 多 ref 循环：`src/vibe3/commands/flow_manage.py:310-320`
+- 字段覆盖：`src/vibe3/services/flow_block_mixin.py:121-127`
+- 累积合并：`src/vibe3/services/flow_block_mixin.py:23-65`
+
+### 最佳实践
+
+**不推荐**同时绑定多个依赖：
+```bash
+# 可能造成语义混淆
+vibe3 flow bind --role dependency 100 101 102
+```
+
+**推荐**逐个绑定：
+```bash
+vibe3 flow bind --role dependency 100
+vibe3 flow bind --role dependency 101
+vibe3 flow bind --role dependency 102
+```
+
+或使用 `flow blocked --task` 命令建立依赖关系，语义更明确。
+
+### 详细说明
+
+参见 [Flow Bind 使用指南](../v3/infrastructure/flow-bind-usage.md) 获取完整用法说明。
+
+---
+
 ## 查询与验证
 
 ### 查看依赖关系

--- a/docs/v3/infrastructure/flow-bind-usage.md
+++ b/docs/v3/infrastructure/flow-bind-usage.md
@@ -1,0 +1,85 @@
+# Flow Bind 使用指南
+
+## 概述
+
+`flow bind` 命令用于建立 flow 与 issue 之间的关联关系，支持三种角色：
+- `task`: 表示该 flow 对应的 task issue
+- `related`: 表示相关联的 issue（不阻塞）
+- `dependency`: 表示依赖的 issue（阻塞当前 flow）
+
+## 基本用法
+
+```bash
+# 绑定 task issue
+vibe3 flow bind --role task <issue-number>
+
+# 绑定相关 issue
+vibe3 flow bind --role related <issue-number>
+
+# 绑定依赖 issue
+vibe3 flow bind --role dependency <issue-number>
+```
+
+## 多依赖语义（重要）
+
+### 行为描述
+
+当使用 `flow bind --role dependency A B C` 绑定多个依赖时：
+
+1. **按顺序调用**: 对每个依赖 issue 按顺序调用 `block_flow()`（A → B → C）
+2. **数据库字段**: flow state 的 `blocked_by_issue` 字段被最后一次调用覆盖，最终值为 C
+3. **Issue Body 累积**: 所有依赖都会累积到 issue body 的 `blocked_by` 列表中（A, B, C 都会保留）
+4. **链接记录**: 所有依赖都记录在 `flow_issue_links` 表中，角色为 `dependency`
+
+### 示例
+
+```bash
+# 绑定多个依赖
+vibe3 flow bind --role dependency 100 101 102
+```
+
+执行后：
+- Flow state 表: `blocked_by_issue = 102`（最后一个）
+- Issue body 的 blocked_by 字段: `[100, 101, 102]`（全部累积）
+- Flow issue links 表: 三条记录，issue_number 分别为 100, 101, 102
+
+### 实现细节
+
+这种"双重语义"源于两层存储机制：
+- **Flow State 表**: 单值字段 `blocked_by_issue`，每次 `block_flow()` 调用都会覆盖
+- **Issue Body**: 列表字段 `blocked_by`，通过 `_project_blocked_state()` 方法合并去重
+
+代码位置：`src/vibe3/commands/flow_manage.py:310-320`
+
+## 最佳实践
+
+### 避免同时绑定多个依赖
+
+由于多依赖语义的复杂性，建议：
+
+**不推荐**:
+```bash
+vibe3 flow bind --role dependency 100 101 102
+```
+
+**推荐**:
+```bash
+# 逐个绑定，明确主依赖
+vibe3 flow bind --role dependency 100
+vibe3 flow bind --role dependency 101
+vibe3 flow bind --role dependency 102
+```
+
+或使用 `vibe3 flow blocked --task <issue>` 命令逐个建立依赖关系。
+
+### 使用场景区分
+
+- **Task**: 每个 flow 只有一个 task issue
+- **Related**: 可绑定多个相关 issue
+- **Dependency**: 建议绑定主依赖 issue，避免多依赖混淆
+
+## 参考文档
+
+- 命令标准: `docs/standards/v3/command-standard.md` (flow bind 章节)
+- 依赖管理: `docs/references/flow-dependency.md`
+- 代码实现: `src/vibe3/commands/flow_manage.py`


### PR DESCRIPTION
Closes #896

## Summary

- Added comprehensive documentation for `flow bind --role dependency` behavior when binding multiple dependencies simultaneously
- Created `docs/v3/infrastructure/flow-bind-usage.md`: detailed user guide with examples and edge cases
- Updated `docs/references/flow-dependency.md`: added multi-dependency section explaining storage semantics

## Key Findings Documented

**Dual Storage Mechanism**:
- `flow_state.blocked_by_issue`: overwritten by last dependency (single reference)
- `issue body blocked_by`: accumulates all dependencies (multiple references)
- `flow_issue_links`: records all dependencies with `role='dependency'`

**Recommendation**: Bind dependencies individually for clearer semantics

## Code References Verified

- `flow_manage.py:310-320`: multi-ref loop processes dependencies sequentially
- `flow_block_mixin.py:121-127`: field overwrite behavior
- `flow_block_mixin.py:23-65`: accumulation merge logic

## Test Plan

- [x] Documentation cross-references validated
- [x] Code references verified line-by-line
- [x] No structural changes (documentation-only task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
