### PR TITLE
feat(labels): 统一 roadmap 标签使用标准，引入 roadmap/epic

### DIFF
--- a/docs/standards/github-labels-reference.md
+++ b/docs/standards/github-labels-reference.md
@@ -96,6 +96,7 @@
 | `roadmap/next` | 下个迭代规划中 | `gh issue edit 123 --add-label "roadmap/next"` |
 | `roadmap/future` | 未来考虑 | `gh issue edit 123 --add-label "roadmap/future"` |
 | `roadmap/rfc` | RFC/设计阶段 | `gh issue edit 123 --add-label "roadmap/rfc"` |
+| `roadmap/epic` | Epic 主 issue（有 Sub-issues） | `gh issue edit 123 --add-label "roadmap/epic"` |
 
 ### 2.4 关系镜像标签
 
@@ -222,6 +223,7 @@ gh issue list --milestone "Phase 1: 基础设施"
 | 中优先级 bug 修复 | `type/fix` + `priority/5` + `roadmap/p1` |
 | 低优先级文档更新 | `type/docs` + `priority/3` + `roadmap/p2` |
 | 需要讨论的设计 | `type/feature` + `roadmap/rfc` |
+| Epic 主 issue | `roadmap/epic` + `type/feature`（引导用户选择 sub-issue 进入） |
 | 性能优化 | `type/perf` + `priority/7` + `roadmap/p0` |
 | 技术债务清理 | `tech-debt` + `priority/5` + `roadmap/p1` |
 | 编排系统改进 | `component/orchestra` + `type/feature` + `roadmap/p1` |

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -342,12 +342,16 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 | `roadmap/next` | 下个迭代规划中 | 待确认的功能 |
 | `roadmap/future` | 未来考虑 | 长期规划、想法阶段 |
 | `roadmap/rfc` | RFC/设计阶段 | 需要讨论设计的功能 |
+| `roadmap/epic` | Epic 主 issue | 有 Sub-issues 的主 issue，需引导选择 sub-issue 进入 |
 
 ### 4.3 标签组合原则
 
 - 一个 issue 应该同时有 `type/*` 和 `priority/*` 标签
 - `roadmap/p0` 通常配合 `priority/high` 使用
 - `roadmap/rfc` 可以没有 `priority/*` 标签
+- `roadmap/epic` 表示主 issue 有 Sub-issues，不应直接进入执行，需引导用户选择具体 sub-issue
+- `roadmap/epic` 与 `roadmap/rfc` 语义不同：epic 是结构维度（主/子），rfc 是讨论维度（设计阶段）
+- 一个 issue 可以同时是 `roadmap/epic` 和 `roadmap/rfc`（需要设计讨论的 epic）
 - flow 绑定的 issue 会自动镜像 `vibe-task` 标签；执行状态以 flow 状态为准
 
 ---
@@ -433,6 +437,38 @@ uv run python src/vibe3/cli.py flow show --branch <branch>
 - 版本目标不明确
 - 技术方案需要评估
 - 资源分配需要协调
+
+### 6.4 Epic 处理流程
+
+当遇到标记为 `roadmap/epic` 的 issue 时：
+
+**检查逻辑**：
+```bash
+gh issue view <issue-number> --json labels,body
+```
+
+**阻断条件**：
+- 如果 issue 有 `roadmap/epic` 标签且 body 包含 `## Sub-issues` section：
+  - **禁止直接进入规划流程**
+  - 告知用户："该 issue 是 Epic 主 issue，请选择具体 sub-issue 进入"
+  - 列出 Sub-issues 列表供选择
+  - 停止 — 不继续规划
+
+**引导逻辑**：
+- 如果用户尝试对 Epic 主 issue 进行规划：
+  - 检查是否所有 Sub-issues 已完成
+  - 若全部完成，允许关闭主 issue
+  - 若未完成，引导用户选择未完成的 sub-issue
+
+**特殊情况**：
+- Epic + RFC：issue 既是 Epic 主 issue 又需要设计讨论
+  - 先完成设计讨论（`roadmap/rfc`）
+  - 设计确定后再处理 Sub-issues
+
+**语义分离原则**：
+- `roadmap/epic`：结构维度（主/子关系）
+- `roadmap/rfc`：讨论维度（设计阶段）
+- 一个 issue 可以同时具有两个标签，也可以只有其中一个
 
 ---
 

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -90,6 +90,7 @@ sync_label "roadmap/p2" "有容量时完成" "FFCC00"
 sync_label "roadmap/next" "下个迭代规划中" "99CCFF"
 sync_label "roadmap/future" "未来考虑" "CCCCFF"
 sync_label "roadmap/rfc" "RFC/设计阶段" "CC99FF"
+sync_label "roadmap/epic" "Epic 主 issue（有 Sub-issues）" "9933FF"
 
 echo ""
 echo -e "${BLUE}=== Scope Labels ===${NC}"

--- a/skills/vibe-issue/SKILL.md
+++ b/skills/vibe-issue/SKILL.md
@@ -95,7 +95,7 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 **命中后的行为**：
 1. 明确询问用户：「这个 issue 看起来 scope 较大，建议拆为主 issue + sub-issues 结构。是否要建主/子结构？」
 2. 若用户确认拆分：
-   - 当前 issue 作为主 issue，建议添加 `roadmap/rfc` 标签
+   - 当前 issue 作为主 issue，建议添加 `roadmap/epic` 标签
    - body 写入 `## Sub-issues` section（留空模板，格式见下方「标准 Section」）
    - 引导用户单独触发 `/vibe-issue` 创建每个 sub-issue
 3. 若用户坚持单 issue：

--- a/skills/vibe-new/SKILL.md
+++ b/skills/vibe-new/SKILL.md
@@ -51,7 +51,27 @@ git log main..origin/main --oneline | wc -l
 
 **原因**：避免 Issue #1250 类型的问题——长时间重构期间 main 已演进，新分支从一开始就落后会导致后续严重冲突。
 
-## 3. 询问两件事
+## 3. Epic 入口阻断检查
+
+在确认目标 issue 后，检查是否为 Epic 主 issue：
+
+```bash
+gh issue view <issue-number> --json labels,body
+```
+
+检查逻辑：
+- 如果 issue 有 `roadmap/epic` 标签 **且** body 包含 `## Sub-issues` 或 `## 子任务` section：
+  - 打印 Sub-issues 列表（从 body 的 `## Sub-issues` section 解析）
+  - 告知用户："该 issue 是 Epic 主 issue，请选择具体 sub-issue 进入 /vibe-new"
+  - 停止 — 不继续 bootstrap
+- 如果只有 `roadmap/epic` 标签但无 `## Sub-issues` section：
+  - 提示用户："该 issue 标记为 Epic 但缺少 ## Sub-issues section，请先补齐 Sub-issues 或移除标签"
+  - 停止 — 不继续 bootstrap
+- 否则继续正常流程
+
+**注意**：必须同时满足标签和 section 两个条件才是有效的 Epic 主 issue。
+
+## 4. 询问两件事
 
 只需要确认：
 - 用当前仓库还是新建 worktree
@@ -63,7 +83,42 @@ git log main..origin/main --oneline | wc -l
 - `openspec:ff`
 - repo-native `vibe3 plan/run/review`
 
-## 4. Bootstrap flow scene
+## 5. 自动解析依赖关系
+
+在 bootstrap 前，自动解析依赖关系：
+
+1. 读取目标 issue body（已在 Step 1 获取，或重新获取）：
+   ```bash
+   gh issue view <issue-number> --json body
+   ```
+
+2. 解析 `## Dependencies` 或 `## 依赖` section
+
+3. 提取依赖关系（匹配以下任一格式）：
+   - `Depends on #<id>`
+   - `依赖 #<id>`
+   - `blocked by #<id>`
+   
+   对每个匹配项，提取 issue number
+
+4. 检查依赖状态：
+   ```bash
+   gh issue view <dep-id> --json state
+   ```
+   
+   - 如果依赖状态为 `open`：
+     - 添加 `--dependency <id>` 参数到 bootstrap 命令
+     - 警告用户："当前 issue 存在未关闭的依赖 #<id>，bootstrap 后 flow 将立即进入 blocked 状态。是否继续？"
+     - 等待用户确认
+   - 如果依赖状态为 `closed`：
+     - **不添加** `--dependency` 参数（依赖已满足）
+     - 提示用户："依赖 #<id> 已关闭，无需阻塞"
+   - 如果无依赖：继续
+
+5. 组装 bootstrap 命令：
+   - **只对未关闭（open）的依赖**添加 `--dependency <id>` 参数
+
+## 6. Bootstrap flow scene
 
 **强制要求**：必须使用 `vibe3 internal bootstrap` 作为唯一 bootstrap 路径，禁止手工拼接。
 
@@ -92,10 +147,10 @@ vibe3 internal bootstrap <issue-number> \
 - branch/flow bootstrap
 - task issue 绑定
 - related issue 绑定
-- dependency issue 阻塞登记
+- dependency issue 阻塞登记（仅 open 状态的依赖）
 - worktree context 准备（如果传了 `--worktree`）
 
-## 5. 记录 handoff
+## 7. 记录 handoff
 
 bootstrap 成功后记录稳定恢复点：
 
@@ -103,7 +158,7 @@ bootstrap 成功后记录稳定恢复点：
 vibe3 handoff append "vibe-new: flow ready" --actor vibe-new --kind milestone
 ```
 
-## 6. 按需继续
+## 8. 按需继续
 
 如果已经具备条件，可以继续：
 

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -349,6 +349,11 @@ gh issue list -l "roadmap/p0"
 **场景 B: 有版本目标但有新 `GitHub issue`**
 
 - 对新的 `GitHub issue` 进行分类：
+- **Epic 检查**（强制阻断）：
+  - 如果 issue 有 `roadmap/epic` 标签且 body 包含 `## Sub-issues` section：
+    - 告知用户："该 issue 是 Epic 主 issue，请先规划 sub-issues 或选择具体 sub-issue 进入"
+    - 停止 — 不继续规划主 issue
+    - 引导用户处理 sub-issues
 - 1.  分配适当的 Milestone
 - 2.  添加 roadmap 状态标签（`roadmap/p0`、`roadmap/p1`、`roadmap/p2` 等）
 - 3.  必要时补 `priority/[0-9]` 作为同一 roadmap 桶内的细粒度顺位提示
@@ -374,9 +379,9 @@ gh issue list -l "roadmap/p0"
 - 已被 `[governance suggest] needs split` 标记
 
 **强制拆分动作**：
-1. 主 issue 加 `roadmap/rfc` 标签：
+1. 主 issue 加 `roadmap/epic` 标签：
    ```bash
-   gh issue edit <epic-number> --add-label "roadmap/rfc"
+   gh issue edit <epic-number> --add-label "roadmap/epic"
    ```
 2. 主 issue **不分配** `vibe-manager-agent` assignee（epic 本身不入 manager pool）
 3. 调用 `/vibe-issue` 创建 sub-issues（每个 sub-issue body 中包含 `## Parent issue\n- #<epic-number>`）

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -146,6 +146,10 @@ Forbidden:
 
 ```
 issue 是否可纳入？
+  ├─ **Epic 检查**（强制阻断）
+  │   └─ 有 `roadmap/epic` 标签 + `## Sub-issues` section？
+  │       └─ 是 → 跳过（主 issue 不入池，等待 sub-issues 完成）
+  │
   ├─ 检查实质条件
   │   ├─ 范围是否明确？
   │   ├─ 验收标准是否清晰？

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -85,6 +85,9 @@
 - issue 的目标/验收口径本身不明确，无法确定做完算什么
 - 需要先决定架构方向、产品策略或跨团队边界
 - 不确定是否过时
+- **Epic 主 issue**（有 `roadmap/epic` 标签且 body 包含 `## Sub-issues`）：
+  - 不纳入 assignee pool（主 issue 本身不应进入执行）
+  - 等待所有 sub-issues 完成后再处理主 issue 的关闭
 
 **不要误判为 `needs human decision` 的情况**：
 - 同一目标下有 2-3 个局部实现路径，但 issue 本身已说明要修什么、验收看什么

--- a/tests/vibe3/skills/test_vibe_new_alignment.py
+++ b/tests/vibe3/skills/test_vibe_new_alignment.py
@@ -7,7 +7,7 @@ def test_vibe_new_skill_uses_layered_pseudocode_sections() -> None:
 
     # Simplified structure: numbered steps instead of explicit section headers
     assert "## 1. 强制前置检查" in content
-    assert "## 4. Bootstrap flow scene" in content
+    assert "## 6. Bootstrap flow scene" in content
     assert "## 停止条件" in content
 
 


### PR DESCRIPTION
## Summary

- 引入 `roadmap/epic` 标签，明确区分"Epic 主 issue"与"RFC/设计讨论"
- 统一各工具（vibe-issue, vibe-new, vibe-roadmap, roadmap-intake, assignee-pool）对 epic 的检查和阻断逻辑
- 修正 PR #1455 中 `roadmap/rfc` + `## Sub-issues` 混淆概念的问题

## 问题背景

PR #1455 中将 `roadmap/rfc`（设计讨论阶段）与 Epic（有 Sub-issues 的主 issue）混为一谈。现有各工具对 epic 的处理不统一，vibe-issue 甚至在 epic 场景建议添加 `roadmap/rfc` 标签，与标签定义矛盾。

## 改动详情

### 标签定义
- `scripts/sync-labels.sh`: 添加 `roadmap/epic` 标签（颜色 `9933FF`，描述"Epic 主 issue（有 Sub-issues）"）
- `docs/standards/github-labels-reference.md`: 添加 `roadmap/epic` 定义和标签组合示例
- `docs/standards/roadmap-label-management.md`: 添加 Epic 管理流程和语义分离原则

### Skills 层（人机交互）
- `skills/vibe-issue/SKILL.md`: epic 标签推荐从 `roadmap/rfc` 改为 `roadmap/epic`
- `skills/vibe-new/SKILL.md`: 添加 Epic 入口阻断检查（检查 `roadmap/epic`）+ 自动依赖解析
- `skills/vibe-roadmap/SKILL.md`: 添加 Epic 检查逻辑 + 修正 Step 2.5 中 epic 标签

### Supervisor 层（自动化流程）
- `supervisor/governance/roadmap-intake.md`: 跳过 `roadmap/epic` 标记的主 issue
- `supervisor/governance/assignee-pool.md`: Intake 决策流程中添加 Epic 阻断检查

## 语义分离原则

| 标签 | 维度 | 语义 |
|------|------|------|
| `roadmap/epic` | 结构维度 | 主/子关系（有 Sub-issues 的主 issue） |
| `roadmap/rfc` | 讨论维度 | 设计阶段（需要架构/产品方向决策） |

一个 issue 可以同时具有两个标签，也可以只有其中一个。

## Test plan

- [ ] 运行 `scripts/sync-labels.sh` 确认 `roadmap/epic` 标签正确创建
- [ ] 确认各文档中 `roadmap/epic` 定义一致
- [ ] 确认 `roadmap/rfc` 保持"设计讨论阶段"语义
- [ ] 创建测试 issue 验证 epic 阻断逻辑

Closes #1457

## Contributors

AI Agent (claude/opus)