### PR TITLE
fix(test): clear database state in test fixture to prevent MagicMock leakage

### DIFF
--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -18,6 +18,17 @@ def reset_error_tracking() -> Iterator[None]:
 
     ErrorTrackingService.clear_instance()
 
+    for instance in list(ErrorTrackingService._registry.values()):
+        try:
+            with sqlite3.connect(instance.db_path) as conn:
+                conn.execute("DELETE FROM error_log")
+                conn.execute(
+                    "UPDATE failed_gate_state SET is_active = 0, "
+                    "reason = NULL, triggered_at = NULL WHERE id = 1"
+                )
+        except Exception:
+            pass
+
 
 @pytest.fixture
 def temp_store(tmp_path: Path) -> SQLiteClient:

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -16,18 +16,23 @@ def reset_error_tracking() -> Iterator[None]:
     yield
     from vibe3.exceptions.error_tracking import ErrorTrackingService
 
+    db_paths = [
+        instance.db_path for instance in ErrorTrackingService._registry.values()
+    ]
+    if ErrorTrackingService._instance is not None:
+        db_paths.append(ErrorTrackingService._instance.db_path)
+    if ErrorTrackingService._default_instance is not None:
+        db_paths.append(ErrorTrackingService._default_instance.db_path)
+
     ErrorTrackingService.clear_instance()
 
-    for instance in list(ErrorTrackingService._registry.values()):
-        try:
-            with sqlite3.connect(instance.db_path) as conn:
-                conn.execute("DELETE FROM error_log")
-                conn.execute(
-                    "UPDATE failed_gate_state SET is_active = 0, "
-                    "reason = NULL, triggered_at = NULL WHERE id = 1"
-                )
-        except Exception:
-            pass
+    for db_path in set(db_paths):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DELETE FROM error_log")
+            conn.execute(
+                "UPDATE failed_gate_state SET is_active = 0, "
+                "reason = NULL, triggered_at = NULL, blocked_ticks = 0 WHERE id = 1"
+            )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Fix test fixture `reset_error_tracking` to clear both in-memory instances and database state
- Prevents MagicMock errors from leaking into production database

## Root Cause

PR #1291 only cleared `_registry` in memory, but database records (`error_log`, `failed_gate_state`) persisted between tests, causing:

1. MagicMock comparison errors in FailedGate threshold checks
2. Repeated FailedGate ACTIVE state activation
3. Orchestra dispatch blocked by stale test artifacts

## Changes

```python
# Before: only cleared in-memory singleton
ErrorTrackingService.clear_instance()

# After: also clears database state
for instance in list(ErrorTrackingService._registry.values()):
    conn.execute("DELETE FROM error_log")
    conn.execute("UPDATE failed_gate_state SET is_active = 0, ...")
```

## Test Plan

- [x] All 12 tests in `test_failed_gate.py` pass
- [x] Pre-push hooks passed (type check, tests, LOC)
- [x] Verified `vibe3 serve status` shows OPEN state

Fixes recurrence of issue #42 errors.