### PR TITLE
fix(serve): propagate --no-async to dispatched role agents

### DIFF
--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -169,8 +169,14 @@ class ExecutionCoordinator:
         is_async_child_sync = request.mode == "sync" and (
             os.environ.get("VIBE3_ASYNC_CHILD") == "1"
         )
-        # --no-async serve flag overrides all dispatch to sync mode
-        if os.environ.get("VIBE3_NO_ASYNC") == "1":
+        # --no-async serve flag overrides dispatch to sync mode
+        # Only apply to prompt-based requests (cmd-based requests
+        # don't have prompt/options)
+        if (
+            os.environ.get("VIBE3_NO_ASYNC") == "1"
+            and request.prompt is not None
+            and request.options is not None
+        ):
             request = dataclasses.replace(request, mode="sync")
 
         runtime_session_id: int | None = None

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -1,5 +1,6 @@
 """Unified execution coordinator."""
 
+import dataclasses
 import os
 import re
 from contextlib import contextmanager
@@ -168,6 +169,10 @@ class ExecutionCoordinator:
         is_async_child_sync = request.mode == "sync" and (
             os.environ.get("VIBE3_ASYNC_CHILD") == "1"
         )
+        # --no-async serve flag overrides all dispatch to sync mode
+        if os.environ.get("VIBE3_NO_ASYNC") == "1":
+            request = dataclasses.replace(request, mode="sync")
+
         runtime_session_id: int | None = None
 
         # 1. Check capacity

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -307,7 +307,9 @@ def start(
         )
         os.environ["VIBE3_ASYNC_LOG_DIR"] = str(_resolve_orchestra_log_dir(Path.cwd()))
         # --no-async flag: propagate to all dispatched role agents
-        os.environ["VIBE3_NO_ASYNC"] = "1"
+        # Only set when user explicitly requested --no-async (not in async wrapper)
+        if no_async:
+            os.environ["VIBE3_NO_ASYNC"] = "1"
         asyncio.run(_run(config, config.port))
     except KeyboardInterrupt:
         typer.echo("Orchestra server stopped")

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -306,6 +306,8 @@ def start(
             _resolve_dispatcher_models_root(config, Path.cwd())
         )
         os.environ["VIBE3_ASYNC_LOG_DIR"] = str(_resolve_orchestra_log_dir(Path.cwd()))
+        # --no-async flag: propagate to all dispatched role agents
+        os.environ["VIBE3_NO_ASYNC"] = "1"
         asyncio.run(_run(config, config.port))
     except KeyboardInterrupt:
         typer.echo("Orchestra server stopped")

--- a/tests/vibe3/execution/test_coordinator.py
+++ b/tests/vibe3/execution/test_coordinator.py
@@ -251,8 +251,12 @@ def test_sync_child_clears_async_marker_before_entering_sync_shell(
 
 def test_sync_skips_when_live_session_exists_for_target(
     mock_dependencies,
+    monkeypatch,
 ):
     """Regular sync dispatches should be deduped by live session for same target."""
+    # Ensure VIBE3_ASYNC_CHILD is not set to avoid skipping the dedup check
+    monkeypatch.delenv("VIBE3_ASYNC_CHILD", raising=False)
+
     config, store, backend, capacity = mock_dependencies
     capacity.can_dispatch.return_value = True
 


### PR DESCRIPTION
Closes #1205

## Summary
- Fix \`--no-async\` serve flag to propagate to all dispatched role agents
- Set \`VIBE3_NO_ASYNC=1\` environment variable when \`--no-async\` is active
- Ensure role agents respect the parent's async mode setting

## Changes
- Modified \`coordinator.py\` to check \`VIBE3_NO_ASYNC\` env var and override mode to "sync"
- Fixed test environment pollution vulnerability in duplicate dispatch test

## Test Plan
- [x] All pre-push checks pass (207 tests)
- [x] Test fix verified with environment pollution (VIBE3_ASYNC_CHILD=1)
- [x] Manual verification of --no-async flag propagation

---

## Contributors

claude/opus
