### PR TITLE
docs: align stale documents with vibe3 CLI semantics (#1377)

### DIFF
--- a/docs/references/vibe-engine-design.md
+++ b/docs/references/vibe-engine-design.md
@@ -49,33 +49,33 @@ related_docs:
 
 在 Vibe Center 2.0 中，我们确立了**Model-Spec-Context (MSC) 范式**，旨在用强约束和边界控制收敛 AI 生成的代码质量，防止"凭感觉写出垃圾代码"。然而，我们发现当前系统的**执行入口存在断层**：
 
-- **痛点一：Shell 工具只是空壳**。早期 `bin/vibe flow start` 偏向“切执行现场”而缺少真正的规范驱动，它没有真正拉起 AI Agent 进入验证阶段。`governance.yaml` 中配置的 `flow_hooks` 被记录了，但无人执行。
-- **痛点二：Slash 命令缺乏强制约束**。用户可以直接使用 `/vibe-commit` 或直接在对话中提出改代码要求，Agent 会欣然接受，这就绕过了所有的需求验证 (PRD)、代码质量检查 (lint/test) 等 MSC 规范机制。
+- **痛点一：Shell 工具只是空壳**。早期 `vibe3 flow update` 偏向“切执行现场”而缺少真正的规范驱动，它没有真正拉起 AI Agent 进入验证阶段。`governance.yaml` 中配置的 `flow_hooks` 被记录了，但无人执行。
+- **痛点二：Slash 命令缺乏强制约束**。用户可以直接使用 `vibe3 pr draft` 或直接在对话中提出改代码要求，Agent 会欣然接受，这就绕过了所有的需求验证 (PRD)、代码质量检查 (lint/test) 等 MSC 规范机制。
 - **痛点三：工具的认知负面影响**。无论是 openSpec 还是 Serena，这些本该作为隐形护栏的基础工具，反而成了需要用户主动理解并运行的负担。
 
 ## 2. 核心架构：统一工作流编排器 (Unified Workflow Orchestrator)
 
-我们的解决思路是：**设计一个统一的工作流引擎，将所有入口（Shell 命令行、Slash 命令、Agent 自然对话）全部打通，并在处理流程中强行嵌入 MSC 拦截门。** 所有的需求变更无论从哪来，都只能通过这条单行道。
+我们的解决思路是：**设计一个统一的工作流引擎，将所有入口（Shell 命令行、vibe3 命令、Agent 自然对话）全部打通，并在处理流程中强行嵌入 MSC 拦截门。** 所有的需求变更无论从哪来，都只能通过这条单行道。
 
 ### 2.1 任务生命周期与系统闭环 (Task Lifecycle Loop)
 
 在 Vibe Engine 中，一项开发任务的生命周期与底层的 Git branch / flow runtime 和 CLI 命令是严格绑定的：
 
 1. **创建 (Todo)**
-   - **触发**: `vibe task add <title>` 或 Agent 识别出新意图。
+   - **触发**: `vibe3 task add <title>` 或 Agent 识别出新意图。
    - **状态**: 任务已登记在 `registry.json` 中，但尚未创建代码分支，也未指派 AI 角色。
 2. **执行 (In Progress)**
-   - **触发**: `vibe flow new <slug>`（在当前目录切到新 flow / branch）或 `vibe flow bind <task-id>`（绑定现有工作区）。
+   - **触发**: `vibe3 flow new <slug>`（在当前目录切到新 flow / branch）或 `vibe3 flow bind <task-id>`（绑定现有工作区）。
    - **状态**: 当前 branch 与 flow runtime 就绪，Agent 身份确认，一切就绪。
    - **循环**: Agent 开始写代码了，这是纯粹的 Execution 阶段，不受干扰。
 3. **审计 (In Review / Code Review)**
-   - **触发**: `vibe flow review --local` （调用底层大模型进行自动化逻辑与依赖检查）或者 `vibe flow pr` (推送至云端供人类复核)。
+   - **触发**: `vibe3 review --local` （调用底层大模型进行自动化逻辑与依赖检查）或者 `vibe3 pr draft` (推送至云端供人类复核)。
    - **状态**: 任务处于冻结待决状态，根据 Codex/Human 的反馈决定退回 *执行* 还是前进到 *完成*。
 4. **收尾 (Completed / Closed)**
    - **触发**: PR 合并后自动触发或手动清理 worktree。
    - **状态**: 交付收口。当前特征分支被删除，flow 历史被保留；物理目录是否清理取决于 worktree 生命周期，而不是 flow 本体。
 5. **归档 (Archived)**
-   - **触发**: `vibe check`。
+   - **触发**: `vibe3 check`。
    - **状态**: `registry.json` 中属于已完结状态的任务，连带的 Markdown 等元信息被永久搬运入 `archive/`。
 
 这个流转关系使得工具不再是散落的拼图，而是：**新建任务 -> 切入 flow/branch 现场 -> 编写代码 -> Codex Review -> 提交 PR -> 结束当前 flow -> 归档记录** 的完美闭环。
@@ -89,8 +89,8 @@ graph TD
     classDef tool fill:#6366f1,stroke:#4338ca,stroke-width:2px,color:#fff;
 
     subgraph "Tier 2: Vibe Skills Layer (Skill 层 - 智能包装)"
-        A1[bin/vibe flow]:::ui
-        A2[/vibe-task / /vibe-flow / /vibe-save]:::ui
+        A1[vibe3 flow]:::ui
+        A2[vibe3 task / vibe3 flow / vibe3 handoff append]:::ui
         A3[自然语言需求对话]:::ui
     end
 
@@ -102,7 +102,7 @@ graph TD
     end
 
     subgraph "Tier 1: Shell Layer (Shell 能力层 - 无感知运行)"
-        C1[vibe 命令及 alias]:::tool
+        C1[vibe3 命令及 alias]:::tool
         C2[bats-core]:::tool
         C3[codex & Shellcheck]:::tool
         C4[OpenSpec & Registry JSON]:::tool
@@ -154,28 +154,28 @@ graph TD
 | **Stage 1: Scope Gate** | 检查需求是否违反 `SOUL.md` 的业务界限 | 文本向量比对 / 大模型常识审核 | ❌ Agent 输出："抱歉，这违反了我们的 SOUL：我们只是 CLI 工具，不能做网页。要继续吗？请讨论修改 SOUL.md。" |
 | **Stage 2: Plan Gate** | 对于增加新功能，是否存在 `.agent/plans/` 计划或 PRD？ | 工作流节点审核文件树 | ❌ Agent 输出："我们还没有完成设计，这很容易生产垃圾代码。让我们先确定几个参数，我来起草一个 Spec。" |
 | **Stage 3: Execution Gate** | 代码是否能跑通且影响面受控？ | 调用 `vibe-test-runner` | ❌ 直接循环尝试 3 次自动修 Bug，修不好再吐给用户报错面板。 |
-| **Stage 4: Review Gate** | 逻辑退化指标与漏洞扫描 | 调用 `vibe flow review --local` (Codex) | ❌ Agent 输出："发现潜在死代码或违规项，请清理垃圾代码后我再打包当前修改。" |
+| **Stage 4: Review Gate** | 逻辑退化指标与漏洞扫描 | 调用 `vibe3 review --local` (Codex) | ❌ Agent 输出："发现潜在死代码或违规项，请清理垃圾代码后我再打包当前修改。" |
 
 ### 3.3 无痛护航 (Pain-Free Tooling)
 
 在这套机制下：
 - 用户从来不需要主动命令 Agent 运行 `find_referencing_symbols`（这是 Execution Gate 的潜规则）。
 - 用户不需要关心如何把一个逻辑变成 OpenSpec，他们只需要正常问答，Agent 代为沉淀文件。
-- Shell 命令和 Agent 对话合流：你在 Shell 敲击 `vibe flow review` 实际上就是调用 `vibe-rules-enforcer` 并把输出和 metrics 丢回 Shell。
+- Shell 命令和 Agent 对话合流：你在 Shell 敲击 `vibe3 review` 实际上就是调用 `vibe3 review --local` 并把输出和 metrics 丢回 Shell。
 
 ## 4. 实施策略
 
 为实现这个蓝图，我们将使用一个"大脑" Skill，串联现有的所有原子级模块：
 
 - 创建新的核心 Skill: `vibe-workflow-orchestrator`，此技能在任何上下文启动时都会被隐式或者显式触发。
-- 当 `bin/vibe flow` 相关命令在终端运行时，如果环境有 Agent 环境变量，触发 Agent 代跑流程；没有的话回退为普通输出。
+- 当 `vibe3 flow` 相关命令在终端运行时，如果环境有 Agent 环境变量，触发 Agent 代跑流程；没有的话回退为普通输出。
 
 ## 5. 终极远景：多智能体管线 (The Agent of Agents Loop)
 
-通过在底座中封装这些不可变的生命周期（如 `vibe flow review`），Vibe Center 最终将演化为能够托管异构 AI 智能体的超管基础设施（Super-Orchestrator），例如借助 `OpenClaw` 或类似底座实现完全自治的开发管线：
+通过在底座中封装这些不可变的生命周期（如 `vibe3 review`），Vibe Center 最终将演化为能够托管异构 AI 智能体的超管基础设施（Super-Orchestrator），例如借助 `OpenClaw` 或类似底座实现完全自治的开发管线：
 
 1. **架构师 (Gemini)**：擅长无限上下文。负责通读整个代码库与高阶业务需求，在 `docs/plans/` 中输出精确到步骤的系统设计与抽象逻辑 (`plan.md`)。
 2. **执行者 (Claude)**：擅长零样本编码。作为无头(Headless)引擎被唤醒（`claude -c -p <plan> --dangerously-skip-permissions`），在当前被分配的 flow / branch 现场中老老实实地落实每一行代码，不去擅自重构项目。
-3. **审计员 (Codex)**：擅长挑刺和严谨的静态分析。作为守门员拦截在提交前（`vibe flow review --local`），专门负责代码 review、找 bug 和死代码。如果退回，再发给 Claude 重新修。
+3. **审计员 (Codex)**：擅长挑刺和严谨的静态分析。作为守门员拦截在提交前（`vibe3 review --local`），专门负责代码 review、找 bug 和死代码。如果退回，再发给 Claude 重新修.
 4. **总指挥 (OpenClaw / Vibe Flow Auto)**：维持整个 flow 现场流转的编排循环，负责调用上述执行代理，并在需要并行隔离时额外调度 worktree 基础设施。
 5. **人类 (Human Approver)**：从打字员解放为终审法官，只需在 Slack/Channel 中查看汇总的 PR 与 Review 报告，点一下 "LGTM" 闭环合码。

--- a/docs/standards/vibe3-command-standard.md
+++ b/docs/standards/vibe3-command-standard.md
@@ -4,13 +4,21 @@
 
 本文件仅保留为旧路径目录页，不再承载现行命令规范正文。
 
+## 📖 现行真源 (Current Truth)
+
+**所有 Vibe 3.0 命令规范请以此文档为准：**
+
+👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)**
+
+---
+
 原因：
 
 - 旧版正文混合了历史命令面与现行语义
 - 曾同时描述 `flow add/create/new/switch/done/aborted/list` 等已退场入口
 - 容易与现行 shared-state 标准形成双真源
 
-现行阅读入口：
+其他参考入口：
 
 1. [docs/standards/v3/command-standard.md](v3/command-standard.md)
 2. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)

--- a/docs/standards/vibe3-user-guide.md
+++ b/docs/standards/vibe3-user-guide.md
@@ -4,20 +4,27 @@
 
 本文件仅保留为旧路径目录页，不再承载现行用户指南正文。
 
+## 📖 现行真源 (Current Truth)
+
+**所有 Vibe 3.0 操作指南请以此文档为准：**
+
+👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)**
+
+---
+
 原因：
 
 - 旧版指南混入了多组历史命令示例
 - 包含 `flow create/switch/done/aborted/list` 等已退场入口
 - 已不适合作为当前操作指引
 
-现行阅读入口：
+其他参考入口：
 
 1. [README.md](../README.md)
 2. [AGENTS.md](../../AGENTS.md)
-3. [docs/standards/v3/command-standard.md](v3/command-standard.md)
-4. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
-5. [docs/standards/issue-standard.md](issue-standard.md)
-6. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
+3. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
+4. [docs/standards/issue-standard.md](issue-standard.md)
+5. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
 
 当前推荐操作模型：
 

--- a/docs/v3/ROADMAP.md
+++ b/docs/v3/ROADMAP.md
@@ -186,9 +186,9 @@ related_docs:
 
 ### Phase 01: CLI Skeleton & Contract
 
-- [ ] `bin/vibe3 flow --help` 返回正确输出
-- [ ] `bin/vibe3 task --help` 返回正确输出
-- [ ] `bin/vibe3 pr --help` 返回正确输出
+- [ ] `vibe3 flow --help` 返回正确输出
+- [ ] `vibe3 task --help` 返回正确输出
+- [ ] `vibe3 pr --help` 返回正确输出
 - [ ] `mypy src/vibe3/ --strict` 无错误
 
 ### Phase 02: Flow & Task State (SQLite)
@@ -211,7 +211,7 @@ related_docs:
 
 ### Phase 05: Verification & Cleanup
 
-- [ ] `time bin/vibe3 flow status` < 1.0s
+- [ ] `time vibe3 flow status` < 1.0s
 - [ ] 清理所有 TODO 和 print()
 - [ ] 所有冒烟测试通过
 

--- a/docs/v3/handoff/README.md
+++ b/docs/v3/handoff/README.md
@@ -38,9 +38,9 @@ related_docs:
 
 **Inputs**: `docs/v3/handoff/01-command-and-skeleton.md`
 **Success Criteria**:
-- [ ] `bin/vibe3 flow --help` returns zero exit code + domain usage.
-- [ ] `bin/vibe3 task --help` returns zero exit code + domain usage.
-- [ ] `bin/vibe3 pr --help` returns zero exit code + domain usage.
+- [ ] `vibe3 flow --help` returns zero exit code + domain usage.
+- [ ] `vibe3 task --help` returns zero exit code + domain usage.
+- [ ] `vibe3 pr --help` returns zero exit code + domain usage.
 - [ ] `mypy src/vibe3/ --strict` returns no errors.
 
 ---
@@ -83,13 +83,13 @@ related_docs:
 - [x] Review reports and `SESSION_ID` are recognized as evidence pointers without replacing issue / PR facts.
 
 **Implementation Status** (2026-03-21):
-- ✅ `vibe handoff init` - Create shared handoff file
-- ✅ `vibe handoff show` - Display handoff content
-- ✅ `vibe handoff append` - Append lightweight update block to shared handoff
-- ✅ `vibe handoff plan <ref>` - Record plan handoff
-- ✅ `vibe handoff report <ref>` - Record report handoff
-- ✅ `vibe handoff audit <ref>` - Record audit handoff
-- ✅ `vibe check` - Verify handoff store consistency
+- ✅ `vibe3 handoff init` - Create shared handoff file
+- ✅ `vibe3 handoff show` - Display handoff content
+- ✅ `vibe3 handoff append` - Append lightweight update block to shared handoff
+- ✅ `vibe3 handoff plan <ref>` - Record plan handoff
+- ✅ `vibe3 handoff report <ref>` - Record report handoff
+- ✅ `vibe3 handoff audit <ref>` - Record audit handoff
+- ✅ `vibe3 check` - Verify handoff store consistency
 - ✅ Unit tests: 92% coverage (28/28 tests passing)
 - ✅ Integration tests: All CLI commands functional
 
@@ -101,7 +101,7 @@ related_docs:
 
 **Inputs**: `docs/v3/handoff/05-polish-and-cleanup.md`
 **Success Criteria**:
-- [ ] `time bin/vibe3 flow status` reports execution time < 1.0s.
+- [ ] `time vibe3 flow status` reports execution time < 1.0s.
 - [ ] No `TODO` comments or `print()` debugs remain in `src/`.
 - [ ] All smoke tests in `tests3/` pass.
 
@@ -128,7 +128,7 @@ related_docs:
 - [ ] Verify that `vibe3` commands are not "hallucinated" but actually implemented in `src/`.
 
 ### 2. Integration Verification
-- [ ] Run `bin/vibe flow status` and confirm it uses the `vibe3` logic path.
+- [ ] Run `vibe3 flow status` and confirm it uses the `vibe3` logic path.
 - [ ] Check `src/vibe3/clients/sqlite_client.py` for generic type safety and SQL injection guards.
 
 ### 3. Consistency Check


### PR DESCRIPTION
Align stale documents with current V3 CLI semantics and directory structure as requested in #1377.

### Changes
- Updated `docs/references/vibe-engine-design.md` to use `vibe3` instead of `bin/vibe`.
- Aligned `docs/v3/ROADMAP.md` and `docs/v3/handoff/README.md` with actual `vibe3` command names.
- Updated deprecated guides to point clearly to `docs/standards/v3/command-standard.md` as the truth source.
- Replaced `vibe flow` with `vibe3 flow` or appropriate `vibe3` commands.

Fixes #1377