### PR TITLE
docs: align roadmap and label documentation with vibe3 automatic mirroring

### DIFF
--- a/docs/standards/github-labels-reference.md
+++ b/docs/standards/github-labels-reference.md
@@ -102,9 +102,10 @@
 |---------|------|----------|
 | `vibe-task` | 执行项镜像标签 | 自动镜像，不建议手动维护 |
 
-**说明**：
-- `vibe-task` 是 `vibe3 flow bind` 绑定的自动镜像（副作用）。
-- 它不是 Governance 判定的真源，仅用于 GitHub 视角过滤。
+**说明 (Truth Source)**：
+- `vibe-task` 是 `vibe3 flow bind` 成功的**自动镜像（副作用）**。
+- **非真源**：它不是 Governance 或执行引擎判定的真源。真源位于本地 SQLite `flow_issue_links`。
+- **可视化用途**：仅用于 GitHub 视角（如 Projects 视图）过滤和识别已绑定的任务。
 
 ### 2.5 编排状态标签 (state/*)
 
@@ -119,9 +120,10 @@
 | `state/merge-ready` | 已满足合并条件 | 通常由自动化镜像，不建议手工维护 |
 | `state/done` | 已完成 | 通常由自动化镜像，不建议手工维护 |
 
-**说明**：
-- `state/*` 标签是执行状态的**可选镜像**，不是执行态主真源。
-- `assignee issue` 的真实执行状态优先以 flow 状态与 orchestration scene 为准。
+**说明 (State Mirroring)**：
+- `state/*` 标签是执行状态的**可选镜像**。
+- **真源分离**：`assignee issue` 的真实执行状态优先以本地 SQLite `flow_state` 表与 orchestration scene 为准。
+- **自动同步**：由 `vibe3` 在状态迁移时自动更新 GitHub 标签。
 
 ### 2.6 触发器标签 (trigger/*)
 

--- a/docs/standards/github-labels-standard.md
+++ b/docs/standards/github-labels-standard.md
@@ -122,23 +122,22 @@
 
 **职责**: 让 GitHub 视图能通过标签快速识别"曾被 vibe3 flow bind 管理的 issue"。
 
-**映射规则**:
-- 由 `vibe3 flow bind` 在 issue 进入 flow 时自动添加（副作用）。
-- 不作为 governance 的判定依据。
-- 当前 governance 使用 SQLite `flow_issue_links` 表作为 assignee pool 的真源。
-- `state/*` 标签为可选镜像，flow 状态以 SQLite `flow_state` 表为准。
-
+**真源与映射规则**:
+- **生命周期绑定**：由 `vibe3 flow bind` 在 issue 进入 flow 时自动添加；在 `vibe3 flow unbind` 或 flow 销毁时自动移除。
+- **单向镜像**：标签仅作为 SQLite `flow_issue_links` 真源记录的远端展示。
+- **非控制位**：不作为 governance 或执行引擎的判定依据。
+- **手动操作后果**：手动添加/移除此标签不会改变 issue 的执行角色。系统在下次同步时会尝试根据真源状态纠正此标签。
 
 ### 3.4 编排状态标签语义 (state/*)
 
 **语义**: 说明"当前处于 flow 循环的哪一阶段"
 
 **使用原则**:
-- 编排状态标签是多 agent 协作的远端状态机真源
-- 一个 issue 任一时刻只能有一个 `state/*` 标签
-- 状态变更优先发生在 issue 上，而不是 Project 字段上
-
-#### 状态集合
+- **状态镜像**：编排状态标签是多 agent 协作的远端状态机镜像。
+- **真源位置**：本地 SQLite `flow_state` 表是执行状态的绝对真源。
+- **自动同步**：由 `vibe3` 在状态迁移事件发生时自动更新 GitHub 标签。
+- **单值约束**：一个 issue 任一时刻只能有一个 `state/*` 标签。
+- **同步方向**：状态变更应通过 flow 命令触发（如 `vibe3 flow move`），然后由系统同步到标签，而非通过修改标签来改变执行态。
 
 | 标签名称 | 语义 | 使用场景 |
 |---------|------|----------|

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -217,12 +217,12 @@ gh issue edit <issue_number> --milestone "Phase 1: 基础设施"
 ```bash
 # 绑定到 Flow（开始执行）
 uv run python src/vibe3/cli.py flow bind <issue_number>
-# 自动镜像 vibe-task 标签（副作用，不作为真源）
 ```
 
-**注意**：
-- `flow bind` 是 issue 进入执行现场的正式绑定入口。
-- `vibe-task` 与 `state/*` 标签是由绑定和执行状态自动镜像的副作用，**不建议作为手工主入口**。
+**注意 (Truth Source Boundary)**：
+- `flow bind` 是 issue 进入执行现场的正式绑定入口，它会在 SQLite `flow_issue_links` 中建立真源记录。
+- **`vibe-task` 是自动镜像标签**：一旦 `flow bind` 成功，系统会自动为 issue 添加 `vibe-task` 标签。这只是一个可视化副作用，用于在 GitHub 界面识别任务，**不作为控制逻辑的真源**。手动添加/移除此标签不会改变 issue 的执行角色。
+- **`state/*` 标签是状态镜像**：执行状态的真源在 SQLite 的 `flow_state` 中。`state/*` 标签由 `vibe3` 根据 flow 状态自动同步到 GitHub。手动修改标签不会改变实际执行状态。
 - 一旦绑定，issue 进入 manager 主执行闭环，由 Manager/Plan/Run/Review 推进。
 
 ### 3.2 版本管理流程


### PR DESCRIPTION
Aligns roadmap and label management documentation with vibe3 automatic mirroring behavior as requested in #1395.

- Updates roadmap-label-management.md to explicitly state that vibe-task is an automatic mirror and not a primary control label.
- Aligns github-labels-reference.md and github-labels-standard.md with the automated labeling behavior of vibe3 (truth source in SQLite).
- Clarifies the effect of flow bind/unbind on the vibe-task label.