### PR TITLE
docs: add migration guide for features.skills split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,14 @@
 - **Skill Layer**: 100% complete (full audit workflow with AI analysis)
 - **Integration**: 100% complete (vibe check --audit-tasks working)
 
+### ⚠️ Deprecations
+- **`features.skills` split into `features.local_skills` and `features.global_skills`**
+  - Old key: `features.skills: <bool>` (no longer generated)
+  - New keys: `features.local_skills: <bool>` + `features.global_skills: <bool>`
+  - Migration: re-run `vibe init` to regenerate `.vibe/config.yaml` in the new format
+  - Detection: `vibe init` warns when legacy `features.skills` key is present without the new keys
+  - Source: PR #1133
+
 ## [2.1.5] - 2026-03-07
 
 ### ✨ New Features


### PR DESCRIPTION
Closes #1159

## Summary

Add deprecation notice in CHANGELOG.md documenting the split of `features.skills` into `features.local_skills` and `features.global_skills` (PR #1133).

## Changes

- Old key deprecation notice
- New key documentation  
- Migration path: re-run `vibe init`
- Detection: `vibe init` warns on legacy key

## Test plan

- [x] Content matches implementation in `lib/profiles.sh` and `lib/init.sh`
- [x] Format follows existing CHANGELOG conventions
- [x] Audit passed (see handoff)

---

## Contributors

claude/opus
