### PR TITLE
fix(task show): support issue-number position arg without local flow

### DIFF
--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -13,7 +13,6 @@ from vibe3.exceptions import SystemError, UserError
 from vibe3.models.orchestration import IssueState
 from vibe3.observability.logger import setup_logging
 from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
 from vibe3.services.task_resume_usecase import TaskResumeUsecase
 from vibe3.services.task_service import TaskService
 from vibe3.ui.task_ui import (
@@ -96,8 +95,9 @@ def show(
 
     try:
         # Pass branch_opt and issue separately for conflict detection
+        # allow_no_flow=True allows showing remote issue info without local flow
         target_branch = task_svc.resolve_branch(
-            branch_opt, pr_number=pr_opt, position_arg=issue
+            branch_opt, pr_number=pr_opt, position_arg=issue, allow_no_flow=True
         )
     except (UserError, SystemError) as error:
         typer.echo(f"Error: {error}", err=True)
@@ -109,19 +109,15 @@ def show(
     if trace:
         enable_method_trace()
 
-    # Resolve issue number from branch using standard resolver
-    resolved_branch = (
-        resolve_issue_branch_input(target_branch, task_svc.flow_service)
-        or target_branch
-    )
-    task_result = task_svc.show_task(resolved_branch)
+    # Pass target_branch directly to show_task (re-resolution is handled inside)
+    task_result = task_svc.show_task(target_branch)
 
     issue_number = None
     if task_result.local_task and task_result.local_task.task_issue_number:
         issue_number = task_result.local_task.task_issue_number
-    elif resolved_branch.isdigit():
+    elif target_branch.isdigit():
         # Branch resolved to numeric issue (no flow exists)
-        issue_number = int(resolved_branch)
+        issue_number = int(target_branch)
 
     render_task_show(task_result, output_format, full=full)
 

--- a/src/vibe3/services/issue_branch_resolver.py
+++ b/src/vibe3/services/issue_branch_resolver.py
@@ -15,7 +15,12 @@ def iter_issue_branch_candidates(issue_number: int) -> Iterable[str]:
     yield convention.branch.dev_branch(issue_number)
 
 
-def resolve_issue_branch_input(branch: str | None, flow_service: Any) -> str | None:
+def resolve_issue_branch_input(
+    branch: str | None,
+    flow_service: Any,
+    *,
+    allow_no_flow: bool = False,
+) -> str | None:
     """Resolve numeric issue input with conflict detection.
 
     Changes from original:
@@ -26,9 +31,12 @@ def resolve_issue_branch_input(branch: str | None, flow_service: Any) -> str | N
     Args:
         branch: User input (branch name or issue number)
         flow_service: FlowService instance
+        allow_no_flow: If True, return None instead of raising UserError
+            when no flows exist at all (Step 5). All other error paths
+            (conflict, all-aborted, unbound-candidates) still raise.
 
     Returns:
-        Resolved branch name
+        Resolved branch name, or None if allow_no_flow=True and no flows exist
 
     Raises:
         UserError: When conflicts or missing flows detected
@@ -69,6 +77,8 @@ def resolve_issue_branch_input(branch: str | None, flow_service: Any) -> str | N
         )
 
     # Step 5: No flows at all
+    if allow_no_flow:
+        return None
     raise UserError(
         f"No flow found for issue #{issue_number}. "
         f"Use '/vibe-new issue {issue_number}' to create a flow.\n"

--- a/src/vibe3/services/pr_branch_resolver.py
+++ b/src/vibe3/services/pr_branch_resolver.py
@@ -68,6 +68,7 @@ def resolve_command_branch(
     position_arg: str | None = None,
     flow_service: FlowService,
     github_client: GitHubClient | None = None,
+    allow_no_flow: bool = False,
 ) -> str:
     """Unified branch resolution for flow/handoff/task commands.
 
@@ -83,6 +84,9 @@ def resolve_command_branch(
         position_arg: Positional argument (issue/branch)
         flow_service: FlowService for issue resolution
         github_client: Optional GitHub client (for testing)
+        allow_no_flow: If True, return raw numeric string instead of raising
+            UserError when no flows exist for an issue number. Only affects
+            --branch and <position-arg> paths.
 
     Returns:
         Resolved branch name
@@ -111,7 +115,12 @@ def resolve_command_branch(
 
     # Step 2: Priority 1 - Explicit --branch
     if branch_opt is not None:
-        return resolve_issue_branch_input(branch_opt, flow_service) or branch_opt
+        return (
+            resolve_issue_branch_input(
+                branch_opt, flow_service, allow_no_flow=allow_no_flow
+            )
+            or branch_opt
+        )
 
     # Step 3: Priority 2 - --pr option
     if pr_opt is not None:
@@ -122,7 +131,12 @@ def resolve_command_branch(
 
     # Step 4: Priority 3 - Positional argument
     if position_arg is not None:
-        return resolve_issue_branch_input(position_arg, flow_service) or position_arg
+        return (
+            resolve_issue_branch_input(
+                position_arg, flow_service, allow_no_flow=allow_no_flow
+            )
+            or position_arg
+        )
 
     # Step 5: Priority 4 - Current branch (fallback)
     return flow_service.get_current_branch()

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -410,6 +410,7 @@ class TaskService:
         *,
         pr_number: int | None = None,
         position_arg: str | None = None,
+        allow_no_flow: bool = False,
     ) -> str:
         """Resolve explicit or current branch for task commands.
 
@@ -417,12 +418,17 @@ class TaskService:
             branch: --branch option value
             pr_number: PR number to resolve branch from
             position_arg: Positional argument (issue number or branch)
+            allow_no_flow: If True, return raw numeric string instead of raising
+                UserError when no flows exist for an issue number.
 
         Returns:
             Resolved branch name
         """
         return self._show_service.resolve_branch(
-            branch, pr_number=pr_number, position_arg=position_arg
+            branch,
+            pr_number=pr_number,
+            position_arg=position_arg,
+            allow_no_flow=allow_no_flow,
         )
 
     def show_task(self, branch: str | None = None) -> TaskShowResult:

--- a/src/vibe3/services/task_show_service.py
+++ b/src/vibe3/services/task_show_service.py
@@ -126,11 +126,7 @@ class TaskShowService:
             position_arg: Positional argument (issue number or branch)
             allow_no_flow: If True, return raw numeric string instead of raising
                 UserError when no flows exist for an issue number.
-
-        Returns:
-            Resolved branch name
         """
-        # Import here to avoid circular dependency
         from vibe3.services.pr_branch_resolver import resolve_command_branch
 
         return resolve_command_branch(
@@ -230,36 +226,22 @@ class TaskShowService:
     ) -> TaskRefSummary | None:
         """Select the latest ref from previous round based on state transitions.
 
-        Uses state machine logic to determine which role worked in the
-        previous round:
-        - reviewer_status == done → show audit_ref (most recent completed work)
-        - executor_status == done → show report_ref
-        - planner_status == done → show plan_ref
-        - Otherwise, fallback to most recent ref by mtime
-
-        Args:
-            branch: Branch name
-            flow: Flow status response
-
-        Returns:
-            TaskRefSummary for the previous round's work, or None if not found
+        Uses state machine logic: reviewer_status==done → audit_ref,
+        executor_status==done → report_ref, planner_status==done → plan_ref.
+        Falls back to most recent ref by mtime if no status is done.
         """
         worktree_root = flow.worktree_root
 
-        # State transition mapping: execution_status → ref_kind
-        # Check in reverse order (reviewer → executor → planner) to show
-        # the most recent completed work
+        # Check state transitions in reverse order: reviewer → executor → planner
         status_to_ref = {
             "reviewer_status": ("audit_ref", "audit"),
             "executor_status": ("report_ref", "report"),
             "planner_status": ("plan_ref", "plan"),
         }
 
-        # Check state transitions in reverse order: reviewer → executor → planner
         for status_field, (ref_field, kind) in status_to_ref.items():
             status_value = getattr(flow, status_field, None)
             if status_value == "done":
-                # This role completed in previous round
                 ref_value = getattr(flow, ref_field, None)
                 if ref_value:
                     summary = self._build_ref_summary(kind, ref_value, worktree_root)

--- a/src/vibe3/services/task_show_service.py
+++ b/src/vibe3/services/task_show_service.py
@@ -116,6 +116,7 @@ class TaskShowService:
         *,
         pr_number: int | None = None,
         position_arg: str | None = None,
+        allow_no_flow: bool = False,
     ) -> str:
         """Resolve explicit or current branch for task commands.
 
@@ -123,6 +124,8 @@ class TaskShowService:
             branch: Branch name or issue number (--branch option)
             pr_number: PR number to resolve branch from
             position_arg: Positional argument (issue number or branch)
+            allow_no_flow: If True, return raw numeric string instead of raising
+                UserError when no flows exist for an issue number.
 
         Returns:
             Resolved branch name
@@ -136,6 +139,7 @@ class TaskShowService:
             position_arg=position_arg,
             flow_service=self.flow_service,
             github_client=self.github_client,
+            allow_no_flow=allow_no_flow,
         )
 
     @staticmethod
@@ -328,7 +332,11 @@ class TaskShowService:
 
     def show_task(self, branch: str | None = None) -> TaskShowResult:
         """Load task detail from local state plus quick remote summary."""
-        target_branch = self.resolve_branch(branch)
+        # Skip re-resolution if branch is already provided (resolved by command layer)
+        if branch is None:
+            target_branch = self.resolve_branch()
+        else:
+            target_branch = branch
         local_task = self.flow_service.get_flow_status(target_branch)
 
         issue_links = self.store.get_issue_links(target_branch)

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -85,9 +85,8 @@ def render_task_show(
                         markup=False,
                     )
                 else:
-                    console.print(f"[yellow]No flow found for issue #{branch}[/]")
+                    console.print(f"Remote issue #{branch} (no local flow)")
                     console.print()
-                    console.print("[bold]Issue Info[/]")
                     if task_result.issue_title:
                         console.print(f"Title:  {task_result.issue_title}")
                     if task_result.issue_state:

--- a/tests/vibe3/commands/test_task_show.py
+++ b/tests/vibe3/commands/test_task_show.py
@@ -20,8 +20,7 @@ runner = CliRunner(env={"NO_COLOR": "1"})
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
 def test_task_show_renders_quick_summary(
-    mock_task_service_cls,
-    mock_render_task_comments,
+    mock_task_service_cls, mock_render_task_comments
 ) -> None:
     """task show should present a compact scene summary at a glance."""
     task_service = MagicMock()
@@ -46,8 +45,7 @@ def test_task_show_renders_quick_summary(
             summary="上一轮已经收敛到 reviewer 前的实现，待复核。",
         ),
         latest_human_instruction=TaskCommentSummary(
-            author="alice",
-            body="请优先确认 retry 重入后是否还能直接看懂现场。",
+            author="alice", body="请优先确认 retry 重入后是否还能直接看懂现场。"
         ),
         pr_summary=TaskPRSummary(
             number=479,
@@ -58,28 +56,23 @@ def test_task_show_renders_quick_summary(
             checks="pending",
         ),
     )
-    # Mock fetch_issue_with_comments for render_task_comments
     task_service.fetch_issue_with_comments.return_value = None
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show"])
-
     assert result.exit_code == 0
     output = result.output
     assert "Current Task" in output
     assert "Task:   #123  Task show quick summary" in output
     assert "Latest Work" in output
     assert "notes/report.md" in output
-    # Comments section removed (now shown via render_task_comments by default)
     assert "PR / CI" in output
     assert "#479" in output
     assert "pending" in output
 
 
 @patch("vibe3.commands.task.TaskService")
-def test_task_show_json_includes_summary_fields(
-    mock_task_service_cls,
-) -> None:
+def test_task_show_json_includes_summary_fields(mock_task_service_cls) -> None:
     """task show --json should expose the same summary contract."""
     task_service = MagicMock()
     task_service.resolve_branch.return_value = "task/issue-456"
@@ -93,13 +86,10 @@ def test_task_show_json_includes_summary_fields(
         ),
         issue_title="JSON summary view",
         latest_ref=TaskRefSummary(
-            kind="plan",
-            ref="plans/456.md",
-            summary="拆出 task show 快速视图字段。",
+            kind="plan", ref="plans/456.md", summary="拆出 task show 快速视图字段。"
         ),
         latest_comment=TaskCommentSummary(
-            author="reviewer-bot",
-            body="请补一个针对 task show 的回归测试。",
+            author="reviewer-bot", body="请补一个针对 task show 的回归测试。"
         ),
         pr_summary=TaskPRSummary(
             number=500,
@@ -113,7 +103,6 @@ def test_task_show_json_includes_summary_fields(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show", "--json"])
-
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["issue_title"] == "JSON summary view"
@@ -125,8 +114,7 @@ def test_task_show_json_includes_summary_fields(
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
 def test_task_show_always_renders_comments(
-    mock_task_service_cls,
-    mock_render_task_comments,
+    mock_task_service_cls, mock_render_task_comments
 ) -> None:
     """task show should always render comments (no --comments flag needed)."""
     issue_payload = {
@@ -140,7 +128,6 @@ def test_task_show_always_renders_comments(
             }
         ],
     }
-
     task_service = MagicMock()
     task_service.resolve_branch.return_value = "task/issue-123"
     task_service.show_task.return_value = TaskShowResult(
@@ -156,7 +143,6 @@ def test_task_show_always_renders_comments(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show"])
-
     assert result.exit_code == 0
     mock_render_task_comments.assert_called_once_with(issue_payload)
 
@@ -177,9 +163,7 @@ def test_task_show_format_json(mock_task_service_cls) -> None:
         issue_title="Format test",
     )
     mock_task_service_cls.return_value = task_service
-
     result = runner.invoke(app, ["task", "show", "--format", "json"])
-
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["issue_title"] == "Format test"
@@ -201,9 +185,7 @@ def test_task_show_format_yaml(mock_task_service_cls) -> None:
         issue_title="Format test",
     )
     mock_task_service_cls.return_value = task_service
-
     result = runner.invoke(app, ["task", "show", "--format", "yaml"])
-
     assert result.exit_code == 0
     assert "branch: task/issue-456" in result.output
     assert "issue_title: Format test" in result.output
@@ -225,25 +207,18 @@ def test_task_show_deprecated_json_flag(mock_task_service_cls) -> None:
         issue_title="Format test",
     )
     mock_task_service_cls.return_value = task_service
-
     result = runner.invoke(app, ["task", "show", "--json"])
-
     assert result.exit_code == 0
     assert "deprecated" in result.stderr.lower()
-    # Output should still be valid JSON
     payload = json.loads(result.stdout)
     assert payload["issue_title"] == "Format test"
 
 
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
-def test_task_show_full_flag(
-    mock_task_service_cls,
-    mock_render_task_comments,
-) -> None:
+def test_task_show_full_flag(mock_task_service_cls, mock_render_task_comments) -> None:
     """task show --full should show complete summary without truncation."""
     long_summary = "\n".join([f"Line {i}" for i in range(10)])
-
     task_service = MagicMock()
     task_service.resolve_branch.return_value = "task/issue-123"
     task_service.show_task.return_value = TaskShowResult(
@@ -255,22 +230,18 @@ def test_task_show_full_flag(
             task_issue_number=123,
         ),
         latest_ref=TaskRefSummary(
-            kind="report",
-            ref="notes/report.md",
-            summary=long_summary,
+            kind="report", ref="notes/report.md", summary=long_summary
         ),
     )
     task_service.fetch_issue_with_comments.return_value = None
     mock_task_service_cls.return_value = task_service
 
-    # Test without --full (should truncate)
     result = runner.invoke(app, ["task", "show"])
     assert result.exit_code == 0
     assert "Line 0" in result.output
     assert "Line 2" in result.output
     assert "Line 3" not in result.output  # Should be truncated
 
-    # Test with --full (should show all lines)
     result_full = runner.invoke(app, ["task", "show", "--full"])
     assert result_full.exit_code == 0
     for i in range(10):
@@ -280,8 +251,7 @@ def test_task_show_full_flag(
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
 def test_task_show_renders_multiple_tasks(
-    mock_task_service_cls,
-    mock_render_task_comments,
+    mock_task_service_cls, mock_render_task_comments
 ) -> None:
     """task show should display multiple task issues with primary label."""
     task_service = MagicMock()
@@ -302,22 +272,16 @@ def test_task_show_renders_multiple_tasks(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show"])
-
     assert result.exit_code == 0
     output = result.output
-    # Should show "Task Issue(s):" header for multiple tasks
     assert "Task Issue(s):" in output
-    # Should show primary task with label and title
     assert "#123  (primary)  Primary task title" in output
-    # Should show additional tasks
     assert "#456" in output
     assert "#789" in output
 
 
 @patch("vibe3.commands.task.TaskService")
-def test_task_show_json_includes_task_issue_numbers(
-    mock_task_service_cls,
-) -> None:
+def test_task_show_json_includes_task_issue_numbers(mock_task_service_cls) -> None:
     """task show --json should include task_issue_numbers array."""
     task_service = MagicMock()
     task_service.resolve_branch.return_value = "task/issue-123"
@@ -333,12 +297,9 @@ def test_task_show_json_includes_task_issue_numbers(
         issue_title="Multi-task JSON test",
     )
     mock_task_service_cls.return_value = task_service
-
     result = runner.invoke(app, ["task", "show", "--json"])
-
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    # Should include task_issue_numbers array
     assert payload["task_issue_numbers"] == [123, 456]
 
 
@@ -348,15 +309,11 @@ def test_task_show_json_includes_task_issue_numbers(
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
 def test_task_show_issue_no_flow_renders_issue_info(
-    mock_task_service_cls,
-    mock_render_task_comments,
+    mock_task_service_cls, mock_render_task_comments
 ) -> None:
     """task show <issue> with no local flow should render remote issue info."""
     task_service = MagicMock()
-    # resolve_branch returns raw numeric string when allow_no_flow=True
-    # and no flow exists
     task_service.resolve_branch.return_value = "999"
-    # show_task returns result with remote issue info but no local_task
     task_service.show_task.return_value = TaskShowResult(
         branch="999",
         local_task=None,
@@ -367,26 +324,21 @@ def test_task_show_issue_no_flow_renders_issue_info(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show", "999"])
-
     assert result.exit_code == 0
     output = result.output
-    # Should show neutral informational line (not yellow warning)
     assert "Remote issue #999 (no local flow)" in output
     assert "Title:  Remote issue without local flow" in output
     assert "State:  open" in output
-    # Should NOT show yellow warning about "No flow found"
     assert "[yellow]" not in output
 
 
 @patch("vibe3.commands.task.render_task_comments")
 @patch("vibe3.commands.task.TaskService")
 def test_task_show_issue_with_flow_resolves_to_branch(
-    mock_task_service_cls,
-    mock_render_task_comments,
+    mock_task_service_cls, mock_render_task_comments
 ) -> None:
     """task show <issue> with existing active flow should show normal task view."""
     task_service = MagicMock()
-    # resolve_branch returns resolved branch name
     task_service.resolve_branch.return_value = "task/issue-999"
     task_service.show_task.return_value = TaskShowResult(
         branch="task/issue-999",
@@ -403,25 +355,19 @@ def test_task_show_issue_with_flow_resolves_to_branch(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show", "999"])
-
     assert result.exit_code == 0
     output = result.output
-    # Should show normal task view (Current Task header)
     assert "Current Task" in output
     assert "Branch: task/issue-999" in output
-    # Should NOT show "Remote issue" message
     assert "Remote issue" not in output
 
 
 @patch("vibe3.commands.task.TaskService")
-def test_task_show_issue_all_aborted_raises_error(
-    mock_task_service_cls,
-) -> None:
+def test_task_show_issue_all_aborted_raises_error(mock_task_service_cls) -> None:
     """task show <issue> with only aborted flows should exit with error."""
     task_service = MagicMock()
     from vibe3.exceptions import UserError
 
-    # resolve_branch raises UserError for all-aborted case
     task_service.resolve_branch.side_effect = UserError(
         "All flows for issue #999 are aborted:\n"
         "  - task/issue-999 (status: aborted, pr: none)\n\n"
@@ -430,8 +376,6 @@ def test_task_show_issue_all_aborted_raises_error(
     mock_task_service_cls.return_value = task_service
 
     result = runner.invoke(app, ["task", "show", "999"])
-
-    # Should exit with error
     assert result.exit_code == 1
     output = result.output
     assert "Error:" in output

--- a/tests/vibe3/commands/test_task_show.py
+++ b/tests/vibe3/commands/test_task_show.py
@@ -340,3 +340,99 @@ def test_task_show_json_includes_task_issue_numbers(
     payload = json.loads(result.stdout)
     # Should include task_issue_numbers array
     assert payload["task_issue_numbers"] == [123, 456]
+
+
+# Tests for issue number without local flow
+
+
+@patch("vibe3.commands.task.render_task_comments")
+@patch("vibe3.commands.task.TaskService")
+def test_task_show_issue_no_flow_renders_issue_info(
+    mock_task_service_cls,
+    mock_render_task_comments,
+) -> None:
+    """task show <issue> with no local flow should render remote issue info."""
+    task_service = MagicMock()
+    # resolve_branch returns raw numeric string when allow_no_flow=True
+    # and no flow exists
+    task_service.resolve_branch.return_value = "999"
+    # show_task returns result with remote issue info but no local_task
+    task_service.show_task.return_value = TaskShowResult(
+        branch="999",
+        local_task=None,
+        issue_title="Remote issue without local flow",
+        issue_state="OPEN",
+    )
+    task_service.fetch_issue_with_comments.return_value = None
+    mock_task_service_cls.return_value = task_service
+
+    result = runner.invoke(app, ["task", "show", "999"])
+
+    assert result.exit_code == 0
+    output = result.output
+    # Should show neutral informational line (not yellow warning)
+    assert "Remote issue #999 (no local flow)" in output
+    assert "Title:  Remote issue without local flow" in output
+    assert "State:  open" in output
+    # Should NOT show yellow warning about "No flow found"
+    assert "[yellow]" not in output
+
+
+@patch("vibe3.commands.task.render_task_comments")
+@patch("vibe3.commands.task.TaskService")
+def test_task_show_issue_with_flow_resolves_to_branch(
+    mock_task_service_cls,
+    mock_render_task_comments,
+) -> None:
+    """task show <issue> with existing active flow should show normal task view."""
+    task_service = MagicMock()
+    # resolve_branch returns resolved branch name
+    task_service.resolve_branch.return_value = "task/issue-999"
+    task_service.show_task.return_value = TaskShowResult(
+        branch="task/issue-999",
+        local_task=FlowStatusResponse(
+            branch="task/issue-999",
+            flow_slug="issue-999",
+            flow_status="active",
+            task_issue_number=999,
+        ),
+        issue_title="Issue with active flow",
+        issue_state="OPEN",
+    )
+    task_service.fetch_issue_with_comments.return_value = None
+    mock_task_service_cls.return_value = task_service
+
+    result = runner.invoke(app, ["task", "show", "999"])
+
+    assert result.exit_code == 0
+    output = result.output
+    # Should show normal task view (Current Task header)
+    assert "Current Task" in output
+    assert "Branch: task/issue-999" in output
+    # Should NOT show "Remote issue" message
+    assert "Remote issue" not in output
+
+
+@patch("vibe3.commands.task.TaskService")
+def test_task_show_issue_all_aborted_raises_error(
+    mock_task_service_cls,
+) -> None:
+    """task show <issue> with only aborted flows should exit with error."""
+    task_service = MagicMock()
+    from vibe3.exceptions import UserError
+
+    # resolve_branch raises UserError for all-aborted case
+    task_service.resolve_branch.side_effect = UserError(
+        "All flows for issue #999 are aborted:\n"
+        "  - task/issue-999 (status: aborted, pr: none)\n\n"
+        "Use 'vibe3 flow restore <branch>' to reactivate a flow."
+    )
+    mock_task_service_cls.return_value = task_service
+
+    result = runner.invoke(app, ["task", "show", "999"])
+
+    # Should exit with error
+    assert result.exit_code == 1
+    output = result.output
+    assert "Error:" in output
+    assert "All flows for issue #999 are aborted" in output

--- a/tests/vibe3/services/test_pr_branch_resolver.py
+++ b/tests/vibe3/services/test_pr_branch_resolver.py
@@ -82,7 +82,9 @@ class TestResolveCommandBranch:
             )
 
             # 应该调用 resolve_issue_branch_input
-            mock_resolve.assert_called_once_with("dev/issue-476", mock_flow_service)
+            mock_resolve.assert_called_once_with(
+                "dev/issue-476", mock_flow_service, allow_no_flow=False
+            )
             # 返回解析后的分支
             assert result == "dev/issue-476"
 
@@ -119,7 +121,9 @@ class TestResolveCommandBranch:
                 flow_service=mock_flow_service,
             )
 
-            mock_resolve.assert_called_once_with("999", mock_flow_service)
+            mock_resolve.assert_called_once_with(
+                "999", mock_flow_service, allow_no_flow=False
+            )
             assert result == "task/issue-999"
 
     def test_fallback_current_branch(self):

--- a/tests/vibe3/utils/test_issue_branch_resolver.py
+++ b/tests/vibe3/utils/test_issue_branch_resolver.py
@@ -182,3 +182,95 @@ def test_format_flow_details_without_pr():
     result = _format_flow_details(flow)
 
     assert result == "task/issue-976 (status: aborted, pr: none)"
+
+
+# Tests for allow_no_flow parameter
+
+
+def test_allow_no_flow_returns_none_when_no_flows(
+    mock_flow_service: Mock, mock_store: Mock
+):
+    """Test allow_no_flow=True returns None when no flows exist at all."""
+    # Arrange: No flows anywhere
+    mock_store.get_flows_by_issue.return_value = []
+    mock_store.get_flow_state.return_value = None
+
+    # Act: With allow_no_flow=True, should return None instead of raising
+    result = resolve_issue_branch_input("976", mock_flow_service, allow_no_flow=True)
+
+    # Assert: Returns None (no flow, but no error)
+    assert result is None
+
+
+def test_allow_no_flow_still_raises_all_aborted(
+    mock_flow_service: Mock, mock_store: Mock
+):
+    """Test allow_no_flow=True still raises UserError when all flows are aborted."""
+    # Arrange: All flows aborted
+    mock_store.get_flows_by_issue.return_value = [
+        {
+            "branch": "task/issue-976",
+            "flow_status": "aborted",
+            "pr_ref": None,
+        },
+        {
+            "branch": "dev/issue-976",
+            "flow_status": "aborted",
+            "pr_ref": None,
+        },
+    ]
+
+    # Act & Assert: Should still raise UserError with restore hint
+    with pytest.raises(UserError) as exc_info:
+        resolve_issue_branch_input("976", mock_flow_service, allow_no_flow=True)
+
+    error_message = str(exc_info.value)
+    assert "All flows for issue" in error_message
+    assert "aborted" in error_message
+    assert "vibe3 flow restore" in error_message
+
+
+def test_allow_no_flow_still_raises_conflict(mock_flow_service: Mock, mock_store: Mock):
+    """Test allow_no_flow=True still raises UserError for multiple active flows."""
+    # Arrange: Multiple active flows
+    mock_store.get_flows_by_issue.return_value = [
+        {
+            "branch": "dev/issue-976",
+            "flow_status": "active",
+            "pr_ref": "https://github.com/jacobcy/vibe-center/pull/990",
+        },
+        {
+            "branch": "task/issue-976",
+            "flow_status": "active",
+            "pr_ref": None,
+        },
+    ]
+
+    # Act & Assert: Should still raise UserError with conflict hint
+    with pytest.raises(UserError) as exc_info:
+        resolve_issue_branch_input("976", mock_flow_service, allow_no_flow=True)
+
+    error_message = str(exc_info.value)
+    assert "Multiple active flows detected" in error_message
+    assert "vibe3 flow abort" in error_message
+
+
+def test_allow_no_flow_still_raises_unbound_candidates(
+    mock_flow_service: Mock, mock_store: Mock
+):
+    """Test allow_no_flow=True still raises UserError when unbound candidates exist."""
+    # Arrange: No flows by issue, but unbound candidate exists
+    mock_store.get_flows_by_issue.return_value = []
+    mock_store.get_flow_state.return_value = {
+        "branch": "dev/issue-976",
+        "flow_status": "active",
+        "pr_ref": None,
+    }
+
+    # Act & Assert: Should still raise UserError with bind hint
+    with pytest.raises(UserError) as exc_info:
+        resolve_issue_branch_input("976", mock_flow_service, allow_no_flow=True)
+
+    error_message = str(exc_info.value)
+    assert "without task binding" in error_message
+    assert "vibe3 flow bind" in error_message


### PR DESCRIPTION
Closes #1429

## Summary

- Add `allow_no_flow` parameter throughout branch resolution chain
- Enable `vibe3 task show <issue_number>` to display remote issue info when no local flow exists
- Preserve backward compatibility for all existing callers

## Changes

- `src/vibe3/services/issue_branch_resolver.py`: Add `allow_no_flow` parameter with proper error handling
- `src/vibe3/commands/task.py`: Thread parameter through command layer
- Related service layer updates for parameter propagation

## Test plan

- [x] 24 tests pass in affected files
- [x] All pre-commit checks pass (black, ruff, mypy)
- [x] Pre-push checks pass (82 tests, type check, LOC check)
- [x] Backward compatibility verified (20+13 callers analyzed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
