### PR TITLE
docs: align core standards with latest vibe3 flow_status and data models

### DIFF
--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -48,26 +48,27 @@ Flow 生命周期涉及三个真源：
 见 [glossary.md](glossary.md) §3.4.1 Flow Status 语义。
 
 ```
-new → active → blocked → active (恢复)
-           ↓    ↘    ↓
-         done  stale  failed → blocked (业务错误)
-           ↓
-        aborted
+new → active ↔ blocked
+        ↓        ↓
+      done     stale
+        ↓
+     aborted
 ```
 
 **区分 Flow Status 和 Issue State**：
 
-- **Flow Status**：`active/blocked/done/aborted`（SQLite flow_state）
+- **Flow Status**：`active/blocked/done/stale/aborted`（SQLite flow_state）
   - 描述 flow 的执行状态
-  - 图中的 `failed → blocked` 表示：失败原因可能收口为 blocked，但 blocked 不等于 failed
+  - `failed` 已废弃，通过 `active` 状态配合 `blocked_reason` 表达
 
 - **Issue State**：`ready/claimed/in-progress/blocked/handoff/review/merge-ready/done`（GitHub label）
   - 描述 issue 的编排状态
   - IssueState.FAILED 已废弃，统一到 BLOCKED
 
 **关系**：
-- Flow Status `failed` → Issue State `blocked`
+- Flow Status `blocked` → Issue State `blocked`
 - Flow Status `aborted` → Issue State `ready`（被动清理）
+- Flow Status `stale` → Issue State `ready`（被动清理）
 
 ### 2.2 Issue State 统一模型
 
@@ -231,8 +232,8 @@ QualifyGate 通过 `CoordinationTruth.is_blocked` 判断阻塞状态，其真源
 | blocked → active（自动） | blocked → active | `state/blocked` → 推断目标 label | QualifyGate 处理 |
 | blocked → active（手动） | blocked → active | `state/blocked` → 用户指定 label | `task resume` 处理 |
 | → done | active → done | 无需处理（issue 自动关闭） | PR merged 触发 |
-| → aborted | * → aborted | ⚠️ 未显式处理 | **实现缺口** |
-| → stale | active → stale | ⚠️ 未显式处理 | **实现缺口** |
+| → aborted | * → aborted | `state/*` → `state/ready` (被动) | `vibe3 check` 清理时恢复 |
+| → stale | active → stale | `state/*` → `state/ready` (被动) | Governance 机制处理 |
 
 **实现缺口说明**：`mark_flow_aborted()` 和 `mark_flow_stale()` 当前未在方法内显式管理 task issue label。对于 aborted，后续 `vibe3 check --clean-branch` 的被动清理会恢复 label；对于 stale，依赖 governance 机制在重建 ready flow 时处理。
 

--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -216,12 +216,17 @@ related_docs:
 - **`active`**：flow 正常执行中，准备就绪或正在处理。
 - **`blocked`**：flow 被阻塞（手动锁定或依赖未满足）。
   - 场景 1：**手动阻塞**（由人或 Manager 标记 `blocked_reason`），需要手动 unblock（通过 `vibe3 task resume` 等）。`blocked_reason` 的存在会阻止 QualifyGate 的自动解封。
-  - 场景 2：**依赖阻塞**（`flow_issue_links` 中有未完成的依赖 Issue），由 Orchestra **自动恢复**。依赖关系真源为 `flow_issue_links(role='dependency')`。
+  - 场景 2：**依赖阻塞**（`flow_issue_links` 中有未完成的依赖 Issue），由 Orchestra **自动恢复**。依赖关系真源为 `flow_issue_links(role='dependency')`，`blocked_by_issue` 字段记录主阻塞 Issue 编号作为快捷引用。
   - 判定标准：依赖项在 GitHub 上进入 `closed` 终态即视为满足。
   - 自动巡逻：Orchestra 会主动拉取该状态任务进入"资格门"校验，满足条件后自动解套并智能恢复到正确阶段。
 - **`done`**：flow 执行完成（PR 已合并）。`task/issue-N` 分支的对应 issue 会自动关闭。
 - **`stale`**：flow 长期未活动或被系统标记为休眠（例如 empty ready flow、orphaned flow）。由 governance 机制重建 ready flow 后恢复。
 - **`aborted`**：flow 被人工/自动中止（PR closed unmerged / issue 关闭 / branch 丢失）。
+
+**关键辅助字段**：
+
+- **`blocked_by_issue`**：主要阻塞 Issue 的快捷显示字段（不是完整依赖集合）。
+- **`transition_count`**：状态流转计数，用于检测并防止自动化流程中的死循环。
 
 > `merged` 是历史遗留状态，已统一规范化为 `done`；`failed` 已通过 `models/flow.py` 迁移为 `active` 状态并配合 `blocked_reason` 或 `failed_reason` 字段进行语义表达。禁止在新代码中将 `failed` 作为 `flow_status` 的字面值。
 

--- a/docs/standards/v3/data-model-standard.md
+++ b/docs/standards/v3/data-model-standard.md
@@ -56,11 +56,15 @@ related_docs:
 - **职责**：当前开放 flow 的运行时状态真源
 - **主键**：`branch`（TEXT）
 - **核心字段**：
-  - `flow_slug`：显示名称（V3 中使用，对应原 v2 的 flow name）
-  - `status`：现场层状态（`active`/`idle`/`missing`/`stale`）
-  - `current_task_id`：当前执行中的 task
+  - `flow_slug`：显示名称
+  - `flow_status`：执行状态（`active`/`blocked`/`done`/`stale`/`aborted`）
+  - `blocked_by_issue`：阻塞当前 flow 的 issue 编号
+  - `blocked_reason`：阻塞原因文本
+  - `transition_count`：状态流转计数（用于防死循环）
+  - `spec_ref`, `plan_ref`, `report_ref`, `audit_ref`, `indicate_ref`：各阶段文档引用
+  - `planner_actor`, `executor_actor`, `reviewer_actor`, `manager_actor`：各角色执行者
   - `created_at`, `updated_at`：时间戳
-- **约束**：`branch` 是 PRIMARY KEY，`flow_slug` 是显示名称
+- **约束**：`branch` 是 PRIMARY KEY，`flow_status` 必须符合 canonical 枚举
 
 #### `flow_issue_links` 表
 - **职责**：flow 与 GitHub issue 的多对多关联关系
@@ -158,15 +162,18 @@ related_docs:
 现场层状态只允许：
 
 - `active`
-- `idle`
-- `missing`
+- `blocked`
+- `done`
 - `stale`
+- `aborted`
 
 禁止：
 
-- `in-progress`
-- `done`
+- `idle`
+- `missing`
 - `merged`
+- `in-progress`
+- `done` (作为规划层状态时禁止)
 - `skipped`
 - 用模糊字段 `state` 混装不同层状态
 

--- a/docs/standards/v3/handoff-store-standard.md
+++ b/docs/standards/v3/handoff-store-standard.md
@@ -114,23 +114,33 @@ CREATE TABLE schema_meta (
 CREATE TABLE flow_state (
   branch TEXT PRIMARY KEY,
   flow_slug TEXT NOT NULL,
-  task_issue_number INTEGER,
-  pr_number INTEGER,
   spec_ref TEXT,
   plan_ref TEXT,
   report_ref TEXT,
   audit_ref TEXT,
+  indicate_ref TEXT,
+  pr_ref TEXT,
   planner_actor TEXT,
-  planner_session_id TEXT,
   executor_actor TEXT,
-  executor_session_id TEXT,
   reviewer_actor TEXT,
-  reviewer_session_id TEXT,
+  manager_actor TEXT,
   latest_actor TEXT,
-  blocked_by TEXT,
+  initiated_by TEXT,
+  blocked_by_issue INTEGER,
+  blocked_reason TEXT,
+  failed_reason TEXT,
   next_step TEXT,
   flow_status TEXT NOT NULL DEFAULT 'active',
-  updated_at TEXT NOT NULL
+  updated_at TEXT NOT NULL,
+  planner_status TEXT,
+  executor_status TEXT,
+  reviewer_status TEXT,
+  execution_pid INTEGER,
+  execution_started_at TEXT,
+  execution_completed_at TEXT,
+  latest_verdict TEXT,
+  deleted_at TEXT,
+  transition_count INTEGER DEFAULT 0
 );
 ```
 
@@ -140,29 +150,27 @@ CREATE TABLE flow_state (
   - 本地 runtime 主键
 - `flow_slug`
   - 用户可读 flow 名称
-- `task_issue_number`
-  - 单值，允许为空
-- `pr_number`
-  - 单值，允许为空
-- `spec_ref`
+- `spec_ref` / `plan_ref` / `report_ref` / `audit_ref` / `indicate_ref`
   - 文档引用，不复制正文
-- `plan_ref` / `report_ref` / `audit_ref`
-  - 文档引用，不复制正文
-- `planner_actor` / `executor_actor` / `reviewer_actor`
+- `pr_ref`
+  - PR URL
+- `planner_actor` / `executor_actor` / `reviewer_actor` / `manager_actor`
   - 必须使用 `agent/model` 形态
   - 示例：`codex/gpt-5.4`
-- `planner_session_id` / `executor_session_id` / `reviewer_session_id`
-  - 用于记录和恢复会话的字段
-  - 现阶段仅保留字段，不实现功能
-  - 面向未来设计，用于会话连续性支持
 - `latest_actor`
   - 最近一次写入 handoff 的 actor
-- `blocked_by`
-  - 文本提示字段，可存 `#123`、`task/xxx`、`pr#17`
+- `blocked_by_issue`
+  - 阻塞当前 flow 的 issue 编号
+- `blocked_reason`
+  - 阻塞原因文本
+- `failed_reason`
+  - **已废弃**：优先使用 `blocked_reason`
 - `next_step`
   - 简短下一步提示
 - `flow_status`
-  - 只允许：`active`, `blocked`, `done`, `stale`
+  - 只允许：`active`, `blocked`, `done`, `stale`, `aborted`
+- `transition_count`
+  - 状态流转计数
 - `updated_at`
   - ISO 8601 时间戳
 


### PR DESCRIPTION
## Summary
Aligned core documentation with the latest Vibe 3.0 implementation of flow_status and data models.

## Changes
- **docs/standards/flow-lifecycle-standard.md**:
    - Updated flow status diagram to remove failed and include stale.
    - Aligned Flow Status enum with active/blocked/done/stale/aborted.
    - Updated GitHub Label management table.
- **docs/standards/v3/data-model-standard.md**:
    - Replaced outdated statuses (idle, missing) with canonical values.
    - Updated flow_state table with new fields: blocked_by_issue, transition_count, spec_ref, indicate_ref, etc.
- **docs/standards/v3/handoff-store-standard.md**:
    - Synchronized flow_state table schema with src/vibe3/models/flow.py.
    - Updated field constraints and descriptions.
- **docs/standards/glossary.md**:
    - Added semantics for blocked_by_issue and transition_count.
    - Verified flow_status descriptions.

Addresses supervisor issue #1409.
