### PR TITLE
fix(check): remove unnecessary handoff file existence check

### DIFF
--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -19,12 +19,10 @@ from vibe3.services.check_remote import (
     CheckRemote,
     is_empty_auto_scene,
     issue_state_from_payload,
-    requires_handoff,
     resolve_task_issue_number,
 )
 from vibe3.services.flow_status_service import FlowStatusService
 from vibe3.services.pr_service import PRService
-from vibe3.utils.git_helpers import get_branch_handoff_dir
 
 if TYPE_CHECKING:
     from vibe3.models.pr import PRResponse
@@ -468,15 +466,6 @@ class CheckService(CheckRemote):
                                 f"{task_issue}' to reset."
                             )
 
-        # shared current.md
-        if flow_status not in self.INACTIVE_FLOW_STATUSES and requires_handoff(
-            orchestration_state
-        ):
-            git_dir = self.git_client.get_git_common_dir()
-            handoff_path = get_branch_handoff_dir(git_dir, branch) / "current.md"
-            if not handoff_path.exists():
-                issues.append(f"Shared handoff file not found: {handoff_path}")
-
         is_valid = len(issues) == 0
         logger.bind(branch=branch, is_valid=is_valid, issues_count=len(issues)).debug(
             "Check completed"
@@ -527,18 +516,7 @@ class CheckService(CheckRemote):
         branch = branch or self.git_client.get_current_branch()
         fixed: list[str] = []
 
-        for issue in issues:
-            if "Shared handoff file not found" in issue:
-                git_dir = self.git_client.get_git_common_dir()
-                handoff_path = get_branch_handoff_dir(git_dir, branch) / "current.md"
-                handoff_path.parent.mkdir(parents=True, exist_ok=True)
-                handoff_path.write_text(f"# {branch}\n", encoding="utf-8")
-                fixed.append(issue)
-                logger.bind(domain="check", action="fix", branch=branch).debug(
-                    f"Created missing handoff file: {handoff_path}"
-                )
-
-        unfixed = [i for i in issues if i not in fixed]
+        unfixed = issues
         if unfixed:
             hint = (
                 "  Some issues cannot be auto-fixed. "

--- a/tests/vibe3/services/test_check_auto_fix_branch.py
+++ b/tests/vibe3/services/test_check_auto_fix_branch.py
@@ -46,8 +46,8 @@ def check_service(mock_store, mock_git_client, mock_github_client):
 class TestAutoFixBranch:
     """Tests for auto_fix_branch method."""
 
-    def test_auto_fix_branch_creates_handoff(self, check_service, mock_git_client):
-        """auto_fix creates handoff for the specified branch."""
+    def test_auto_fix_branch_cannot_fix_handoff(self, check_service, mock_git_client):
+        """auto_fix cannot fix handoff issues."""
         with tempfile.TemporaryDirectory() as tmpdir:
             git_dir = Path(tmpdir) / ".git"
             git_dir.mkdir()
@@ -62,7 +62,7 @@ class TestAutoFixBranch:
                     branch="feature/other-branch",
                 )
 
-        assert result.success
+        assert not result.success
 
     def test_auto_fix_branch_unknown_issue_is_unfixable(
         self, check_service, mock_github_client

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -257,8 +257,8 @@ class TestAutoFix:
         assert call_kwargs["status"] == ["active", "stale"]
         assert "on_progress" in call_kwargs
 
-    def test_auto_fix_creates_handoff_file(self, check_service, mock_git_client):
-        """Test that auto_fix creates missing handoff file."""
+    def test_auto_fix_cannot_fix_handoff(self, check_service, mock_git_client):
+        """Test that auto_fix cannot fix handoff issues."""
 
         with tempfile.TemporaryDirectory() as tmpdir:
             git_dir = Path(tmpdir) / ".git"
@@ -276,7 +276,7 @@ class TestAutoFix:
                     ]
                 )
 
-        assert result.success
+        assert not result.success
 
     def test_auto_fix_unfixable_returns_hint(self, check_service):
         """Test that unfixable issues return error with --init hint."""

--- a/tests/vibe3/services/test_check_verify.py
+++ b/tests/vibe3/services/test_check_verify.py
@@ -201,7 +201,7 @@ class TestVerifyCurrentFlow:
         assert any("plan_ref file not found" in issue for issue in result.issues)
 
     def test_verify_current_handoff_missing(self, check_service, mock_store):
-        """Test shared handoff file missing."""
+        """Handoff file check removed - missing file is not an error."""
         mock_store.get_flow_state.return_value = {
             "branch": "feature/test-branch",
             "task_issue_number": 123,
@@ -213,7 +213,6 @@ class TestVerifyCurrentFlow:
         with tempfile.TemporaryDirectory() as tmpdir:
             git_dir = Path(tmpdir) / ".git"
             git_dir.mkdir()
-            # Don't create handoff file
 
             with patch.object(
                 check_service.github_client,
@@ -231,8 +230,10 @@ class TestVerifyCurrentFlow:
                 ):
                     result = check_service.verify_current_flow()
 
-        assert not result.is_valid
-        assert any("Shared handoff file not found" in issue for issue in result.issues)
+        assert result.is_valid
+        assert not any(
+            "Shared handoff file not found" in issue for issue in result.issues
+        )
 
     def test_verify_ready_issue_does_not_require_handoff(
         self, check_service, mock_store, mock_github_client


### PR DESCRIPTION
## Summary

Remove the handoff file existence check that was reporting false positives.

## Problem

The check was flagging missing handoff files as errors, but this is normal behavior when:
- A flow hasn't started writing handoff yet
- No agent has called `handoff append`

## Solution

Remove the check entirely because:
1. `handoff append` already has `ensure_current_handoff()` that auto-creates files
2. The check was creating noise in `vibe task status` output
3. Manual file creation has no value

## Changes

- Remove handoff file existence check from `_check_branch()`
- Remove corresponding auto_fix logic
- Remove unused imports (`requires_handoff`, `get_branch_handoff_dir`)
- Update tests to reflect new behavior

## Test Plan

- [x] All existing tests pass
- [x] Updated tests for new behavior