### PR TITLE
fix(handoff): remove automatic blocked_reason clearing

### DIFF
--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -248,11 +248,12 @@ class HandoffService:
         if actor_field:
             flow_updates[actor_field] = effective_actor
 
-        # Clear blocked_reason when required refs are written
-        # This handles the case where gate was skipped (e.g., no state label)
-        # but executor/planner successfully wrote the required artifact
-        if ref_field in ("plan_ref", "report_ref"):
-            flow_updates["blocked_reason"] = None
+        # NOTE: blocked_reason management is handled by BlockedStateService.
+        # Handoff service does NOT clear blocked_reason automatically because:
+        # 1. ERROR and BLOCK systems are now separated (PR #1366)
+        # 2. blocked_reason is managed by BlockedStateService for consistency
+        # 3. User-set blocked_reason should only be cleared via unblock command
+        # 4. No transient blocked_reason patterns exist in current architecture
 
         if verdict:
             role = extract_role_from_actor(effective_actor)


### PR DESCRIPTION
## Summary

Removed automatic `blocked_reason` clearing from `handoff_service` because the original assumption about transient blocked reasons was incorrect, and the architecture has evolved.

## Problem

PR #1327 added automatic `blocked_reason` clearing when writing `plan_ref`/`report_ref`, which would mask legitimate block reasons. PR #1378 attempted to fix this with a scoped allowlist, but the allowlist was based on incorrect assumptions.

## Root Cause Analysis

1. **"waiting for" prefix too broad** (Copilot correctly identified)
   - Users can set arbitrary text via `vibe3 flow blocked --reason`
   - Example: "Waiting for dependency approval" is a real block
   - Would be incorrectly cleared

2. **"gate skipped" and "no state label" do not exist**
   - `noop_gate.py` skips when no state label (line 73-80)
   - **No `blocked_reason` is set in this case**
   - These patterns never appear in `blocked_reason` field

3. **Architecture has evolved**
   - ERROR and BLOCK systems separated (PR #1366)
   - `BlockedStateService` now manages all blocked state
   - No transient blocked_reason patterns exist

## Solution

**Completely remove automatic clearing** because:

1. ERROR and BLOCK systems are now separated
   - ERROR tracking uses `error_log` table
   - FLOW BLOCK uses `flow_state.blocked_reason`
   - Systems are orthogonal and should not interfere

2. `BlockedStateService` provides unified management
   - All blocked state operations centralized
   - Ensures consistency across database, issue body, and labels

3. No transient patterns exist
   - All `blocked_reason` values represent real blocking conditions
   - Should only be cleared via explicit unblock command

## Changes

- Removed `_CLEARABLE_BLOCK_REASONS` tuple (unused in practice)
- Removed automatic clearing logic from `_record_ref()`
- Removed 3 tests for non-existent functionality
- Added architectural note explaining the decision

## Test Coverage

- All existing tests pass (17/17)
- mypy PASS
- ruff PASS
- pre-commit PASS

## Verification

```bash
# Run tests
uv run pytest tests/vibe3/services/test_handoff_service.py -xvs

# Type check
uv run mypy src/vibe3/services/handoff_service.py

# Lint
uv run ruff check src/vibe3/services/handoff_service.py
```

Fixes #1332

---

## Contributors

claude/opus