### PR TITLE
fix(orchestra): downgrade expected events from ERROR to WARNING

### DIFF
--- a/src/vibe3/orchestra/failed_gate.py
+++ b/src/vibe3/orchestra/failed_gate.py
@@ -178,7 +178,7 @@ class FailedGate:
         error_count = error_tracking.get_threshold_error_count()
 
         if error_count >= ErrorTrackingService.THRESHOLD_COUNT:
-            log.error(
+            log.warning(
                 f"ERROR-severity threshold reached: {error_count} errors "
                 f"(threshold: {ErrorTrackingService.THRESHOLD_COUNT} in "
                 f"{ErrorTrackingService.TIME_WINDOW_MINUTES} minutes)"
@@ -204,7 +204,7 @@ class FailedGate:
             error_code: Optional error code that triggered activation
         """
         log = logger.bind(domain="orchestra", action="failed_gate_activate")
-        log.error(f"Activating failed gate: {reason}")
+        log.warning(f"Activating failed gate: {reason}")
 
         now = datetime.now(UTC).isoformat()
 

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -166,7 +166,7 @@ class HeartbeatServer:
                             f"{gate_result.reason}"
                         ),
                     )
-                    logger.bind(domain="orchestra", action="tick").error(
+                    logger.bind(domain="orchestra", action="tick").warning(
                         f"Tick #{tick_number} blocked by failed gate: "
                         f"{gate_result.reason}"
                     )
@@ -291,7 +291,7 @@ class HeartbeatServer:
                     "server",
                     f"tick error in {type(service).__name__}: {exc}",
                 )
-                logger.bind(domain="orchestra").error(
+                logger.bind(domain="orchestra").warning(
                     f"Tick error in {type(service).__name__}: {exc}"
                 )
 


### PR DESCRIPTION
## Summary

将 4 处预期内事件的日志级别从 ERROR 降级为 WARNING：

**修改文件**：
- `src/vibe3/orchestra/failed_gate.py`: 2 处
- `src/vibe3/runtime/heartbeat.py`: 2 处

**具体改动**：
1. **heartbeat.py:168** - FailedGate 阻塞 tick（熔断器行为）
2. **heartbeat.py:277** - 单个服务 tick 错误（非致命）
3. **failed_gate.py:173** - 错误阈值检测（监控功能）
4. **failed_gate.py:199** - Gate 激活（保护行为）

**理由**：
这些是正常的操作行为，而非系统故障。真正的 ERROR 级别（如 failed_gate.py:120 和 :163）保持不变。

Fixes #1085

---

## Contributors

claude/opus
