### PR TITLE
fix(blocked-state): remove force=True from block() to respect state machine

### DIFF
--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -8,7 +8,7 @@ This module handles reading/writing blocked state to individual sources:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
@@ -147,7 +147,7 @@ class BlockedStateIO:
         target_state: IssueState,
         actor: str = "system",
         force: bool = False,
-    ) -> None:
+    ) -> Literal["confirmed", "advanced", "blocked"]:
         """Write state to issue labels.
 
         Args:
@@ -155,8 +155,13 @@ class BlockedStateIO:
             target_state: Target state to set
             actor: Actor performing the transition
             force: If True, bypass transition validation (for unblock/resume)
+
+        Returns:
+            "confirmed": Already in target state
+            "advanced": Transition succeeded
+            "blocked": Transition rejected by state machine
         """
-        self.label_service.confirm_issue_state(
+        return self.label_service.confirm_issue_state(
             issue_number,
             target_state,
             actor=actor,

--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -94,11 +94,21 @@ class BlockedStateService:
 
         if issue_number:
             try:
-                self._io.write_label_state(
+                result = self._io.write_label_state(
                     issue_number=issue_number,
                     target_state=IssueState.BLOCKED,
                     actor=actor,
                 )
+                if result == "blocked":
+                    logger.bind(
+                        domain="blocked_state",
+                        action="block",
+                        branch=branch,
+                        issue_number=issue_number,
+                    ).warning(
+                        "Label state machine blocked transition to BLOCKED; "
+                        "label may be out of sync with body/DB"
+                    )
             except Exception as exc:
                 logger.bind(
                     domain="blocked_state",
@@ -157,12 +167,22 @@ class BlockedStateService:
 
         if issue_number:
             try:
-                self._io.write_label_state(
+                result = self._io.write_label_state(
                     issue_number=issue_number,
                     target_state=target_state,
                     actor=actor,
                     force=True,
                 )
+                if result == "blocked":
+                    logger.bind(
+                        domain="blocked_state",
+                        action="unblock",
+                        branch=branch,
+                        issue_number=issue_number,
+                    ).warning(
+                        "Label state machine blocked transition from BLOCKED; "
+                        "label may be out of sync with body/DB"
+                    )
             except Exception as exc:
                 logger.bind(
                     domain="blocked_state",

--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -98,7 +98,6 @@ class BlockedStateService:
                     issue_number=issue_number,
                     target_state=IssueState.BLOCKED,
                     actor=actor,
-                    force=True,
                 )
             except Exception as exc:
                 logger.bind(

--- a/tests/vibe3/services/test_blocked_state_service.py
+++ b/tests/vibe3/services/test_blocked_state_service.py
@@ -34,8 +34,20 @@ class StubLabelService:
 
     def confirm_issue_state(
         self, issue_number: int, state: IssueState, actor: str, force: bool = False
-    ) -> None:
+    ) -> str:
+        """Return values matching real LabelService.confirm_issue_state behavior."""
+        if self.current_state == state:
+            return "confirmed"
+        # Simulate state machine: allow most transitions, block invalid ones
+        # BLOCKED -> BLOCKED is not allowed unless force=True
+        if (
+            self.current_state == IssueState.BLOCKED
+            and state == IssueState.BLOCKED
+            and not force
+        ):
+            return "blocked"
         self.current_state = state
+        return "advanced"
 
 
 def test_block_writes_to_all_three_sources(tmp_path: Path) -> None:
@@ -278,3 +290,34 @@ def test_block_handles_missing_issue_number(tmp_path: Path) -> None:
     assert flow_state is not None
     assert flow_state.get("flow_status") == "blocked"
     assert flow_state.get("blocked_reason") == "No issue linked"
+
+
+def test_block_respects_state_machine_on_double_block(tmp_path: Path) -> None:
+    """Verify block() handles already-blocked label gracefully without force=True."""
+    store = SQLiteClient(db_path=str(tmp_path / "test.db"))
+    store.update_flow_state("test-branch", flow_slug="test")
+
+    github = StubGitHubClient()
+    label_service = StubLabelService()
+    # Simulate issue already in BLOCKED state
+    label_service.current_state = IssueState.BLOCKED
+
+    service = BlockedStateService(
+        store=store,
+        github_client=github,
+        label_service=label_service,
+    )
+
+    # Should not raise even though BLOCKED → BLOCKED is not in ALLOWED_TRANSITIONS
+    service.block(
+        branch="test-branch",
+        reason="Second failure",
+        actor="system",
+        issue_number=123,
+    )
+
+    # DB and body still written; label stays BLOCKED
+    flow_state = store.get_flow_state("test-branch")
+    assert flow_state.get("flow_status") == "blocked"
+    assert flow_state.get("blocked_reason") == "Second failure"
+    assert label_service.current_state == IssueState.BLOCKED

--- a/tests/vibe3/services/test_blocked_state_service.py
+++ b/tests/vibe3/services/test_blocked_state_service.py
@@ -38,14 +38,6 @@ class StubLabelService:
         """Return values matching real LabelService.confirm_issue_state behavior."""
         if self.current_state == state:
             return "confirmed"
-        # Simulate state machine: allow most transitions, block invalid ones
-        # BLOCKED -> BLOCKED is not allowed unless force=True
-        if (
-            self.current_state == IssueState.BLOCKED
-            and state == IssueState.BLOCKED
-            and not force
-        ):
-            return "blocked"
         self.current_state = state
         return "advanced"
 

--- a/tests/vibe3/services/test_flow_block_enhanced.py
+++ b/tests/vibe3/services/test_flow_block_enhanced.py
@@ -88,7 +88,7 @@ class TestBlockFlowEnhanced:
 
         # Assert - Issue state transition (via confirm_issue_state)
         mock_label_service.confirm_issue_state.assert_called_once_with(
-            42, IssueState.BLOCKED, actor=actor, force=True
+            42, IssueState.BLOCKED, actor=actor, force=False
         )
 
         # Assert - Timeline comment added
@@ -165,7 +165,7 @@ class TestBlockFlowEnhanced:
 
         # Assert - Issue state transition still happens (via confirm_issue_state)
         mock_label_service.confirm_issue_state.assert_called_once_with(
-            42, IssueState.BLOCKED, actor=actor, force=True
+            42, IssueState.BLOCKED, actor=actor, force=False
         )
 
         # Assert - Timeline comment added with empty reason


### PR DESCRIPTION
## Summary

移除 `BlockedStateService.block()` 中的 `force=True` 参数，使 label 状态转换遵循状态机规则。

## Changes

- **src/vibe3/services/blocked_state_service.py**: 移除 `block()` 方法中的 `force=True` 参数（第101行），让 `confirm_issue_state` 按照 `ALLOWED_TRANSITIONS` 处理状态转换
- `unblock()` 方法保留 `force=True`，因为 BLOCKED → 其他状态不在 `ALLOWED_TRANSITIONS` 中，需要人工命令强制转换

## Verification

✅ 所有针对性测试通过 (test_blocked_state_service.py, test_flow_block_enhanced.py, test_state_machine.py)
✅ 类型检查通过 (mypy)
✅ Lint 检查通过 (ruff)
✅ 相关测试通过 (test_flow_block_mixin.py, test_issue_failure_service.py, test_flow_orchestrator_service.py)
✅ Pre-push checks 全部通过 (35/35 tests)

## Key Behaviors

1. **正常 block**: 状态机规则生效，转换必须符合 `ALLOWED_TRANSITIONS`
2. **double-block 场景**: `confirm_issue_state` 返回 "confirmed"，优雅处理已 blocked 状态
3. **unblock 保留强制**: BLOCKED → 其他状态仍需 `force=True`，由人工命令触发

Fixes #1329

---

## Contributors

claude/opus
