### PR TITLE
fix(orchestra): persist frozen queue after dispatch but before collect

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -637,7 +637,15 @@ class GlobalDispatchCoordinator:
         # Note: dispatch event logging is handled by _dispatch_loop internally
         dispatched_count = self._dispatch_loop(tick_id)
 
-        # Step 5: Rebuild active candidates once active queue is exhausted.
+        # Step 5: Persist queue state AFTER dispatch but BEFORE collection.
+        # This preserves the qualify-gate filtered queue (blocked entries that
+        # failed qualification have been popped). Freshly collected entries
+        # are NOT persisted — they will be qualified in the next tick's
+        # dispatch loop before being persisted.
+        self._queue_persistence.frozen_queue = self._frozen_queue
+        self._queue_persistence.persist()
+
+        # Step 6: Rebuild active candidates once active queue is exhausted.
         need_collect = self._should_collect_after_dispatch(dispatched_count)
         if need_collect:
             fresh = await self._collect_frozen_queue()
@@ -662,7 +670,3 @@ class GlobalDispatchCoordinator:
             else:
                 self._dispatch_paused = False
                 self._frozen_queue = self._merge_queue(self._frozen_queue or [], fresh)
-
-        # Step 6: Persist queue state
-        self._queue_persistence.frozen_queue = self._frozen_queue
-        self._queue_persistence.persist()

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -638,10 +638,10 @@ class GlobalDispatchCoordinator:
         dispatched_count = self._dispatch_loop(tick_id)
 
         # Step 5: Persist queue state AFTER dispatch but BEFORE collection.
-        # This preserves the qualify-gate filtered queue (blocked entries that
-        # failed qualification have been popped). Freshly collected entries
-        # are NOT persisted — they will be qualified in the next tick's
-        # dispatch loop before being persisted.
+        # Entries that were dispatched this tick have been popped (blocked entries
+        # that failed qualify_gate are removed). Entries skipped due to capacity
+        # limits remain in the queue and are persisted as-is.
+        # Freshly collected entries from Step 6 are NOT included in this snapshot.
         self._queue_persistence.frozen_queue = self._frozen_queue
         self._queue_persistence.persist()
 


### PR DESCRIPTION
## Summary
- Fixed queue persistence ordering in `GlobalDispatchCoordinator.coordinate()`
- Previously, persist ran AFTER `_collect_frozen_queue()` + `_merge_queue()`, causing freshly collected blocked issues (not yet through qualify_gate) to be persisted and restored in the next tick
- This resulted in redundant qualification checks on blocked issues across consecutive ticks
- Fix: Move persist to run after `_dispatch_loop()` (when blocked entries have been popped) but before `_collect_frozen_queue()` (before new blocked entries are merged)

## Test plan
- [x] All 124 orchestra tests pass
- [x] Queue operation tests pass
- [ ] Verify tick logs show no redundant qualification of blocked issues across consecutive ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)