### PR TITLE
fix(pr show): keep positional argument as PR number only

### DIFF
--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -98,13 +98,21 @@ def _resolve_pr_target(
     Returns:
         PrQueryTarget with resolved PR number and branch
     """
-    # Priority 1: Explicit PR number or branch (resolve branch if needed)
-    if pr_number or branch:
+    # Short-circuit: explicit PR number bypasses all issue/branch resolution
+    if pr_number is not None:
+        return PrQueryTarget(
+            pr_number=pr_number,
+            branch=branch,
+            current_branch=None,
+            from_flow=False,
+        )
+
+    # Priority 1: Explicit branch (resolve if needed)
+    if branch:
         # Resolve branch if it looks like an issue number
-        resolved_branch = branch
-        if branch:
-            flow_service = FlowService(store=pr_svc.store)
-            resolved_branch = resolve_issue_branch_input(branch, flow_service)
+        resolved_branch: str | None = branch
+        flow_service = FlowService(store=pr_svc.store)
+        resolved_branch = resolve_issue_branch_input(branch, flow_service)
 
         # Short-circuit: if resolve returned the original numeric input unchanged,
         # no real branch was found — skip the misleading API call

--- a/tests/vibe3/commands/test_pr_query.py
+++ b/tests/vibe3/commands/test_pr_query.py
@@ -91,12 +91,35 @@ def test_resolve_pr_target_no_pr_for_branch():
 
 
 def test_resolve_pr_target_explicit_pr_number_priority():
-    """Test that explicit pr_number takes priority over branch."""
+    """Test that explicit pr_number takes priority and bypasses all resolution."""
     pr_svc = Mock()
 
-    target = _resolve_pr_target(pr_svc, pr_number=985, branch="dev/issue-946")
+    # Mock FlowService to ensure it's NOT called
+    with patch("vibe3.commands.pr_query.FlowService") as mock_fs:
+        target = _resolve_pr_target(pr_svc, pr_number=985, branch="dev/issue-946")
 
     # Should return both without inference
     assert target.pr_number == 985
     assert target.branch == "dev/issue-946"
     assert target.from_flow is False
+
+    # Must NOT construct FlowService or call resolve_issue_branch_input
+    mock_fs.assert_not_called()
+    pr_svc.store.get_flows_by_issue.assert_not_called()
+
+
+def test_resolve_pr_target_pr_number_only_no_flow():
+    """Positional pr_number must not invoke FlowService or issue resolution."""
+    pr_svc = Mock()
+
+    with patch("vibe3.commands.pr_query.FlowService") as mock_fs:
+        target = _resolve_pr_target(pr_svc, pr_number=1422, branch=None)
+
+    # Must return the pr_number directly
+    assert target.pr_number == 1422
+    assert target.branch is None
+    assert target.from_flow is False
+
+    # Must NOT construct FlowService or call resolve_issue_branch_input
+    mock_fs.assert_not_called()
+    pr_svc.store.get_flows_by_issue.assert_not_called()


### PR DESCRIPTION
## Summary
- Enforce clean contract: positional argument to `pr show` is a PR number only
- Add early return in `_resolve_pr_target()` to bypass all issue/branch resolution when PR number is provided
- Prevent ambiguity between PR numbers and issue numbers in command interface

## Changes
- Modified `src/vibe3/commands/pr_query.py` to add early return check
- When `pr_number` is provided positionally, immediately return `PrQueryTarget` without calling `resolve_issue_branch_input()`
- This ensures `vibe3 pr show 1414` always treats `1414` as PR #1414, not issue #1414

## Test Coverage
- All existing tests pass (5 tests in test_pr_query.py)
- Type check clean (mypy)
- No regression risk: minimal change (+8 LOC)

## Verification
- Tests: `pytest tests/vibe3/commands/test_pr_query.py` - all pass
- Type check: `mypy src/vibe3` - clean
- Pre-push checks: all passed

Closes #1430

---

## Contributors

claude/opus
