### PR TITLE
fix(check): PR closed resets issue to READY via TaskResumeOperations

### DIFF
--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -185,14 +185,16 @@ class CheckService(CheckRemote):
 
         if pr.state == PRState.CLOSED:
             # PR closed without merge → clean up and return to READY
-            self._reset_issue_after_pr_closed(branch, pr.number)
+            reset_error = self._reset_issue_after_pr_closed(branch, pr.number)
             self._update_pr_cache(branch, pr)
 
+            if reset_error:
+                return CheckResult(is_valid=False, branch=branch, issues=[reset_error])
             return CheckResult(is_valid=True, branch=branch, issues=result_issues)
 
         return None
 
-    def _reset_issue_after_pr_closed(self, branch: str, pr_number: int) -> None:
+    def _reset_issue_after_pr_closed(self, branch: str, pr_number: int) -> str | None:
         """Reset issue to READY after PR closed without merge.
 
         Cleans up flow scene (worktree, branch, flow record) and
@@ -224,7 +226,7 @@ class CheckService(CheckRemote):
             self._flow_status_service.mark_flow_aborted(
                 branch, f"PR #{pr_number} closed without merge (no issue link)"
             )
-            return
+            return None
 
         # Check if issue already closed
         gh_issue = self.github_client.view_issue(task_issue_number)
@@ -237,7 +239,7 @@ class CheckService(CheckRemote):
                     branch=branch,
                     issue_number=task_issue_number,
                 ).info(f"Issue #{task_issue_number} already closed, skip reset")
-                return
+                return None
 
         # Build minimal FlowStatusResponse for task resume
         flow = FlowStatusResponse(
@@ -290,6 +292,12 @@ class CheckService(CheckRemote):
                 branch=branch,
                 issue_number=task_issue_number,
             ).warning(f"Failed to reset issue: {exc}")
+            return (
+                f"Failed to reset issue #{task_issue_number} after PR "
+                f"#{pr_number} closed: {exc}"
+            )
+
+        return None
 
     def _check_multiple_state_labels(
         self, issue_number: int, issue_payload: dict

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -157,104 +157,6 @@ class CheckService(CheckRemote):
         except Exception:
             return None
 
-    def _block_issue_for_pr_closed(self, branch: str, pr_number: int) -> None:
-        """Block issue when PR closed without merge.
-
-        Calls standard FlowService.block_flow() to ensure flow state
-        and issue state are synchronized, then adds guidance comment.
-
-        Args:
-            branch: Branch name (e.g., "task/issue-456")
-            pr_number: Closed PR number
-        """
-        # Find task issue from flow
-        issue_links = self.store.get_issue_links(branch)
-        task_issue_number: int | None = None
-        for link in issue_links:
-            if link.get("issue_role") == "task":
-                task_issue_number = link.get("issue_number")
-                if isinstance(task_issue_number, int):
-                    break
-
-        if not task_issue_number:
-            logger.bind(
-                domain="check",
-                action="block_pr_closed",
-                branch=branch,
-            ).debug("No task issue linked, skipping issue blocking")
-            return
-
-        # Check if issue already closed
-        gh_issue = self.github_client.view_issue(task_issue_number)
-        if isinstance(gh_issue, dict):
-            issue_state = str(gh_issue.get("state", "")).upper()
-            if issue_state == "CLOSED":
-                logger.bind(
-                    domain="check",
-                    action="block_pr_closed",
-                    branch=branch,
-                    issue_number=task_issue_number,
-                ).info(f"Issue #{task_issue_number} already closed, skip blocking")
-                return
-
-        # Transition issue state to BLOCKED while keeping flow_status as "aborted"
-        # This allows --clean-branch to properly clean up these flows
-        from vibe3.services.label_service import LabelService
-
-        label_service = LabelService()
-
-        try:
-            label_service.transition(
-                task_issue_number, IssueState.BLOCKED, actor="vibe:check"
-            )
-
-            logger.bind(
-                domain="check",
-                action="block_pr_closed",
-                branch=branch,
-                issue_number=task_issue_number,
-            ).info(
-                f"Transitioned issue #{task_issue_number} to BLOCKED for "
-                f"closed PR #{pr_number}"
-            )
-        except Exception as exc:
-            logger.bind(
-                domain="check",
-                action="block_pr_closed",
-                branch=branch,
-                issue_number=task_issue_number,
-            ).warning(f"Failed to block flow: {exc}")
-            # Continue to add comment even if blocking failed
-
-        # Add guidance comment
-        comment_body = f"""PR #{pr_number} 已关闭（未合并）。
-
-**建议方案：**
-
-1. **关闭此 issue** - 如果需求已不再需要或已被其他方式解决
-2. **创建 follow-up issue** - 如果需要继续开发，建议创建新 issue 重新规划
-3. **评估 scope 变化** - 根据最新代码确定是否需要调整范围
-
-**恢复执行选项：**
-
-- `vibe task resume --label ready` - 恢复执行（建议先评估 scope）
-- `vibe check --clean-branch` - 清理旧 flow 并重新开始
-
-**注意：** 不建议在已关闭 PR 的基础上继续开发。"""
-
-        try:
-            self.github_client.add_comment(
-                task_issue_number,
-                comment_body,
-            )
-        except Exception as exc:
-            logger.bind(
-                domain="check",
-                action="block_pr_closed",
-                branch=branch,
-                issue_number=task_issue_number,
-            ).warning(f"Failed to add comment: {exc}")
-
     def _handle_closed_pr(self, branch: str, pr: "PRResponse") -> CheckResult | None:
         """Handle PR state changes detected during check.
 
@@ -281,19 +183,108 @@ class CheckService(CheckRemote):
             return CheckResult(is_valid=True, branch=branch, issues=result_issues)
 
         if pr.state == PRState.CLOSED:
-            # PR closed without merge → aborted (task abandoned)
-            self._flow_status_service.mark_flow_aborted(
-                branch,
-                f"PR #{pr.number} closed without merge (detected from GitHub)",
-            )
+            # PR closed without merge → clean up and return to READY
+            self._reset_issue_after_pr_closed(branch, pr.number)
             self._update_pr_cache(branch, pr)
-
-            # Block issue with guidance comment
-            self._block_issue_for_pr_closed(branch, pr.number)
 
             return CheckResult(is_valid=True, branch=branch, issues=result_issues)
 
         return None
+
+    def _reset_issue_after_pr_closed(self, branch: str, pr_number: int) -> None:
+        """Reset issue to READY after PR closed without merge.
+
+        Cleans up flow scene (worktree, branch, flow record) and
+        restores issue to READY state so it can be dispatched again.
+
+        Args:
+            branch: Branch name (e.g., "task/issue-456")
+            pr_number: Closed PR number
+        """
+        from vibe3.models.flow import FlowStatusResponse
+        from vibe3.services.task_resume_operations import TaskResumeOperations
+
+        # Find task issue number
+        issue_links = self.store.get_issue_links(branch)
+        task_issue_number: int | None = None
+        for link in issue_links:
+            if link.get("issue_role") == "task":
+                task_issue_number = link.get("issue_number")
+                if isinstance(task_issue_number, int):
+                    break
+
+        if not task_issue_number:
+            logger.bind(
+                domain="check",
+                action="reset_pr_closed",
+                branch=branch,
+            ).debug("No task issue linked, skipping issue reset")
+            return
+
+        # Check if issue already closed
+        gh_issue = self.github_client.view_issue(task_issue_number)
+        if isinstance(gh_issue, dict):
+            issue_state = str(gh_issue.get("state", "")).upper()
+            if issue_state == "CLOSED":
+                logger.bind(
+                    domain="check",
+                    action="reset_pr_closed",
+                    branch=branch,
+                    issue_number=task_issue_number,
+                ).info(f"Issue #{task_issue_number} already closed, skip reset")
+                return
+
+        # Build minimal FlowStatusResponse for task resume
+        flow = FlowStatusResponse(
+            branch=branch,
+            flow_slug=branch,
+            flow_status="active",
+            latest_actor="vibe:check",
+            task_issue_number=task_issue_number,
+        )
+
+        # Create TaskResumeOperations and reset to READY
+        from vibe3.services.flow_service import FlowService
+        from vibe3.services.issue_flow_service import IssueFlowService
+        from vibe3.services.label_service import LabelService
+
+        label_service = LabelService()
+        flow_service = FlowService(store=self.store)
+        issue_flow_service = IssueFlowService(store=self.store)
+
+        resume_ops = TaskResumeOperations(
+            git_client=self.git_client,
+            github_client=self.github_client,
+            flow_service=flow_service,
+            label_service=label_service,
+            issue_flow_service=issue_flow_service,
+        )
+
+        try:
+            resume_ops.reset_issue_to_ready(
+                issue_number=task_issue_number,
+                resume_kind="pr_closed",
+                flow=flow,
+                repo=None,
+                reason=f"PR #{pr_number} closed without merge, resetting to READY",
+            )
+
+            logger.bind(
+                domain="check",
+                action="reset_pr_closed",
+                branch=branch,
+                issue_number=task_issue_number,
+            ).info(
+                f"Reset issue #{task_issue_number} to READY after "
+                f"PR #{pr_number} closed"
+            )
+        except Exception as exc:
+            logger.bind(
+                domain="check",
+                action="reset_pr_closed",
+                branch=branch,
+                issue_number=task_issue_number,
+            ).warning(f"Failed to reset issue: {exc}")
 
     def _check_multiple_state_labels(
         self, issue_number: int, issue_payload: dict

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -164,7 +164,8 @@ class CheckService(CheckRemote):
 
         - PR MERGED: flow is successfully completed → mark done.
           Also auto-closes any linked task issues when no other active flows exist.
-        - PR CLOSED (without merge): PR was abandoned → mark aborted.
+        - PR CLOSED (without merge): flow was abandoned → reset issue to READY
+          and clean up flow scene (worktree, branch, flow record).
         """
         result_issues: list[str] = []
 
@@ -218,7 +219,11 @@ class CheckService(CheckRemote):
                 domain="check",
                 action="reset_pr_closed",
                 branch=branch,
-            ).debug("No task issue linked, skipping issue reset")
+            ).debug("No task issue linked, marking flow as aborted instead")
+            # No issue link → just mark flow as aborted (PR abandoned)
+            self._flow_status_service.mark_flow_aborted(
+                branch, f"PR #{pr_number} closed without merge (no issue link)"
+            )
             return
 
         # Check if issue already closed

--- a/tests/vibe3/services/test_check_pr_status.py
+++ b/tests/vibe3/services/test_check_pr_status.py
@@ -65,7 +65,7 @@ class TestPRStatusDetection:
         assert flow["flow_status"] == "done"
 
     def test_check_detects_closed_pr(self, tmp_path):
-        """Should mark flow as aborted when PR is closed (without merge)."""
+        """Should reset issue to READY when PR is closed (without merge)."""
         # ARRANGE: Flow with closed PR
         store = SQLiteClient(db_path=tmp_path / "test.db")
         store.update_flow_state(
@@ -79,7 +79,6 @@ class TestPRStatusDetection:
 
         git_client = MagicMock(spec=GitClient)
         git_client.get_current_branch.return_value = "task/my-feature"
-        # Return tmp_path/.git so that parent calculation gives tmp_path
         git_client.get_git_common_dir.return_value = tmp_path / ".git"
 
         # Mock GitHub client to return closed PR (not merged)
@@ -105,15 +104,15 @@ class TestPRStatusDetection:
         handoff_dir.mkdir(parents=True, exist_ok=True)
         (handoff_dir / "current.md").touch()
 
-        # ACT: Run check
+        # ACT: Run check with mocked reset method
         service = CheckService(
             store=store, git_client=git_client, github_client=github_client
         )
-        service.verify_current_flow()
+        with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
+            service.verify_current_flow()
 
-        # ASSERT: Flow should be marked as aborted (closed without merge)
-        flow = store.get_flow_state("task/my-feature")
-        assert flow["flow_status"] == "aborted"
+            # ASSERT: Should call reset to READY (not mark as aborted)
+            mock_reset.assert_called_once_with("task/my-feature", 42)
 
     def test_check_keeps_active_flow_for_open_pr(self, tmp_path):
         """Should NOT mark flow as done when PR is still open."""

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -61,6 +61,40 @@ def test_handle_closed_pr_resets_issue_to_ready() -> None:
         assert result.is_valid is True
 
 
+def test_handle_closed_pr_reports_reset_failure() -> None:
+    """When reset fails, check should report the closed PR cleanup as invalid."""
+    service = _make_check_service()
+
+    mock_pr = MagicMock()
+    mock_pr.number = 123
+    mock_pr.state = PRState.CLOSED
+    mock_pr.merged_at = None
+
+    service.store.get_issue_links.return_value = [
+        {"issue_role": "task", "issue_number": 456}
+    ]
+    service.github_client.view_issue.return_value = {
+        "state": "open",
+    }
+
+    with patch(
+        "vibe3.services.task_resume_operations.TaskResumeOperations"
+    ) as mock_resume_ops_cls:
+        mock_resume_ops = MagicMock()
+        mock_resume_ops.reset_issue_to_ready.side_effect = RuntimeError(
+            "scene cleanup failed"
+        )
+        mock_resume_ops_cls.return_value = mock_resume_ops
+
+        result = service._handle_closed_pr("task/issue-456", mock_pr)
+
+    assert result is not None
+    assert result.is_valid is False
+    assert result.issues == [
+        "Failed to reset issue #456 after PR #123 closed: scene cleanup failed"
+    ]
+
+
 def test_handle_closed_pr_skips_already_closed_issue() -> None:
     """When issue already closed, skip reset."""
     service = _make_check_service()

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -23,8 +23,8 @@ def _make_check_service():
     )
 
 
-def test_handle_closed_pr_blocks_issue_state_with_comment() -> None:
-    """When PR is closed (not merged), issue should be blocked with guidance comment."""
+def test_handle_closed_pr_resets_issue_to_ready() -> None:
+    """When PR is closed (not merged), issue should be reset to READY."""
     service = _make_check_service()
 
     # Mock PR closed (not merged)
@@ -33,50 +33,42 @@ def test_handle_closed_pr_blocks_issue_state_with_comment() -> None:
     mock_pr.state = PRState.CLOSED
     mock_pr.merged_at = None
 
-    # Mock flow state exists
-    service.store.get_flow_state.return_value = {
-        "branch": "task/issue-456",
-        "flow_status": "active",
-        "latest_actor": "agent:test",
-    }
-
     # Mock issue links
     service.store.get_issue_links.return_value = [
         {"issue_role": "task", "issue_number": 456}
     ]
 
-    # Mock issue state
+    # Mock issue state (open)
     service.github_client.view_issue.return_value = {
         "state": "open",
-        "labels": [{"name": "state/in-progress"}],
     }
 
-    with patch.object(service._flow_status_service, "mark_flow_aborted") as mock_abort:
-        with patch.object(service, "_block_issue_for_pr_closed") as mock_block:
-            result = service._handle_closed_pr("task/issue-456", mock_pr)
+    with patch(
+        "vibe3.services.task_resume_operations.TaskResumeOperations"
+    ) as mock_resume_ops_cls:
+        mock_resume_ops = MagicMock()
+        mock_resume_ops_cls.return_value = mock_resume_ops
 
-    # Verify flow marked aborted
-    mock_abort.assert_called_once()
+        result = service._handle_closed_pr("task/issue-456", mock_pr)
 
-    # Verify issue blocked with comment
-    mock_block.assert_called_once_with("task/issue-456", 123)
+        # Verify reset_issue_to_ready was called
+        mock_resume_ops.reset_issue_to_ready.assert_called_once()
+        call_kwargs = mock_resume_ops.reset_issue_to_ready.call_args[1]
+        assert call_kwargs["issue_number"] == 456
+        assert call_kwargs["resume_kind"] == "pr_closed"
 
-    # Verify check result is valid
-    assert result.is_valid is True
+        # Verify check result is valid
+        assert result.is_valid is True
 
 
 def test_handle_closed_pr_skips_already_closed_issue() -> None:
-    """When issue already closed, skip blocking."""
+    """When issue already closed, skip reset."""
     service = _make_check_service()
 
     mock_pr = MagicMock()
     mock_pr.number = 123
     mock_pr.state = PRState.CLOSED
 
-    service.store.get_flow_state.return_value = {
-        "branch": "task/issue-456",
-        "flow_status": "active",
-    }
     service.store.get_issue_links.return_value = [
         {"issue_role": "task", "issue_number": 456}
     ]
@@ -86,41 +78,14 @@ def test_handle_closed_pr_skips_already_closed_issue() -> None:
         "state": "CLOSED",
     }
 
-    with patch.object(service._flow_status_service, "mark_flow_aborted"):
+    with patch(
+        "vibe3.services.task_resume_operations.TaskResumeOperations"
+    ) as mock_resume_ops_cls:
+        mock_resume_ops = MagicMock()
+        mock_resume_ops_cls.return_value = mock_resume_ops
+
         result = service._handle_closed_pr("task/issue-456", mock_pr)
 
-    # Should not try to block closed issue
-    # Check that no label transition was attempted
-    assert result.is_valid is True
-
-
-def test_block_issue_for_pr_closed_adds_guidance_comment() -> None:
-    """Blocking issue should add helpful guidance comment."""
-    service = _make_check_service()
-
-    service.store.get_issue_links.return_value = [
-        {"issue_role": "task", "issue_number": 456}
-    ]
-    service.github_client.view_issue.return_value = {
-        "state": "open",
-    }
-
-    with patch("vibe3.services.label_service.LabelService") as mock_label_cls:
-        mock_label = MagicMock()
-        mock_label_cls.return_value = mock_label
-
-        service._block_issue_for_pr_closed("task/issue-456", pr_number=123)
-
-    # Verify comment added
-    service.github_client.add_comment.assert_called_once()
-    call_args = service.github_client.add_comment.call_args
-    assert call_args[0][0] == 456  # issue_number
-
-    comment_body = call_args[0][1]
-    assert "PR #123" in comment_body
-    assert "已关闭" in comment_body
-    assert "follow-up issue" in comment_body.lower()
-    assert (
-        "vibe task resume" in comment_body.lower()
-        or "vibe check --clean-branch" in comment_body.lower()
-    )
+        # Should not try to reset closed issue
+        mock_resume_ops.reset_issue_to_ready.assert_not_called()
+        assert result.is_valid is True

--- a/tests/vibe3/services/test_check_service_verify_branch.py
+++ b/tests/vibe3/services/test_check_service_verify_branch.py
@@ -212,6 +212,7 @@ def test_verify_branch_handles_closed_pr(tmp_path: Path) -> None:
 
     # Mock _reset_issue_after_pr_closed to avoid side effects
     with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
+        mock_reset.return_value = None
         result = service.verify_branch(branch)
 
         # Should call _reset_issue_after_pr_closed

--- a/tests/vibe3/services/test_check_service_verify_branch.py
+++ b/tests/vibe3/services/test_check_service_verify_branch.py
@@ -210,14 +210,12 @@ def test_verify_branch_handles_closed_pr(tmp_path: Path) -> None:
     )
     service._branch_to_pr = {branch: closed_pr}
 
-    # Mock flow_status_service.mark_flow_aborted to avoid side effects
-    with patch.object(
-        service._flow_status_service, "mark_flow_aborted"
-    ) as mock_mark_aborted:
+    # Mock _reset_issue_after_pr_closed to avoid side effects
+    with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
         result = service.verify_branch(branch)
 
-        # Should call mark_flow_aborted
-        mock_mark_aborted.assert_called_once()
+        # Should call _reset_issue_after_pr_closed
+        mock_reset.assert_called_once()
         assert result.is_valid is True
 
 


### PR DESCRIPTION
## Summary

- PR closed without merge now resets issue directly to READY via `TaskResumeOperations.reset_issue_to_ready()`
- Removed incorrect `_block_issue_for_pr_closed()` — PR closed should NOT go through BLOCKED state
- Added `_reset_issue_after_pr_closed()` that delegates to the existing resume architecture

## Problem

Issue #1013 showed `state/blocked` label but had no `blocked_reason`. The original fix attempted to use `BlockedStateService.block()` to set blocked_reason in all three sources, but this was semantically wrong:

- **Issue open + PR closed** → should go directly back to READY, not through BLOCKED
- The correct flow: PR closed → `TaskResumeOperations.reset_issue_to_ready()` → issue back to READY, worktree/branch/flow record deleted

## Solution

When a PR is closed without merge:
1. Find the linked task issue number
2. Check if issue is already closed (skip reset if so)
3. Call `TaskResumeOperations.reset_issue_to_ready(resume_kind="pr_closed")` which handles:
   - `BlockedStateService.unblock()` — clears blocked state from DB, body, labels
   - Worktree deletion
   - Branch deletion
   - Flow record cleanup

**Deleted**: `_block_issue_for_pr_closed()` — was using BLOCKED state incorrectly

**Added**: `_reset_issue_after_pr_closed()` — delegates to existing resume architecture

## Test Plan

- [x] `test_handle_closed_pr_resets_issue_to_ready` — verifies `reset_issue_to_ready` called with `resume_kind="pr_closed"`
- [x] `test_handle_closed_pr_skips_already_closed_issue` — verifies skip when issue already closed
- [x] `test_verify_branch_handles_closed_pr` — verifies `_reset_issue_after_pr_closed` called in verify_branch
- [x] `test_check_detects_closed_pr` — verifies reset called in PR status detection
- [x] All 29 check service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)