### PR TITLE
config: raise Python LOC limit to 65000

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -305,7 +305,7 @@ code_limits:
     # Milestone 1: 45,000 LOC (intermediate target)
     # Milestone 2: 40,000 LOC (stretch target)
     # Final target: 35,000 LOC (governance goal)
-    v3_python: 60000        # Python 核心代码总行数
+    v3_python: 65000        # Python 核心代码总行数（临时提升 5000，待模块化重构后清理）
     warning_threshold_percent: 90  # Trigger warning at 90% of limit (Issue #625)
     last_reviewed: "2026-05-01"    # Track last governance review (Issue #625)
 

--- a/tests/vibe3/hooks/test_loc_settings.py
+++ b/tests/vibe3/hooks/test_loc_settings.py
@@ -77,8 +77,8 @@ def test_migrated_loc_config_loads_total_limits() -> None:
     new_settings = module.load_loc_settings("config/v3/loc_limits.yaml")
 
     assert new_settings.total_v2_shell == 3000
-    # Temporary increase to 60000 to handle PR backlog (see config/v3/loc_limits.yaml)
-    assert new_settings.total_v3_python == 60000
+    # Temp 65000 for refactor prep (see config/v3/loc_limits.yaml)
+    assert new_settings.total_v3_python == 65000
     assert new_settings.warning_threshold_percent == 90
     assert new_settings.last_reviewed != ""
     assert new_settings.exceptions


### PR DESCRIPTION
## Summary

临时提升 Python LOC 限制 60000 → 65000（+5000），为后续模块化重构做准备。

## Context

当前多个 PR 因 LOC 超限被 CI 阻塞：
- #1381: 60003 / 60000（超 3 行）
- #1376: 60008 / 60000（超 8 行）
- #1380: +296 行测试

主分支 LOC 已接近上限，这些 PR 只是压死骆驼的最后一根稻草。

## Plan

1. **临时方案**：提升 LOC 限制至 65000，解除当前 PR 阻塞
2. **长期方案**：下一步模块化重构时清理死代码，降低 LOC

## Testing

- ✅ Pre-push checks pass
- ✅ Python LOC: 59988 / 65000 (92%)
- ✅ Shell LOC: 2720 / 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)