### PR TITLE
docs(prompts): align scope split governance

### DIFF
--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -573,6 +573,9 @@ plan:
     Before starting, read the current task context:
     `uv run python src/vibe3/cli.py task show` — shows branch, flow, issue number, latest ref, and next step.
     Use `--comments` flag to load the latest human instruction in full.
+    Scope split decisions are owned by roadmap decider / manager before this planning handoff.
+    Do not split the issue into sub-issues during planning.
+    If the current issue scope cannot be planned as-is, write a blocker comment and stop instead of changing scope.
 
     ### Pre-Planning Sync Check
     **For architectural refactors** (labels: component/*, type/refactor; or title contains "refactor"/"重构"):

--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -575,7 +575,9 @@ plan:
     Use `--comments` flag to load the latest human instruction in full.
     Scope split decisions are owned by roadmap decider / manager before this planning handoff.
     Do not split the issue into sub-issues during planning.
-    If the current issue scope cannot be planned as-is, write a blocker comment and stop instead of changing scope.
+    If the current issue scope cannot be planned as-is, write a blocker comment, then run:
+    `uv run python src/vibe3/cli.py flow blocked --reason "Planner cannot produce plan as-is after state/claimed; scope or split shape needs manager/human decision."`
+    This moves `state/claimed` to `state/blocked` through the unified blocked writer. Then stop instead of changing scope.
 
     ### Pre-Planning Sync Check
     **For architectural refactors** (labels: component/*, type/refactor; or title contains "refactor"/"重构"):
@@ -620,7 +622,7 @@ plan:
     1. **Understand your current position and task** — Run `task show` and `handoff status` first
     2. **If you cannot clearly answer "where am I" and "what should I do"** — Block immediately
        - Write blocker explaining confusion: `uv run python src/vibe3/cli.py handoff append "任务理解困难：<具体困惑点>" --kind blocker --actor "<actor>"`
-       - Set to blocked: `gh issue edit <ISSUE_NUMBER> --add-label "state/blocked" --remove-label "state/claimed"`
+       - Set to blocked with reason: `uv run python src/vibe3/cli.py flow blocked --reason "Planner retry cannot determine current task: <具体困惑点>"`
        - Comment explaining situation: `gh issue comment <ISSUE_NUMBER> --body "[plan] 无法理解当前任务：\n\n<具体困惑点>\n\n需要人类澄清后才能继续。"`
        - **Then stop working and exit** — do not attempt any planning
     3. **If you can determine your task** — Read manager instructions in handoff

--- a/docs/standards/github-labels-reference.md
+++ b/docs/standards/github-labels-reference.md
@@ -95,8 +95,8 @@
 | `roadmap/p2` | 有容量时完成 | `gh issue edit 123 --add-label "roadmap/p2"` |
 | `roadmap/next` | 下个迭代规划中 | `gh issue edit 123 --add-label "roadmap/next"` |
 | `roadmap/future` | 未来考虑 | `gh issue edit 123 --add-label "roadmap/future"` |
-| `roadmap/rfc` | RFC/设计阶段 | `gh issue edit 123 --add-label "roadmap/rfc"` |
-| `roadmap/epic` | Epic 主 issue（有 Sub-issues） | `gh issue edit 123 --add-label "roadmap/epic"` |
+| `roadmap/rfc` | RFC/设计阶段（agent 无法判断目标/拆分形态） | `gh issue edit 123 --add-label "roadmap/rfc"` |
+| `roadmap/epic` | Epic 主 issue（有 Sub-issues，主 issue 作为治理容器） | `gh issue edit 123 --add-label "roadmap/epic"` |
 
 ### 2.4 关系镜像标签
 
@@ -222,8 +222,8 @@ gh issue list --milestone "Phase 1: 基础设施"
 | 高优先级功能开发 | `type/feature` + `priority/9` + `roadmap/p0` |
 | 中优先级 bug 修复 | `type/fix` + `priority/5` + `roadmap/p1` |
 | 低优先级文档更新 | `type/docs` + `priority/3` + `roadmap/p2` |
-| 需要讨论的设计 | `type/feature` + `roadmap/rfc` |
-| Epic 主 issue | `roadmap/epic` + `type/feature`（引导用户选择 sub-issue 进入） |
+| agent 无法判断目标/拆分形态 | `type/feature` + `roadmap/rfc` |
+| Epic 主 issue | `roadmap/epic` + `type/feature`（主 issue 保持治理容器，执行进入 sub-issue） |
 | 性能优化 | `type/perf` + `priority/7` + `roadmap/p0` |
 | 技术债务清理 | `tech-debt` + `priority/5` + `roadmap/p1` |
 | 编排系统改进 | `component/orchestra` + `type/feature` + `roadmap/p1` |

--- a/docs/standards/roadmap-label-management.md
+++ b/docs/standards/roadmap-label-management.md
@@ -341,15 +341,15 @@ uv run python src/vibe3/cli.py flow bind <issue_number>
 | `roadmap/p2` | 有容量时完成 | 一般功能、改进项 |
 | `roadmap/next` | 下个迭代规划中 | 待确认的功能 |
 | `roadmap/future` | 未来考虑 | 长期规划、想法阶段 |
-| `roadmap/rfc` | RFC/设计阶段 | 需要讨论设计的功能 |
-| `roadmap/epic` | Epic 主 issue | 有 Sub-issues 的主 issue，需引导选择 sub-issue 进入 |
+| `roadmap/rfc` | RFC/设计阶段 | agent 无法判断目标、架构方向或拆分形态，需要人类输入 |
+| `roadmap/epic` | Epic 主 issue | 有 Sub-issues 的主 issue，作为治理容器保留 |
 
 ### 4.3 标签组合原则
 
 - 一个 issue 应该同时有 `type/*` 和 `priority/*` 标签
 - `roadmap/p0` 通常配合 `priority/high` 使用
 - `roadmap/rfc` 可以没有 `priority/*` 标签
-- `roadmap/epic` 表示主 issue 有 Sub-issues，不应直接进入执行，需引导用户选择具体 sub-issue
+- `roadmap/epic` 表示主 issue 有 Sub-issues；主 issue 作为治理容器，具体执行通常进入 sub-issue
 - `roadmap/epic` 与 `roadmap/rfc` 语义不同：epic 是结构维度（主/子），rfc 是讨论维度（设计阶段）
 - 一个 issue 可以同时是 `roadmap/epic` 和 `roadmap/rfc`（需要设计讨论的 epic）
 - flow 绑定的 issue 会自动镜像 `vibe-task` 标签；执行状态以 flow 状态为准
@@ -447,22 +447,21 @@ uv run python src/vibe3/cli.py flow show --branch <branch>
 gh issue view <issue-number> --json labels,body
 ```
 
-**阻断条件**：
+**分流条件**：
 - 如果 issue 有 `roadmap/epic` 标签且 body 包含 `## Sub-issues` section：
-  - **禁止直接进入规划流程**
-  - 告知用户："该 issue 是 Epic 主 issue，请选择具体 sub-issue 进入"
+  - 将主 issue 视为治理容器
   - 列出 Sub-issues 列表供选择
-  - 停止 — 不继续规划
+  - 优先规划未完成 sub-issues；如果所有 sub-issues 已完成，则处理主 issue 收口
 
 **引导逻辑**：
 - 如果用户尝试对 Epic 主 issue 进行规划：
   - 检查是否所有 Sub-issues 已完成
   - 若全部完成，允许关闭主 issue
-  - 若未完成，引导用户选择未完成的 sub-issue
+  - 若未完成，引导用户选择未完成的 sub-issue 或补齐拆分
 
 **特殊情况**：
 - Epic + RFC：issue 既是 Epic 主 issue 又需要设计讨论
-  - 先完成设计讨论（`roadmap/rfc`）
+  - 先完成无法由 agent 判断的设计讨论（`roadmap/rfc`）
   - 设计确定后再处理 Sub-issues
 
 **语义分离原则**：

--- a/skills/vibe-issue/SKILL.md
+++ b/skills/vibe-issue/SKILL.md
@@ -28,7 +28,7 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 - **进入执行现场属于后续阶段**：创建完成后，若要做版本规划转给 `vibe-roadmap`；若用户已明确要人工开工，则转给 `vibe-new`。
 - **范围先定义**：若采用主 issue / sub-issue 结构，必须先写清主 issue 的治理母题与范围边界。
 - **依赖必须显式**：草稿中出现的依赖引用必须解析并标准化到 `## Dependencies` section。
-- **Scope 必须自检**：命中 epic 信号的 issue 必须触发拆分询问或写入 `## Scope estimate`。
+- **Scope 必须自检**：命中 epic 信号的 issue 必须触发拆分判断；能拆则建立主/子结构，不拆则写入 `## Scope estimate` 供 roadmap decider / manager 继续判断。
 
 ## 使用逻辑
 
@@ -93,14 +93,14 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 - body 列出 >3 个独立子任务（编号列表或 checkbox 列表项 >3）
 
 **命中后的行为**：
-1. 明确询问用户：「这个 issue 看起来 scope 较大，建议拆为主 issue + sub-issues 结构。是否要建主/子结构？」
-2. 若用户确认拆分：
+1. 明确提示用户：「这个 issue 看起来 scope 较大，建议拆为主 issue + sub-issues 结构；拆分不会改变主 issue，只是把独立执行环节显式化。」
+2. 若用户确认拆分，或用户授权 agent 直接处理 scope：
    - 当前 issue 作为主 issue，建议添加 `roadmap/epic` 标签
    - body 写入 `## Sub-issues` section（留空模板，格式见下方「标准 Section」）
    - 引导用户单独触发 `/vibe-issue` 创建每个 sub-issue
-3. 若用户坚持单 issue：
+3. 若用户坚持单 issue，或拆分边界暂时无法判断：
    - body 写入 `## Scope estimate` section，记录范围预估（文件数/模块数/预期工作量）
-   - 便于 roadmap-intake 后续判断
+   - 便于 roadmap decider / manager 后续决定继续单 issue、拆分，或标记 `roadmap/rfc`
 
 #### 现有主/子结构判断
 
@@ -146,8 +146,8 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 记录主 issue 下的子任务清单。
 
 - **格式**: 一行一条 `- [ ] #<id> — <子任务短描述>`（checkbox 格式）
-- **写入者**: 用户确认拆分后，`vibe-issue` 写入空模板；sub-issue 创建后回填
-- **消费者**: manager 读取子任务完成进度，roadmap-intake 判断主 issue scope
+- **写入者**: 用户确认拆分、roadmap decider 决定拆分，或 manager 在执行规划中决定拆分后维护；sub-issue 创建后回填
+- **消费者**: manager 读取子任务完成进度，roadmap-intake / vibe-roadmap 判断主 issue scope
 - **示例**:
   ```markdown
   ## Sub-issues
@@ -160,8 +160,8 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 记录 scope 自检结果（仅单 issue 模式写入）。
 
 - **格式**: 自由文本，建议包含预估文件数/模块数/工作量级别
-- **写入者**: 用户拒绝拆分但 issue 命中 epic 信号时，`vibe-issue` 引导用户填写
-- **消费者**: roadmap-intake 用于判断是否应在 intake 阶段拦截过大 scope
+- **写入者**: issue 继续保持单 issue 或暂时无法判断拆分形态时，`vibe-issue` 引导用户填写
+- **消费者**: roadmap-intake / vibe-roadmap / manager 用于判断继续单 issue、拆分，或标记 `roadmap/rfc`
 - **示例**:
   ```markdown
   ## Scope estimate

--- a/skills/vibe-new/SKILL.md
+++ b/skills/vibe-new/SKILL.md
@@ -51,7 +51,7 @@ git log main..origin/main --oneline | wc -l
 
 **原因**：避免 Issue #1250 类型的问题——长时间重构期间 main 已演进，新分支从一开始就落后会导致后续严重冲突。
 
-## 3. Epic 入口阻断检查
+## 3. Epic 入口分流检查
 
 在确认目标 issue 后，检查是否为 Epic 主 issue：
 
@@ -62,10 +62,10 @@ gh issue view <issue-number> --json labels,body
 检查逻辑：
 - 如果 issue 有 `roadmap/epic` 标签 **且** body 包含 `## Sub-issues` 或 `## 子任务` section：
   - 打印 Sub-issues 列表（从 body 的 `## Sub-issues` section 解析）
-  - 告知用户："该 issue 是 Epic 主 issue，请选择具体 sub-issue 进入 /vibe-new"
-  - 停止 — 不继续 bootstrap
+  - 告知用户："该 issue 是 Epic 主 issue；主 issue 保持为治理容器，请选择具体 sub-issue 进入 /vibe-new，或先补齐拆分。"
+  - 停止 — 不继续 bootstrap 主 issue
 - 如果只有 `roadmap/epic` 标签但无 `## Sub-issues` section：
-  - 提示用户："该 issue 标记为 Epic 但缺少 ## Sub-issues section，请先补齐 Sub-issues 或移除标签"
+  - 提示用户："该 issue 标记为 Epic 但缺少 ## Sub-issues section，请先由 roadmap decider/manager 补齐拆分，或移除标签后按单 issue 继续"
   - 停止 — 不继续 bootstrap
 - 否则继续正常流程
 

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -61,7 +61,7 @@ intake gate 约束：
 - 远端写操作优先通过 `gh` / GitHub 原生命令完成
 - 只有涉及本地 flow 绑定时才使用 `vibe3 flow bind`
 - 调度器无法判断优先级时，必须要求人类讨论
-- 若涉及主 issue / sub-issue，只承接 skill/workflow 已做出的范围判断，不在 shell 层发明 parent/sub-issue 运行时逻辑
+- 若涉及主 issue / sub-issue，vibe-roadmap 可以作为 decider 决定拆分或不拆分；只有无法判断拆分形态时才标记 `roadmap/rfc`
 - 所有 roadmap 管理通过 GitHub issue labels 触发，不在本地实现数据存储
 - 不负责根据当前 active / ready / blocked 现场判断”现在下一个该做谁”；这是 `vibe-orchestra` 的职责
 
@@ -100,7 +100,7 @@ print(usernames[0] if usernames else 'vibe-manager-agent')
 - `task <-> flow` 映射核对与修复：交给 `vibe-task`
 - `task <-> flow` / worktree runtime 修复：交给 `vibe-check`
 - 基于当前运行现场寻找下一个值得处理的 issue：交给 `vibe-orchestra`
-- parent issue / sub-issue 的范围判断：交给 `vibe-issue` 等 skill/workflow；`vibe-roadmap` 只消费判断结果
+- parent issue / sub-issue 的范围判断：`vibe-issue` 可在 intake 时创建结构，`vibe-roadmap` 可在规划时决定拆分或继续单 issue
 
 ## Intake Gate 机制
 
@@ -124,20 +124,19 @@ print(usernames[0] if usernames else 'vibe-manager-agent')
 
 ### 决策逻辑（决策矩阵）
 
-vibe-roadmap 作为 decider，对 governance observer 层的输出执行**强制决策**，不再只写建议：
+vibe-roadmap 作为 decider，对 governance observer 层的输出执行**强制决策**，不再只写建议。scope 过大时优先自己判断是否拆分；拆分不会改变主 issue 的治理真源，只是把独立执行环节显式化。
 
 | governance observer 输出 | vibe-roadmap decision | 执行动作 |
 |---|---|---|
-| `[governance suggest] needs split` | `[roadmap decision] split` | 调用 `/vibe-issue` 拆分 → 写 decision comment |
+| `[governance suggest] needs split` | `[roadmap decision] split` 或 `[roadmap decision] continue` | 能拆就拆；判断单 issue 足够清晰则继续规划 |
 | `[governance suggest] Recommend Close` | `[roadmap decision] close` | 写 comment 说明关闭理由；建议人类关闭（不自动关闭） |
-| `[governance suggest] Skipped (needs human)` | `[roadmap decision] deferred` | 进入用户对话；用户决策后写 decision comment |
-| `[governance auto-split]` (来自 #1100) | `[roadmap decision] confirm split` 或 `[roadmap decision] revert split` | 复核拆分结果；合理则确认，不合理则回滚 |
+| `[governance suggest] Skipped (needs human)` | `[roadmap decision] rfc` 或 `[roadmap decision] continue` | 只有无法判断目标或拆分形态时标记 `roadmap/rfc`；能判断则继续 |
 | `[governance suggest] waiting on #X` | `[roadmap decision] hold until #X` 或调整 milestone | 校验依赖图无循环 → 写 decision |
 
 **决策原则**：
 - 每个 suggest 必须产生一个对应的 decision
 - decision 优先于 suggest（decider 覆盖 observer）
-- 无法自动决策时（如 `needs human`），标记为 `[roadmap decision] deferred` 并说明等待人类输入
+- 无法判断 scope、目标或拆分形态时，标记为 `[roadmap decision] rfc` 并添加 `roadmap/rfc`
 
 ## Assignee 自动分配
 
@@ -171,10 +170,10 @@ Manager assignee 配置位于：
 
 ### 人机协作路径
 
-**要求人类讨论**（审查不通过）：
-- 未通过三级审查 → 写 comment 说明原因
+**要求人类讨论**（decider 无法判断）：
+- 目标、架构方向或拆分形态无法由 roadmap decider 判断 → 写 comment 说明原因
 - 不分配 assignee
-- 标记为 `roadmap/rfc` 或 `roadmap/next`
+- 标记为 `roadmap/rfc`
 
 **建议关闭**（Level 2/3 不通过）：
 - 写 comment 说明关闭原因
@@ -191,8 +190,8 @@ Manager assignee 配置位于：
 
 **Human-Machine Collaboration Path（人机协作路径）**：
 - Roadmap skill + human decision gate
-- 三级审查不通过 → 要求人类讨论 → 人类决定后继续
-- 需要人类确认
+- 只有 decider 无法判断目标或拆分形态时才进入 `roadmap/rfc`
+- 人类明确方向后再回到 roadmap / manager 自动路径
 
 ### 决策逻辑
 
@@ -201,10 +200,10 @@ Manager assignee 配置位于：
 - small feature：方案明确 + 范围小
 - refactor：范围明确 + 边界清晰
 
-**要求人类讨论**（Level 1 不通过）：
+**要求人类讨论**（decider 无法判断）：
 - issue 目标不明确
 - 需要架构/产品方向决策
-- 范围过大需拆分
+- 范围过大且 decider 无法判断如何拆分
 
 **建议关闭**（Level 2/3 不通过）：
 - 依赖已移除
@@ -229,9 +228,10 @@ vibe-roadmap 作为治理-决策双轨中的**决策者**，使用独立的 `[ro
 合规示例：
 ```
 [roadmap decision] split epic into #42, #43, #44; reason: scope exceeds single-iteration threshold.
+[roadmap decision] continue #78; reason: bounded enough for manager to plan inside one issue.
 [roadmap decision] close #99; reason: dependency removed in #123, API deprecated.
 [roadmap decision] hold #55 until #56 completes; reason: dependency graph constraint.
-[roadmap decision] confirm auto-split from #110; sub-issues #111, #112 validated.
+[roadmap decision] rfc #77; reason: cannot determine split shape without architecture input.
 ```
 
 ## 基于 Label 的 Roadmap 管理
@@ -260,7 +260,7 @@ vibe-roadmap 作为治理-决策双轨中的**决策者**，使用独立的 `[ro
 | `roadmap/p2`     | 有容量时完成     | 一般功能           |
 | `roadmap/next`   | 下个迭代规划中   | 待确认的功能       |
 | `roadmap/future` | 未来考虑         | 长期规划           |
-| `roadmap/rfc`    | RFC/设计阶段     | 需要讨论设计的功能 |
+| `roadmap/rfc`    | RFC/设计阶段     | agent 无法判断目标、架构方向或拆分形态 |
 
 ### Milestone 管理
 
@@ -302,14 +302,13 @@ vibe-roadmap 作为治理-决策双轨中的**决策者**，使用独立的 `[ro
 
 3. **按 issue × suggest 类型分组展示**：
    - 格式：`#N: [governance suggest] <type> — <summary>`
-   - 类型：`needs split` / `Recommend Close` / `Skipped (needs human)` / `auto-split` / `waiting on #X`
+   - 类型：`needs split` / `Recommend Close` / `Skipped (needs human)` / `waiting on #X`
 
 4. **决策优先级**：
-   - 先处理 `[governance auto-split]`（复核最轻量）
-   - 再处理 `[governance suggest] needs split`（产出最大）
+   - 先处理 `[governance suggest] needs split`（拆分或继续，产出最大）
    - 再处理 `[governance suggest] Recommend Close`（清积压）
    - 再处理 `[governance suggest] waiting on #X`（依赖校验）
-   - 最后处理 `[governance suggest] Skipped (needs human)`（需用户参与）
+   - 最后处理 `[governance suggest] Skipped (needs human)`（判断是 `rfc` 还是可继续）
 
 5. **闭环要求**：处理完每个 suggest 后必须写 `[roadmap decision]` 评论关闭闭环。
 
@@ -349,11 +348,11 @@ gh issue list -l "roadmap/p0"
 **场景 B: 有版本目标但有新 `GitHub issue`**
 
 - 对新的 `GitHub issue` 进行分类：
-- **Epic 检查**（强制阻断）：
+- **Epic 检查**（结构分流）：
   - 如果 issue 有 `roadmap/epic` 标签且 body 包含 `## Sub-issues` section：
-    - 告知用户："该 issue 是 Epic 主 issue，请先规划 sub-issues 或选择具体 sub-issue 进入"
-    - 停止 — 不继续规划主 issue
-    - 引导用户处理 sub-issues
+    - 将主 issue 视为治理容器，优先规划未完成 sub-issues
+    - 如果所有 sub-issues 已完成，写 closure/summary decision
+    - 如果 sub-issues 不完整，补齐或调整拆分；不要把 epic 本身当成失败状态
 - 1.  分配适当的 Milestone
 - 2.  添加 roadmap 状态标签（`roadmap/p0`、`roadmap/p1`、`roadmap/p2` 等）
 - 3.  必要时补 `priority/[0-9]` 作为同一 roadmap 桶内的细粒度顺位提示
@@ -369,21 +368,21 @@ gh issue list -l "roadmap/p0"
 - 重新评估待分类 Issue
 - 更新 roadmap 状态标签
 
-### Step 2.5: Epic 拆分（强制）
+### Step 2.5: Scope 拆分决策
 
-在版本规划决策过程中，发现 epic 候选时必须**强制执行拆分**，不再只写 suggest。
+在版本规划决策过程中，roadmap decider 必须在三种结果里选择一个：拆分、继续单 issue、或标记 `roadmap/rfc`。拆分本身不是破坏性动作：主 issue 保持为治理容器，sub-issues 只是独立执行环节。
 
 **Epic 候选识别条件**（满足任一即触发）：
 - Issue body 中已有 `## Sub-issues` section（人工预标注）
 - Scope estimate 超阈值（涉及 3+ 模块、预估 >1 迭代窗口）
 - 已被 `[governance suggest] needs split` 标记
 
-**强制拆分动作**：
+**拆分动作**：
 1. 主 issue 加 `roadmap/epic` 标签：
    ```bash
    gh issue edit <epic-number> --add-label "roadmap/epic"
    ```
-2. 主 issue **不分配** `vibe-manager-agent` assignee（epic 本身不入 manager pool）
+2. 主 issue 通常不分配 `vibe-manager-agent` assignee；由具体 sub-issues 进入 manager pool
 3. 调用 `/vibe-issue` 创建 sub-issues（每个 sub-issue body 中包含 `## Parent issue\n- #<epic-number>`）
 4. 在主 issue body 中追加或更新 `## Sub-issues` 清单：
    ```markdown
@@ -401,7 +400,7 @@ gh issue list -l "roadmap/p0"
 **阈值参考**：
 - 涉及 1 个模块、≤200 LOC → single issue，不拆分
 - 涉及 2 个模块、200-500 LOC → 视耦合度决定
-- 涉及 3+ 模块、>500 LOC → 强制拆分
+- 涉及 3+ 模块、>500 LOC → 优先拆分；如果无法判断拆分边界，标记 `roadmap/rfc`
 
 ### Step X: Intake 判断（新增）
 
@@ -419,12 +418,12 @@ gh issue list -l "roadmap/p0"
      ```
 
 **场景 B: 需要人类讨论**
-- 检查：未通过 Level 1（目标不明确、范围过大、架构变更）
-- 决策：要求人类讨论
+- 检查：目标不明确、架构方向需要人类判断，或 scope 过大但无法判断拆分形态
+- 决策：标记 RFC
 - 执行动作：
   1. 写 comment 说明原因：
      ```bash
-     gh issue comment <number> --body "[roadmap decision] deferred: needs human scope confirmation before automation. Reason: <具体原因>."
+     gh issue comment <number> --body "[roadmap decision] rfc: needs human scope confirmation before automation. Reason: <具体原因>."
      ```
   2. 不分配 assignee
   3. 标记为待讨论：
@@ -578,7 +577,6 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 | 角色 | Marker | 性质 |
 |---|---|---|
 | roadmap-intake / assignee-pool（observer） | `[governance suggest]` | 观察者意见，无强制力 |
-| roadmap-intake（obvious-split 场景） | `[governance auto-split]` | 例外：清晰可拆 epic 的自主拆分（见 #1100） |
 | **vibe-roadmap（decider）** | `[roadmap decision]` | 决策者结论，覆盖 governance 建议 |
 
 ### 强制规则
@@ -590,16 +588,16 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
    ```text
    [roadmap decision] <动作动词>: <简要理由>
    ```
-   动作动词统一使用：`split`, `close`, `hold`, `deferred`, `confirm split`, `revert split`, `assign`, `unblock`
+   动作动词统一使用：`split`, `continue`, `close`, `hold`, `rfc`, `assign`, `unblock`
 
 ### 示例
 
 ```
 [roadmap decision] split epic into #42, #43, #44; reason: 3 modules, ~800 LOC, exceeds single-iteration threshold.
+[roadmap decision] continue #78; reason: bounded to one module and manager can plan within the existing issue.
 [roadmap decision] close #99; reason: dependency removed in #123, API deprecated.
 [roadmap decision] hold #55 until #56 completes; reason: #56 provides core infrastructure #55 depends on.
-[roadmap decision] deferred #77; reason: needs human decision on architecture direction.
-[roadmap decision] confirm auto-split from #110; sub-issues #111, #112 correctly scoped.
+[roadmap decision] rfc #77; reason: needs human decision on architecture direction.
 ```
 
 ## Reference Documents

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -129,11 +129,12 @@ Forbidden:
 - 必须在建议中说明关闭原因（如"依赖 X 已在 #123 移除"）
 - 不要让确定不做的 issue 悬而不决
 
-**不确定 → 看池子状态**
-- 若 assignee pool 为空（无任何候选 issue），且 issue 不确定是否可执行：
-  - 写 `[governance suggest]` 说明不确定性
-  - 放行给 manager 判断是否值得执行
-- 若 assignee pool 非空，保守等待
+**不确定 → 优先交给 manager 或标记 RFC**
+- 若 issue 目标明确，只是 scope 偏大或拆分选择未定：
+  - 写 `[governance suggest]` 建议 manager 拆分或继续单 issue
+  - 不把普通拆分选择升级为人类阻塞
+- 若目标、架构方向或拆分形态都无法判断：
+  - 写 `[governance suggest]` 建议标记 `roadmap/rfc`
 
 **队列偏浅时的保守边界**：
 - 如果当前 ready queue 只剩少量候选，或 blocked / in-progress 已经占住大部分池子，不要机械地把所有灰区 issue 都归入“保守等待”
@@ -146,24 +147,12 @@ Forbidden:
 
 ```
 issue 是否可纳入？
-  ├─ **Epic 检查**（强制阻断）
-  │   └─ 有 `roadmap/epic` 标签 + `## Sub-issues` section？
-  │       └─ 是 → 跳过（主 issue 不入池，等待 sub-issues 完成）
-  │
-  ├─ 检查实质条件
-  │   ├─ 范围是否明确？
-  │   ├─ 验收标准是否清晰？
-  │   └─ 代码缺口是否可确定？
-  │
-  ├─ 明确范围 + 清晰验收 → 可纳入（包括重构）
-  │
-  ├─ 范围过大 → 建议 manager 拆分
-  │
-  ├─ 确定不适用 → 建议关闭（附原因）
-  │
-  └─ 不确定
-      ├─ pool 为空 → 建议放行给 manager 判断
-      └─ pool 非空 → 保守等待
+  - Epic 主 issue：主 issue 保持治理容器；检查 sub-issues 是否完整，建议补齐或选择具体 sub-issue
+  - 明确范围 + 清晰验收：可纳入（包括重构）
+  - 范围过大但边界可拆：建议 manager 拆分，或由 roadmap decider 先拆
+  - 范围偏大但 manager 可收敛：放行给 manager 继续单 issue
+  - 确定不适用：建议关闭（附原因）
+  - 目标/架构/拆分形态无法判断：建议 `roadmap/rfc`
 ```
 
 ### 例子
@@ -179,7 +168,7 @@ issue 是否可纳入？
 - #503: chore: src/vibe3 总行数超过35000行限制
   - 范围过大：涉及整个 src/vibe3
   - 建议：拆分为多个模块级别的清理任务
-  - **结论**：写 `[governance suggest]` 建议拆分
+  - **结论**：写 `[governance suggest]` 建议 manager / roadmap decider 拆分；拆分后主 issue 继续作为治理容器
 
 **应关闭的 issue**
 - #556: tech-debt: 清理事件系统向后兼容别名
@@ -189,8 +178,7 @@ issue 是否可纳入？
 **不确定的 issue**
 - #539: 讨论：统一 vibe3 plan/review/run 命令参数和行为
   - 范围不明确，需要架构讨论
-  - 若 pool 为空：写 `[governance suggest]` 说明不确定性，放行给 manager
-  - 若 pool 非空：保守等待
+  - **结论**：写 `[governance suggest]` 建议补 scope 或标记 `roadmap/rfc`
 
 **可自动恢复的 blocked issue**
 - #123: state/blocked (blocked_reason: state unchanged)
@@ -243,7 +231,11 @@ issue 是否可纳入？
 
 Steps:
 
-1. 读取当前 running issues 与 queue / flow 现场
+1. 运行全局现场观察命令，读取当前 running issues、ready queue、blocked issues、remote tasks 与 flow 现场：
+   ```bash
+   uv run python src/vibe3/cli.py task status
+   ```
+   这是 assignee pool 的主观察入口；单个 issue 的评论、refs 与去重细节再用 `vibe3 task show <issue-number>`。
 2. **依赖过滤**：从候选中排除不可进入 ready queue 的 issue：
    - 检查 issue body 和 comments 中的依赖引用（如 "Depends on #123"）
    - 若被依赖的 issue 未关闭或未处于 `state/done`，从候选中排除
@@ -283,6 +275,7 @@ Steps:
 输出时额外检查：
 - 如果你写出“already in assignee pool”，必须同时回答这些 issue 当前是否仍有 assignee、state、ready queue 资格
 - 如果当前 ready queue 少于稳定运行所需的候选量，必须明确指出缺口来源，而不是仅罗列历史已纳入对象
+- 如果你判断某个 issue 应拆分或继续单 issue，必须说明该判断来自 `task status` 现场、issue body/comment、还是代码缺口；不要只凭标签判断
 
 Decision sketch:
 

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -98,12 +98,13 @@
 
 ### 与 Assignee Pool 的职责边界
 
-**Roadmap Intake（第一道闸门 / decider）**：
+**Roadmap Intake（第一道观察 / observer）**：
 - 重点：**是否应该存在** + **架构一致性**
 - 检查：生命周期、依赖、API、模块
-- 决策：纳入 / 拆分 / 关闭 / RFC
+- 输出：`[governance suggest]` 建议纳入 / 拆分 / 关闭 / RFC
+- 边界：Roadmap Intake 不自称最终 decider；真正的规划决策由 `vibe-roadmap`（roadmap decider）或 manager 在接手前执行
 
-**Manager / Assignee Pool（第二道闸门）**：
+**Vibe Roadmap / Manager（两道决策闸门）**：
 - 重点：**优先级** + **可执行性**
 - 检查：实质范围、验收标准、代码缺口
 - 决策：接受 / 拆分 / 继续单 issue / RFC
@@ -112,14 +113,14 @@
 ```
 Issue: #556 清理事件系统向后兼容别名
 
-Roadmap Intake（第一道）：
+Roadmap Intake（observer）：
   ├─ 检查：事件系统旧别名是否还存在？
-  ├─ 若已移除：建议关闭（原因：依赖已在 #XYZ 移除）
-  └─ 若存在：纳入 pool
+  ├─ 若已移除：写 [governance suggest] 建议关闭（原因：依赖已在 #XYZ 移除）
+  └─ 若存在：建议纳入 pool
 
-Assignee Pool（第二道）：
+Vibe Roadmap / Manager（decider）：
   ├─ 检查：范围、验收、代码缺口
-  └─ 决策：接受为重构任务 / 建议 manager 处理
+  └─ 决策：接受为重构任务 / 拆分 / RFC / 不执行
 ```
 
 ### Supervisor Issue Intake

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -19,7 +19,8 @@
 **闭环目标**：
 - broader repo issue pool 中只要存在边界明确、依赖就绪、可由 manager 继续收敛的 issue，就应尽量纳入 assignee issue pool
 - 不要把“尚有若干实现选项”误判成“必须人类拍板”
-- 只有当 issue 的目标本身不明确，或会改变架构/产品方向时，才用 `needs human decision` 跳过
+- scope 较大但拆分形态清楚时，交给 roadmap decider / manager 拆分；拆分只是保留主 issue 的治理容器并显式化执行环节
+- 只有当 issue 的目标本身不明确、会改变架构/产品方向，或连如何拆分都无法判断时，才用 `roadmap/rfc` / `needs human decision` 跳过
 
 ## 职责
 
@@ -60,7 +61,7 @@
 - ✅ 范围明确：涉及哪些模块/文件清晰可列
 - ✅ 边界清晰：不涉及未定义的跨模块协调
 - ✅ 验收标准确定：可明确判断"完成"（如测试通过、移除旧代码）
-- ❌ 若范围不明确：建议拆分或等待架构讨论
+- ❌ 若范围不明确：优先建议拆分；无法判断拆分形态时再等待架构讨论
 - 例子：
   - ✅ #550 refactor(error): decouple ErrorTrackingService singleton
     - 范围明确：只涉及 `error/tracking.py`
@@ -77,34 +78,35 @@
 - 明确不适用当前架构
 
 **建议调整**（Level 1 或 Level 2 部分不通过）：
-- 范围过大 → 建议拆分
+- 范围过大 → 建议 roadmap decider / manager 拆分；若边界清楚，也可直接纳入让 manager 拆
 - 架构已变更 → 建议更新内容
 - 依赖未就绪 → 建议等依赖完成后重新提出
 
-**跳过（保守等待）**：
+**跳过（保守等待 / RFC）**：
 - issue 的目标/验收口径本身不明确，无法确定做完算什么
 - 需要先决定架构方向、产品策略或跨团队边界
 - 不确定是否过时
 - **Epic 主 issue**（有 `roadmap/epic` 标签且 body 包含 `## Sub-issues`）：
-  - 不纳入 assignee pool（主 issue 本身不应进入执行）
-  - 等待所有 sub-issues 完成后再处理主 issue 的关闭
+  - 主 issue 是治理容器，不直接作为执行任务纳入 assignee pool
+  - 优先检查 sub-issues 是否已经覆盖拆分；不完整时建议补齐，而不是把 epic 当成失败状态
 
 **不要误判为 `needs human decision` 的情况**：
 - 同一目标下有 2-3 个局部实现路径，但 issue 本身已说明要修什么、验收看什么
 - manager 可以先读代码再决定采用哪种小范围实现
 - 描述里列了若干候选方案，但这些方案不会改变系统边界，只影响落地细节
+- 范围偏大但可以自然拆成独立执行环节；这种情况应建议拆分或交给 manager 拆分
 
 ### 与 Assignee Pool 的职责边界
 
-**Roadmap Intake（第一道闸门）**：
+**Roadmap Intake（第一道闸门 / decider）**：
 - 重点：**是否应该存在** + **架构一致性**
 - 检查：生命周期、依赖、API、模块
-- 决策：纳入 / 关闭 / 调整 / 等待
+- 决策：纳入 / 拆分 / 关闭 / RFC
 
-**Assignee Pool（第二道闸门）**：
+**Manager / Assignee Pool（第二道闸门）**：
 - 重点：**优先级** + **可执行性**
 - 检查：实质范围、验收标准、代码缺口
-- 决策：接受 / 拆分 / 放行 / 等待
+- 决策：接受 / 拆分 / 继续单 issue / RFC
 
 **协同示例**：
 ```
@@ -167,8 +169,8 @@ Assignee Pool（第二道）：
     ```
   - 在 Actions 中记录：`Supervisor #YYY: suggest close (duplicate with #ZZZ)`
 - **不确定**：
-  - 保守等待，不修改 state
-  - 在 Actions 中记录：`Supervisor #ZZZ: waiting (unclear scope, needs human review)`
+  - 等待或建议 `roadmap/rfc`，不修改 state
+  - 在 Actions 中记录：`Supervisor #ZZZ: rfc/waiting (unclear scope, needs human review)`
 
 **输出要求**：
 
@@ -190,7 +192,7 @@ Why: ...
 - **架构检查优先于标签分类**：不只是看 bug/feature 标签，要看代码架构是否仍相关
 - **关闭优于等待**：明确过时的 issue 应关闭，不要留在 pool 中悬而不决
 - **调整优于拒绝**：有问题的 issue 建议调整内容，而不是保守等待
-- **保守兜底**：不确定时等待，避免误纳入或误关闭
+- **RFC 兜底**：无法判断目标、架构方向或拆分形态时，建议 `roadmap/rfc`，避免误纳入或误关闭
 - **纳入优于空转**：如果当前 ready queue 很浅，且候选 issue 满足三级审查，不要因为“可能有别的实现写法”而空转
 
 ## Assignee Selection Rule
@@ -273,22 +275,27 @@ Forbidden:
 ## Execution Pattern
 
 1. 先看 broader repo issue pool 中当前 open issues
-2. 先过滤掉 discussion、明确的大 feature、以及真正需要人类先定方向的 issue
-3. 重点识别以下可纳入对象：
+2. 先运行全局现场观察命令，确认当前 assignee pool / ready queue / blocked / remote tasks 事实：
+   ```bash
+   uv run python src/vibe3/cli.py task status
+   ```
+   `task status` 用于理解池子深浅、已有 flow、ready queue 与 blocked 现场；单个 issue 的最近评论与细节仍用 `vibe3 task show <issue-number>`。
+3. 先过滤掉 discussion、明确的大 feature、以及真正需要人类先定方向的 issue
+4. 重点识别以下可纳入对象：
    - bug fix
    - 方案明确的 small feature
    - **边界明确的 refactor / cleanup**
-4. **事实确认（强制）**：在决定对某个 issue 写 `[governance suggest]` comment 前，必须先运行：
+5. **事实确认（强制）**：在决定对某个 issue 写 `[governance suggest]` comment 前，必须先运行：
    ```bash
    vibe3 task show <issue-number>
    ```
    查看该 issue 最近的 2-3 条评论。如果最近已有 `[governance suggest]` 或 `[governance]` 开头的评论（无论是你自己还是其他 agent 写的），**一律跳过，不再重复写 comment**。靠事实判断，不靠猜测。
-5. 检查这些 issue 是否已在 assignee issue pool，避免重复纳入
-6. 对可纳入对象执行最小动作：
+6. 检查这些 issue 是否已在 assignee issue pool，避免重复纳入
+7. 对可纳入对象执行最小动作：
    - 派为 assignee issue，并明确指派给一个配置中的 manager assignee（必须使用 `{manager_bot}`，禁止使用人类用户名）
    - 如有必要补最小 routing labels
-7. 对不适合纳入的对象记录简短原因
-8. **扫描 `supervisor + state/ready` issues**，对每个执行：
+8. 对不适合纳入的对象记录简短原因
+9. **扫描 `supervisor + state/ready` issues**，对每个执行：
    - 先运行 `vibe3 task show <issue-number>` 确认最近没有重复 governance comment
    - 三级审查（基础条件 + 架构一致性 + 生命周期）
    - 通过：移除 `state/ready`，补 `state/handoff`，记录到 Actions
@@ -300,12 +307,12 @@ Forbidden:
      ```bash
      gh issue close <issue-number> --comment "关闭理由：<具体理由>"
      ```
-   - 不确定：保守等待，记录到 Actions
-9. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
+   - 不确定：等待或建议 `roadmap/rfc`，记录到 Actions
+10. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
    - 是因为候选确实都不满足三级审查
    - 还是因为当前材料把”实现选择”误当成了”人类拍板”
    - 若 ready queue 偏浅，优先重新检查是否存在被误判可纳入的 bounded refactor / bugfix
-10. 输出结论后停止
+11. 输出结论后停止
 
 ## Comment Contract
 
@@ -318,7 +325,7 @@ Forbidden:
 合规示例：
 ```
 [governance suggest] Intake: assigned to @{manager_bot} (manager-pool); scope=bugfix.
-[governance suggest] Skipped: needs human scope confirmation before automation.
+[governance suggest] Skipped: recommend roadmap/rfc; needs human scope confirmation before automation.
 ```
 
 ## Output Contract

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -59,6 +59,7 @@ vibe-commit: BLOCKED - test failure in pre-push hook
 Allowed:
 
 - `issue`: read, write (包括编辑 title、body 以纠正事实错误，但不得修改 scope)
+- `issue.create`: allowed only when splitting the current ready issue into sub-issues before plan handoff
 - `labels`: read, write
 - `comments`: read, write
 - `handoff`: read, write
@@ -95,10 +96,11 @@ Forbidden:
 - `code_write`: 任何形式的源码修改
 - `direct_implementation`: 直接实现功能或修复
 - `direct_code_fix`: 直接修改代码文件
-- `scope_expansion`: 擅自扩大或缩小 issue scope（纠正 title/body 信息不等于改 scope）
+- `scope_expansion`: 擅自扩大或缩小 issue scope（纠正 title/body 信息不等于改 scope；plan 前拆分为 sub-issues 不改变主 issue scope）
 - `multi_flow_orchestration`: 多 flow 编排
 - 替代 planner/executor/reviewer 执行具体技术工作（可以审查评判质量，但不能替代实现）
 - 在 `ready` 阶段跳过 `claimed`
+- 在 plan agent 接手后再拆分 issue；拆分决策必须发生在 `state/ready` 进入 `state/claimed` 之前
 - 在未核验 labels 前假设已经进入下一状态
 - 因为当前 flow 绑定了别的 issue，就切换处理别的 issue
 - 把 labels 治理当成实现任务
@@ -296,6 +298,14 @@ uv run python src/vibe3/cli.py handoff show @task-xxx/run-yyy.md
   4. 返回 scene 是否健康的结果
 - 注意：`state/ready` 阶段的 scene 健康只根据 **target issue + target branch/worktree/task-scene** 判断；全局 `task status`、server `stopped/unreachable`、或"当前没有 active issues"这些全局信号本身都**不能单独构成 blocker**
 
+#### `check_scope_split_before_plan()`
+- 作用：在 plan agent 接手之前判断当前 issue 是否应拆分。
+- 允许结果：
+  1. `continue`：scope 足够清楚，可作为单 issue 进入 `state/claimed`
+  2. `split`：scope 可拆成独立执行环节，主 issue 保持治理容器，创建或要求补齐 sub-issues
+  3. `rfc`：目标、架构方向或拆分形态无法判断，标记 `roadmap/rfc` 并进入 `state/blocked`
+- Hard rule：一旦 manager 将 issue 推进到 `state/claimed` 并等待 plan agent，拆分窗口关闭；后续 plan/run/review 只能在当前 issue scope 内执行或因 scope 不清而 blocked，不能再改成 sub-issue 拆分。
+
 #### `is_flow_terminal()`
 - 作用：检查 flow 是否处于终态（done/aborted）
 - Steps:
@@ -319,6 +329,7 @@ Inputs:
 - latest governance suggest (if exists)
 - current labels/state
 - current scene
+- global task status summary
 - current handoff
 
 Steps:
@@ -330,9 +341,10 @@ Steps:
    - 忽略历史中无前缀的自动化状态报告（通常由旧版 manager 产生）。
 3. **识别最新 governance 建议**：
    - 署名为 `[governance suggest]` 或含 `[governance]` 标记。
-4. 读取当前 labels/state
-5. 核查当前 issue / flow / task / branch / worktree / session
-6. 读取 handoff 与 refs
+4. 运行 `uv run python src/vibe3/cli.py task status` 读取全局队列/flow/blocked 现场，仅作为背景和去重依据
+5. 读取当前 labels/state
+6. 核查当前 issue / flow / task / branch / worktree / session
+7. 读取 handoff 与 refs
 
 Exit:
 
@@ -403,7 +415,20 @@ Steps:
    - 调用 `check_scene_health()` 确认 scene 是否健康
    - 确认最新评论中没有明确的暂停/阻止指示
 
-4.5. **依赖检查**：检查 Issue 是否有未解决的依赖：
+4.5. **Scope 拆分判断（plan 前最后窗口）**：调用 `check_scope_split_before_plan()`：
+   - 若结果为 `split`：
+     - 写 `[manager]` comment 说明拆分理由，并指出主 issue 保持治理容器
+     - 创建 sub-issues，或在权限不足时要求补齐 sub-issues；必要时添加 `roadmap/epic`
+     - 当前 issue 不进入 `state/claimed`
+     - `exit()`
+   - 若结果为 `rfc`：
+     - 添加 `roadmap/rfc`
+     - 将当前 issue 调整为 `state/blocked`
+     - comment 说明目标、架构方向或拆分形态需要人类判断
+     - `exit()`
+   - 若结果为 `continue`：继续后续依赖检查与 claim 流程
+
+4.6. **依赖检查**：检查 Issue 是否有未解决的依赖：
    - 检查 issue body 和 comments 中引用的其他 issue（如 "Depends on #123"、"blocked by #456"）
    - 对每个被依赖的 issue，检查其状态是否已关闭或处于 `state/done`
    - 如果存在未解除的依赖：
@@ -501,9 +526,10 @@ Steps:
        - 写 handoff append: 说明架构冲突风险，建议人工判断是否需要 rebase 或调整 scope
        - `exit()`
 3. 复述当前已进入 claimed
-4. 写 issue comment：当前 scene、当前风险、下一阶段应由 plan agent 接手
-5. 写 handoff append：说明当前已进入 claimed，等待 plan
-6. `exit()`
+4. 明确记录：拆分窗口已关闭，后续 plan/run/review 不得再改变为 sub-issue 拆分；若 plan agent 发现 scope 无法执行，应 blocked 回 manager/人类，而不是自行拆分
+5. 写 issue comment：当前 scene、当前风险、下一阶段为 plan agent 接手，scope 按当前 issue 执行
+6. 写 handoff append：说明当前已进入 claimed，等待 plan，且不得再拆分
+7. `exit()`
 
 ### `handle_handoff()`
 

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -419,12 +419,21 @@ Steps:
    - 若结果为 `split`：
      - 写 `[manager]` comment 说明拆分理由，并指出主 issue 保持治理容器
      - 创建 sub-issues，或在权限不足时要求补齐 sub-issues；必要时添加 `roadmap/epic`
-     - 当前 issue 不进入 `state/claimed`
+     - 当前 issue 不进入 `state/claimed`；它必须离开 `state/ready`
+     - 调用：
+       ```bash
+       uv run python src/vibe3/cli.py flow blocked --reason "Scope split: parent issue remains roadmap/epic governance container; execution continues in sub-issues."
+       ```
+       这会原子写入 `blocked_reason` 并转换为 `state/blocked`，表示主 issue 未关闭但不再派发执行
      - `exit()`
    - 若结果为 `rfc`：
      - 添加 `roadmap/rfc`
-     - 将当前 issue 调整为 `state/blocked`
      - comment 说明目标、架构方向或拆分形态需要人类判断
+     - 调用：
+       ```bash
+       uv run python src/vibe3/cli.py flow blocked --reason "RFC required: target, architecture direction, or split shape needs human decision before dispatch."
+       ```
+       这会原子写入 `blocked_reason` 并转换为 `state/blocked`
      - `exit()`
    - 若结果为 `continue`：继续后续依赖检查与 claim 流程
 


### PR DESCRIPTION
## Summary

- Align roadmap, governance, manager, and planner prompt materials to the simplified two-gate scope split model.
- Make roadmap decider and manager responsible for split / continue / rfc decisions before plan handoff.
- Clarify `roadmap/epic` as a parent governance container and `roadmap/rfc` as human input only when agents cannot determine scope or split shape.
- Update #1462 remotely to own `task status` RFC/Epic display and the closed-loop dependency standard doc.

## Verification

- `uv run black src tests/vibe3`
- `uv run ruff check --fix src tests/vibe3`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/vibe3/roles/test_manager.py tests/vibe3/config/test_migrated_config_paths.py tests/vibe3/ui/test_scan_display.py`
- pre-push checks: type check + smoke fallback (`5 passed`)

Fixes #1464

---

## Contributors

AI Agent
