### PR TITLE
feat(task-status): 标记 remote-owned issues（非 state/ready 且本地无 flow）

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -34,6 +34,11 @@ def _include_issue_in_task_progress(item: dict[str, object]) -> bool:
     state = cast(IssueState, item["state"])
 
     if flow is None:
+        # Include issues without flow if they are remote (claimed by manager)
+        # or in states that should show even without flow
+        is_remote = cast(bool, item.get("remote", False))
+        if is_remote:
+            return True
         return state in {
             IssueState.READY,
             IssueState.HANDOFF,
@@ -87,6 +92,7 @@ def status(
         render_completed_flows,
         render_issue_progress,
         render_pr_ref_items,
+        render_remote_items,
         render_scene_sections,
         render_supervisor_issues,
     )
@@ -201,7 +207,10 @@ def status(
         queued_set = set(orch_snapshot.queued_issues)
         query_service = StatusQueryService(repo=config.repo)
         orchestrated_issues = query_service.fetch_orchestrated_issues(
-            flows, queued_set, stale_flows=stale_flows
+            flows,
+            queued_set,
+            stale_flows=stale_flows,
+            manager_usernames=config.get_manager_usernames(),
         )
 
         supervisor_label = config.supervisor_handoff.issue_label
@@ -218,13 +227,22 @@ def status(
             if _include_issue_in_task_progress(item)
             and cast(int, item["number"]) not in supervisor_numbers
         ]
+
+        # Separate remote and non-remote items for rendering
+        remote_items = [
+            item for item in task_progress_items if cast(bool, item.get("remote"))
+        ]
+        non_remote_items = [
+            item for item in task_progress_items if not cast(bool, item.get("remote"))
+        ]
+
         bucketed_items: dict[TaskStatusBucket, list[dict[str, object]]] = {
             TaskStatusBucket.ASSIGNEE_INTAKE: [],
             TaskStatusBucket.READY_QUEUE: [],
             TaskStatusBucket.READY_ANOMALY: [],
             TaskStatusBucket.OTHER: [],
         }
-        for item in task_progress_items:
+        for item in non_remote_items:
             state = cast(IssueState | None, item["state"])
             if state == IssueState.DONE:
                 continue
@@ -237,6 +255,9 @@ def status(
             bucketed_items[bucket].append(item)
 
         render_issue_progress(bucketed_items, config)
+        console.print()
+
+        render_remote_items(remote_items)
         console.print()
 
         render_supervisor_issues(supervisor_items)

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -142,6 +142,16 @@ def status(
             service = FlowService()
             flows = service.list_flows(status=None if all_flows else "active")
 
+            # Fetch orchestrated issues for JSON/YAML output
+            queued_set = set(orch_snapshot.queued_issues)
+            query_service = StatusQueryService(repo=config.repo)
+            orchestrated_issues = query_service.fetch_orchestrated_issues(
+                flows,
+                queued_set,
+                stale_flows=[],
+                manager_usernames=config.get_manager_usernames(),
+            )
+
             output_data = {
                 "orchestra": (
                     orch_snapshot.model_dump()
@@ -149,6 +159,7 @@ def status(
                     else str(orch_snapshot)
                 ),
                 "flows": [f.model_dump() for f in flows],
+                "orchestrated_issues": orchestrated_issues,
             }
 
             if output_format == "json":

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -192,6 +192,26 @@ def render_issue_progress(
         console.print("  [dim](none)[/]")
 
 
+def render_remote_items(remote_items: list[dict[str, object]]) -> None:
+    """Render Remote Tasks (no local flow) section."""
+    console.print("[bold cyan]Remote Tasks (no local flow):[/]")
+    if remote_items:
+        for item in remote_items:
+            number = cast(int, item["number"])
+            title = cast(str, item["title"])
+            state = cast(IssueState, item["state"])
+            assignee = cast(str | None, item.get("assignee"))
+            display_title = title[:48] + "..." if len(title) > 48 else title
+            state_str = state.value.upper()
+            assignee_str = f" [dim]({assignee})[/]" if assignee else ""
+            console.print(
+                f"  #{number:4}  [{state_str}][remote]{assignee_str}"
+                f"  {display_title}"
+            )
+    else:
+        console.print("  [dim](none)[/]")
+
+
 def render_supervisor_issues(supervisor_items: list[dict[str, object]]) -> None:
     """Render Supervisor Issues section."""
     console.print("[bold cyan]Supervisor Issues:[/]")

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -204,9 +204,10 @@ def render_remote_items(remote_items: list[dict[str, object]]) -> None:
             display_title = title[:48] + "..." if len(title) > 48 else title
             state_str = state.value.upper()
             assignee_str = f" [dim]({assignee})[/]" if assignee else ""
+            remote_marker = "[dim][remote][/]"
             console.print(
-                f"  #{number:4}  [{state_str}][remote]{assignee_str}"
-                f" {display_title}"
+                f"  #{number:4}  [yellow]{state_str:10}[/]  "
+                f"{remote_marker}{assignee_str} {display_title}"
             )
     else:
         console.print("  [dim](none)[/]")
@@ -242,7 +243,7 @@ def render_pr_ref_items(pr_ref_items: list[dict[str, object]]) -> None:
             status_str = state.value.upper()
 
             display_title = title[:48] + "..." if len(title) > 48 else title
-            console.print(f"  #{number:4}  [{status_str:10}]  {display_title}")
+            console.print(f"  #{number:4}  [cyan]{status_str:10}[/]  {display_title}")
             if pr_url:
                 console.print(f"         [cyan]PR: {pr_url}[/]")
     else:

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -206,7 +206,7 @@ def render_remote_items(remote_items: list[dict[str, object]]) -> None:
             assignee_str = f" [dim]({assignee})[/]" if assignee else ""
             console.print(
                 f"  #{number:4}  [{state_str}][remote]{assignee_str}"
-                f"  {display_title}"
+                f" {display_title}"
             )
     else:
         console.print("  [dim](none)[/]")

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -322,8 +322,16 @@ class StatusQueryService:
                     pr_state = pr.state.value
 
             # Calculate remote flag: issue claimed by manager but no local flow
+            # Only mark as remote for active states (not BLOCKED, not DONE)
             is_remote = (
-                state != IssueState.READY
+                state
+                in {
+                    IssueState.CLAIMED,
+                    IssueState.IN_PROGRESS,
+                    IssueState.HANDOFF,
+                    IssueState.REVIEW,
+                    IssueState.MERGE_READY,
+                }
                 and assignee is not None
                 and assignee in (manager_usernames or [])
                 and flow is None

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -215,6 +215,7 @@ class StatusQueryService:
         flows: list[FlowStatusResponse],
         queued_set: set[int],
         stale_flows: list[FlowStatusResponse] | None = None,
+        manager_usernames: list[str] | None = None,
     ) -> list[dict[str, object]]:
         """Fetch GitHub issues and cross-reference with flow state.
 
@@ -222,9 +223,10 @@ class StatusQueryService:
             flows: Active flow status responses
             queued_set: Set of issue numbers in the queue
             stale_flows: Stale flow status responses
+            manager_usernames: List of manager usernames for remote task detection
 
         Returns:
-            Sorted list of issue dicts with number, title, state, flow, queued
+            Sorted list of issue dicts with number, title, state, flow, queued, remote
         """
 
         # stale flows first, active flows overwrite (active priority)
@@ -319,6 +321,14 @@ class StatusQueryService:
                     pr_number = pr.number
                     pr_state = pr.state.value
 
+            # Calculate remote flag: issue claimed by manager but no local flow
+            is_remote = (
+                state != IssueState.READY
+                and assignee is not None
+                and assignee in (manager_usernames or [])
+                and flow is None
+            )
+
             orchestrated_issues.append(
                 {
                     "number": number,
@@ -337,6 +347,8 @@ class StatusQueryService:
                     "roadmap": roadmap,
                     "priority": priority,
                     "labels": labels,
+                    # Remote task flag
+                    "remote": is_remote,
                 }
             )
 

--- a/tests/vibe3/commands/test_task_status_dashboard.py
+++ b/tests/vibe3/commands/test_task_status_dashboard.py
@@ -73,6 +73,7 @@ def test_task_status_splits_assignee_ready_and_anomaly(
             "roadmap": None,
             "priority": 0,
             "labels": [],
+            "remote": False,
         },
         {
             "number": 202,
@@ -88,6 +89,7 @@ def test_task_status_splits_assignee_ready_and_anomaly(
             "roadmap": None,
             "priority": 0,
             "labels": [],
+            "remote": False,
         },
         {
             "number": 303,
@@ -103,6 +105,7 @@ def test_task_status_splits_assignee_ready_and_anomaly(
             "roadmap": None,
             "priority": 0,
             "labels": [],
+            "remote": False,
         },
     ]
     mock_status_service_cls.return_value = status_service
@@ -159,6 +162,7 @@ def test_task_status_shows_flows_with_prs(
             "flow": flow_with_pr,
             "queued": False,
             "labels": [],
+            "remote": False,
         }
     ]
     mock_status_service_cls.return_value = status_service
@@ -274,3 +278,92 @@ class TestComputeEffectiveServerRunning:
     def test_snapshot_false_pid_invalid(self) -> None:
         """Snapshot says down and PID invalid → effective False."""
         assert self._call(snapshot_running=False, pid_valid=False) is False
+
+
+@patch("vibe3.commands.status.load_orchestra_config")
+@patch("vibe3.commands.status.OrchestraStatusService.fetch_live_snapshot")
+@patch("vibe3.commands.status.FlowService")
+@patch("vibe3.commands.status.StatusQueryService")
+def test_task_status_shows_remote_tasks_section(
+    mock_status_service_cls,
+    mock_flow_service_cls,
+    mock_fetch_live_snapshot,
+    mock_load_orchestra_config,
+) -> None:
+    """task status should show remote tasks in a separate section."""
+    config_mock = MagicMock()
+    config_mock.pid_file = "/tmp/vibe3.pid"
+    config_mock.repo = "openai/vibe-center"
+    config_mock.port = 1234
+    config_mock.supervisor_handoff = MagicMock(issue_label="supervisor")
+    config_mock.manager_usernames = ["manager-bot"]
+    config_mock.get_manager_usernames.return_value = ["manager-bot"]
+    mock_load_orchestra_config.return_value = config_mock
+    mock_fetch_live_snapshot.return_value = OrchestraSnapshot(
+        timestamp=1234567890.0,
+        server_running=True,
+        active_issues=tuple(),
+        active_flows=0,
+        active_worktrees=0,
+    )
+
+    flow_service = MagicMock()
+    flow_service.list_flows.return_value = []
+    mock_flow_service_cls.return_value = flow_service
+
+    status_service = MagicMock()
+    status_service.fetch_worktree_map.return_value = {}
+    status_service.fetch_orchestrated_issues.return_value = [
+        {
+            "number": 505,
+            "title": "Remote task on another machine",
+            "state": IssueState.CLAIMED,
+            "assignee": "manager-bot",
+            "flow": None,  # No local flow
+            "queued": False,
+            "failed_reason": None,
+            "blocked_by": None,
+            "blocked_reason": None,
+            "milestone": None,
+            "roadmap": None,
+            "priority": 0,
+            "labels": [],
+            "remote": True,  # Marked as remote
+        },
+        {
+            "number": 606,
+            "title": "Local task",
+            "state": IssueState.CLAIMED,
+            "assignee": "manager-bot",
+            "flow": _make_flow(606),  # Has local flow
+            "queued": False,
+            "failed_reason": None,
+            "blocked_by": None,
+            "blocked_reason": None,
+            "milestone": None,
+            "roadmap": None,
+            "priority": 0,
+            "labels": [],
+            "remote": False,
+        },
+    ]
+    mock_status_service_cls.return_value = status_service
+
+    result = runner.invoke(app, ["task", "status"])
+
+    assert result.exit_code == 0
+    output = result.output
+    # Remote tasks section should appear
+    assert "Remote Tasks (no local flow):" in output
+    # Remote issue should be in remote section
+    assert "# 505" in output
+    assert "Remote task on another machine" in output
+    # Local task should still be in Assignee Intake
+    assert "Assignee Intake:" in output
+    assert "# 606" in output
+    # Remote task should NOT be in Assignee Intake
+    # (it should only appear in Remote Tasks section)
+    intake_section = output[
+        output.index("Assignee Intake:") : output.index("Ready Queue:")
+    ]
+    assert "# 505" not in intake_section

--- a/tests/vibe3/services/test_status_query_utils.py
+++ b/tests/vibe3/services/test_status_query_utils.py
@@ -189,3 +189,72 @@ class TestRemoteField:
 
         assert len(result) == 1
         assert result[0]["remote"] is False
+
+    def test_blocked_state_not_remote(self) -> None:
+        """BLOCKED state should not be marked as remote."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 106,
+                "title": "Blocked task",
+                "labels": [{"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is False
+        assert result[0]["state"] == IssueState.BLOCKED
+
+    def test_handoff_state_remote(self) -> None:
+        """HANDOFF state with manager assignee and no flow should be remote."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 107,
+                "title": "Handoff task",
+                "labels": [{"name": "state/handoff"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is True
+        assert result[0]["state"] == IssueState.HANDOFF
+
+    def test_merge_ready_state_remote(self) -> None:
+        """MERGE_READY state with manager assignee and no flow should be remote."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 108,
+                "title": "Merge ready task",
+                "labels": [{"name": "state/merge-ready"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is True
+        assert result[0]["state"] == IssueState.MERGE_READY

--- a/tests/vibe3/services/test_status_query_utils.py
+++ b/tests/vibe3/services/test_status_query_utils.py
@@ -1,7 +1,10 @@
 """Unit tests for StatusQueryService utility functions."""
 
+from unittest.mock import MagicMock
+
 from vibe3.models.orchestration import IssueState
 from vibe3.services.status_query_service import (
+    StatusQueryService,
     is_auto_task_branch,
     is_canonical_task_branch,
     issue_priority,
@@ -46,3 +49,143 @@ class TestBranchClassification:
         assert is_canonical_task_branch("task/issue-278", 320) is False
         assert is_canonical_task_branch("dev/issue-278", 278) is False
         assert is_canonical_task_branch("task/issue-278", None) is False
+
+
+class TestRemoteField:
+    """Tests for remote field calculation in fetch_orchestrated_issues."""
+
+    def _make_mock_service(self) -> StatusQueryService:
+        """Create a StatusQueryService with mocked dependencies."""
+        github_mock = MagicMock()
+        github_mock.list_issues.return_value = []
+        git_mock = MagicMock()
+        store_mock = MagicMock()
+
+        return StatusQueryService(
+            github_client=github_mock,
+            git_client=git_mock,
+            store=store_mock,
+        )
+
+    def test_remote_true_when_claimed_by_manager_without_flow(self) -> None:
+        """state ≠ ready + manager assignee + no flow → remote=True."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 101,
+                "title": "Remote task",
+                "labels": [{"name": "state/claimed"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is True
+        assert result[0]["assignee"] == "manager-bot"
+        assert result[0]["state"] == IssueState.CLAIMED
+
+    def test_remote_false_when_non_manager_assignee(self) -> None:
+        """state ≠ ready + non-manager assignee → remote=False."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 102,
+                "title": "Human task",
+                "labels": [{"name": "state/claimed"}],
+                "assignees": [{"login": "jacobcy"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is False
+        assert result[0]["assignee"] == "jacobcy"
+
+    def test_remote_false_when_ready_state(self) -> None:
+        """state = ready + manager assignee + no flow → remote=False."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 103,
+                "title": "Ready task",
+                "labels": [{"name": "state/ready"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is False
+        assert result[0]["state"] == IssueState.READY
+
+    def test_remote_false_when_has_flow(self) -> None:
+        """state ≠ ready + manager assignee + has flow → remote=False."""
+        from types import SimpleNamespace
+
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 104,
+                "title": "Active task",
+                "labels": [{"name": "state/claimed"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        flow = SimpleNamespace(
+            branch="task/issue-104",
+            flow_status="active",
+            task_issue_number=104,
+        )
+
+        result = service.fetch_orchestrated_issues(
+            flows=[flow],
+            queued_set=set(),
+            manager_usernames=["manager-bot"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is False
+        assert result[0]["flow"] is not None
+
+    def test_remote_false_when_manager_usernames_none(self) -> None:
+        """manager_usernames=None → remote=False."""
+        service = self._make_mock_service()
+        service.github.list_issues.return_value = [
+            {
+                "number": 105,
+                "title": "Unconfigured manager",
+                "labels": [{"name": "state/claimed"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+            }
+        ]
+
+        result = service.fetch_orchestrated_issues(
+            flows=[],
+            queued_set=set(),
+            manager_usernames=None,
+        )
+
+        assert len(result) == 1
+        assert result[0]["remote"] is False


### PR DESCRIPTION
## Summary

- 在 `task status` 输出中新增 `remote` 字段，标记非 ready 状态且无本地 flow 的 issues
- 优化远程任务分组显示，单独列出 "Remote tasks (no local flow)"
- 修复 BLOCKED state 被错误标记为 remote 的问题（限定为活跃状态：CLAIMED, IN_PROGRESS, HANDOFF, REVIEW, MERGE_READY）
- 新增边界测试用例，覆盖 BLOCKED, HANDOFF, MERGE_READY 状态

## Key Changes

### 1. 核心功能
- `src/vibe3/services/status_query_service.py`: 在 `fetch_orchestrated_issues` 返回数据中新增 `remote: bool` 字段
- `src/vibe3/commands/status_render.py`: 远程任务单独分组渲染

### 2. Bug Fix (CRITICAL)
- 修复 BLOCKED state 被错误标记为 remote 的 false positive
- 限定 remote 检测仅对活跃状态生效（CLAIMED, IN_PROGRESS, HANDOFF, REVIEW, MERGE_READY）

### 3. 测试覆盖
- 新增 `test_blocked_state_not_remote` 测试
- 新增 `test_handoff_state_remote` 测试
- 新增 `test_merge_ready_state_remote` 测试

## Test Plan

- [x] `uv run pytest tests/vibe3/services/test_status_query_utils.py -v`
- [x] `uv run pytest tests/vibe3/commands/test_task_status_dashboard.py -v`
- [x] Pre-push checks passed (38 tests)
- [x] Type check passed (mypy)

Closes #1113

---

## Contributors

claude/opus
