### PR TITLE
refactor(orchestra): use Protocol interfaces to eliminate circular dependencies

### DIFF
--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -24,6 +24,7 @@ from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.runtime.service_protocol import ServiceBase
 
 if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.orchestra.failed_gate import FailedGate
@@ -86,7 +87,7 @@ class OrchestrationFacade(ServiceBase):
         self._coordinator: GlobalDispatchCoordinator | None = None
         self._failed_gate = failed_gate
         self._github = github or GitHubClient()
-        self._flow_manager = flow_manager or FlowManager(self._config)
+        self._flow_manager: FlowManager | None = None
         self._registry: SessionRegistryService | None = registry
 
         if self._capacity is not None:
@@ -94,11 +95,65 @@ class OrchestrationFacade(ServiceBase):
             from vibe3.orchestra.global_dispatch_coordinator import (
                 GlobalDispatchCoordinator,
             )
+            from vibe3.services.check_service import CheckService
+            from vibe3.services.flow_orchestrator_service import (
+                FlowOrchestratorService,
+            )
+            from vibe3.services.flow_service import FlowService
+            from vibe3.services.issue_flow_service import IssueFlowService
+            from vibe3.services.label_service import LabelService
+            from vibe3.services.task_service import TaskService
 
             actual_store = store or SQLiteClient()
+            git = flow_manager.git if flow_manager else None
+            git = git or self._create_git_client()
+
             self._registry = registry or SessionRegistryService(
                 actual_store, self._capacity._backend
             )
+
+            # Create concrete services for injection
+            flow_service = FlowService(store=actual_store, git_client=git)
+            task_service = TaskService(store=actual_store)
+            label_service = LabelService(repo=self._config.repo)
+            issue_flow_service = IssueFlowService(store=actual_store)
+            bootstrap_service = FlowOrchestratorService(
+                self._config,
+                store=actual_store,
+                git=git,
+                github=self._github,
+            )
+
+            # Inject services into FlowManager
+            self._flow_manager = flow_manager or FlowManager(
+                self._config,
+                flow_service=flow_service,
+                task_service=task_service,
+                label_service=label_service,
+                issue_flow_service=issue_flow_service,
+                bootstrap_service=bootstrap_service,
+                store=actual_store,
+                git=git,
+                github=self._github,
+                registry=self._registry,
+            )
+
+            # Create CheckService factory for injection
+            def check_service_factory() -> CheckService:
+                assert self._flow_manager is not None  # Set above
+                return CheckService(
+                    store=actual_store,
+                    git_client=self._flow_manager.git,
+                    github_client=self._github,
+                )
+
+            # Create block_flow function for injection
+            def block_flow_fn(branch: str, reason: str, actor: str) -> None:
+                assert self._flow_manager is not None  # Set above
+                FlowService(
+                    store=actual_store, git_client=self._flow_manager.git
+                ).block_flow(branch=branch, reason=reason, actor=actor)
+
             self._coordinator = GlobalDispatchCoordinator(
                 config=self._config,
                 capacity=self._capacity,
@@ -106,12 +161,23 @@ class OrchestrationFacade(ServiceBase):
                 store=actual_store,
                 flow_manager=self._flow_manager,
                 registry=self._registry,
+                check_service_factory=check_service_factory,
+                block_flow_fn=block_flow_fn,
             )
+        else:
+            # Fallback to legacy path without capacity-aware dispatch
+            self._flow_manager = flow_manager or FlowManager(self._config)
 
     def shutdown(self) -> None:
         """Cleanup resources owned by the facade."""
         if self._coordinator:
             self._coordinator.shutdown()
+
+    def _create_git_client(self) -> "GitClient":
+        """Create a GitClient instance."""
+        from vibe3.clients.git_client import GitClient
+
+        return GitClient()
 
     def get_queued_issue_numbers(self) -> set[int]:
         """Get issue numbers currently in the dispatch queue."""

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -23,7 +23,7 @@ from vibe3.services.flow_resume_resolver import infer_resume_label
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.orchestra.flow_dispatch import FlowManager
+    from vibe3.orchestra.protocols import FlowManagerPort
 
 
 class QualifyGateService:
@@ -38,7 +38,7 @@ class QualifyGateService:
         config: OrchestraConfig,
         github: GitHubClient,
         store: "SQLiteClient",
-        flow_manager: "FlowManager",
+        flow_manager: "FlowManagerPort",
     ) -> None:
         """Initialize qualify gate service.
 

--- a/src/vibe3/orchestra/flow_dispatch.py
+++ b/src/vibe3/orchestra/flow_dispatch.py
@@ -5,7 +5,7 @@ It was moved out of manager/ so manager can keep shrinking toward a role shell.
 """
 
 import subprocess
-from typing import Any, cast
+from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
@@ -16,6 +16,13 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
+
+if TYPE_CHECKING:
+    from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+    from vibe3.services.flow_service import FlowService
+    from vibe3.services.issue_flow_service import IssueFlowService
+    from vibe3.services.label_service import LabelService
+    from vibe3.services.task_service import TaskService
 
 
 class FlowManager:
@@ -29,11 +36,11 @@ class FlowManager:
         git: GitClient | None = None,
         github: GitHubClient | None = None,
         registry: SessionRegistryService | None = None,
-        flow_service: Any = None,
-        task_service: Any = None,
-        label_service: Any = None,
-        issue_flow_service: Any = None,
-        bootstrap_service: Any = None,
+        flow_service: "FlowService | None" = None,
+        task_service: "TaskService | None" = None,
+        label_service: "LabelService | None" = None,
+        issue_flow_service: "IssueFlowService | None" = None,
+        bootstrap_service: "FlowOrchestratorService | None" = None,
     ) -> None:
         self.config = config
         self.store = SQLiteClient() if store is None else store

--- a/src/vibe3/orchestra/flow_dispatch.py
+++ b/src/vibe3/orchestra/flow_dispatch.py
@@ -5,7 +5,7 @@ It was moved out of manager/ so manager can keep shrinking toward a role shell.
 """
 
 import subprocess
-from typing import cast
+from typing import Any, cast
 
 from loguru import logger
 
@@ -16,12 +16,6 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
-from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_flow_service import IssueFlowService
-from vibe3.services.label_service import LabelService
-from vibe3.services.pr_service import PRService
-from vibe3.services.task_service import TaskService
 
 
 class FlowManager:
@@ -35,22 +29,63 @@ class FlowManager:
         git: GitClient | None = None,
         github: GitHubClient | None = None,
         registry: SessionRegistryService | None = None,
+        flow_service: Any = None,
+        task_service: Any = None,
+        label_service: Any = None,
+        issue_flow_service: Any = None,
+        bootstrap_service: Any = None,
     ) -> None:
         self.config = config
         self.store = SQLiteClient() if store is None else store
         self.git = GitClient() if git is None else git
-        self.flow_service = FlowService(store=self.store, git_client=self.git)
-        self.task_service = TaskService(store=self.store)
         self.github = GitHubClient() if github is None else github
-        self.label_service = LabelService(repo=config.repo)
-        self.issue_flow_service = IssueFlowService(store=self.store)
         self._registry = registry
-        self._bootstrap_service = FlowOrchestratorService(
-            config,
-            store=self.store,
-            git=self.git,
-            github=self.github,
-        )
+
+        # Services are injected; fallback to concrete implementations
+        # for backward compatibility with direct instantiation.
+        if flow_service is not None:
+            self.flow_service = flow_service
+        else:
+            from vibe3.services.flow_service import FlowService as _FlowService
+
+            self.flow_service = _FlowService(store=self.store, git_client=self.git)
+
+        if task_service is not None:
+            self.task_service = task_service
+        else:
+            from vibe3.services.task_service import TaskService as _TaskService
+
+            self.task_service = _TaskService(store=self.store)
+
+        if label_service is not None:
+            self.label_service = label_service
+        else:
+            from vibe3.services.label_service import LabelService as _LabelService
+
+            self.label_service = _LabelService(repo=config.repo)
+
+        if issue_flow_service is not None:
+            self.issue_flow_service = issue_flow_service
+        else:
+            from vibe3.services.issue_flow_service import (
+                IssueFlowService as _IssueFlowService,
+            )
+
+            self.issue_flow_service = _IssueFlowService(store=self.store)
+
+        if bootstrap_service is not None:
+            self._bootstrap_service = bootstrap_service
+        else:
+            from vibe3.services.flow_orchestrator_service import (
+                FlowOrchestratorService as _FlowOrchestratorService,
+            )
+
+            self._bootstrap_service = _FlowOrchestratorService(
+                config,
+                store=self.store,
+                git=self.git,
+                github=self.github,
+            )
 
     def get_flow_for_issue(self, issue_number: int) -> dict | None:
         """Find the latest flow for an issue, regardless of active status.
@@ -230,6 +265,8 @@ class FlowManager:
             branch = self.issue_flow_service.canonical_branch_name(issue_number)
 
         try:
+            from vibe3.services.pr_service import PRService
+
             pr = PRService(
                 github_client=cast(GitHubClientProtocol, self.github),
                 git_client=self.git,

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -12,24 +12,23 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.domain import publish
 from vibe3.domain.qualify_gate import QualifyGateService
-from vibe3.execution.capacity_service import CapacityService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.observability.degraded_mode import get_degraded_manager
-from vibe3.orchestra.flow_dispatch import FlowManager
 from vibe3.orchestra.issue_loader import (
     find_role_for_state,
     get_flow_context,
     load_issue,
 )
 from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.orchestra.protocols import FlowManagerPort
 from vibe3.orchestra.queue_operations import (
     collect_raw_issues_without_qualify,
     select_ready_issues,
@@ -38,9 +37,6 @@ from vibe3.orchestra.queue_persistence_mixin import (
     QueueEntry,
     QueuePersistenceMixin,
 )
-from vibe3.roles.registry import build_label_dispatch_event
-from vibe3.services.check_service import CheckService
-from vibe3.services.flow_service import FlowService
 from vibe3.services.label_utils import (
     clean_old_state_labels,
     should_skip_from_queue,
@@ -50,6 +46,7 @@ if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.roles.definitions import TriggerableRoleDefinition
+    from vibe3.services.check_service import CheckService
 
 # Hard limit to prevent extreme tick duration in edge cases
 MAX_INTENTS_PER_TICK = 10
@@ -61,12 +58,14 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
     def __init__(
         self,
         config: OrchestraConfig,
-        capacity: CapacityService,
+        capacity: Any,
         github: GitHubClient,
         store: "SQLiteClient",
-        flow_manager: FlowManager,
+        flow_manager: FlowManagerPort,
         registry: "SessionRegistryService | None" = None,
         executor: ThreadPoolExecutor | None = None,
+        check_service_factory: Callable[..., Any] | None = None,
+        block_flow_fn: Callable[..., Any] | None = None,
     ) -> None:
         self._config = config
         self._capacity = capacity
@@ -80,7 +79,9 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
         self._owns_executor = executor is None
         self._frozen_queue: list[QueueEntry] | None = None
         self._qualify_gate = QualifyGateService(config, github, store, flow_manager)
-        self._check_service: CheckService | None = None
+        self._check_service: "CheckService | None" = None
+        self._check_service_factory = check_service_factory
+        self._block_flow_fn = block_flow_fn
         self._dispatch_paused = False
         self._supervisor_label = config.supervisor_handoff.issue_label
 
@@ -163,6 +164,8 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
         clean_old_state_labels(issue, role, self._config)
 
         branch, _ = self._flow_context(issue.number)
+        from vibe3.roles.registry import build_label_dispatch_event
+
         publish(build_label_dispatch_event(role, issue, branch=branch, tick_id=tick_id))
 
     def _flow_context(self, issue_number: int) -> tuple[str, dict[str, object] | None]:
@@ -201,11 +204,16 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
 
         # Use CheckService for unified health check
         if self._check_service is None:
-            self._check_service = CheckService(
-                store=self._store,
-                git_client=self._flow_manager.git,
-                github_client=self._github,
-            )
+            if self._check_service_factory is not None:
+                self._check_service = self._check_service_factory()
+            else:
+                from vibe3.services.check_service import CheckService as _CheckService
+
+                self._check_service = _CheckService(
+                    store=self._store,
+                    git_client=self._flow_manager.git,
+                    github_client=self._github,
+                )
         result = self._check_service.verify_branch(branch)
 
         # Get flow status to determine if dispatch should proceed
@@ -243,9 +251,20 @@ class GlobalDispatchCoordinator(QueuePersistenceMixin):
             reason = f"Health check failed: {', '.join(result.issues)}"
             block_succeeded = False
             try:
-                FlowService(
-                    store=self._store, git_client=self._flow_manager.git
-                ).block_flow(branch=branch, reason=reason, actor="orchestra:dispatcher")
+                if self._block_flow_fn is not None:
+                    self._block_flow_fn(
+                        branch=branch,
+                        reason=reason,
+                        actor="orchestra:dispatcher",
+                    )
+                else:
+                    from vibe3.services.flow_service import FlowService
+
+                    FlowService(
+                        store=self._store, git_client=self._flow_manager.git
+                    ).block_flow(
+                        branch=branch, reason=reason, actor="orchestra:dispatcher"
+                    )
                 block_succeeded = True
             except Exception as exc:
                 logger.bind(domain="orchestra", action="health_check").warning(

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -7,25 +7,22 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
-from vibe3.roles.registry import LABEL_DISPATCH_ROLES
+from vibe3.orchestra.role_mapping import find_role_for_state
+
+# Re-export find_role_for_state for backward compatibility
+# (previously defined in this module, now in role_mapping.py)
+__all__ = [
+    "find_role_for_state",
+    "is_auto_task_branch",
+    "get_flow_context",
+    "load_issue",
+]
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.models.orchestration import IssueInfo
-    from vibe3.orchestra.flow_dispatch import FlowManager
-    from vibe3.roles.definitions import TriggerableRoleDefinition
-
-
-def find_role_for_state(
-    state: IssueState,
-) -> "TriggerableRoleDefinition | None":
-    """Find the role definition for a state label."""
-    for role in LABEL_DISPATCH_ROLES:
-        if role.trigger_state == state:
-            return role
-    return None
+    from vibe3.orchestra.protocols import FlowManagerPort
 
 
 def is_auto_task_branch(branch: str) -> bool:
@@ -45,7 +42,7 @@ def get_flow_context(
     config: OrchestraConfig,
     github: "GitHubClient",
     store: "SQLiteClient",
-    flow_manager: "FlowManager",
+    flow_manager: "FlowManagerPort",
 ) -> tuple[str, dict[str, object] | None]:
     """Get flow context (branch and state) for an issue.
 

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -1,0 +1,41 @@
+"""Protocol definitions for orchestra layer dependency injection.
+
+These Protocols (Ports) define abstract interfaces that allow the orchestra
+layer to depend on abstractions rather than concrete implementations from
+services/execution/roles, eliminating circular dependencies.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
+    from vibe3.models.orchestration import IssueInfo
+
+
+@runtime_checkable
+class FlowManagerPort(Protocol):
+    """Abstract interface for flow management operations.
+
+    This Protocol defines the operations that GlobalDispatchCoordinator and other
+    orchestra components need from FlowManager, without depending on the concrete
+    implementation.
+    """
+
+    # Attributes (Protocol treats these as required attributes on the concrete class)
+    git: "GitClient"
+
+    def get_flow_for_issue(self, issue_number: int) -> dict | None:
+        """Find the latest flow for an issue, regardless of active status."""
+        ...
+
+    def create_flow_for_issue(self, issue: "IssueInfo") -> dict | None:
+        """Create a new flow for an issue or return existing reusable flow."""
+        ...
+
+    def get_active_flow_count(self) -> int:
+        """Count active flows that count toward capacity limit."""
+        ...
+
+    def get_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return the PR number associated with the issue's flow, or None."""
+        ...

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -15,17 +15,43 @@ from vibe3.orchestra.issue_loader import (
 )
 from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.orchestra.queue_ordering import sort_ready_issues
-from vibe3.services.label_utils import normalize_labels, should_skip_from_queue
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
-    from vibe3.orchestra.flow_dispatch import FlowManager
+    from vibe3.orchestra.protocols import FlowManagerPort
+
+
+# Default implementations (lazy import to avoid circular dependency)
+def _default_normalize_labels(raw_labels: object) -> list[str]:
+    """Default implementation using services.label_utils."""
+    from vibe3.services.label_utils import normalize_labels
+
+    return normalize_labels(raw_labels)
+
+
+def _default_should_skip_from_queue(
+    issue: IssueInfo,
+    *,
+    supervisor_label: str,
+    manager_usernames: list[str] | tuple[str, ...],
+    require_manager_assignee: bool = True,
+) -> bool:
+    """Default implementation using services.label_utils."""
+    from vibe3.services.label_utils import should_skip_from_queue
+
+    return should_skip_from_queue(
+        issue,
+        supervisor_label=supervisor_label,
+        manager_usernames=manager_usernames,
+        require_manager_assignee=require_manager_assignee,
+    )
 
 
 def collect_raw_issues_without_qualify(
     raw_issues: list[dict[str, object]],
+    normalize_labels_fn: Callable[[object], list[str]] | None = None,
 ) -> list[IssueInfo]:
     """Apply collection-time filters without running the qualify gate.
 
@@ -41,9 +67,10 @@ def collect_raw_issues_without_qualify(
     behavior where issues flow through qualify gate first for side effects
     (blocked-label alignment, auto-resume).
     """
+    _normalize_labels = normalize_labels_fn or _default_normalize_labels
     selected: list[IssueInfo] = []
     for item in raw_issues:
-        labels = normalize_labels(item.get("labels"))
+        labels = _normalize_labels(item.get("labels"))
         if not any(lbl.startswith("state/") for lbl in labels):
             continue
         issue = IssueInfo.from_github_payload(item)
@@ -59,9 +86,11 @@ def select_ready_issues(
     config: OrchestraConfig,
     github: "GitHubClient",
     store: "SQLiteClient",
-    flow_manager: "FlowManager",
+    flow_manager: "FlowManagerPort",
     qualify_gate: QualifyGateService,
     supervisor_label: str,
+    should_skip_fn: Callable[..., bool] | None = None,
+    normalize_labels_fn: Callable[[object], list[str]] | None = None,
 ) -> list[IssueInfo]:
     """Select ready issues by filtering through qualify gate and other checks.
 
@@ -74,21 +103,26 @@ def select_ready_issues(
         flow_manager: Flow manager
         qualify_gate: Qualify gate service
         supervisor_label: Supervisor label to check
+        should_skip_fn: Optional custom should_skip_from_queue function
+        normalize_labels_fn: Optional custom normalize_labels function
 
     Returns:
         Filtered and sorted ready issues
     """
+    _should_skip = should_skip_fn or _default_should_skip_from_queue
     selected: list[IssueInfo] = []
     role = find_role_for_state(trigger_state)
     if role is None:
         return selected
 
-    raw_selected = collect_raw_issues_without_qualify(raw_issues)
+    raw_selected = collect_raw_issues_without_qualify(
+        raw_issues, normalize_labels_fn=normalize_labels_fn
+    )
 
     for issue in raw_selected:
         # Verify assignee/supervisor filters
         # Always require manager assignee for all dispatch stages
-        if should_skip_from_queue(
+        if _should_skip(
             issue,
             supervisor_label=supervisor_label,
             manager_usernames=config.get_manager_usernames(),
@@ -133,6 +167,7 @@ def promote_progressed_entries(
     registry: "SessionRegistryService | None",
     supervisor_label: str,
     load_issue_func: Callable[[int], IssueInfo | None] | None = None,
+    should_skip_fn: Callable[..., bool] | None = None,
 ) -> tuple[list[dict], list[dict], list[dict]]:
     """Process frozen queue entries and categorize them.
 
@@ -143,10 +178,13 @@ def promote_progressed_entries(
         registry: Session registry (optional)
         supervisor_label: Supervisor label to check
         load_issue_func: Optional function to load issues (for backward compatibility)
+        should_skip_fn: Optional custom should_skip_from_queue function
 
     Returns:
         Tuple of (promoted, retained, removed) entries
     """
+
+    _should_skip = should_skip_fn or _default_should_skip_from_queue
 
     promoted: list[dict] = []
     retained: list[dict] = []
@@ -164,7 +202,7 @@ def promote_progressed_entries(
         if issue is None or issue.state is None:
             continue
 
-        if should_skip_from_queue(
+        if _should_skip(
             issue,
             supervisor_label=supervisor_label,
             manager_usernames=config.get_manager_usernames(),

--- a/src/vibe3/orchestra/queue_persistence_mixin.py
+++ b/src/vibe3/orchestra/queue_persistence_mixin.py
@@ -13,7 +13,6 @@ from loguru import logger
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.orchestra.queue_operations import promote_progressed_entries
-from vibe3.services.label_utils import should_skip_from_queue
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
@@ -21,6 +20,25 @@ if TYPE_CHECKING:
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.models.orchestra_config import OrchestraConfig
     from vibe3.services.check_service import CheckService
+
+
+# Default implementation (lazy import to avoid circular dependency)
+def _default_should_skip_from_queue(
+    issue: IssueInfo,
+    *,
+    supervisor_label: str,
+    manager_usernames: list[str] | tuple[str, ...],
+    require_manager_assignee: bool = True,
+) -> bool:
+    """Default implementation using services.label_utils."""
+    from vibe3.services.label_utils import should_skip_from_queue
+
+    return should_skip_from_queue(
+        issue,
+        supervisor_label=supervisor_label,
+        manager_usernames=manager_usernames,
+        require_manager_assignee=require_manager_assignee,
+    )
 
 
 @dataclass
@@ -95,7 +113,7 @@ class QueuePersistenceMixin:
                 continue
 
             # Skip supervisor-labeled issues
-            if should_skip_from_queue(
+            if _default_should_skip_from_queue(
                 issue,
                 supervisor_label=self._supervisor_label,
                 manager_usernames=self._config.get_manager_usernames(),

--- a/src/vibe3/orchestra/role_mapping.py
+++ b/src/vibe3/orchestra/role_mapping.py
@@ -1,0 +1,42 @@
+"""Role mapping for orchestra dispatch.
+
+This module provides the dispatch role mappings needed by orchestra layer,
+eliminating direct dependency on roles.registry which could cause circular imports.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vibe3.roles.definitions import TriggerableRoleDefinition
+
+
+def get_label_dispatch_roles() -> tuple["TriggerableRoleDefinition", ...]:
+    """Get the label dispatch roles.
+
+    Uses lazy import to avoid circular dependency at module load time.
+    """
+    from vibe3.roles.registry import LABEL_DISPATCH_ROLES
+
+    return LABEL_DISPATCH_ROLES
+
+
+def find_role_for_state(
+    state: "IssueState",
+) -> "TriggerableRoleDefinition | None":
+    """Find the role definition for a state label.
+
+    Args:
+        state: The issue state to find a role for
+
+    Returns:
+        The matching TriggerableRoleDefinition, or None if not found
+    """
+    for role in get_label_dispatch_roles():
+        if role.trigger_state == state:
+            return role
+    return None
+
+
+# Import IssueState at module level for type checking
+if TYPE_CHECKING:
+    from vibe3.models.orchestration import IssueState

--- a/tests/vibe3/orchestra/test_dispatch_health_checks.py
+++ b/tests/vibe3/orchestra/test_dispatch_health_checks.py
@@ -59,9 +59,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return invalid result (non-transient)
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=False,
@@ -119,9 +117,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return valid result
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=True,
@@ -178,9 +174,7 @@ class TestPreDispatchHealthChecks:
 
         # Mock CheckService to return valid (CheckService handles PR check
         # internally and marks flow as done, then returns valid)
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=True,
@@ -236,9 +230,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return valid (open PR is not a failure)
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=True,
@@ -294,9 +286,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return invalid with transient error
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=False,
@@ -354,9 +344,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return invalid with genuine error (no worktree)
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=False,
@@ -368,9 +356,7 @@ class TestPreDispatchHealthChecks:
             )
 
             # Mock FlowService to verify constructor and block_flow call
-            with patch(
-                "vibe3.orchestra.global_dispatch_coordinator.FlowService"
-            ) as mock_flow_service:
+            with patch("vibe3.services.flow_service.FlowService") as mock_flow_service:
                 mock_flow = mock_flow_service.return_value
                 result = coordinator._health_check_before_dispatch(issue)
 
@@ -434,9 +420,7 @@ class TestPreDispatchHealthChecks:
         }
 
         # Mock CheckService to return invalid with transient error
-        with patch(
-            "vibe3.orchestra.global_dispatch_coordinator.CheckService"
-        ) as mock_check_service:
+        with patch("vibe3.services.check_service.CheckService") as mock_check_service:
             mock_service = mock_check_service.return_value
             mock_service.verify_branch.return_value = CheckResult(
                 is_valid=False,
@@ -445,9 +429,7 @@ class TestPreDispatchHealthChecks:
             )
 
             # Mock FlowService.block_flow to ensure it's NOT called
-            with patch(
-                "vibe3.orchestra.global_dispatch_coordinator.FlowService"
-            ) as mock_flow_service:
+            with patch("vibe3.services.flow_service.FlowService") as mock_flow_service:
                 mock_flow = mock_flow_service.return_value
                 result = coordinator._health_check_before_dispatch(issue)
 


### PR DESCRIPTION
## Summary

- Implement dependency injection pattern to decouple orchestra layer from direct imports of services/execution/roles modules
- Define `FlowManagerPort` Protocol for abstract interface
- Use lazy imports and parameter injection to eliminate circular dependencies
- Add proper type annotations for injected services to fix mypy errors

## Changes

### New Files
- `orchestra/protocols.py`: Define `FlowManagerPort` Protocol with required operations
- `orchestra/role_mapping.py`: Provide `find_role_for_state` with lazy import

### Modified Files
- `orchestra/flow_dispatch.py`: Accept services as constructor parameters with fallback defaults
- `orchestra/global_dispatch_coordinator.py`: Use `FlowManagerPort` type hints, inject factories
- `orchestra/queue_operations.py`: Accept label utils functions as parameters
- `orchestra/queue_persistence_mixin.py`: Use lazy import for `should_skip_from_queue`
- `orchestra/issue_loader.py`: Import `find_role_for_state` from `role_mapping`
- `domain/orchestration_facade.py`: Explicitly create and inject all services
- `domain/qualify_gate.py`: Use `FlowManagerPort` type hint

### Test Updates
- Fixed mock patches to use correct import locations

## Architecture Impact

**Before**: orchestra → services/execution/roles (direct imports causing circular dependencies)

**After**: orchestra → protocols (abstractions) + lazy imports; orchestration_facade (composition root) → concrete implementations

The orchestra layer now depends on abstractions (Protocols) rather than concrete implementations, following the Dependency Inversion Principle.

## Tests

All 151 tests pass:
- 122 orchestra tests
- 7 orchestration facade tests
- 9 dispatch error propagation tests
- 13 heartbeat tests

## Backward Compatibility

All changes maintain backward compatibility through:
- Fallback defaults with lazy imports
- Re-exports for existing imports
- Optional parameters with sensible defaults

Fixes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Contributors**: Claude Opus 4.6, Claude Sonnet 4.5