### PR TITLE
fix(serve): resume always clears error_log regardless of gate state

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -263,6 +263,9 @@ code_limits:
       - path: "tests/vibe3/orchestra/test_failed_gate.py"
         limit: 470
         reason: "FailedGate 测试集，覆盖 unit + integration 测试（gate open/close、severity-aware checks、serve start preflight、heartbeat tick loop），合并后内聚度高，拆分会破坏测试场景完整性"
+      - path: "tests/vibe3/orchestra/test_serve.py"
+        limit: 500
+        reason: "Serve 命令测试集，覆盖 start/stop/status/resume/logs 命令、tmux session 管理、port auto-discovery、FailedGate resume 逻辑等紧密耦合场景，新增 2 个 resume 回归测试"
       - path: "tests/vibe3/commands/test_scan.py"
         limit: 410
         reason: "Scan 命令测试集，覆盖 governance/supervisor/all 三个完整命令的 dry-run 和实际执行场景，每个测试需要完整的 mock 设置和验证逻辑，拆分收益低"

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -402,6 +402,9 @@ def resume(
     - error_log table (clear all error records)
 
     The next tick will proceed normally after clearing.
+
+    Note: Even if the gate is already OPEN, this command will clear
+    error_log to ensure old errors don't trigger the gate again.
     """
     from rich.console import Console
 
@@ -412,15 +415,18 @@ def resume(
 
     # Check if gate is ACTIVE
     gate_status = failed_gate.get_status()
-    if not gate_status.is_active:
-        console.print("[yellow]Failed Gate is already OPEN[/yellow]")
-        console.print("No need to resume - orchestra is operating normally")
-        raise typer.Exit(0)
 
-    # Clear gate
-    console.print("[cyan]Clearing Failed Gate[/cyan]")
-    console.print(f"  - Reason: {gate_status.reason}")
-    console.print(f"  - Blocked ticks: {gate_status.blocked_ticks}")
+    # Always clear error_log, even if gate is already OPEN
+    # This prevents stale errors from re-triggering the gate
+    if gate_status.is_active:
+        # Gate is ACTIVE: show blocking info
+        console.print("[cyan]Clearing Failed Gate[/cyan]")
+        console.print(f"  - Reason: {gate_status.reason}")
+        console.print(f"  - Blocked ticks: {gate_status.blocked_ticks}")
+    else:
+        # Gate is OPEN: inform user but still clear errors
+        console.print("[yellow]Failed Gate is already OPEN[/yellow]")
+        console.print("[cyan]Clearing error_log to prevent re-triggering[/cyan]")
 
     cleared_by = "admin:manual"
     failed_gate.clear(cleared_by, reason)

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -385,3 +385,79 @@ def test_start_auto_discovers_port_when_default_occupied(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "auto-discovered" in result.stdout.lower()
     assert "8081" in result.stdout
+
+
+def test_resume_clears_errors_even_when_gate_is_open(monkeypatch) -> None:
+    """Test that serve resume clears error_log even when gate is already OPEN.
+
+    This is a regression test for a bug where:
+    - User runs `serve resume` when gate is OPEN
+    - Command exits early without clearing error_log
+    - Old errors remain and re-trigger the gate on next tick
+
+    Fix: resume should always clear error_log, regardless of gate state.
+    """
+    from unittest.mock import MagicMock
+
+    from vibe3.orchestra.failed_gate import GateStatus
+
+    # Mock FailedGate to return OPEN state
+    mock_gate = MagicMock()
+    mock_gate.get_status.return_value = GateStatus(
+        is_active=False,
+        reason=None,
+        triggered_at=None,
+        triggered_by_error_code=None,
+        cleared_at=None,
+        cleared_by=None,
+        cleared_reason=None,
+        blocked_ticks=0,
+    )
+
+    # Patch where FailedGate is defined, not where it's imported
+    with patch("vibe3.orchestra.failed_gate.FailedGate", return_value=mock_gate):
+        runner = CliRunner()
+        result = runner.invoke(app, ["serve", "resume", "--reason", "test"])
+
+    # Command should succeed
+    assert result.exit_code == 0
+
+    # Should show gate is already OPEN
+    assert "already OPEN" in result.stdout
+
+    # But still call clear() to prevent stale errors
+    mock_gate.clear.assert_called_once_with("admin:manual", "test")
+
+
+def test_resume_clears_gate_when_active(monkeypatch) -> None:
+    """Test that serve resume clears gate when it is ACTIVE."""
+    from unittest.mock import MagicMock
+
+    from vibe3.orchestra.failed_gate import GateStatus
+
+    # Mock FailedGate to return ACTIVE state
+    mock_gate = MagicMock()
+    mock_gate.get_status.return_value = GateStatus(
+        is_active=True,
+        reason="ERROR-severity threshold: 2 recent errors",
+        triggered_at="2026-05-23T05:14:08",
+        triggered_by_error_code="E_API_RATE_LIMIT",
+        cleared_at=None,
+        cleared_by=None,
+        cleared_reason=None,
+        blocked_ticks=3,
+    )
+
+    # Patch where FailedGate is defined
+    with patch("vibe3.orchestra.failed_gate.FailedGate", return_value=mock_gate):
+        runner = CliRunner()
+        result = runner.invoke(app, ["serve", "resume", "--reason", "fixed"])
+
+    # Command should succeed
+    assert result.exit_code == 0
+
+    # Should show clearing message (ACTIVE state)
+    assert "Clearing Failed Gate" in result.stdout
+
+    # Should call clear()
+    mock_gate.clear.assert_called_once_with("admin:manual", "fixed")


### PR DESCRIPTION
## Summary

- Fix `serve resume` to always clear `error_log` table, even when FailedGate is already OPEN
- Prevents stale errors from re-triggering FailedGate on next tick

## Problem

`serve resume` 命令存在一个关键缺口：
- 当 FailedGate 状态为 OPEN 时，命令会提前退出
- `error_log` 表不会被清除
- 旧错误记录（如 severity=ERROR 的 E_EXEC_UNKNOWN）仍然存在
- 下次 tick 检查时，这些旧错误会重新触发 FailedGate

**时间线重建**：
1. 05:05-05:14 - 测试泄露产生 9 个 `E_EXEC_UNKNOWN` (severity=ERROR)
2. 05:14 - FailedGate 激活（2+ ERROR in 10min）
3. 某个时间点 - FailedGate 被临时重置为 OPEN
4. 用户执行 `serve resume` - 因为 `is_active=False`，提前退出，**没有清除 error_log**
5. 后续 tick - error_log 中的旧错误继续触发 FailedGate

## Solution

修改 `serve resume` 逻辑：
- 无论 gate 状态如何，都调用 `failed_gate.clear()`
- OPEN 状态时显示提示信息
- 确保 error_log 被清除，防止旧错误重新触发

## Test Plan

- [x] `test_resume_clears_errors_even_when_gate_is_open` - 验证 OPEN 状态仍清除 error_log
- [x] `test_resume_clears_gate_when_active` - 验证 ACTIVE 状态正常清除
- [x] 所有 14 个 test_serve.py 测试通过

## Related

- Issue #42 - 测试泄露问题
- Commit b3081659 - E_EXEC_UNKNOWN 降级为 WARNING
- PR #1291 - 清除测试单例泄露