### PR TITLE
docs: align V3 standards and roadmap with Tier 3 governance architecture

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -65,16 +65,19 @@ Publisher.publish(event) → EventPublisher 查找订阅者 → 调用 handlers
 **五层架构**：
 ```
 L0  Orchestra / Heartbeat          -- 调度主循环
-L1  Governance Service             -- 定期扫描，只操作 GitHub labels
-L2  Supervisor + Apply             -- 轻量治理执行，临时 worktree 隔离
+L1  Governance Service             -- 定期扫描（cron-supervisor, roadmap-intake），只操作 GitHub labels
+                                      真源：supervisor/governance/ (cron-supervisor.md, roadmap-intake.md)
+L2  Supervisor + Apply             -- 轻量治理执行（supervisor-apply），临时 worktree 隔离
+                                      真源：supervisor/apply.md
 L3  Manager / Plan / Run / Review  -- 代码开发核心，独立 worktree
 L4  Human collaboration            -- 人工协作流程
 ```
 
 **Worktree 语义**：
-- **L1**: 无 worktree（`cwd=None`）
+- **L0/L1**: 无 worktree（`cwd=None`）
 - **L2**: 临时 worktree（`--worktree` 标志）
 - **L3**: 持久 worktree（`cwd=wt_path`）
+
 
 **详细文档**: [vibe3-worktree-ownership-standard.md](standards/vibe3-worktree-ownership-standard.md)
 

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -44,6 +44,12 @@
 - **版本规划**: 通过 `roadmap/*` 标签控制
 - **Milestone 分配**: 通过 GitHub Milestone 功能控制
 - **执行状态**: 通过 `state/*` 标签控制（由执行层管理）
+  - `state/ready`: 已识别的待治理/待 intake 候选（由 `cron-supervisor` 识别或人工标记）
+  - `state/handoff`: 已通过审查、准备执行的任务（由 `roadmap-intake` 判定）
+  - `state/claimed`: 已被 agent 认领
+  - `state/in-progress`: 正在执行中
+  - `state/done`: 已完成
+  - `state/blocked`: 已阻塞
 
 ### 2.3 队列排序规则
 
@@ -76,6 +82,14 @@ state/* (当前状态)
 ### 3.1 新 Issue 处理流程
 
 当有新 issue 创建时，按照以下流程处理：
+
+#### Step 0: 治理与分诊 (Governance & Intake)
+
+对于治理类任务（带 `supervisor` 标签）或待入库任务，遵循以下 Tier 3 治理流程：
+
+1.  **识别 (Identification)**: `cron-supervisor` 周期性扫描过时文档或治理需求，创建 issue 并标记 `state/ready`。
+2.  **审查 (Intake)**: `roadmap-intake` 执行三级审查（基础条件、架构一致性、生命周期），通过后将 `state/ready` 晋升为 `state/handoff`。
+3.  **派发 (Dispatch)**: Orchestra 检测到 `state/handoff` 标签，根据角色材料（`supervisor/apply.md` 等）启动异步执行 session。
 
 #### Step 1: 评估类型
 

--- a/docs/standards/vibe3-orchestra-runtime-standard.md
+++ b/docs/standards/vibe3-orchestra-runtime-standard.md
@@ -77,10 +77,9 @@ heartbeat tick 是 driver 进程内部的一次轮询循环。
 
 例如：
 
-- governance scan
-- manager issue run
-- supervisor handoff apply
-- state-driven `plan / run / review`
+- **Governance (L1)**: `cron-supervisor` (识别), `roadmap-intake` (审查)
+- **Governance Execution (L2)**: `supervisor-apply` (执行治理 issue)
+- **Development (L3)**: `manager`, `plan`, `run`, `review` (主开发链)
 
 这些 child session 才是实际调用 codeagent 的执行壳。
 
@@ -157,19 +156,22 @@ service 在这一层只负责：
 
 ### 4.1 Governance 是什么
 
-governance 是一个**周期性治理扫描任务**。
+governance 是一个**周期性治理与审查任务组**。
 
-它负责：
+它包含：
+
+- **`cron-supervisor`**: 扫描全局事实（docs/standards），识别偏差，创建 `state/ready` 治理 issue。
+- **`roadmap-intake`**: 审查 `state/ready` issue，执行架构一致性检查，晋升为 `state/handoff`。
+
+它们共同负责：
 
 - 查看全局 issue / flow / scene 事实
-- 判定哪些 issue 可以进入 `state/ready`
-- 创建治理 issue
-- 或对治理 issue 做进一步处理
+- 判定哪些 issue 可以进入可执行状态
+- 维护仓库健康度
 
-它不负责：
+它们不负责：
 
 - 充当 heartbeat driver
-- 直接替代 manager
 - 长时间阻塞主 server
 
 ### 4.2 Governance 在 runtime 中的位置

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -142,14 +142,18 @@ src/vibe3/
 
 ---
 
-### Phase 4: Orchestra（自动编排层）✅ 运行中
+### Phase 4: Orchestra（自动编排层）✅ Active
 
-**状态**: ✅ **运行中** - 已实现核心调度功能，持续优化中
+**状态**: ✅ **Active** - 已实现核心调度功能，治理层（Tier 3）已上线并持续优化中
 
-**目标**: 实现 agent 自动编排，借鉴 Symphony 的调度理念
+**目标**: 实现 agent 自动编排，架构上对齐 Tier 3 治理体系（cron-supervisor, roadmap-intake）
 
 **设计理念**:
 - **不学习 Symphony 的 agent 模型**（v3 已有更完整的 handoff 体系）
+- **实现 Tier 3 治理分层**：
+  - L1: Cron-supervisor & Roadmap-intake（无 worktree 观察层）
+  - L2: Supervisor Apply（轻量治理执行层）
+  - L3: Manager 主链（代码开发层）
 - **借鉴 Symphony 的调度工程问题**：
   - 如何让 daemon 安全地并发管理多个 agent 执行
   - 如何保证不重复 dispatch
@@ -189,7 +193,7 @@ src/vibe3/
 | Phase 1 | Infrastructure（基础设施层） | ✅ 已完成 | 100% |
 | Phase 2 | Trace（调试追踪层） | ⏸️ 待启动 | 0% |
 | Phase 3 | Handoff（责任链层） | ✅ 已完成 | 100% |
-| Phase 4 | Orchestra（自动编排层） | ✅ 运行中 | 持续优化 |
+| Phase 4 | Orchestra（自动编排层） | ✅ Active | 持续优化 |
 
 ### 已完成
 
@@ -205,6 +209,7 @@ src/vibe3/
 - ✅ 核心参数集（`--trace`, `-v`, `--json`, `-y`）
 - ✅ Handoff 责任链系统（SQLite handoff store, HandoffService）
 - ✅ Orchestra 自动编排（Manager, dispatcher, ready queue）
+- ✅ **Tier 3 Governance** - Cron-supervisor, Roadmap-intake, Supervisor-apply
 
 ### 现行 CLI 命令面
 

--- a/docs/v3/ROADMAP.md
+++ b/docs/v3/ROADMAP.md
@@ -24,9 +24,9 @@ related_docs:
 
 **当前状态**:
 - ✅ Phase 1 (Infrastructure): 100% 完成
-- ⏸️ Phase 2 (Trace): 0% 完成（待启动）
+- ⏸️ Phase 2 (Trace): 待启动（优先级暂低于 Governance）
 - ✅ Phase 3 (Handoff): 100% 完成
-- ✅ Phase 4 (Orchestra): 运行中（Orchestra server 已部署）
+- ✅ Phase 4 (Orchestra): Active/Delivered (Orchestra server 已部署，治理层已上线)
 
 **文档规模**: 40 个文档，约 11,233 行
 
@@ -162,7 +162,7 @@ related_docs:
 
 ## 🎭 Phase 4: Orchestra（自动编排层）
 
-**状态**: ✅ 运行中（Orchestra server 已部署）
+**状态**: ✅ Active/Delivered（Orchestra server 已部署）
 
 **当前进展**:
 - ✅ Orchestra server 已上线（`vibe3 serve`）
@@ -170,7 +170,11 @@ related_docs:
 - ✅ GitHub webhook 接收器已部署
 - ✅ Heartbeat 轮询机制已实现
 - ✅ Issue 分诊与 flow 触发已实现
-- 🔄 多 issue 编排优化进行中
+- ✅ **Tier 3 Governance 实现**
+  - `cron-supervisor`: 自动文档治理识别
+  - `roadmap-intake`: 三级审查机制
+  - `supervisor-apply`: 自动化治理执行
+- 🔄 多 issue 编排与治理闭环持续优化中
 
 **文档**: 设计已完成，核心功能已实现
 


### PR DESCRIPTION
Align documentation with the active Tier 3 governance layer (cron-supervisor, roadmap-intake). Fixes #1347.