### PR TITLE
refactor(test): split test_task_resume_operations.py into 3 files

### DIFF
--- a/tests/vibe3/services/conftest.py
+++ b/tests/vibe3/services/conftest.py
@@ -1,10 +1,13 @@
 """Shared fixtures for services tests."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from vibe3.analysis.coverage_service import CoverageService
+from vibe3.models.orchestration import IssueState
+from vibe3.services.task_resume_operations import TaskResumeOperations
 
 
 @pytest.fixture(autouse=True)
@@ -77,3 +80,29 @@ def sample_coverage_data() -> dict:
             },
         }
     }
+
+
+def _make_operations() -> TaskResumeOperations:
+    """Create a TaskResumeOperations instance with mocked dependencies."""
+    git_client = MagicMock()
+    github_client = MagicMock()
+    flow_service = MagicMock()
+    flow_service.store = MagicMock()
+    label_service = MagicMock()
+    issue_flow_service = MagicMock()
+    issue_flow_service.is_task_branch.return_value = True
+    return TaskResumeOperations(
+        git_client=git_client,
+        github_client=github_client,
+        flow_service=flow_service,
+        label_service=label_service,
+        issue_flow_service=issue_flow_service,
+    )
+
+
+def _mock_label_service():
+    """Create a mock LabelService for BlockedStateService.unblock tests."""
+    mock_label = MagicMock()
+    mock_label.confirm_issue_state = MagicMock()
+    mock_label.get_state = MagicMock(return_value=IssueState.READY)
+    return mock_label

--- a/tests/vibe3/services/test_task_resume_core.py
+++ b/tests/vibe3/services/test_task_resume_core.py
@@ -1,6 +1,5 @@
 """Tests for core reset_issue_to_ready operations."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tests.vibe3.services.conftest import _make_operations
@@ -10,10 +9,6 @@ from vibe3.models.orchestration import IssueState
 def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
     """Without --label, should call reset_task_scene to delete worktree."""
     operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-303"
-    )
-    operations.git_client.branch_exists.return_value = True
     operations.label_service.get_state.return_value = IssueState.BLOCKED
     operations.github_client.get_issue_body.return_value = "User content"
 
@@ -21,38 +16,44 @@ def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
     mock_flow.branch = "task/issue-303"
 
     with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
+        "vibe3.services.blocked_state_service.BlockedStateService"
+    ) as mock_service_cls:
+        mock_service = MagicMock()
+        mock_service_cls.return_value = mock_service
 
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state=None,  # No --label
-        )
+        with patch(
+            "vibe3.services.flow_cleanup_service.FlowCleanupService"
+        ) as mock_cleanup_cls:
+            mock_cleanup_instance = MagicMock()
+            mock_cleanup_instance.cleanup_flow_scene.return_value = {
+                "worktree": True,
+                "local_branch": True,
+                "remote_branch": True,
+                "handoff": True,
+                "flow_record": True,
+            }
+            mock_cleanup_cls.return_value = mock_cleanup_instance
 
-        # Verify: cleanup_flow_scene was called (via reset_task_scene)
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
+            operations.reset_issue_to_ready(
+                issue_number=303,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume",
+                worktree_path="/tmp/issue-303",
+                label_state=None,  # No --label
+            )
+
+            # Verify: unblock was called
+            mock_service.unblock.assert_called_once()
+
+            # Verify: cleanup_flow_scene was called (via reset_task_scene)
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
 
 
 def test_reset_issue_to_ready_with_remote_flag() -> None:
     """Test reset_issue_to_ready with remote=True (--remote flag)."""
     operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-456"
-    )
     operations.label_service.get_state.return_value = IssueState.BLOCKED
     operations.github_client.view_issue.return_value = {"comments": []}
 

--- a/tests/vibe3/services/test_task_resume_core.py
+++ b/tests/vibe3/services/test_task_resume_core.py
@@ -1,0 +1,97 @@
+"""Tests for core reset_issue_to_ready operations."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tests.vibe3.services.conftest import _make_operations
+from vibe3.models.orchestration import IssueState
+
+
+def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
+    """Without --label, should call reset_task_scene to delete worktree."""
+    operations = _make_operations()
+    operations.git_client.find_worktree_path_for_branch.return_value = Path(
+        "/tmp/issue-303"
+    )
+    operations.git_client.branch_exists.return_value = True
+    operations.label_service.get_state.return_value = IssueState.BLOCKED
+    operations.github_client.get_issue_body.return_value = "User content"
+
+    mock_flow = MagicMock()
+    mock_flow.branch = "task/issue-303"
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        operations.reset_issue_to_ready(
+            issue_number=303,
+            resume_kind="blocked",
+            flow=mock_flow,
+            repo=None,
+            reason="test resume",
+            worktree_path="/tmp/issue-303",
+            label_state=None,  # No --label
+        )
+
+        # Verify: cleanup_flow_scene was called (via reset_task_scene)
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
+
+
+def test_reset_issue_to_ready_with_remote_flag() -> None:
+    """Test reset_issue_to_ready with remote=True (--remote flag)."""
+    operations = _make_operations()
+    operations.git_client.find_worktree_path_for_branch.return_value = Path(
+        "/tmp/issue-456"
+    )
+    operations.label_service.get_state.return_value = IssueState.BLOCKED
+    operations.github_client.view_issue.return_value = {"comments": []}
+
+    mock_flow = MagicMock()
+    mock_flow.branch = "task/issue-456"
+
+    with patch(
+        "vibe3.services.blocked_state_service.BlockedStateService"
+    ) as mock_service_cls:
+        mock_service = MagicMock()
+
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "vibe3.services.flow_cleanup_service.FlowCleanupService"
+        ) as mock_cleanup_cls:
+            mock_cleanup_instance = MagicMock()
+            mock_cleanup_instance.cleanup_flow_scene.return_value = {
+                "worktree": True,
+                "local_branch": True,
+                "remote_branch": True,
+                "handoff": True,
+                "flow_record": True,
+            }
+            mock_cleanup_cls.return_value = mock_cleanup_instance
+
+            operations.reset_issue_to_ready(
+                issue_number=456,
+                resume_kind="blocked",
+                flow=mock_flow,
+                repo=None,
+                reason="test resume with --remote",
+                remote=True,  # --remote flag
+            )
+
+            # Verify: cleanup called with include_remote=False (keep remote branch)
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+                "task/issue-456",
+                include_remote=False,  # Key assertion
+                terminate_sessions=True,
+                keep_flow_record=False,
+            )

--- a/tests/vibe3/services/test_task_resume_label_state.py
+++ b/tests/vibe3/services/test_task_resume_label_state.py
@@ -1,110 +1,9 @@
-"""Tests for task resume scene reset operations."""
+"""Tests for reset_issue_to_ready with --label flag state transitions."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from tests.vibe3.services.conftest import _make_operations
 from vibe3.models.orchestration import IssueState
-from vibe3.services.task_resume_operations import TaskResumeOperations
-
-
-def _make_operations() -> TaskResumeOperations:
-    git_client = MagicMock()
-    github_client = MagicMock()
-    flow_service = MagicMock()
-    flow_service.store = MagicMock()
-    label_service = MagicMock()
-    issue_flow_service = MagicMock()
-    issue_flow_service.is_task_branch.return_value = True
-    return TaskResumeOperations(
-        git_client=git_client,
-        github_client=github_client,
-        flow_service=flow_service,
-        label_service=label_service,
-        issue_flow_service=issue_flow_service,
-    )
-
-
-def _mock_label_service():
-    """Create a mock LabelService for BlockedStateService.unblock tests."""
-    mock_label = MagicMock()
-    mock_label.confirm_issue_state = MagicMock()
-    mock_label.get_state = MagicMock(return_value=IssueState.READY)
-    return mock_label
-
-
-def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
-    """Test that reset_task_scene uses FlowCleanupService for complete cleanup."""
-    operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-329"
-    )
-    operations.git_client.branch_exists.return_value = True
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        operations.reset_task_scene("task/issue-329")
-
-        # Verify FlowCleanupService was instantiated
-        mock_cleanup_cls.assert_called_once()
-
-        # Verify cleanup_flow_scene was called with correct parameters
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-            "task/issue-329",
-            include_remote=True,
-            terminate_sessions=True,
-            keep_flow_record=False,  # Resume always deletes flow record
-        )
-
-
-def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
-    """Without --label, should call reset_task_scene to delete worktree."""
-    operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-303"
-    )
-    operations.git_client.branch_exists.return_value = True
-    operations.label_service.get_state.return_value = IssueState.BLOCKED
-    operations.github_client.get_issue_body.return_value = "User content"
-
-    mock_flow = MagicMock()
-    mock_flow.branch = "task/issue-303"
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        operations.reset_issue_to_ready(
-            issue_number=303,
-            resume_kind="blocked",
-            flow=mock_flow,
-            repo=None,
-            reason="test resume",
-            worktree_path="/tmp/issue-303",
-            label_state=None,  # ← No --label
-        )
-
-        # Verify: cleanup_flow_scene was called (via reset_task_scene)
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once()
 
 
 def test_reset_issue_to_ready_with_label_keeps_worktree() -> None:
@@ -143,7 +42,7 @@ def test_reset_issue_to_ready_with_label_keeps_worktree() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="",  # ← --label auto (converted to empty string internally)
+            label_state="",  # --label auto (converted to empty string internally)
         )
 
         # Verify: worktree NOT deleted (reset_task_scene NOT called)
@@ -179,7 +78,7 @@ def test_reset_issue_to_ready_with_label_ready_restores_to_ready() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="ready",  # ← --label ready
+            label_state="ready",  # --label ready
         )
 
         # Verify: worktree NOT deleted
@@ -214,7 +113,7 @@ def test_reset_issue_to_ready_with_label_handoff_explicit() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="handoff",  # ← --label handoff (explicit)
+            label_state="handoff",  # --label handoff (explicit)
         )
 
         # Verify: worktree NOT deleted
@@ -249,7 +148,7 @@ def test_reset_issue_to_ready_with_label_claimed() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="claimed",  # ← --label claimed
+            label_state="claimed",  # --label claimed
         )
 
         # Verify: worktree NOT deleted
@@ -282,7 +181,7 @@ def test_reset_issue_to_ready_with_label_in_progress() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="in-progress",  # ← --label in-progress
+            label_state="in-progress",  # --label in-progress
         )
 
         # Verify: worktree NOT deleted
@@ -315,7 +214,7 @@ def test_reset_issue_to_ready_with_label_review() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="review",  # ← --label review
+            label_state="review",  # --label review
         )
 
         # Verify: worktree NOT deleted
@@ -348,7 +247,7 @@ def test_reset_issue_to_ready_with_label_merge_ready() -> None:
             repo=None,
             reason="test resume",
             worktree_path="/tmp/issue-303",
-            label_state="merge-ready",  # ← --label merge-ready
+            label_state="merge-ready",  # --label merge-ready
         )
 
         # Verify: worktree NOT deleted
@@ -356,134 +255,6 @@ def test_reset_issue_to_ready_with_label_merge_ready() -> None:
 
         # Verify: state restored to MERGE_READY via BlockedStateService.unblock()
         mock_service.unblock.assert_called_once()
-
-
-def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
-    """Test that reset_task_scene calls cleanup service for tombstone creation."""
-    operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-999"
-    )
-    operations.git_client.branch_exists.return_value = True
-
-    branch = "task/issue-999"
-
-    # Mock FlowCleanupService to make test hermetic
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_class:
-        mock_cleanup_service = MagicMock()
-        mock_cleanup_class.return_value = mock_cleanup_service
-
-        # Setup cleanup result
-        mock_cleanup_service.cleanup_flow_scene.return_value = {
-            "tmux_sessions": {"success": True, "sessions": []},
-            "worktree": {"success": True, "path": None},
-            "local_branch": {"success": True, "deleted": True},
-            "remote_branch": {"success": True, "deleted": True},
-            "handoff_files": {"success": True, "files": []},
-            "flow_record": {"success": True, "deleted": True},
-        }
-
-        # Execute reset
-        operations.reset_task_scene(branch)
-
-        # Verify cleanup_flow_scene called with correct parameters
-        mock_cleanup_service.cleanup_flow_scene.assert_called_once_with(
-            branch,
-            include_remote=True,
-            terminate_sessions=True,
-            keep_flow_record=False,
-        )
-
-        # Note: Tombstone normalization is validated in repository tests
-        # This test verifies the call path through FlowCleanupService
-
-
-def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
-    """Test reset_task_scene with include_remote=False (--remote mode)."""
-    operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-123"
-    )
-    operations.git_client.branch_exists.return_value = True
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,  # Though we're keeping it
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Call with include_remote=False (--remote mode)
-        operations.reset_task_scene("task/issue-123", include_remote=False)
-
-        # Verify FlowCleanupService was instantiated
-        mock_cleanup_cls.assert_called_once()
-
-        # Verify cleanup_flow_scene was called with include_remote=False
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-            "task/issue-123",
-            include_remote=False,  # Key assertion: keep remote branch
-            terminate_sessions=True,
-            keep_flow_record=False,
-        )
-
-
-def test_reset_issue_to_ready_with_remote_flag() -> None:
-    """Test reset_issue_to_ready with remote=True (--remote flag)."""
-    operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-456"
-    )
-    operations.label_service.get_state.return_value = IssueState.BLOCKED
-    operations.github_client.view_issue.return_value = {"comments": []}
-
-    mock_flow = MagicMock()
-    mock_flow.branch = "task/issue-456"
-
-    with patch(
-        "vibe3.services.blocked_state_service.BlockedStateService"
-    ) as mock_service_cls:
-        mock_service = MagicMock()
-
-        mock_service_cls.return_value = mock_service
-
-        with patch(
-            "vibe3.services.flow_cleanup_service.FlowCleanupService"
-        ) as mock_cleanup_cls:
-            mock_cleanup_instance = MagicMock()
-            mock_cleanup_instance.cleanup_flow_scene.return_value = {
-                "worktree": True,
-                "local_branch": True,
-                "remote_branch": True,
-                "handoff": True,
-                "flow_record": True,
-            }
-            mock_cleanup_cls.return_value = mock_cleanup_instance
-
-            operations.reset_issue_to_ready(
-                issue_number=456,
-                resume_kind="blocked",
-                flow=mock_flow,
-                repo=None,
-                reason="test resume with --remote",
-                remote=True,  # ← --remote flag
-            )
-
-            # Verify: cleanup called with include_remote=False (keep remote branch)
-            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-                "task/issue-456",
-                include_remote=False,  # Key assertion
-                terminate_sessions=True,
-                keep_flow_record=False,
-            )
 
 
 def test_reset_issue_to_ready_with_label_auto_no_flow_restores_to_ready() -> None:
@@ -513,7 +284,7 @@ def test_reset_issue_to_ready_with_label_auto_no_flow_restores_to_ready() -> Non
             repo=None,
             reason="test resume",
             worktree_path=None,
-            label_state="",  # ← --label auto (no flow exists)
+            label_state="",  # --label auto (no flow exists)
         )
 
         # Verify: BlockedStateService.unblock was called

--- a/tests/vibe3/services/test_task_resume_reset_scene.py
+++ b/tests/vibe3/services/test_task_resume_reset_scene.py
@@ -1,0 +1,119 @@
+"""Tests for reset_task_scene operation."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tests.vibe3.services.conftest import _make_operations
+
+
+def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
+    """Test that reset_task_scene uses FlowCleanupService for complete cleanup."""
+    operations = _make_operations()
+    operations.git_client.find_worktree_path_for_branch.return_value = Path(
+        "/tmp/issue-329"
+    )
+    operations.git_client.branch_exists.return_value = True
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        operations.reset_task_scene("task/issue-329")
+
+        # Verify FlowCleanupService was instantiated
+        mock_cleanup_cls.assert_called_once()
+
+        # Verify cleanup_flow_scene was called with correct parameters
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-329",
+            include_remote=True,
+            terminate_sessions=True,
+            keep_flow_record=False,  # Resume always deletes flow record
+        )
+
+
+def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
+    """Test that reset_task_scene calls cleanup service for tombstone creation."""
+    operations = _make_operations()
+    operations.git_client.find_worktree_path_for_branch.return_value = Path(
+        "/tmp/issue-999"
+    )
+    operations.git_client.branch_exists.return_value = True
+
+    branch = "task/issue-999"
+
+    # Mock FlowCleanupService to make test hermetic
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_class:
+        mock_cleanup_service = MagicMock()
+        mock_cleanup_class.return_value = mock_cleanup_service
+
+        # Setup cleanup result
+        mock_cleanup_service.cleanup_flow_scene.return_value = {
+            "tmux_sessions": {"success": True, "sessions": []},
+            "worktree": {"success": True, "path": None},
+            "local_branch": {"success": True, "deleted": True},
+            "remote_branch": {"success": True, "deleted": True},
+            "handoff_files": {"success": True, "files": []},
+            "flow_record": {"success": True, "deleted": True},
+        }
+
+        # Execute reset
+        operations.reset_task_scene(branch)
+
+        # Verify cleanup_flow_scene called with correct parameters
+        mock_cleanup_service.cleanup_flow_scene.assert_called_once_with(
+            branch,
+            include_remote=True,
+            terminate_sessions=True,
+            keep_flow_record=False,
+        )
+
+        # Note: Tombstone normalization is validated in repository tests
+        # This test verifies the call path through FlowCleanupService
+
+
+def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
+    """Test reset_task_scene with include_remote=False (--remote mode)."""
+    operations = _make_operations()
+    operations.git_client.find_worktree_path_for_branch.return_value = Path(
+        "/tmp/issue-123"
+    )
+    operations.git_client.branch_exists.return_value = True
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,  # Though we're keeping it
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Call with include_remote=False (--remote mode)
+        operations.reset_task_scene("task/issue-123", include_remote=False)
+
+        # Verify FlowCleanupService was instantiated
+        mock_cleanup_cls.assert_called_once()
+
+        # Verify cleanup_flow_scene was called with include_remote=False
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-123",
+            include_remote=False,  # Key assertion: keep remote branch
+            terminate_sessions=True,
+            keep_flow_record=False,
+        )

--- a/tests/vibe3/services/test_task_resume_reset_scene.py
+++ b/tests/vibe3/services/test_task_resume_reset_scene.py
@@ -1,6 +1,5 @@
 """Tests for reset_task_scene operation."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tests.vibe3.services.conftest import _make_operations
@@ -9,10 +8,6 @@ from tests.vibe3.services.conftest import _make_operations
 def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
     """Test that reset_task_scene uses FlowCleanupService for complete cleanup."""
     operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-329"
-    )
-    operations.git_client.branch_exists.return_value = True
 
     with patch(
         "vibe3.services.flow_cleanup_service.FlowCleanupService"
@@ -44,10 +39,6 @@ def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
 def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
     """Test that reset_task_scene calls cleanup service for tombstone creation."""
     operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-999"
-    )
-    operations.git_client.branch_exists.return_value = True
 
     branch = "task/issue-999"
 
@@ -86,10 +77,6 @@ def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
 def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
     """Test reset_task_scene with include_remote=False (--remote mode)."""
     operations = _make_operations()
-    operations.git_client.find_worktree_path_for_branch.return_value = Path(
-        "/tmp/issue-123"
-    )
-    operations.git_client.branch_exists.return_value = True
 
     with patch(
         "vibe3.services.flow_cleanup_service.FlowCleanupService"


### PR DESCRIPTION
## Summary

Split 525-line test file into 3 focused files (< 300 lines each):
- `test_task_resume_reset_scene.py` (119 lines, 3 tests)
- `test_task_resume_label_state.py` (296 lines, 8 tests)  
- `test_task_resume_core.py` (97 lines, 2 tests)

**Changes**:
- Extract shared fixtures (`_make_operations`, `_mock_label_service`) to `conftest.py`
- All 13 tests preserved and passing

Closes #1341

---

## Contributors
- **Planner**: Claude Opus
- **Executor**: Claude Sonnet
- **Reviewer**: Claude Opus (verdict: PASS)

🤖 Generated with [Vibe Center](https://github.com/chenyih/vibe-coding-control-center)