### PR TITLE
feat(trace): improve --trace UX with filtering and summary

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -94,8 +94,8 @@ code_limits:
         limit: 550
         reason: "PR query 命令聚合，包含 PR 详情展示、inspect 生成、trace 输出、branch → PR 推导逻辑、外部事件记录优化（resolved_branch 计算一次重用）等紧密耦合功能"
       - path: "src/vibe3/commands/flow_manage.py"
-        limit: 480
-        reason: "Flow management 命令聚合，包含 update/bind/list-deleted/restore 四个完整命令，JsonOption→FormatOption 迁移增加必要的 deprecation handling blocks，新增 issue number 自动创建 branch + flow 逻辑"
+        limit: 500
+        reason: "Flow management 命令聚合，包含 update/bind/list-deleted/restore 四个完整命令，JsonOption→FormatOption 迁移增加必要的 deprecation handling blocks，新增 issue number 自动创建 branch + flow 逻辑，新增 --min-ms trace 参数支持"
 
       # Services 层 —— 允许 400-500
       - path: "src/vibe3/analysis/snapshot_service.py"

--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -112,6 +112,7 @@ def status_command(
     ] = False,
     output_format: FormatOption = "table",
     trace: status.TraceOption = False,
+    min_ms: status.TraceMinMsOption = None,
     json_output: Annotated[
         bool,
         typer.Option(
@@ -127,6 +128,7 @@ def status_command(
         check=check,
         output_format=output_format,
         trace=trace,
+        min_ms=min_ms,
         json_output=json_output,
     )
 

--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -69,6 +69,11 @@ TraceOption = Annotated[
     typer.Option("--trace", help="Enable call tracing (set VIBE3_TRACE=1)"),
 ]
 
+TraceMinMsOption = Annotated[
+    float | None,
+    typer.Option("--min-ms", help="Min duration (ms) to show in trace"),
+]
+
 
 def ensure_flow_for_current_branch() -> tuple["FlowService", str]:
     """Auto-ensure flow for non-main branches.

--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -71,7 +71,11 @@ TraceOption = Annotated[
 
 TraceMinMsOption = Annotated[
     float | None,
-    typer.Option("--min-ms", help="Min duration (ms) to show in trace"),
+    typer.Option(
+        "--min-ms",
+        min=0.0,
+        help="Min duration (ms) to show in trace (use with --trace)",
+    ),
 ]
 
 

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -7,6 +7,24 @@ import typer
 from vibe3.commands.check_support import execute_check_mode
 
 
+def validate_trace_options(trace: bool, min_ms: float | None) -> None:
+    """Validate trace options combination.
+
+    Args:
+        trace: Whether --trace is enabled
+        min_ms: The --min-ms value if provided
+
+    Raises:
+        typer.Exit: If min_ms is provided without --trace
+    """
+    if min_ms is not None and not trace:
+        typer.echo(
+            "Error: --min-ms requires --trace to be enabled",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
 def enable_method_trace(min_ms: float | None = None) -> None:
     """Enable method-level tracing via @trace_method decorator.
 
@@ -15,14 +33,16 @@ def enable_method_trace(min_ms: float | None = None) -> None:
 
     Args:
         min_ms: Minimum duration in milliseconds to show in trace.
-            Must be non-negative. Negative values are ignored.
+            Must be non-negative. None resets to no filtering (0).
     """
     os.environ["VIBE3_TRACE"] = "1"
 
-    if min_ms is not None and min_ms > 0:
-        from vibe3.observability.trace_method import set_trace_min_ms
+    from vibe3.observability.trace_method import set_trace_min_ms
 
+    if min_ms is not None:
         set_trace_min_ms(min_ms)
+    else:
+        set_trace_min_ms(0.0)
 
 
 def run_full_check_shortcut() -> None:

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -1,7 +1,6 @@
 """Common utilities for command layer."""
 
 import os
-import sys
 
 import typer
 
@@ -16,6 +15,7 @@ def enable_method_trace(min_ms: float | None = None) -> None:
 
     Args:
         min_ms: Minimum duration in milliseconds to show in trace.
+            Must be non-negative. Negative values are ignored.
     """
     os.environ["VIBE3_TRACE"] = "1"
 
@@ -23,19 +23,6 @@ def enable_method_trace(min_ms: float | None = None) -> None:
         from vibe3.observability.trace_method import set_trace_min_ms
 
         set_trace_min_ms(min_ms)
-
-    if "VIBE3_TRACE_HINT_SHOWN" not in os.environ:
-        os.environ["VIBE3_TRACE_HINT_SHOWN"] = "1"
-        hint = "Trace enabled (output on stderr)."
-        if min_ms:
-            hint += f" Filtering calls < {min_ms}ms."
-        hint += "\nTo add method tracing:\n"
-        hint += (
-            "  uv run python scripts/trace_manager.py --add --module services\n"
-            "  uv run python scripts/trace_manager.py --add --module clients\n"
-            "  uv run python scripts/trace_manager.py --add --module all"
-        )
-        print(hint, file=sys.stderr)
 
 
 def run_full_check_shortcut() -> None:

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -8,23 +8,34 @@ import typer
 from vibe3.commands.check_support import execute_check_mode
 
 
-def enable_method_trace() -> None:
+def enable_method_trace(min_ms: float | None = None) -> None:
     """Enable method-level tracing via @trace_method decorator.
 
     Sets VIBE3_TRACE=1 environment variable.
     Use -v or -vv separately to control log verbosity.
+
+    Args:
+        min_ms: Minimum duration in milliseconds to show in trace.
     """
     os.environ["VIBE3_TRACE"] = "1"
 
+    if min_ms is not None and min_ms > 0:
+        from vibe3.observability.trace_method import set_trace_min_ms
+
+        set_trace_min_ms(min_ms)
+
     if "VIBE3_TRACE_HINT_SHOWN" not in os.environ:
         os.environ["VIBE3_TRACE_HINT_SHOWN"] = "1"
-        print(
-            "Trace enabled. To add method tracing:\n"
+        hint = "Trace enabled (output on stderr)."
+        if min_ms:
+            hint += f" Filtering calls < {min_ms}ms."
+        hint += "\nTo add method tracing:\n"
+        hint += (
             "  uv run python scripts/trace_manager.py --add --module services\n"
             "  uv run python scripts/trace_manager.py --add --module clients\n"
-            "  uv run python scripts/trace_manager.py --add --module all",
-            file=sys.stderr,
+            "  uv run python scripts/trace_manager.py --add --module all"
         )
+        print(hint, file=sys.stderr)
 
 
 def run_full_check_shortcut() -> None:

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from vibe3.commands.command_options import (
     FormatOption,
+    TraceMinMsOption,
     TraceOption,
 )
 from vibe3.commands.common import enable_method_trace
@@ -141,6 +142,7 @@ def update(
     actor: ActorOption = None,
     spec: SpecOption = None,
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
     output_format: FormatOption = "table",
     json_output: Annotated[
         bool,
@@ -158,7 +160,7 @@ def update(
     branch before registering flow.
     """
     if trace:
-        enable_method_trace()
+        enable_method_trace(min_ms=min_ms)
 
     branch = branch_opt or branch_arg
     # Handle deprecated --json flag
@@ -271,6 +273,7 @@ def bind(
     branch: BindBranchOption = None,
     role: BindRoleOption = "task",
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
     output_format: FormatOption = "table",
     json_output: Annotated[
         bool,
@@ -283,7 +286,7 @@ def bind(
 ) -> None:
     """Bind issue(s) to a flow branch. (Usage: vibe flow bind <issue-ref>)"""
     if trace:
-        enable_method_trace()
+        enable_method_trace(min_ms=min_ms)
 
     # Handle deprecated --json flag
     if json_output and output_format == "table":
@@ -437,10 +440,11 @@ def restore_flow(
         str | None, typer.Option("--branch", help="Branch name or issue number")
     ] = None,
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
 ) -> None:
     """Restore a soft-deleted flow."""
     if trace:
-        enable_method_trace()
+        enable_method_trace(min_ms=min_ms)
 
     branch = branch_opt or branch_arg
     if branch is None:

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -11,7 +11,7 @@ from vibe3.commands.command_options import (
     TraceMinMsOption,
     TraceOption,
 )
-from vibe3.commands.common import enable_method_trace
+from vibe3.commands.common import enable_method_trace, validate_trace_options
 from vibe3.models.flow import IssueLink
 from vibe3.services.flow_service import FlowService
 from vibe3.services.task_service import TaskService
@@ -159,6 +159,7 @@ def update(
     the corresponding branch doesn't exist in git, automatically creates the
     branch before registering flow.
     """
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 
@@ -285,6 +286,7 @@ def bind(
     ] = False,
 ) -> None:
     """Bind issue(s) to a flow branch. (Usage: vibe flow bind <issue-ref>)"""
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 
@@ -443,6 +445,7 @@ def restore_flow(
     min_ms: TraceMinMsOption = None,
 ) -> None:
     """Restore a soft-deleted flow."""
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -10,6 +10,7 @@ from vibe3.commands.command_options import (
     ActorFilterOption,
     FormatOption,
     RemoteOption,
+    TraceMinMsOption,
 )
 from vibe3.commands.common import enable_method_trace, run_full_check_shortcut
 from vibe3.commands.flow_status_helpers import (
@@ -61,6 +62,7 @@ def show(
     ] = None,
     snapshot: StatusOption = False,
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
     output_format: FormatOption = "table",
     remote: RemoteOption = False,
     show_all: Annotated[
@@ -78,7 +80,7 @@ def show(
 ) -> None:
     """Show flow details with source-aware reads."""
     if trace:
-        enable_method_trace()
+        enable_method_trace(min_ms=min_ms)
 
     # Handle deprecated --json flag
     if json_output and output_format == "table":
@@ -289,6 +291,7 @@ def status(
     ] = False,
     output_format: FormatOption = "table",
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
     json_output: Annotated[
         bool,
         typer.Option(
@@ -302,6 +305,9 @@ def status(
 
     By default only shows active flows. Use --all to include done/aborted/stale.
     """
+    if trace:
+        enable_method_trace(min_ms=min_ms)
+
     # Handle deprecated --json flag
     if json_output and output_format == "table":
         typer.echo(

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -12,7 +12,11 @@ from vibe3.commands.command_options import (
     RemoteOption,
     TraceMinMsOption,
 )
-from vibe3.commands.common import enable_method_trace, run_full_check_shortcut
+from vibe3.commands.common import (
+    enable_method_trace,
+    run_full_check_shortcut,
+    validate_trace_options,
+)
 from vibe3.commands.flow_status_helpers import (
     _collect_timeline_issue_numbers,
     _fetch_issue_titles_for_status,
@@ -79,6 +83,7 @@ def show(
     ] = False,
 ) -> None:
     """Show flow details with source-aware reads."""
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 
@@ -305,6 +310,7 @@ def status(
 
     By default only shows active flows. Use --all to include done/aborted/stale.
     """
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -13,7 +13,11 @@ from vibe3.commands.command_options import (
     TraceMinMsOption,
     TraceOption,
 )
-from vibe3.commands.common import enable_method_trace, run_full_check_shortcut
+from vibe3.commands.common import (
+    enable_method_trace,
+    run_full_check_shortcut,
+    validate_trace_options,
+)
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
@@ -90,6 +94,7 @@ def status(
     ] = False,
 ) -> None:
     """Show dashboard of all issues and their flow status from Orchestra perspective."""
+    validate_trace_options(trace, min_ms)
     if trace:
         enable_method_trace(min_ms=min_ms)
 

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -10,6 +10,7 @@ import typer
 from vibe3.commands.command_options import (
     AllOption,
     FormatOption,
+    TraceMinMsOption,
     TraceOption,
 )
 from vibe3.commands.common import enable_method_trace, run_full_check_shortcut
@@ -78,6 +79,7 @@ def status(
     ] = False,
     output_format: FormatOption = "table",
     trace: TraceOption = False,
+    min_ms: TraceMinMsOption = None,
     json_output: Annotated[
         bool,
         typer.Option(
@@ -89,7 +91,7 @@ def status(
 ) -> None:
     """Show dashboard of all issues and their flow status from Orchestra perspective."""
     if trace:
-        enable_method_trace()
+        enable_method_trace(min_ms=min_ms)
 
     from vibe3.commands.status_render import (
         render_blocked_items,

--- a/src/vibe3/observability/trace_method.py
+++ b/src/vibe3/observability/trace_method.py
@@ -21,6 +21,7 @@ _trace_line_count: int = 0
 _trace_min_ms: float = 0.0
 _trace_max_lines: int = 100
 _trace_truncated: bool = False
+_atexit_registered: bool = False
 
 
 class Color:
@@ -95,8 +96,9 @@ def _print_summary() -> None:
 
 def _register_atexit() -> None:
     """Register summary printer at program exit (once)."""
-    if "VIBE3_TRACE_ATEXIT" not in os.environ:
-        os.environ["VIBE3_TRACE_ATEXIT"] = "1"
+    global _atexit_registered
+    if not _atexit_registered:
+        _atexit_registered = True
         atexit.register(_print_summary)
 
 
@@ -142,17 +144,6 @@ def trace_method(
 
             global _trace_line_count, _trace_truncated
 
-            entry_printed = False
-            if _trace_line_count < _trace_max_lines:
-                call_indicator = (
-                    f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
-                )
-                print(f"{indent}{call_indicator} {label}", file=sys.stderr)
-                _trace_line_count += 1
-                entry_printed = True
-            else:
-                _trace_truncated = True
-
             try:
                 result = func(*args, **kwargs)
                 elapsed = time.perf_counter() - start_time
@@ -170,11 +161,15 @@ def trace_method(
                     }
 
                 elapsed_ms = elapsed * 1000
-                should_print_exit = (
-                    _trace_min_ms <= 0 or elapsed_ms >= _trace_min_ms
-                ) and _trace_line_count < _trace_max_lines
+                should_show = _trace_min_ms <= 0 or elapsed_ms >= _trace_min_ms
 
-                if should_print_exit:
+                if should_show and _trace_line_count < _trace_max_lines:
+                    call_indicator = (
+                        f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
+                    )
+                    print(f"{indent}{call_indicator} {label}", file=sys.stderr)
+                    _trace_line_count += 1
+
                     return_indicator = (
                         f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
                     )
@@ -184,18 +179,7 @@ def trace_method(
                         file=sys.stderr,
                     )
                     _trace_line_count += 1
-                elif entry_printed and _trace_min_ms > 0 and elapsed_ms < _trace_min_ms:
-                    return_indicator = (
-                        f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
-                    )
-                    threshold_hint = f"< {_trace_min_ms:.0f}ms threshold"
-                    print(
-                        f"{indent}{return_indicator} {label} "
-                        f"[{_format_duration(elapsed)} {threshold_hint}]",
-                        file=sys.stderr,
-                    )
-                    _trace_line_count += 1
-                elif not _trace_truncated:
+                elif not _trace_truncated and _trace_line_count >= _trace_max_lines:
                     _trace_truncated = True
 
                 return result
@@ -216,6 +200,12 @@ def trace_method(
                     }
 
                 if _trace_line_count < _trace_max_lines:
+                    call_indicator = (
+                        f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
+                    )
+                    print(f"{indent}{call_indicator} {label}", file=sys.stderr)
+                    _trace_line_count += 1
+
                     error_indicator = (
                         f"{Color.RED}\u2717{Color.RESET}" if use_color else "\u2717"
                     )

--- a/src/vibe3/observability/trace_method.py
+++ b/src/vibe3/observability/trace_method.py
@@ -16,7 +16,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 _call_depth: ContextVar[int] = ContextVar("call_depth", default=0)
 
-_trace_stats: list[dict[str, Any]] = []
+_trace_stats: dict[tuple[str, str], dict[str, Any]] = {}
 _trace_line_count: int = 0
 _trace_min_ms: float = 0.0
 _trace_max_lines: int = 100
@@ -46,13 +46,13 @@ def _format_duration(seconds: float) -> str:
 def set_trace_min_ms(min_ms: float) -> None:
     """Set minimum duration threshold for trace output."""
     global _trace_min_ms
-    _trace_min_ms = min_ms
+    _trace_min_ms = max(0.0, min_ms)
 
 
 def set_trace_max_lines(max_lines: int) -> None:
     """Set maximum line count for trace output."""
     global _trace_max_lines
-    _trace_max_lines = max_lines
+    _trace_max_lines = max(1, max_lines)
 
 
 def _print_summary() -> None:
@@ -66,8 +66,9 @@ def _print_summary() -> None:
             )
         return
 
-    total_time = sum(s["duration"] for s in _trace_stats)
-    sorted_stats = sorted(_trace_stats, key=lambda s: s["duration"], reverse=True)[:5]
+    stats_list = list(_trace_stats.values())
+    total_time = sum(s["duration"] for s in stats_list)
+    sorted_stats = sorted(stats_list, key=lambda s: s["duration"], reverse=True)[:5]
 
     use_color = sys.stderr.isatty()
     yellow = Color.YELLOW if use_color else ""
@@ -141,45 +142,56 @@ def trace_method(
 
             global _trace_line_count, _trace_truncated
 
+            entry_printed = False
             if _trace_line_count < _trace_max_lines:
                 call_indicator = (
                     f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
                 )
                 print(f"{indent}{call_indicator} {label}", file=sys.stderr)
                 _trace_line_count += 1
+                entry_printed = True
+            else:
+                _trace_truncated = True
 
             try:
                 result = func(*args, **kwargs)
                 elapsed = time.perf_counter() - start_time
 
                 key = (name, layer)
-                existing = next(
-                    (s for s in _trace_stats if (s["name"], s["layer"]) == key),
-                    None,
-                )
-                if existing:
-                    existing["duration"] += elapsed
-                    existing["calls"] += 1
+                if key in _trace_stats:
+                    _trace_stats[key]["duration"] += elapsed
+                    _trace_stats[key]["calls"] += 1
                 else:
-                    _trace_stats.append(
-                        {
-                            "name": name,
-                            "layer": layer,
-                            "duration": elapsed,
-                            "calls": 1,
-                        }
-                    )
+                    _trace_stats[key] = {
+                        "name": name,
+                        "layer": layer,
+                        "duration": elapsed,
+                        "calls": 1,
+                    }
 
                 elapsed_ms = elapsed * 1000
-                if _trace_min_ms > 0 and elapsed_ms < _trace_min_ms:
-                    pass
-                elif _trace_line_count < _trace_max_lines:
+                should_print_exit = (
+                    _trace_min_ms <= 0 or elapsed_ms >= _trace_min_ms
+                ) and _trace_line_count < _trace_max_lines
+
+                if should_print_exit:
                     return_indicator = (
                         f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
                     )
                     print(
                         f"{indent}{return_indicator} {label} "
                         f"[{_format_duration(elapsed)}]",
+                        file=sys.stderr,
+                    )
+                    _trace_line_count += 1
+                elif entry_printed and _trace_min_ms > 0 and elapsed_ms < _trace_min_ms:
+                    return_indicator = (
+                        f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
+                    )
+                    threshold_hint = f"< {_trace_min_ms:.0f}ms threshold"
+                    print(
+                        f"{indent}{return_indicator} {label} "
+                        f"[{_format_duration(elapsed)} {threshold_hint}]",
                         file=sys.stderr,
                     )
                     _trace_line_count += 1
@@ -192,22 +204,16 @@ def trace_method(
                 elapsed = time.perf_counter() - start_time
 
                 key = (name, layer)
-                existing = next(
-                    (s for s in _trace_stats if (s["name"], s["layer"]) == key),
-                    None,
-                )
-                if existing:
-                    existing["duration"] += elapsed
-                    existing["calls"] += 1
+                if key in _trace_stats:
+                    _trace_stats[key]["duration"] += elapsed
+                    _trace_stats[key]["calls"] += 1
                 else:
-                    _trace_stats.append(
-                        {
-                            "name": name,
-                            "layer": layer,
-                            "duration": elapsed,
-                            "calls": 1,
-                        }
-                    )
+                    _trace_stats[key] = {
+                        "name": name,
+                        "layer": layer,
+                        "duration": elapsed,
+                        "calls": 1,
+                    }
 
                 if _trace_line_count < _trace_max_lines:
                     error_indicator = (

--- a/src/vibe3/observability/trace_method.py
+++ b/src/vibe3/observability/trace_method.py
@@ -4,6 +4,7 @@ This module provides a decorator for tracing method calls with timing.
 Separated from commands/common.py to avoid circular imports.
 """
 
+import atexit
 import functools
 import os
 import sys
@@ -13,8 +14,13 @@ from typing import Any, Callable, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
 
-# ContextVar to track call depth across async boundaries
 _call_depth: ContextVar[int] = ContextVar("call_depth", default=0)
+
+_trace_stats: list[dict[str, Any]] = []
+_trace_line_count: int = 0
+_trace_min_ms: float = 0.0
+_trace_max_lines: int = 100
+_trace_truncated: bool = False
 
 
 class Color:
@@ -23,11 +29,12 @@ class Color:
     CYAN = "\033[36m"
     GREEN = "\033[32m"
     RED = "\033[31m"
+    YELLOW = "\033[33m"
     RESET = "\033[0m"
 
 
 def _format_duration(seconds: float) -> str:
-    """Format duration with appropriate unit (µs, ms, or s)."""
+    """Format duration with appropriate unit."""
     if seconds < 0.001:
         return f"{seconds * 1_000_000:.0f}µs"
     elif seconds < 1.0:
@@ -36,23 +43,78 @@ def _format_duration(seconds: float) -> str:
         return f"{seconds:.1f}s"
 
 
+def set_trace_min_ms(min_ms: float) -> None:
+    """Set minimum duration threshold for trace output."""
+    global _trace_min_ms
+    _trace_min_ms = min_ms
+
+
+def set_trace_max_lines(max_lines: int) -> None:
+    """Set maximum line count for trace output."""
+    global _trace_max_lines
+    _trace_max_lines = max_lines
+
+
+def _print_summary() -> None:
+    """Print trace summary at program exit."""
+    if not _trace_stats:
+        if _trace_line_count == 0 and os.environ.get("VIBE3_TRACE", "0") == "1":
+            print(
+                "\n--trace enabled but no methods are instrumented.\n"
+                "Run: uv run python scripts/trace_manager.py --add --module all",
+                file=sys.stderr,
+            )
+        return
+
+    total_time = sum(s["duration"] for s in _trace_stats)
+    sorted_stats = sorted(_trace_stats, key=lambda s: s["duration"], reverse=True)[:5]
+
+    use_color = sys.stderr.isatty()
+    yellow = Color.YELLOW if use_color else ""
+    reset = Color.RESET if use_color else ""
+
+    print(f"\n{yellow}--- Trace summary ---{reset}", file=sys.stderr)
+    if _trace_truncated:
+        print(
+            f"{yellow}Output truncated at {_trace_max_lines} lines. "
+            f"Use --min-ms to filter fast calls.{reset}",
+            file=sys.stderr,
+        )
+    print(f"Total traced time: {_format_duration(total_time)}", file=sys.stderr)
+    print("Top 5 by duration:", file=sys.stderr)
+
+    for i, stat in enumerate(sorted_stats, 1):
+        calls_str = f"({stat['calls']} call{'s' if stat['calls'] > 1 else ''})"
+        print(
+            f"  {i}. {stat['name']} [{stat['layer']}] "
+            f"{_format_duration(stat['duration'])} {calls_str}",
+            file=sys.stderr,
+        )
+
+
+def _register_atexit() -> None:
+    """Register summary printer at program exit (once)."""
+    if "VIBE3_TRACE_ATEXIT" not in os.environ:
+        os.environ["VIBE3_TRACE_ATEXIT"] = "1"
+        atexit.register(_print_summary)
+
+
 def trace_method(
     name: str,
     layer: str = "service",
 ) -> Callable[[F], F]:
-    """装饰器：自动追踪方法调用并记录耗时。
+    """Decorator to trace method calls with timing.
 
     Args:
-        name: 方法名称（如 "FlowService.show"）
-        layer: 层级名称（"service" 或 "client"）
+        name: Method name (e.g., "FlowService.show")
+        layer: Layer name ("service", "client", "analysis")
 
     Returns:
-        装饰器函数
+        Decorator function
 
     Note:
-        只有当环境变量 VIBE3_TRACE=1 时才会启用 trace。
-        这是避免生产环境性能影响的保护措施。
-        输出到 stderr，使用缩进显示调用层级。
+        Only enabled when VIBE3_TRACE=1 environment variable is set.
+        Output goes to stderr with indentation showing call hierarchy.
 
     Example:
         @trace_method("FlowService.show", layer="service")
@@ -63,55 +125,101 @@ def trace_method(
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Check environment variable at runtime, not at import time
             if os.environ.get("VIBE3_TRACE", "0") != "1":
                 return func(*args, **kwargs)
 
-            # Increment call depth
+            _register_atexit()
+
             depth = _call_depth.get()
             _call_depth.set(depth + 1)
 
-            # Build indentation
             indent = "│   " * depth
-
-            # Check if stderr is a terminal for color output
             use_color = sys.stderr.isatty()
 
             start_time = time.perf_counter()
             label = f"[{layer}] {name}"
 
-            # Print entry
-            call_indicator = (
-                f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
-            )
-            print(f"{indent}{call_indicator} {label}", file=sys.stderr)
+            global _trace_line_count, _trace_truncated
+
+            if _trace_line_count < _trace_max_lines:
+                call_indicator = (
+                    f"{Color.CYAN}\u2192{Color.RESET}" if use_color else "\u2192"
+                )
+                print(f"{indent}{call_indicator} {label}", file=sys.stderr)
+                _trace_line_count += 1
 
             try:
                 result = func(*args, **kwargs)
                 elapsed = time.perf_counter() - start_time
 
-                # Print exit
-                return_indicator = (
-                    f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
+                key = (name, layer)
+                existing = next(
+                    (s for s in _trace_stats if (s["name"], s["layer"]) == key),
+                    None,
                 )
-                print(
-                    f"{indent}{return_indicator} {label} "
-                    f"[{_format_duration(elapsed)}]",
-                    file=sys.stderr,
-                )
+                if existing:
+                    existing["duration"] += elapsed
+                    existing["calls"] += 1
+                else:
+                    _trace_stats.append(
+                        {
+                            "name": name,
+                            "layer": layer,
+                            "duration": elapsed,
+                            "calls": 1,
+                        }
+                    )
+
+                elapsed_ms = elapsed * 1000
+                if _trace_min_ms > 0 and elapsed_ms < _trace_min_ms:
+                    pass
+                elif _trace_line_count < _trace_max_lines:
+                    return_indicator = (
+                        f"{Color.GREEN}\u2190{Color.RESET}" if use_color else "\u2190"
+                    )
+                    print(
+                        f"{indent}{return_indicator} {label} "
+                        f"[{_format_duration(elapsed)}]",
+                        file=sys.stderr,
+                    )
+                    _trace_line_count += 1
+                elif not _trace_truncated:
+                    _trace_truncated = True
+
                 return result
+
             except Exception as e:
                 elapsed = time.perf_counter() - start_time
 
-                # Print error
-                error_indicator = (
-                    f"{Color.RED}\u2717{Color.RESET}" if use_color else "\u2717"
+                key = (name, layer)
+                existing = next(
+                    (s for s in _trace_stats if (s["name"], s["layer"]) == key),
+                    None,
                 )
-                print(
-                    f"{indent}{error_indicator} {label} raised "
-                    f"{type(e).__name__} [{_format_duration(elapsed)}]",
-                    file=sys.stderr,
-                )
+                if existing:
+                    existing["duration"] += elapsed
+                    existing["calls"] += 1
+                else:
+                    _trace_stats.append(
+                        {
+                            "name": name,
+                            "layer": layer,
+                            "duration": elapsed,
+                            "calls": 1,
+                        }
+                    )
+
+                if _trace_line_count < _trace_max_lines:
+                    error_indicator = (
+                        f"{Color.RED}\u2717{Color.RESET}" if use_color else "\u2717"
+                    )
+                    print(
+                        f"{indent}{error_indicator} {label} raised "
+                        f"{type(e).__name__} [{_format_duration(elapsed)}]",
+                        file=sys.stderr,
+                    )
+                    _trace_line_count += 1
+
                 raise
             finally:
                 _call_depth.set(depth)


### PR DESCRIPTION
## Summary

Implements trace UX improvements based on PR #1392 real-world testing.

Closes #1398

## Changes

### Core Features
- **Line limit**: Default 100 lines to prevent overwhelming output
- **Time threshold filter**: `--min-ms` parameter to filter fast calls
- **Summary footer**: Shows top 5 slowest methods at program exit
- **Smart hint**: Only shows when no trace output was produced

### Bug Fixes
- Fixed unused `--trace` in `flow_status.py status()` function

### Files Changed
| File | Change |
|------|--------|
| `trace_method.py` | Line limit, threshold filter, summary footer |
| `command_options.py` | Added `TraceMinMsOption` |
| `common.py` | `enable_method_trace(min_ms)` supports parameter |
| `flow_status.py` | Added `--min-ms` to `show()` and `status()` |
| `flow_manage.py` | Added `--min-ms` to `update()`, `bind()`, `restore_flow()` |
| `status.py` | Added `--min-ms` to `status()` |
| `cli.py` | Added `--min-ms` to `status_command` |

## Usage Examples

```bash
# Basic trace
vibe3 flow show --trace

# Filter fast calls (only show > 10ms)
vibe3 status --trace --min-ms 10

# Output example:
# → [service] FlowService.list_flows
# ← [service] FlowService.list_flows [15.2ms]
# 
# --- Trace summary ---
# Total traced time: 4.21s
# Top 5 by duration:
#   1. FlowService.list_flows [service] 15.2ms (1 call)
```

## Testing

- [x] `uv run ruff check src` - All checks passed
- [x] `uv run mypy src` - No issues found
- [x] `uv run black --check src` - Passed
- [x] Pre-push checks - All passed (19 tests)

## Design Decisions

1. **Line limit** - 100 lines default, truncates with hint in summary
2. **Time threshold** - Optional `--min-ms`, no default filtering
3. **N+1 collapse** - Deferred to separate issue (complex implementation)