### PR TITLE
feat(manager + review-skills): governance backlog 三层审查提醒链路

### DIFF
--- a/skills/vibe-review-code/SKILL.md
+++ b/skills/vibe-review-code/SKILL.md
@@ -52,6 +52,33 @@ Route elsewhere when:
 
 ## Execution Flow
 
+### 0. Governance Backlog Check
+
+Before starting the review, check for unprocessed governance suggests on the associated issue:
+
+```bash
+# If reviewing a PR, infer the issue number from branch name first
+ISSUE_NUM=$(gh pr view <number> --json headRefName -q .headRefName | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+# If reviewing local branch, use current branch
+ISSUE_NUM=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+
+if [ -n "$ISSUE_NUM" ]; then
+  # Find unprocessed suggests: those without a later [roadmap decision]
+  SUGGEST_COUNT=$(gh issue view "$ISSUE_NUM" --json comments --jq '[.comments[] | select(.body | startswith("[governance suggest]"))] | length')
+  LATEST_SUGGEST=$(gh issue view "$ISSUE_NUM" --json comments --jq '[.comments[] | select(.body | startswith("[governance suggest]"))] | max_by(.createdAt) | .createdAt')
+  LATEST_DECISION=$(gh issue view "$ISSUE_NUM" --json comments --jq '[.comments[] | select(.body | startswith("[roadmap decision]"))] | max_by(.createdAt) | .createdAt')
+  
+  if [ "$SUGGEST_COUNT" -gt 0 ] && { [ -z "$LATEST_DECISION" ] || [ "$LATEST_SUGGEST" \> "$LATEST_DECISION" ]; }; then
+    echo "⚠️ Governance Backlog: 本 issue 存在未消化的 governance suggest"
+    gh issue view "$ISSUE_NUM" --json comments --jq '.comments[] | select(.body | startswith("[governance suggest]")) | "  - " + .body[:200]'
+  fi
+fi
+```
+
+- 若发现未消化 suggest：在输出顶部加 "⚠️ Governance Backlog" 段落，列出 suggest 摘要
+- 这些提示**不阻断** review 流程，仅作为信息层提醒
+- 若 PR 无关联 issue（非 flow 分支），跳过此检查
+
 ### 1. Resolve Scope
 
 Identify the review target:

--- a/skills/vibe-review-docs/SKILL.md
+++ b/skills/vibe-review-docs/SKILL.md
@@ -32,6 +32,31 @@ TaskCreate(
 
 ---
 
+## Step 0.5: Governance Backlog Check
+
+在开始审查前，检查关联 issue 的 governance backlog：
+
+```bash
+# 获取关联 issue 编号
+ISSUE_NUM=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+
+if [ -n "$ISSUE_NUM" ]; then
+  SUGGEST_COUNT=$(gh issue view "$ISSUE_NUM" --json comments --jq '[.comments[] | select(.body | startswith("[governance suggest]"))] | length')
+  if [ "$SUGGEST_COUNT" -gt 0 ]; then
+    echo "⚠️ Governance Backlog: 本 issue 存在 $SUGGEST_COUNT 条未消化 governance suggest"
+    gh issue view "$ISSUE_NUM" --json comments --jq '.comments[] | select(.body | startswith("[governance suggest]")) | "  - " + .body[:200]'
+  fi
+fi
+```
+
+重点关注：
+- `[governance suggest] needs split` (文档类 epic)
+- `[governance suggest] Recommend Close` (过时文档)
+
+这些提示**不阻断** review 流程。
+
+---
+
 ## Step 1: 确定审查范围
 
 ### PR 文档审查

--- a/skills/vibe-review-pr/SKILL.md
+++ b/skills/vibe-review-pr/SKILL.md
@@ -305,6 +305,22 @@ Phase_0():
   assert TeamCreate, TaskCreate, TaskUpdate available
   // 禁止在此步执行 gh pr view / gh pr diff / git diff
 
+  // Step 1.5: Governance Backlog Check
+  // 检查 PR 关联 issue 是否有未消化 governance suggest
+  PR_BODY=$(gh pr view {PR_NUMBER} --json body -q .body)
+  if PR_BODY contains "## Governance Backlog":
+    output("⚠️ PR body 包含 Governance Backlog section，审查时请注意未消化的 governance suggest")
+    列出 backlog 中 unchecked items
+  else:
+    // PR 无 backlog section，检查关联 issue
+    PR_BRANCH=$(gh pr view {PR_NUMBER} --json headRefName -q .headRefName)
+    ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+    if ISSUE_NUM:
+      SUGGESTS=$(gh issue view "$ISSUE_NUM" --json comments --jq '.comments[] | select(.body | startswith("[governance suggest]"))')
+      if SUGGESTS not empty:
+        output("⚠️ Governance Backlog: 关联 issue #" + ISSUE_NUM + " 存在未消化 governance suggest")
+  // 这些提示不阻断审查流程
+
   // Step 2: 选择执行模式
   // 询问用户选择执行模式
   AskUserQuestion(questions=[{

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -317,6 +317,7 @@ Inputs:
 - target issue
 - latest human comment
 - latest governance suggest (if exists)
+- accumulated governance suggests (all, not just latest)
 - current labels/state
 - current scene
 - current handoff
@@ -331,6 +332,22 @@ Steps:
 3. **识别最新 governance 建议**：
    - 署名为 `[governance suggest]` 或含 `[governance]` 标记。
 4. 读取当前 labels/state
+4.5. 分析 governance suggest 累积状态：
+   - 统计本 issue 上所有 [governance suggest] 评论：
+     ```bash
+     gh issue view <issue-number> --json comments --jq '[.comments[] | select(.body | startswith("[governance suggest]"))] | length'
+     gh issue view <issue-number> --json comments --jq '[.comments[] | select(.body | startswith("[governance suggest]"))] | max_by(.createdAt) | .createdAt'
+     ```
+   - 查找最近一次 [roadmap decision] 评论：
+     ```bash
+     gh issue view <issue-number> --json comments --jq '[.comments[] | select(.body | startswith("[roadmap decision]"))] | max_by(.createdAt) | .createdAt'
+     ```
+   - 若无 [roadmap decision] 或其时间早于最新 [governance suggest] → 标记为"未消化"
+   - 读取未消化 suggest 的具体内容，按类型分类：
+     - needs split / auto-split: 需要 vibe-roadmap 消化
+     - Recommend Close: manager 可在 ready 阶段处理
+     - waiting on #X: 显示依赖状态
+     - pool entry / auto-recover: 已完成，无需提醒
 5. 核查当前 issue / flow / task / branch / worktree / session
 6. 读取 handoff 与 refs
 
@@ -412,6 +429,19 @@ Steps:
        - 这会自动：写入 `blocked_reason`、转换 label、在 `flow_issue_links` 表中记录 `dependency` 角色
      - 多个依赖时，对每个依赖分别调用一次
      - `exit()`
+
+4.6. **Governance Suggest 检查**：检查是否有未消化的 governance suggest：
+   - 从 read_context() 的分析结果中，检查是否存在未消化 suggest
+   - 若存在 "needs split" 或 "auto-split"（待复核）类型未消化 suggest：
+     - 本轮不应推进至 plan，应 blocked 等待 vibe-roadmap 消化拆分建议
+     - 调用：
+       ```bash
+       vibe3 flow blocked --reason "存在未消化的 governance suggest（needs split/auto-split），等待 vibe-roadmap 处理"
+       ```
+     - 写 issue comment 列出相关 suggest 内容
+     - `exit()`
+   - 若存在 "Recommend Close" 类型 suggest：已在步骤 2 的 Governance 建议判断中处理，此处跳过
+   - 若存在 "waiting on #X" 类型 suggest：记录依赖状态，但不在此处阻塞（依赖检查已在步骤 4.5 处理）
 
 5. 如果 scene 不健康：
    - 调用 `check_blocker_explained()` 检查是否需要写新 comment
@@ -883,6 +913,21 @@ Steps:
 2. 调用 `check_scene_health()` 确认 scene 健康
 3. 写 handoff indicate（PR发布指令文件），通知 executor 当前进入 commit + PR 阶段
 
+若 read_context() 发现未消化 governance suggest，在 handoff indicate 文件中包含以下 PR body 追加内容：
+
+```markdown
+## Governance Backlog
+
+本 PR 关联 issue 存在未消化的 governance suggest，建议人类 reviewer 在合并前确认：
+
+- [ ] `[governance suggest] waiting on #1234` — 依赖未关闭，是否仍需阻塞？
+- [ ] `[governance auto-split] split into #5, #6, #7` — vibe-roadmap 是否已复核拆分？
+
+若 backlog 已过时，请触发 `/vibe-roadmap` 综合消化。
+```
+
+每条未消化 suggest 对应一个 checkbox。仅当存在未消化 suggest 时才包含此 section。
+
 ```bash
 uv run python src/vibe3/cli.py handoff indicate <path>
 ```
@@ -963,6 +1008,12 @@ Steps:
     gh api repos/{owner}/{repo}/issues/comments/<comment_id> -X PATCH -f body=”<修正后的完整内容>”
     ```
   - 禁止为纠正自身输出格式问题而发新评论
+
+### Governance Marker 边界
+
+- manager **不写** `[governance suggest]` 评论（这是 governance 层[roadmap-intake/assignee-pool]的职责）
+- manager **可以**在 PR body（通过 handoff indicate）中引用 / 链接到已有的 `[governance suggest]` 评论
+- manager 在 issue comment 中讨论 governance suggest 时，使用自身 `[manager]` 前缀，不伪造 governance marker
 
 ## Handoff Contract
 


### PR DESCRIPTION
实现 Issue #1106 要求的 governance backlog awareness：

## Manager.md 变更

1. 扩展 read_context()：添加步骤 4.5 分析 governance suggest 累积状态
   - 统计所有 [governance suggest] 评论
   - 对比最新 [roadmap decision] 判断是否未消化
   - 按类型分类：needs split/auto-split（阻塞）、Recommend Close、waiting on #X、pool entry（无需提醒）

2. 扩展 handle_ready()：添加步骤 4.6 检查未消化 governance suggest
   - 针对未消化的 needs split/auto-split 类型，调用 vibe3 flow blocked
   - 明确不在此处阻塞 Recommend Close（已在步骤 2 处理）
   - 明确不在此处阻塞 waiting on #X（已在步骤 4.5 依赖检查处理）

3. 扩展 handle_merge_ready()：在 handoff indicate 中添加 Governance Backlog section
   - 包含未消化 suggest 的 checkbox 列表
   - 仅当存在未消化 suggest 时才包含此 section
   - 提示人类 reviewer 在合并前确认

4. 更新 Comment Contract：添加 Governance Marker 边界规则

## Review Skills 变更

1. vibe-review-code：添加 Step 0 启动检查
2. vibe-review-docs：添加 Step 0.5 启动检查
3. vibe-review-pr：添加 Phase 0 Step 1.5 启动检查

## 关键特性

- 三层梯度提醒：manager 内部阻塞 → PR body 人类确认 → review skill info 提醒
- 明确的分类逻辑：needs split/auto-split（阻塞）、Recommend Close（manager 处理）、waiting on #X（依赖检查）、pool entry（无需提醒）
- 明确的"不阻断"语言：所有 review skills 的检查均为 info-layer，不阻断审查流程

## Test Plan

- [ ] Verify manager correctly detects undigested governance suggests
- [ ] Verify manager blocks on needs split/auto-split types
- [ ] Verify review skills show info-layer reminders without blocking
- [ ] Verify Governance Backlog section appears in PR body when applicable

Closes #1106

---

## Contributors

claude/opus
