### PR TITLE
fix(sqlite): handle enqueued_at column migration for orchestra_queue

### DIFF
--- a/src/vibe3/clients/sqlite_base.py
+++ b/src/vibe3/clients/sqlite_base.py
@@ -118,7 +118,7 @@ class SQLiteClientBase:
         with _global_lock:
             # Lightweight guard: check migration version
             # Update required_migration_version when adding new migrations
-            required_migration_version = 1  # Increment when adding
+            required_migration_version = 2  # Increment when adding
 
             try:
                 version_row = conn.execute(

--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -439,14 +439,14 @@ def init_schema(conn: sqlite3.Connection) -> None:
                 "flow_events to transition_history"
             )
 
-    # Migration: remove retry_count and last_attempted_at from orchestra_queue
+    # Migration: remove retry_count, last_attempted_at, enqueued_at from orchestra_queue
     # (SQLite doesn't support DROP COLUMN, so recreate table)
     queue_columns = {
         row[1]
         for row in cursor.execute("PRAGMA table_info(orchestra_queue)").fetchall()
     }
-    if "retry_count" in queue_columns or "last_attempted_at" in queue_columns:
-        # Create new table without retry columns
+    legacy_cols = {"retry_count", "last_attempted_at", "enqueued_at"}
+    if legacy_cols & queue_columns:
         cursor.execute("""
             CREATE TABLE orchestra_queue_new (
                 issue_number INTEGER PRIMARY KEY,
@@ -455,17 +455,16 @@ def init_schema(conn: sqlite3.Connection) -> None:
                 updated_at TEXT NOT NULL
             )
         """)
-        # Copy data (exclude retry columns)
         cursor.execute("""
             INSERT INTO orchestra_queue_new
             SELECT issue_number, collected_state, waiting_state, updated_at
             FROM orchestra_queue
         """)
-        # Replace old table
         cursor.execute("DROP TABLE orchestra_queue")
         cursor.execute("ALTER TABLE orchestra_queue_new RENAME TO orchestra_queue")
+        removed = sorted(legacy_cols & queue_columns)
         logger.bind(external="sqlite", operation="migration").info(
-            "Removed retry_count and last_attempted_at columns from orchestra_queue"
+            f"Removed legacy columns from orchestra_queue: {', '.join(removed)}"
         )
 
     # Create indexes for runtime_session table
@@ -515,7 +514,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
     # Increment this when adding new migrations that need to run on existing DBs
     cursor.execute(
         "INSERT OR REPLACE INTO schema_meta (key, value) "
-        "VALUES ('migration_version', '1')"
+        "VALUES ('migration_version', '2')"
     )
     conn.commit()
     logger.bind(external="sqlite", operation="init_schema").debug(


### PR DESCRIPTION
## Problem

Orchestra tick 失败：
```
ERROR | Tick error in OrchestrationFacade: NOT NULL constraint failed: orchestra_queue.enqueued_at
```

## Root Cause

数据库中 `orchestra_queue` 表有 `enqueued_at TEXT NOT NULL` 列，但：
1. Schema 定义中没有这个列
2. `sqlite_queue_repo.py` 的 INSERT 语句不包含这个列
3. Migration 只处理了 `retry_count` 和 `last_attempted_at`，没有处理 `enqueued_at`

实际数据库表结构：
```
issue_number|INTEGER
collected_state|TEXT
waiting_state|TEXT
enqueued_at|TEXT NOT NULL  ← 问题列
retry_count|INTEGER
updated_at|TEXT
last_attempted_at|TEXT
```

## Fix

1. 将 `enqueued_at` 加入 migration 的 legacy columns 列表
2. Bump `migration_version` 到 2
3. 更新 `required_migration_version` 到 2

Migration 会重建表，只保留 4 个预期列：
- `issue_number`
- `collected_state`
- `waiting_state`
- `updated_at`

## Verification

- 9 个 queue repo 测试全部通过（包括 migration 测试）
- Ruff / Black / MyPy 检查通过
- Pre-push hooks 全部通过（181 tests）

---
Contributors: Sisyphus (GLM-5)