### PR TITLE
test(error-tracking): add tests for get_all_errors_status() and serve status display

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -285,8 +285,8 @@ code_limits:
         limit: 480
         reason: "Flow orchestrator 服务测试集，覆盖 dispatch 协调、frozen queue 管理、issue 状态处理等紧密耦合场景，共享 fixture，拆分收益低"
       - path: "tests/vibe3/exceptions/test_error_tracking.py"
-        limit: 520
-        reason: "Error tracking 测试集，新增 6 个 severity-aware 测试、migration backfill 测试、兼容性测试，覆盖 severity 分类、threshold 计数、时间窗口逻辑"
+        limit: 650
+        reason: "Error tracking 测试集，新增 9 个测试（5 个 get_all_errors_status + 4 个 _display_error_tracking），覆盖 severity 分类、threshold 计数、时间窗口逻辑、NULL severity 默认处理、历史 vs 窗口错误显示"
       - path: "tests/vibe3/services/test_task_service_fresh_db.py"
         limit: 420
         reason: "TaskService fresh DB 测试集，覆盖 issue 链接、角色重分类、flow 降级、ref 选择等核心业务逻辑，包含完整的 mock setup 和参数化状态转换测试，拆分会破坏测试场景完整性"

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -514,3 +514,134 @@ def test_migration_backfills_severity_column(tmp_path: Path) -> None:
     assert rows[2] == ("E_EXEC_NO_OUTPUT", "WARNING")
 
     conn.close()
+
+
+# Tests for get_all_errors_status() (Task #1334)
+
+
+def test_get_all_errors_status_empty_db(temp_store: SQLiteClient) -> None:
+    """get_all_errors_status should return all zeros on empty database."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    status = ErrorTrackingService._instance.get_all_errors_status()
+
+    assert status["total_errors"] == 0
+    assert status["critical_count"] == 0
+    assert status["error_count"] == 0
+    assert status["warning_count"] == 0
+
+
+def test_get_all_errors_status_single_severity(temp_store: SQLiteClient) -> None:
+    """get_all_errors_status should count errors of a single severity."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    from vibe3.exceptions.error_severity import ErrorSeverity
+
+    # Insert 3 ERROR-severity records
+    for i in range(3):
+        ErrorTrackingService._instance.record_error(
+            "E_API_RATE_LIMIT",
+            f"Rate limit {i}",
+            severity=ErrorSeverity.ERROR,
+        )
+
+    status = ErrorTrackingService._instance.get_all_errors_status()
+
+    assert status["total_errors"] == 3
+    assert status["error_count"] == 3
+    assert status["critical_count"] == 0
+    assert status["warning_count"] == 0
+
+
+def test_get_all_errors_status_severity_buckets(temp_store: SQLiteClient) -> None:
+    """get_all_errors_status should correctly bucket mixed severity levels."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    from vibe3.exceptions.error_severity import ErrorSeverity
+
+    # Insert 2 CRITICAL + 3 ERROR + 1 WARNING
+    for i in range(2):
+        ErrorTrackingService._instance.record_error(
+            "E_MODEL_NOT_FOUND",
+            f"Model error {i}",
+            severity=ErrorSeverity.CRITICAL,
+        )
+    for i in range(3):
+        ErrorTrackingService._instance.record_error(
+            "E_API_RATE_LIMIT",
+            f"Rate limit {i}",
+            severity=ErrorSeverity.ERROR,
+        )
+    ErrorTrackingService._instance.record_error(
+        "E_EXEC_NO_OUTPUT",
+        "No output",
+        severity=ErrorSeverity.WARNING,
+    )
+
+    status = ErrorTrackingService._instance.get_all_errors_status()
+
+    assert status["critical_count"] == 2
+    assert status["error_count"] == 3
+    assert status["warning_count"] == 1
+    assert status["total_errors"] == 6
+    assert (
+        status["critical_count"] + status["error_count"] + status["warning_count"]
+        == status["total_errors"]
+    )
+
+
+def test_get_all_errors_status_null_severity_defaults_to_error(
+    temp_store: SQLiteClient,
+) -> None:
+    """get_all_errors_status should count NULL severity as ERROR (default)."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    # Insert row with NULL severity via raw SQL
+    with sqlite3.connect(temp_store.db_path) as conn:
+        conn.execute("""
+            INSERT INTO error_log (tick_id, error_code, error_message)
+            VALUES (1, 'E_CUSTOM_ERROR', 'Error without severity')
+        """)
+        conn.commit()
+
+    status = ErrorTrackingService._instance.get_all_errors_status()
+
+    # NULL severity should be counted as ERROR (line 308 in error_tracking_queries.py)
+    assert status["error_count"] == 1
+    assert status["total_errors"] == 1
+    assert status["critical_count"] == 0
+    assert status["warning_count"] == 0
+
+
+def test_get_all_errors_status_ignores_time_window(temp_store: SQLiteClient) -> None:
+    """get_all_errors_status should count all errors regardless of time window."""
+    ErrorTrackingService._instance = ErrorTrackingService(store=temp_store)
+
+    from vibe3.exceptions.error_severity import ErrorSeverity
+
+    # Insert recent error (within window)
+    ErrorTrackingService._instance.record_error(
+        "E_API_RATE_LIMIT",
+        "Recent error",
+        severity=ErrorSeverity.ERROR,
+    )
+
+    # Insert old error outside window (>10 min)
+    with sqlite3.connect(temp_store.db_path) as conn:
+        conn.execute("""
+            INSERT INTO error_log
+            (tick_id, error_code, error_message, severity, created_at)
+            VALUES (
+                2, 'E_API_TIMEOUT', 'Old error', 'ERROR',
+                datetime('now', '-15 minutes')
+            )
+        """)
+        conn.commit()
+
+    # get_all_errors_status should count BOTH errors (no time filter)
+    all_status = ErrorTrackingService._instance.get_all_errors_status()
+    assert all_status["total_errors"] == 2
+
+    # get_status (windowed) should only count recent error
+    windowed_status = ErrorTrackingService._instance.get_status()
+    assert windowed_status["total_errors"] == 1

--- a/tests/vibe3/services/test_serve_status_service.py
+++ b/tests/vibe3/services/test_serve_status_service.py
@@ -170,3 +170,168 @@ class TestDisplayConfig:
         printed = [str(call.args[0]) for call in service.console.print.call_args_list]
         assert any("60s" in msg for msg in printed)
         assert not any("(override" in msg for msg in printed)
+
+
+class TestDisplayErrorTracking:
+    """Test cases for _display_error_tracking method."""
+
+    @patch("vibe3.services.serve_status_service.ErrorTrackingService.get_instance")
+    def test_display_historical_errors_windowed_zero(self, mock_get_instance):
+        """Display should show historical errors even when windowed count is zero."""
+        from vibe3.services.serve_status_service import ServeStatusService
+
+        # Mock error tracking service
+        mock_service = MagicMock()
+        mock_service.get_all_errors_status.return_value = {
+            "total_errors": 3,
+            "critical_count": 1,
+            "error_count": 2,
+            "warning_count": 0,
+        }
+        mock_service.get_status.return_value = {
+            "total_errors": 0,
+            "time_window_minutes": 10,
+            "threshold": 2,
+        }
+        mock_service.get_recent_errors.return_value = []
+        mock_get_instance.return_value = mock_service
+
+        # Create service with mocked console
+        config = MagicMock()
+        service = ServeStatusService(config)
+        service.console = MagicMock()
+
+        # Call display method
+        service._display_error_tracking()
+
+        # Verify console output
+        printed = [str(call.args[0]) for call in service.console.print.call_args_list]
+
+        # Should show total errors
+        assert any("Total errors: 3" in msg for msg in printed)
+        # Should show severity breakdown
+        assert any("CRITICAL: 1" in msg for msg in printed)
+        assert any("ERROR: 2" in msg for msg in printed)
+        # Should NOT show windowed line (total is 0)
+        assert not any("Windowed" in msg for msg in printed)
+
+    @patch("vibe3.services.serve_status_service.ErrorTrackingService.get_instance")
+    def test_display_historical_and_windowed_both_nonzero(self, mock_get_instance):
+        """Display should show both historical and windowed counts when both nonzero."""
+        from vibe3.services.serve_status_service import ServeStatusService
+
+        # Mock error tracking service
+        mock_service = MagicMock()
+        mock_service.get_all_errors_status.return_value = {
+            "total_errors": 5,
+            "critical_count": 0,
+            "error_count": 5,
+            "warning_count": 0,
+        }
+        mock_service.get_status.return_value = {
+            "total_errors": 2,
+            "time_window_minutes": 10,
+            "threshold": 2,
+        }
+        mock_service.get_recent_errors.return_value = []
+        mock_get_instance.return_value = mock_service
+
+        # Create service with mocked console
+        config = MagicMock()
+        service = ServeStatusService(config)
+        service.console = MagicMock()
+
+        # Call display method
+        service._display_error_tracking()
+
+        # Verify console output
+        printed = [str(call.args[0]) for call in service.console.print.call_args_list]
+
+        # Should show total errors
+        assert any("Total errors: 5" in msg for msg in printed)
+        # Should show windowed line (total is nonzero)
+        assert any("Windowed" in msg and "2 errors" in msg for msg in printed)
+        assert any("threshold: 2" in msg for msg in printed)
+
+    @patch("vibe3.services.serve_status_service.ErrorTrackingService.get_instance")
+    def test_display_no_errors(self, mock_get_instance):
+        """Display should show 'No errors recorded' when total is zero."""
+        from vibe3.services.serve_status_service import ServeStatusService
+
+        # Mock error tracking service
+        mock_service = MagicMock()
+        mock_service.get_all_errors_status.return_value = {
+            "total_errors": 0,
+            "critical_count": 0,
+            "error_count": 0,
+            "warning_count": 0,
+        }
+        mock_service.get_status.return_value = {
+            "total_errors": 0,
+            "time_window_minutes": 10,
+            "threshold": 2,
+        }
+        mock_service.get_recent_errors.return_value = []
+        mock_get_instance.return_value = mock_service
+
+        # Create service with mocked console
+        config = MagicMock()
+        service = ServeStatusService(config)
+        service.console = MagicMock()
+
+        # Call display method
+        service._display_error_tracking()
+
+        # Verify console output
+        printed = [str(call.args[0]) for call in service.console.print.call_args_list]
+
+        # Should show no errors message
+        assert any("No errors recorded" in msg for msg in printed)
+
+    @patch("vibe3.services.serve_status_service.ErrorTrackingService.get_instance")
+    def test_display_with_recent_errors_table(self, mock_get_instance):
+        """Display should render table with recent errors."""
+        from rich.table import Table
+
+        from vibe3.services.serve_status_service import ServeStatusService
+
+        # Mock error tracking service
+        mock_service = MagicMock()
+        mock_service.get_all_errors_status.return_value = {
+            "total_errors": 2,
+            "critical_count": 0,
+            "error_count": 2,
+            "warning_count": 0,
+        }
+        mock_service.get_status.return_value = {
+            "total_errors": 1,
+            "time_window_minutes": 10,
+            "threshold": 2,
+        }
+        # Mock recent errors with all required fields
+        mock_service.get_recent_errors.return_value = [
+            {
+                "tick_id": 42,
+                "issue_number": 123,
+                "severity": "ERROR",
+                "error_code": "E_API_RATE_LIMIT",
+                "error_message": "Rate limit exceeded",
+                "created_at": "2024-01-01 12:00:00",
+            }
+        ]
+        mock_get_instance.return_value = mock_service
+
+        # Create service with mocked console
+        config = MagicMock()
+        service = ServeStatusService(config)
+        service.console = MagicMock()
+
+        # Call display method
+        service._display_error_tracking()
+
+        # Verify table was printed
+        print_calls = service.console.print.call_args_list
+        table_printed = any(
+            isinstance(call.args[0], Table) for call in print_calls if call.args
+        )
+        assert table_printed


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for error tracking display functionality:
- 5 tests for `get_all_errors_status()` in `test_error_tracking.py`
- 4 tests for `_display_error_tracking()` in `test_serve_status_service.py`

## Test Coverage

### `tests/vibe3/exceptions/test_error_tracking.py`
- `test_get_all_errors_status_empty_db`: verify empty DB returns all zeros
- `test_get_all_errors_status_single_severity`: single severity bucket counting
- `test_get_all_errors_status_severity_buckets`: mixed severity bucketing
- `test_get_all_errors_status_null_severity_defaults_to_error`: NULL handling
- `test_get_all_errors_status_ignores_time_window`: time window independence

### `tests/vibe3/services/test_serve_status_service.py`
- `test_display_historical_errors_windowed_zero`: historical vs windowed display
- `test_display_historical_and_windowed_both_nonzero`: both counts display
- `test_display_no_errors`: empty state display
- `test_display_with_recent_errors_table`: table rendering

## Verification

✅ All 39 tests pass (23 in test_error_tracking.py, 16 in test_serve_status_service.py)
✅ Total test suite: 2238 tests pass
✅ Lint clean
✅ NULL severity edge case covered
✅ Singleton mocking strategy verified

## Related

Addresses Copilot review comments on PR #1327
Closes #1334

---

## Contributors

claude/opus
