### PR TITLE
fix(dispatcher): dispatcher errors should not write GitHub comments

### DIFF
--- a/src/vibe3/services/issue_failure_service.py
+++ b/src/vibe3/services/issue_failure_service.py
@@ -82,13 +82,14 @@ def mark_issue(
 
     if action == "fail":
         timeline = FlowTimelineService(store=store)
+        # Dispatcher error: record to SQLite only, do NOT write GitHub comment
+        # Runtime errors are exposed via `vibe3 serve status`, not issue comments
         timeline.record_timeline_event(
             branch=branch,
             event_type="flow_failed",
             actor=actor,
             detail=f"Flow failed (runtime): {reason}",
-            issue_number=issue_number,
-            repo=repo,
+            # issue_number and repo omitted: prevents GitHub comment write
         )
     else:
         from vibe3.services.flow_service import FlowService


### PR DESCRIPTION
## Summary

Fix dispatcher error tracking to prevent runtime errors from writing GitHub issue comments. Comments should only reflect flow business state, not runtime information.

## Problem

Dispatcher runtime errors (API rate limits, execution failures) were writing GitHub comments like:
```
[flow] Flow failed

Flow failed (runtime): codeagent-wrapper failed (code 1):
API Error: Request rejected (429) · week allocated quota exceeded.
```

This violates the orthogonal separation design between dispatcher error system and flow blocked system.

## Design Principle

| System | Trigger | SQLite | GitHub Comment | Exposure |
|--------|---------|--------|---------------|----------|
| **Dispatcher Error** | Runtime errors | ✅ error_log + flow_events | ❌ **Should NOT** | `vibe3 serve status` |
| **Flow Blocked** | Business blocks | ✅ blocked_reason + flow_events | ✅ Should | Issue comments |

## Fix

Modified `issue_failure_service.py`:
- Removed `issue_number` parameter from `fail_issue()` timeline recording
- Prevents `record_timeline_event()` from writing GitHub comments
- SQLite recording remains intact
- Error tracking via `error_log` table unaffected

## Changes

- `src/vibe3/services/issue_failure_service.py`: Remove issue_number/repo from fail_issue call

## Test Results

- ✅ All existing tests pass (10 tests)
- ✅ `test_issue_failure_service.py`: 6/6 passed
- ✅ `test_flow_timeline_service.py`: 4/4 passed

## Impact

- Runtime errors no longer pollute issue comments
- Comments only reflect flow business state
- Runtime errors still viewable via `vibe3 serve status`
- No data loss - error tracking in error_log table

## Related

- Issue: #1415
- Discovery: #1292 comment
- Design: Dispatcher/flow blocked orthogonal separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)