### PR TITLE
docs: semantic alignment for user-guide, command-standard and glossary

### DIFF
--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -213,7 +213,7 @@ related_docs:
 
 `flow_status` 定义了 flow 当前的执行状态，各状态语义：
 
-- **`active`**：flow 正常执行中，准备就绪或正在处理
+- **`active`**：flow 正常执行中，准备就绪或正在处理。
 - **`blocked`**：flow 被阻塞（手动锁定或依赖未满足）。
   - 场景 1：**手动阻塞**（由人或 Manager 标记 `blocked_reason`），需要手动 unblock（通过 `vibe3 task resume` 等）。`blocked_reason` 的存在会阻止 QualifyGate 的自动解封。
   - 场景 2：**依赖阻塞**（`flow_issue_links` 中有未完成的依赖 Issue），由 Orchestra **自动恢复**。依赖关系真源为 `flow_issue_links(role='dependency')`。
@@ -221,7 +221,7 @@ related_docs:
   - 自动巡逻：Orchestra 会主动拉取该状态任务进入"资格门"校验，满足条件后自动解套并智能恢复到正确阶段。
 - **`done`**：flow 执行完成（PR 已合并）。`task/issue-N` 分支的对应 issue 会自动关闭。
 - **`stale`**：flow 长期未活动或被系统标记为休眠（例如 empty ready flow、orphaned flow）。由 governance 机制重建 ready flow 后恢复。
-- **`aborted`**：flow 被人工/自动中止（PR closed unmerged / issue 关闭 / branch 丢失）
+- **`aborted`**：flow 被人工/自动中止（PR closed unmerged / issue 关闭 / branch 丢失）。
 
 > `merged` 是历史遗留状态，已统一规范化为 `done`；`failed` 已通过 `models/flow.py` 迁移为 `active` 状态并配合 `blocked_reason` 或 `failed_reason` 字段进行语义表达。禁止在新代码中将 `failed` 作为 `flow_status` 的字面值。
 

--- a/docs/standards/vibe3-command-standard.md
+++ b/docs/standards/vibe3-command-standard.md
@@ -10,6 +10,10 @@
 
 👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)**
 
+**项目全局导航与 Agent 协作入口请参考：**
+
+👉 **[AGENTS.md](../../AGENTS.md)**
+
 ---
 
 原因：
@@ -20,14 +24,13 @@
 
 其他参考入口：
 
-1. [docs/standards/v3/command-standard.md](v3/command-standard.md)
-2. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
-3. [docs/standards/issue-standard.md](issue-standard.md)
-4. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
+1. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
+2. [docs/standards/issue-standard.md](issue-standard.md)
+3. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
 
 语义收敛说明：
 
-- branch 生命周期优先直接使用 `git`
-- issue / PR / project 的远端读取与写入优先直接使用 `gh`
+- branch 生命周期管理：直接使用 `git`
+- issue / PR / project 远端操作：直接使用 `gh`
 - `vibe3` 负责本地 flow scene、issue 绑定、events 与 handoff 增强
-- `task` 保留为 execution bridge 语义，不再对应独立公共顶层 CLI
+- `task` 保留为 execution bridge 语义，通过 `vibe3 task status` 统一呈现

--- a/docs/standards/vibe3-user-guide.md
+++ b/docs/standards/vibe3-user-guide.md
@@ -6,9 +6,13 @@
 
 ## 📖 现行真源 (Current Truth)
 
-**所有 Vibe 3.0 操作指南请以此文档为准：**
+**所有 Vibe 3.0 操作指南与命令规范请以此文档为准：**
 
 👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)**
+
+**项目全局导航与 Agent 协作入口请参考：**
+
+👉 **[AGENTS.md](../../AGENTS.md)**
 
 ---
 
@@ -21,15 +25,14 @@
 其他参考入口：
 
 1. [README.md](../README.md)
-2. [AGENTS.md](../../AGENTS.md)
-3. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
-4. [docs/standards/issue-standard.md](issue-standard.md)
-5. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
+2. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
+3. [docs/standards/issue-standard.md](issue-standard.md)
+4. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
 
 当前推荐操作模型：
 
-- branch 创建、切换、merge、删除：直接使用 `git`
-- issue / PR / project 的远端读取与写入：直接使用 `gh`
+- branch 生命周期管理：直接使用 `git`
+- issue / PR / project 远端操作：直接使用 `gh`
 - 本地 flow 注册与绑定：使用 `vibe3 flow update`、`vibe3 flow bind`
-- 本地现场读取：使用 `vibe3 flow show`、`vibe3 flow status`、`vibe3 task status`
-- 本地协作增强：使用 `vibe3 handoff`
+- 本地现场与任务状态读取：使用 `vibe3 task status`、`vibe3 flow show`
+- 本地协作与交接增强：使用 `vibe3 handoff`


### PR DESCRIPTION
Aligns documentation with latest truth sources:
- vibe3-user-guide.md: Point to AGENTS.md and v3/command-standard.md.
- vibe3-command-standard.md: Point to AGENTS.md and v3/command-standard.md.
- glossary.md: Align flow_status and task semantics.
Fixes #1388