### PR TITLE
refactor(v3/domain): orchestration_facade.py 完善依赖注入

### DIFF
--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -24,6 +24,7 @@ from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.runtime.service_protocol import ServiceBase
 
 if TYPE_CHECKING:
+    from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.orchestra.failed_gate import FailedGate
     from vibe3.orchestra.global_dispatch_coordinator import GlobalDispatchCoordinator
@@ -50,6 +51,7 @@ class OrchestrationFacade(ServiceBase):
         store: "SQLiteClient | None" = None,
         github: "GitHubClient | None" = None,
         flow_manager: "FlowManager | None" = None,
+        registry: "SessionRegistryService | None" = None,
     ) -> None:
         """Initialize facade with tick counter.
 
@@ -70,6 +72,11 @@ class OrchestrationFacade(ServiceBase):
                 creates a new GitHubClient instance.
             flow_manager: Optional FlowManager for dependency injection. When omitted,
                 creates a new FlowManager instance with the provided config.
+            registry: Optional SessionRegistryService for dependency injection.
+                When omitted with capacity provided, creates a new
+                SessionRegistryService instance. This enables reusing a shared
+                registry instance across the facade's lifetime instead of
+                creating a new one on each tick.
         """
         self._tick_count = tick_count
         self._config = config or load_orchestra_config()
@@ -80,6 +87,7 @@ class OrchestrationFacade(ServiceBase):
         self._failed_gate = failed_gate
         self._github = github or GitHubClient()
         self._flow_manager = flow_manager or FlowManager(self._config)
+        self._registry: SessionRegistryService | None = registry
 
         if self._capacity is not None:
             from vibe3.environment.session_registry import SessionRegistryService
@@ -88,14 +96,16 @@ class OrchestrationFacade(ServiceBase):
             )
 
             actual_store = store or SQLiteClient()
-            registry = SessionRegistryService(actual_store, self._capacity._backend)
+            self._registry = registry or SessionRegistryService(
+                actual_store, self._capacity._backend
+            )
             self._coordinator = GlobalDispatchCoordinator(
                 config=self._config,
                 capacity=self._capacity,
                 github=self._github,
                 store=actual_store,
                 flow_manager=self._flow_manager,
-                registry=registry,
+                registry=self._registry,
             )
 
     def shutdown(self) -> None:
@@ -168,17 +178,15 @@ class OrchestrationFacade(ServiceBase):
 
         # Always reconcile session state to prevent stale capacity tracking.
         if self._capacity:
+            # Type guard: registry is guaranteed non-None when capacity exists
+            assert self._registry is not None
             try:
                 # Reconcile session state (mark dead tmux sessions as orphaned)
                 # This ensures count_live_worker_sessions() returns accurate results.
-                from vibe3.environment.session_registry import SessionRegistryService
-
-                store = SQLiteClient()
-                registry = SessionRegistryService(store, self._capacity._backend)
-                # Mark worker sessions as done (not orphaned) when tmux exits
-                registry.mark_worker_sessions_done_when_tmux_gone()
-                # Then orphan any remaining dead sessions (failed launches)
-                registry.reconcile_live_state()
+                # Uses the registry instance from constructor injection instead of
+                # creating a new SQLiteClient + SessionRegistryService per tick.
+                self._registry.mark_worker_sessions_done_when_tmux_gone()
+                self._registry.reconcile_live_state()
             except Exception as exc:
                 append_orchestra_event(
                     "server",

--- a/tests/vibe3/domain/test_orchestration_facade_dispatch.py
+++ b/tests/vibe3/domain/test_orchestration_facade_dispatch.py
@@ -133,3 +133,54 @@ class TestOrchestrationFacadeDispatchServices:
 
         # Verify coordinate was called
         mock_coordinate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("vibe3.domain.orchestration_facade.publish")
+    @patch("vibe3.domain.orchestration_facade.time.monotonic")
+    @patch("vibe3.domain.orchestration_facade.OrchestraConfig")
+    async def test_injected_registry_used_in_on_tick(
+        self,
+        mock_config_cls: MagicMock,
+        mock_monotonic: MagicMock,
+        mock_publish: MagicMock,
+    ) -> None:
+        """Verify that when registry is injected, on_tick() uses it."""
+        from vibe3.environment.session_registry import SessionRegistryService
+
+        mock_config_cls.return_value = MagicMock(
+            polling_interval=1,
+            governance=MagicMock(interval_ticks=1),
+            supervisor_handoff=MagicMock(
+                issue_label="supervisor",
+                handoff_state_label="state/handoff",
+            ),
+        )
+        mock_monotonic.side_effect = [float(i) for i in range(20)]
+
+        mock_capacity = MagicMock()
+        # Skip dispatch to test reconciliation
+        mock_capacity.can_dispatch.return_value = False
+        mock_capacity.get_capacity_status.return_value = {
+            "remaining": 1,
+            "active_count": 0,
+            "max_capacity": 5,
+        }
+
+        # Create mock registry
+        mock_registry = MagicMock(spec=SessionRegistryService)
+
+        facade = OrchestrationFacade(
+            tick_count=0,
+            capacity=mock_capacity,
+            registry=mock_registry,
+        )
+
+        with (
+            patch.object(facade, "on_supervisor_scan", new_callable=AsyncMock),
+            patch.object(facade, "on_heartbeat_tick"),
+        ):
+            await facade.on_tick()
+
+        # Verify registry methods were called on the injected instance
+        mock_registry.mark_worker_sessions_done_when_tmux_gone.assert_called_once()
+        mock_registry.reconcile_live_state.assert_called_once()

--- a/tests/vibe3/domain/test_orchestration_facade_dispatch.py
+++ b/tests/vibe3/domain/test_orchestration_facade_dispatch.py
@@ -136,26 +136,26 @@ class TestOrchestrationFacadeDispatchServices:
 
     @pytest.mark.asyncio
     @patch("vibe3.domain.orchestration_facade.publish")
-    @patch("vibe3.domain.orchestration_facade.time.monotonic")
-    @patch("vibe3.domain.orchestration_facade.OrchestraConfig")
     async def test_injected_registry_used_in_on_tick(
         self,
-        mock_config_cls: MagicMock,
-        mock_monotonic: MagicMock,
         mock_publish: MagicMock,
     ) -> None:
         """Verify that when registry is injected, on_tick() uses it."""
         from vibe3.environment.session_registry import SessionRegistryService
+        from vibe3.models.orchestra_config import OrchestraConfig
 
-        mock_config_cls.return_value = MagicMock(
+        # Create explicit config (no patching needed)
+        mock_config = MagicMock(
+            spec=OrchestraConfig,
             polling_interval=1,
+            max_concurrent_flows=3,  # Required by GlobalDispatchCoordinator
             governance=MagicMock(interval_ticks=1),
             supervisor_handoff=MagicMock(
                 issue_label="supervisor",
                 handoff_state_label="state/handoff",
             ),
+            repo="test-owner/test-repo",  # Required by FlowManager
         )
-        mock_monotonic.side_effect = [float(i) for i in range(20)]
 
         mock_capacity = MagicMock()
         # Skip dispatch to test reconciliation
@@ -171,6 +171,7 @@ class TestOrchestrationFacadeDispatchServices:
 
         facade = OrchestrationFacade(
             tick_count=0,
+            config=mock_config,
             capacity=mock_capacity,
             registry=mock_registry,
         )
@@ -178,9 +179,15 @@ class TestOrchestrationFacadeDispatchServices:
         with (
             patch.object(facade, "on_supervisor_scan", new_callable=AsyncMock),
             patch.object(facade, "on_heartbeat_tick"),
+            # Patch coordinator.coordinate to avoid external GitHub API calls
+            patch.object(
+                facade._coordinator, "coordinate", new_callable=AsyncMock
+            ) as mock_coordinate,
         ):
             await facade.on_tick()
 
         # Verify registry methods were called on the injected instance
         mock_registry.mark_worker_sessions_done_when_tmux_gone.assert_called_once()
         mock_registry.reconcile_live_state.assert_called_once()
+        # Verify coordinator was called (or skipped due to capacity)
+        mock_coordinate.assert_awaited_once()


### PR DESCRIPTION
Closes #1260

## Summary

完善 OrchestrationFacade 的依赖注入实现，将 on_tick() 内部的 SessionRegistryService 创建移到构造函数。

## Changes

### 1. Core DI Refactoring (c8386cfc)
- Add `registry: SessionRegistryService | None = None` constructor parameter
- Store as `self._registry` for reuse across ticks
- Remove per-tick SQLiteClient + SessionRegistryService instantiation
- Add type guard assertion for mypy compatibility

### 2. Test Improvements (d2439fd7)
- Add test for injected registry DI path
- Verify on_tick() uses injected registry instance

## Benefits

- **Resource efficiency**: Reuse registry instance across ticks instead of creating new objects on every tick
- **Better testability**: Enable injection of mock registry for testing
- **Backward compatible**: Existing callers continue to work without passing registry parameter

## Test Results

All 23 tests pass:
- test_orchestration_facade.py: 7 tests
- test_orchestration_facade_dispatch.py: 4 tests  
- test_failed_gate.py: 12 tests

Type check: mypy SUCCESS
Lint: ruff PASSED

## Related

- Issue: #1260
- Plan: docs/plans/issue-1260-di-completion-plan.md
- Report: docs/reports/issue-1260-execution-report.md
- Audit: docs/reports/issue-1260-audit-report.md

---

## Contributors

claude/opus
