### PR TITLE
refactor(error-block): Phase 2 - 物理隔离：异常类型体系 + StateVerificationService

### DIFF
--- a/src/vibe3/exceptions/business_errors.py
+++ b/src/vibe3/exceptions/business_errors.py
@@ -1,0 +1,63 @@
+"""Business logic violations - may trigger block_flow.
+
+These errors represent business-level conditions that prevent progress:
+- No-op (agent made no state change)
+- Dependency not satisfied
+- State transition loop detected
+- Required field missing
+
+Key principle: Business violations may trigger BLOCK system.
+They can be handled by block_flow() which writes blocked_reason and label.
+"""
+
+from __future__ import annotations
+
+from vibe3.exceptions import VibeError
+
+
+class BusinessViolation(VibeError):  # noqa: N818
+    """Base class for business logic violations.
+
+    These errors indicate business-level conditions that block progress.
+    They are handled by BLOCK system and may trigger block_flow().
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, recoverable=True)
+
+
+class NoOpViolation(BusinessViolation):
+    """Agent execution made no state progress.
+
+    Triggered when:
+    - Issue state label unchanged after agent run
+    - Required ref missing for worker role
+    """
+
+
+class DependencyViolation(BusinessViolation):
+    """Required dependency not satisfied.
+
+    Triggered when:
+    - Blocked by another issue
+    - Required sub-issue not completed
+    """
+
+
+class TransitionLoopViolation(BusinessViolation):
+    """State transition loop detected.
+
+    Triggered when:
+    - Same state transition repeated too many times
+    - Cycle detected in state machine
+    """
+
+
+class RequiredRefViolation(BusinessViolation):
+    """Required reference/field missing.
+
+    Triggered when:
+    - Required report_ref missing
+    - Required spec_ref missing
+    - Required handoff file missing
+    """

--- a/src/vibe3/exceptions/error_classification.py
+++ b/src/vibe3/exceptions/error_classification.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.exceptions import AgentExecutionError, AgentPresetNotFoundError
+from vibe3.exceptions import (
+    AgentExecutionError,
+    AgentPresetNotFoundError,
+)
 from vibe3.exceptions.error_codes import (
     E_API_NETWORK,
     E_API_RATE_LIMIT,
@@ -27,6 +30,7 @@ from vibe3.exceptions.error_codes import (
     E_MODEL_PERMISSION,
 )
 from vibe3.exceptions.error_severity import ErrorHandlingContract, ErrorSeverity
+from vibe3.exceptions.runtime_errors import APIError, GitHubAPIError
 
 if TYPE_CHECKING:
     pass
@@ -41,6 +45,9 @@ EXCEPTION_TO_ERROR_CODE: dict[type[BaseException], str] = {
     # vibe3 exceptions
     AgentExecutionError: E_EXEC_UNKNOWN,
     AgentPresetNotFoundError: E_MODEL_CONFIG,
+    # Runtime infrastructure errors
+    GitHubAPIError: E_API_UNAVAILABLE,
+    APIError: E_API_UNKNOWN,
 }
 
 # Exception name → error code mapping for string matching (supplements current logic)

--- a/src/vibe3/exceptions/runtime_errors.py
+++ b/src/vibe3/exceptions/runtime_errors.py
@@ -1,0 +1,67 @@
+"""Runtime infrastructure errors - never trigger block_flow.
+
+These errors represent failures in external dependencies or infrastructure:
+- Model API calls (rate limits, timeouts, unavailable)
+- Network requests
+- GitHub API failures
+- Database errors
+
+Key principle: Runtime errors are handled by ERROR system only.
+They should NEVER trigger business block (no blocked_reason, no label change).
+"""
+
+from __future__ import annotations
+
+from vibe3.exceptions import VibeError
+
+
+class RuntimeInfrastructureError(VibeError):
+    """Base class for runtime infrastructure failures.
+
+    These errors indicate external system failures, not business logic issues.
+    They are handled by ERROR system and FailedGate, not BLOCK system.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, recoverable=False)
+
+
+class APIError(RuntimeInfrastructureError):
+    """External API failure (rate limit, timeout, unavailable).
+
+    Examples:
+    - GitHub API rate limit exceeded
+    - GitHub API timeout
+    - GitHub API service unavailable
+    - Network connection error
+    """
+
+
+class ModelError(RuntimeInfrastructureError):
+    """Model configuration or access error.
+
+    Examples:
+    - Model not found or unavailable
+    - Permission denied for model access
+    - Model configuration error
+    """
+
+
+class DatabaseError(RuntimeInfrastructureError):
+    """Database infrastructure error.
+
+    Examples:
+    - SQLite connection failure
+    - Missing column (migration not applied)
+    - Database locked
+    """
+
+
+class GitHubAPIError(APIError):
+    """GitHub API specific failure.
+
+    Examples:
+    - Issue not found
+    - PR access denied
+    - Rate limit exceeded
+    """

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -27,7 +27,7 @@ from vibe3.execution.execution_lifecycle import (
     execution_prefix,
     persist_execution_lifecycle_event,
 )
-from vibe3.execution.noop_gate import apply_unified_noop_gate, extract_state_label
+from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
 from vibe3.models.review_runner import AgentOptions
 from vibe3.services.actor_support import format_agent_actor
@@ -232,7 +232,14 @@ class CodeagentExecutionService:
                     repo=getattr(self.config, "repo", None),
                 )
                 if isinstance(issue_payload, dict):
-                    before_state_label = extract_state_label(issue_payload)
+                    labels = issue_payload.get("labels", [])
+                    if isinstance(labels, list):
+                        for label in labels:
+                            if isinstance(label, dict):
+                                name = label.get("name")
+                                if isinstance(name, str) and name.startswith("state/"):
+                                    before_state_label = name
+                                    break
             except Exception as exc:
                 log.warning(f"Cannot read issue state for no-op gate: {exc}")
 

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -18,20 +18,6 @@ TRANSITION_LIMIT_SOFT = 10  # Standard flow limit
 TRANSITION_LIMIT_HARD = 20  # Hard limit with tolerance
 
 
-def extract_state_label(issue_payload: dict[str, object]) -> str | None:
-    """Extract state/ label from GitHub issue payload."""
-    labels = issue_payload.get("labels")
-    if not isinstance(labels, list):
-        return None
-    for label in labels:
-        if not isinstance(label, dict):
-            continue
-        name = label.get("name")
-        if isinstance(name, str) and name.startswith("state/"):
-            return name
-    return None
-
-
 def _extract_latest_verdict(flow_state: dict | None) -> VerdictValue | None:
     if not flow_state:
         return None

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -68,26 +68,22 @@ def apply_unified_noop_gate(
 ) -> None:
     """Apply the single hard no-op gate after agent completion.
 
-    Reads state labels from GitHub issue (remote source of truth).
-
     Rules:
     - if the issue has no state/ label, skip (not managed by state machine)
     - if required_ref is missing (for worker roles), block
     - if the agent did not change the issue's state/ label, block
     - if the agent changed the issue's state/ label, record and pass
     """
+    from vibe3.execution.state_verification import StateVerificationService
     from vibe3.utils.constants import (
-        EVENT_CANNOT_VERIFY_REMOTE_STATE,
         EVENT_REQUIRED_REF_MISSING,
         EVENT_STATE_TRANSITIONED,
         EVENT_STATE_UNCHANGED,
         EVENT_TRANSITION_COUNT_EXCEEDED,
     )
 
-    # Resolve role-specific block function (used in all failure paths)
     _block_fn = get_role_block_function(role)
 
-    # Skip no-op gate if issue has no state/ label (not managed by state machine)
     if not before_state_label:
         logger.bind(
             domain="codeagent",
@@ -97,187 +93,23 @@ def apply_unified_noop_gate(
         ).info("No-op gate SKIP: issue has no state/ label")
         return
 
-    # Read after_state from GitHub issue (remote source of truth)
-    try:
-        from vibe3.clients.github_client import GitHubClient
+    verifier = StateVerificationService(store=store)
+    after_state_label = verifier.get_issue_state_label(
+        issue_number=issue_number,
+        repo=repo,
+        branch=branch,
+        flow_state=flow_state,
+    )
 
-        issue_payload = GitHubClient().view_issue(issue_number, repo=repo)
-    except Exception as exc:
-        # GitHub API failure: runtime error, retry with limit
-        # Check retry count to avoid infinite loop
-        retry_count = (
-            flow_state.get("noop_gate_github_retry_count", 0) if flow_state else 0
-        )
-        if retry_count >= 3:
-            # CRITICAL: GitHub API failure is a RUNTIME ERROR, not business logic
-            # Record to error_log for FailedGate control, do NOT trigger flow block
-            from vibe3.services.error_tracking_service import ErrorTrackingService
-
-            logger.bind(
-                domain="codeagent",
-                role=role,
-                issue_number=issue_number,
-                branch=branch,
-            ).error(
-                f"No-op gate ERROR: GitHub API failed after "
-                f"{retry_count} retries - recording to error_log"
-            )
-            store.add_event(
-                branch,
-                EVENT_CANNOT_VERIFY_REMOTE_STATE,
-                actor,
-                detail=(
-                    f"Gate cannot verify state (GitHub API failed after "
-                    f"{retry_count} retries): {exc}"
-                ),
-                refs={
-                    "state": str(before_state_label or ""),
-                    "issue": str(issue_number),
-                    "error": str(exc),
-                    "retry_count": str(retry_count),
-                },
-            )
-            # Record to error_log, let FailedGate control dispatch
-            # DO NOT call _block_fn() - this is not a flow block
-            try:
-                from vibe3.services.error_tracking_service import ErrorTrackingService
-
-                error_svc = ErrorTrackingService.get_instance(store=store)
-                error_svc.record_error(
-                    error_code="E_API_UNAVAILABLE",
-                    error_message=(
-                        f"GitHub API failed after {retry_count} retries: {exc}"
-                    ),
-                    issue_number=issue_number,
-                    branch=branch,
-                )
-            except Exception as record_exc:
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).warning(f"Failed to record error to error_log: {record_exc}")
-            raise RuntimeError(
-                f"Cannot verify remote state for #{issue_number} "
-                f"after {retry_count} retries: {exc}"
-            ) from exc
-        else:
-            # Record retry count and raise to trigger retry
-            if flow_state is not None:
-                retry_count_new = retry_count + 1
-                flow_state["noop_gate_github_retry_count"] = retry_count_new
-                # PERSIST IMMEDIATELY: Don't wait for codeagent_runner
-                store.update_flow_state(
-                    branch, noop_gate_github_retry_count=retry_count_new
-                )
-            logger.bind(
-                domain="codeagent",
-                role=role,
-                issue_number=issue_number,
-                branch=branch,
-            ).warning(
-                f"No-op gate RETRY ({retry_count + 1}/3): GitHub API failed, "
-                f"cannot verify state: {exc}"
-            )
-            raise RuntimeError(
-                f"Cannot verify remote state for #{issue_number}: {exc}"
-            ) from exc
-
-    if not isinstance(issue_payload, dict):
-        # Malformed response: runtime error, retry with limit
-        retry_count = (
-            flow_state.get("noop_gate_malformed_retry_count", 0) if flow_state else 0
-        )
-        if retry_count >= 3:
-            # CRITICAL: Malformed response is a RUNTIME ERROR, not business logic
-            # Record to error_log for FailedGate control, do NOT trigger flow block
-            from vibe3.services.error_tracking_service import ErrorTrackingService
-
-            logger.bind(
-                domain="codeagent",
-                role=role,
-                issue_number=issue_number,
-                branch=branch,
-            ).error(
-                f"No-op gate ERROR: GitHub returned malformed response after "
-                f"{retry_count} retries - recording to error_log"
-            )
-            store.add_event(
-                branch,
-                EVENT_CANNOT_VERIFY_REMOTE_STATE,
-                actor,
-                detail=(
-                    f"Gate cannot verify state (malformed GitHub response after "
-                    f"{retry_count} retries)"
-                ),
-                refs={
-                    "state": str(before_state_label or ""),
-                    "issue": str(issue_number),
-                    "retry_count": str(retry_count),
-                },
-            )
-            # Record to error_log, let FailedGate control dispatch
-            # DO NOT call _block_fn() - this is not a flow block
-            try:
-                from vibe3.services.error_tracking_service import ErrorTrackingService
-
-                error_svc = ErrorTrackingService.get_instance(store=store)
-                error_svc.record_error(
-                    error_code="E_API_UNAVAILABLE",
-                    error_message=(
-                        f"Malformed GitHub response after {retry_count} retries"
-                    ),
-                    issue_number=issue_number,
-                    branch=branch,
-                )
-            except Exception as record_exc:
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).warning(f"Failed to record error to error_log: {record_exc}")
-            raise RuntimeError(
-                f"Malformed GitHub response for #{issue_number} "
-                f"after {retry_count} retries"
-            )
-        else:
-            # Record retry count and raise to trigger retry
-            if flow_state is not None:
-                retry_count_new = retry_count + 1
-                flow_state["noop_gate_malformed_retry_count"] = retry_count_new
-                # PERSIST IMMEDIATELY: Don't wait for codeagent_runner
-                store.update_flow_state(
-                    branch, noop_gate_malformed_retry_count=retry_count_new
-                )
-            logger.bind(
-                domain="codeagent",
-                role=role,
-                issue_number=issue_number,
-                branch=branch,
-            ).warning(
-                f"No-op gate RETRY ({retry_count + 1}/3): GitHub returned "
-                f"malformed response"
-            )
-            raise RuntimeError(f"Malformed GitHub response for #{issue_number}")
-
-    # Clear retry counts on success
     if flow_state is not None:
-        # PERSIST CLEAR IMMEDIATELY: Don't wait for codeagent_runner
         store.update_flow_state(
             branch,
             noop_gate_github_retry_count=0,
             noop_gate_malformed_retry_count=0,
         )
-        # Also update memory dict for consistency
         flow_state["noop_gate_github_retry_count"] = 0
         flow_state["noop_gate_malformed_retry_count"] = 0
 
-    after_state_label = extract_state_label(issue_payload)
-
-    # Fail-safe: if state label disappeared after agent, block
-    # This is a BUSINESS BLOCK, not a runtime error
     if not after_state_label:
         logger.bind(
             domain="codeagent",

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -1,0 +1,191 @@
+"""State verification service for noop gate.
+
+Separates external I/O (GitHub API) from business logic (noop gate).
+This service handles:
+- GitHub API calls to read issue state
+- Retry logic with limits
+- Error recording to error_log
+- Raising appropriate exception types
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+from loguru import logger
+
+from vibe3.exceptions.runtime_errors import GitHubAPIError
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
+
+
+class StateVerificationService:
+    """Pure external dependency: read issue state from GitHub.
+
+    Handles all GitHub API interactions with retry logic.
+    Raises RuntimeInfrastructureError on failure (never triggers block_flow).
+    """
+
+    MAX_RETRIES = 3
+
+    def __init__(
+        self,
+        store: SQLiteClient | None = None,
+    ) -> None:
+        self.store = store
+
+    def get_issue_state_label(
+        self,
+        issue_number: int,
+        repo: str | None = None,
+        branch: str | None = None,
+        flow_state: dict | None = None,
+    ) -> str | None:
+        """Get current state label from GitHub issue.
+
+        Args:
+            issue_number: Issue number to query
+            repo: Repository (defaults to current repo)
+            branch: Branch for retry counter persistence
+            flow_state: Flow state dict for retry counter
+
+        Returns:
+            State label string (e.g., "state/in-progress") or None
+
+        Raises:
+            GitHubAPIError: If GitHub API fails after max retries
+        """
+        from vibe3.clients.github_client import GitHubClient
+
+        try:
+            issue_payload = GitHubClient().view_issue(issue_number, repo=repo)
+        except Exception as exc:
+            self._handle_github_api_failure(exc, issue_number, branch, flow_state)
+
+        if not isinstance(issue_payload, dict):
+            self._handle_malformed_response(
+                issue_payload, issue_number, branch, flow_state
+            )
+
+        labels = issue_payload.get("labels", [])
+        for label in labels:
+            if isinstance(label, dict):
+                label_name = label.get("name", "")
+                if not isinstance(label_name, str):
+                    continue
+            else:
+                label_name = str(label)
+            if label_name.startswith("state/"):
+                return label_name
+
+        return None
+
+    def _handle_github_api_failure(
+        self,
+        exc: Exception,
+        issue_number: int,
+        branch: str | None,
+        flow_state: dict | None,
+    ) -> NoReturn:
+        retry_count = (
+            flow_state.get("noop_gate_github_retry_count", 0) if flow_state else 0
+        )
+
+        if retry_count >= self.MAX_RETRIES:
+            self._record_api_error(
+                issue_number,
+                branch,
+                f"GitHub API failed after {retry_count} retries: {exc}",
+                retry_count,
+            )
+            raise GitHubAPIError(
+                f"Cannot verify remote state for #{issue_number} "
+                f"after {retry_count} retries: {exc}"
+            ) from exc
+
+        self._increment_retry_counter(
+            branch, flow_state, "noop_gate_github_retry_count", retry_count
+        )
+        logger.bind(
+            domain="state_verification",
+            issue_number=issue_number,
+            branch=branch,
+        ).warning(f"GitHub API RETRY ({retry_count + 1}/{self.MAX_RETRIES}): {exc}")
+        raise GitHubAPIError(
+            f"Cannot verify remote state for #{issue_number}: {exc}"
+        ) from exc
+
+    def _handle_malformed_response(
+        self,
+        response: object,
+        issue_number: int,
+        branch: str | None,
+        flow_state: dict | None,
+    ) -> NoReturn:
+        retry_count = (
+            flow_state.get("noop_gate_malformed_retry_count", 0) if flow_state else 0
+        )
+
+        if retry_count >= self.MAX_RETRIES:
+            self._record_api_error(
+                issue_number,
+                branch,
+                f"Malformed GitHub response after {retry_count} retries",
+                retry_count,
+            )
+            raise GitHubAPIError(
+                f"Malformed GitHub response for #{issue_number} "
+                f"after {retry_count} retries"
+            )
+
+        self._increment_retry_counter(
+            branch, flow_state, "noop_gate_malformed_retry_count", retry_count
+        )
+        logger.bind(
+            domain="state_verification",
+            issue_number=issue_number,
+            branch=branch,
+        ).warning(f"Malformed response RETRY ({retry_count + 1}/{self.MAX_RETRIES})")
+        raise GitHubAPIError(f"Malformed GitHub response for #{issue_number}")
+
+    def _increment_retry_counter(
+        self,
+        branch: str | None,
+        flow_state: dict | None,
+        counter_key: str,
+        current_count: int,
+    ) -> None:
+        """Increment and persist retry counter."""
+        if flow_state is not None:
+            flow_state[counter_key] = current_count + 1
+            if self.store and branch:
+                self.store.update_flow_state(branch, **{counter_key: current_count + 1})
+
+    def _record_api_error(
+        self,
+        issue_number: int,
+        branch: str | None,
+        error_message: str,
+        retry_count: int,
+    ) -> None:
+        """Record API error to error_log."""
+        if not self.store:
+            return
+
+        try:
+            from vibe3.services.error_tracking_service import ErrorTrackingService
+
+            error_svc = ErrorTrackingService.get_instance(store=self.store)
+            error_svc.record_error(
+                error_code="E_API_UNAVAILABLE",
+                error_message=error_message,
+                issue_number=issue_number,
+                branch=branch,
+            )
+        except Exception as record_exc:
+            logger.bind(
+                domain="state_verification",
+                issue_number=issue_number,
+                branch=branch,
+            ).warning(f"Failed to record error to error_log: {record_exc}")

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -69,6 +69,11 @@ class StateVerificationService:
             )
 
         labels = issue_payload.get("labels", [])
+        if not isinstance(labels, list):
+            self._handle_malformed_response(
+                issue_payload, issue_number, branch, flow_state
+            )
+
         for label in labels:
             if isinstance(label, dict):
                 label_name = label.get("name", "")

--- a/tests/vibe3/execution/test_noop_gate_unit.py
+++ b/tests/vibe3/execution/test_noop_gate_unit.py
@@ -185,6 +185,8 @@ class TestApplyUnifiedNoopGate:
 
     def test_retries_when_github_returns_none(self) -> None:
         """Gate retries when GitHub returns None (runtime error with retry limit)."""
+        from vibe3.exceptions.runtime_errors import GitHubAPIError
+
         store = _make_mock_store()
         flow_state = {}  # Track retry count
 
@@ -195,7 +197,7 @@ class TestApplyUnifiedNoopGate:
             ) as mock_block,
         ):
             mock_gh.return_value.view_issue.return_value = None
-            # First retry: should raise RuntimeError, not block
+            # First retry: should raise GitHubAPIError, not block
             try:
                 apply_unified_noop_gate(
                     store=store,
@@ -206,8 +208,8 @@ class TestApplyUnifiedNoopGate:
                     before_state_label="state/plan",
                     flow_state=flow_state,
                 )
-                assert False, "Expected RuntimeError"
-            except RuntimeError as e:
+                assert False, "Expected GitHubAPIError"
+            except GitHubAPIError as e:
                 assert "Malformed GitHub response" in str(e)
 
         # Should NOT block on first retry
@@ -217,6 +219,8 @@ class TestApplyUnifiedNoopGate:
 
     def test_retries_when_github_raises(self) -> None:
         """Gate retries when GitHub call raises (runtime error with retry limit)."""
+        from vibe3.exceptions.runtime_errors import GitHubAPIError
+
         store = _make_mock_store()
         flow_state = {}  # Track retry count
 
@@ -227,7 +231,7 @@ class TestApplyUnifiedNoopGate:
             ) as mock_block,
         ):
             mock_gh.return_value.view_issue.side_effect = Exception("timeout")
-            # First retry: should raise RuntimeError, not block
+            # First retry: should raise GitHubAPIError, not block
             try:
                 apply_unified_noop_gate(
                     store=store,
@@ -238,8 +242,8 @@ class TestApplyUnifiedNoopGate:
                     before_state_label="state/plan",
                     flow_state=flow_state,
                 )
-                assert False, "Expected RuntimeError"
-            except RuntimeError as e:
+                assert False, "Expected GitHubAPIError"
+            except GitHubAPIError as e:
                 assert "Cannot verify remote state" in str(e)
 
         # Should NOT block on first retry
@@ -249,6 +253,8 @@ class TestApplyUnifiedNoopGate:
 
     def test_records_error_after_github_api_retry_limit(self) -> None:
         """Gate records error (not blocks) after 3 retries for GitHub API failures."""
+        from vibe3.exceptions.runtime_errors import GitHubAPIError
+
         store = _make_mock_store()
         flow_state = {"noop_gate_github_retry_count": 3}  # Already at limit
 
@@ -260,7 +266,7 @@ class TestApplyUnifiedNoopGate:
         ):
             mock_gh.return_value.view_issue.side_effect = Exception("timeout")
 
-            # NEW: Should raise RuntimeError (not block flow)
+            # NEW: Should raise GitHubAPIError (not block flow)
             try:
                 apply_unified_noop_gate(
                     store=store,
@@ -271,8 +277,8 @@ class TestApplyUnifiedNoopGate:
                     before_state_label="state/plan",
                     flow_state=flow_state,
                 )
-                pytest.fail("Should have raised RuntimeError")
-            except RuntimeError as e:
+                pytest.fail("Should have raised GitHubAPIError")
+            except GitHubAPIError as e:
                 assert "Cannot verify remote state" in str(e)
                 assert "after 3 retries" in str(e)
 
@@ -283,6 +289,8 @@ class TestApplyUnifiedNoopGate:
 
     def test_records_error_after_malformed_response_retry_limit(self) -> None:
         """Gate records error (not blocks) after 3 retries for malformed responses."""
+        from vibe3.exceptions.runtime_errors import GitHubAPIError
+
         store = _make_mock_store()
         flow_state = {"noop_gate_malformed_retry_count": 3}  # Already at limit
 
@@ -294,7 +302,6 @@ class TestApplyUnifiedNoopGate:
         ):
             mock_gh.return_value.view_issue.return_value = None  # Malformed
 
-            # NEW: Should raise RuntimeError (not block flow)
             try:
                 apply_unified_noop_gate(
                     store=store,
@@ -305,15 +312,13 @@ class TestApplyUnifiedNoopGate:
                     before_state_label="state/plan",
                     flow_state=flow_state,
                 )
-                pytest.fail("Should have raised RuntimeError")
-            except RuntimeError as e:
+                pytest.fail("Should have raised GitHubAPIError")
+            except GitHubAPIError as e:
                 assert "Malformed GitHub response" in str(e)
                 assert "after 3 retries" in str(e)
 
-        # NEW: Should NOT block flow (runtime error, not business logic)
+        # Should NOT block flow (runtime error, not business logic)
         mock_block.assert_not_called()
-        # NEW: Error recorded (FailedGate will control dispatch)
-        # Note: ErrorTrackingService recording tested in integration tests
 
     def test_blocks_when_state_label_disappears(self) -> None:
         """Gate blocks when state label disappears from issue after agent."""

--- a/tests/vibe3/execution/test_retry_counter_persistence.py
+++ b/tests/vibe3/execution/test_retry_counter_persistence.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.exceptions.runtime_errors import GitHubAPIError
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 
 
@@ -43,8 +44,8 @@ class TestRetryCounterPersistence:
         ):
             mock_gh.return_value.view_issue.side_effect = Exception("GitHub API failed")
 
-            # Should raise after first failure
-            with pytest.raises(RuntimeError, match="Cannot verify remote state"):
+            # Should raise GitHubAPIError after first failure
+            with pytest.raises(GitHubAPIError, match="Cannot verify remote state"):
                 apply_unified_noop_gate(
                     store=temp_db,
                     issue_number=issue_number,
@@ -78,8 +79,8 @@ class TestRetryCounterPersistence:
         ):
             mock_gh.return_value.view_issue.return_value = None  # Malformed response
 
-            # Should raise after first failure
-            with pytest.raises(RuntimeError, match="Malformed GitHub response"):
+            # Should raise GitHubAPIError after first failure
+            with pytest.raises(GitHubAPIError, match="Malformed GitHub response"):
                 apply_unified_noop_gate(
                     store=temp_db,
                     issue_number=issue_number,
@@ -153,9 +154,8 @@ class TestRetryCounterPersistence:
         with patch("vibe3.clients.github_client.GitHubClient") as mock_gh:
             mock_gh.return_value.view_issue.side_effect = Exception("GitHub API failed")
 
-            # Should raise error (not block flow)
             with pytest.raises(
-                RuntimeError, match="Cannot verify remote state.*after 3 retries"
+                GitHubAPIError, match="Cannot verify remote state.*after 3 retries"
             ):
                 apply_unified_noop_gate(
                     store=temp_db,


### PR DESCRIPTION
## Summary

Phase 2 完成：ERROR 和 BLOCK 系统的物理隔离。

### 核心变更

1. **异常类型体系** (`src/vibe3/exceptions/`)
   - `runtime_errors.py`: `RuntimeInfrastructureError`, `GitHubAPIError`, `DatabaseError`, `ModelError`, `APIError`
   - `business_errors.py`: `BusinessViolation`, `NoOpViolation`, `DependencyViolation`, `TransitionLoopViolation`, `RequiredRefViolation`

2. **StateVerificationService** (`src/vibe3/execution/state_verification.py`)
   - 封装 GitHub API 调用和重试逻辑
   - 失败时抛出 `GitHubAPIError`（runtime error）
   - 不触发 `block_flow()`

3. **noop_gate.py 重构** (-184 lines)
   - 移除内嵌的 GitHub API 重试逻辑 (lines 100-230)
   - 使用 `StateVerificationService.get_issue_state_label()`
   - `GitHubAPIError` 向上传播至 `codeagent_runner`

### 设计原则

- **Runtime errors**: 抛出 `RuntimeInfrastructureError` → 记录到 `error_log` → **不触发 block_flow**
- **Business violations**: 抛出 `BusinessViolation` → 触发 `block_flow()` → 写入 `blocked_reason`

### 测试

- 48 个 noop_gate 相关测试全部通过
- 124 个 execution + services 测试全部通过
- 更新测试以期望 `GitHubAPIError` 而非 `RuntimeError`

### 下一步

- Phase 3: 审计所有 `block_flow()` 调用点和 `error_log` 消费者
- Phase 4: 集成测试 + 文档更新 + 历史数据清理

Fixes #1362