### PR TITLE
fix(worktree): reuse existing registered worktree instead of error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ wt-*/
 .agent/context/task.md
 .agent/reports/
 .sisyphus/
+.omo/
 docs/audits/
 docs/plans/
 docs/reports/

--- a/src/vibe3/environment/worktree_lifecycle.py
+++ b/src/vibe3/environment/worktree_lifecycle.py
@@ -71,6 +71,32 @@ class WorktreeLifecycle:
         # Pre-flight: cleanup stale references
         self._prune_worktrees()
 
+        # Check if worktree already exists and is registered
+        if wt_path.exists() and find_worktree_by_path(self.repo_path, wt_path):
+            # Verify branch matches before reusing
+            if self.validate_branch_matches(wt_path, branch):
+                logger.info(
+                    "Reusing existing registered worktree",
+                    path=str(wt_path),
+                    branch=branch,
+                    issue=issue_number,
+                )
+                return WorktreeContext(
+                    path=wt_path,
+                    is_temporary=False,
+                    branch=branch,
+                    issue_number=issue_number,
+                )
+            else:
+                logger.warning(
+                    "Existing worktree has different branch, removing",
+                    path=str(wt_path),
+                    expected_branch=branch,
+                )
+                from vibe3.environment.worktree_support import recycle_worktree_path
+
+                recycle_worktree_path(self.repo_path, wt_path)
+
         # If path exists but is not registered, delete it
         if wt_path.exists() and not find_worktree_by_path(self.repo_path, wt_path):
             logger.warning(

--- a/src/vibe3/environment/worktree_lifecycle.py
+++ b/src/vibe3/environment/worktree_lifecycle.py
@@ -18,6 +18,7 @@ from vibe3.environment.worktree_context import WorktreeContext
 from vibe3.environment.worktree_support import (
     find_worktree_by_path,
     initialize_worktree,
+    recycle_worktree_path,
 )
 from vibe3.exceptions import SystemError
 from vibe3.services.status_query_service import is_auto_task_branch
@@ -71,39 +72,39 @@ class WorktreeLifecycle:
         # Pre-flight: cleanup stale references
         self._prune_worktrees()
 
-        # Check if worktree already exists and is registered
-        if wt_path.exists() and find_worktree_by_path(self.repo_path, wt_path):
-            # Verify branch matches before reusing
-            if self.validate_branch_matches(wt_path, branch):
-                logger.info(
-                    "Reusing existing registered worktree",
-                    path=str(wt_path),
-                    branch=branch,
-                    issue=issue_number,
-                )
-                return WorktreeContext(
-                    path=wt_path,
-                    is_temporary=False,
-                    branch=branch,
-                    issue_number=issue_number,
-                )
+        if wt_path.exists():
+            is_registered = find_worktree_by_path(self.repo_path, wt_path)
+
+            if is_registered:
+                if self.validate_branch_matches(wt_path, branch):
+                    logger.info(
+                        "Reusing existing registered worktree",
+                        path=str(wt_path),
+                        branch=branch,
+                        issue=issue_number,
+                    )
+                    return WorktreeContext(
+                        path=wt_path,
+                        is_temporary=False,
+                        branch=branch,
+                        issue_number=issue_number,
+                    )
+                else:
+                    logger.warning(
+                        "Existing worktree has different branch, removing",
+                        path=str(wt_path),
+                        expected_branch=branch,
+                    )
+                    # recycle_worktree_path is git-aware: runs
+                    # `git worktree remove --force` before rmtree,
+                    # so both filesystem and git metadata are cleaned.
+                    recycle_worktree_path(self.repo_path, wt_path)
             else:
                 logger.warning(
-                    "Existing worktree has different branch, removing",
+                    "Deleting unregistered directory at target worktree path",
                     path=str(wt_path),
-                    expected_branch=branch,
                 )
-                from vibe3.environment.worktree_support import recycle_worktree_path
-
-                recycle_worktree_path(self.repo_path, wt_path)
-
-        # If path exists but is not registered, delete it
-        if wt_path.exists() and not find_worktree_by_path(self.repo_path, wt_path):
-            logger.warning(
-                "Deleting unregistered directory at target worktree path",
-                path=str(wt_path),
-            )
-            shutil.rmtree(wt_path)
+                shutil.rmtree(wt_path)
 
         try:
             result = subprocess.run(

--- a/tests/vibe3/environment/test_worktree_robustness.py
+++ b/tests/vibe3/environment/test_worktree_robustness.py
@@ -169,9 +169,16 @@ class TestOrphanDirectoryCleanup:
                     stdout="",
                     stderr="",
                 ),
-                # _find_worktree_by_path returns False (not registered)
+                # _find_worktree_by_path returns False (not registered) - first call
                 subprocess.CompletedProcess(
-                    args=["git", "worktree", "list"],
+                    args=["git", "worktree", "list", "--porcelain"],
+                    returncode=0,
+                    stdout="worktree /other/path\n",  # Different worktree
+                    stderr="",
+                ),
+                # _find_worktree_by_path returns False (not registered) - second call
+                subprocess.CompletedProcess(
+                    args=["git", "worktree", "list", "--porcelain"],
                     returncode=0,
                     stdout="worktree /other/path\n",  # Different worktree
                     stderr="",


### PR DESCRIPTION
## Problem

Orchestra dispatch 失败，当 worktree 路径已存在且已注册时报错而非复用：

```
ERROR | Git worktree add failed
ERROR | Failed to create worktree: Git worktree add failed: Preparing worktree (checking out 'task/issue-994')
fatal: '/Users/chenyi/src/vibe-coding-control-center/.worktrees/task/issue-994' already exists
ERROR | Worktree creation failed while use_worktree=True
ERROR | Failed to prepare role execution request
```

## Root Cause

`create_issue_worktree()` 只处理了两种情况：
1. 路径存在但未注册 → 删除后重新创建
2. 分支已在其他 worktree 检出 → 复用

**缺失**：路径存在且已注册 → 应该复用，但代码直接尝试 `git worktree add`，导致 `already exists` 错误。

## Fix

在 `create_issue_worktree()` 中，`git worktree add` 之前增加检查：

1. 路径存在且已注册 + 分支匹配 → 复用（返回 WorktreeContext）
2. 路径存在且已注册 + 分支不匹配 → 删除后重新创建
3. 路径存在但未注册 → 删除后重新创建（原有逻辑不变）

## Changes

- `src/vibe3/environment/worktree_lifecycle.py` — 添加已注册 worktree 复用逻辑
- `tests/vibe3/environment/test_worktree_robustness.py` — 更新 mock 顺序适配新调用
- `.gitignore` — 添加 `.omo/` 目录

## Verification

- 23 个 worktree 测试全部通过
- Ruff / Black / MyPy 检查通过
- Pre-push hooks 全部通过

---
Contributors: Sisyphus (GLM-5)