### PR TITLE
feat(check): clean physical resources when closed PR has no task issue link

### DIFF
--- a/docs/closeout/task-issue-1433.md
+++ b/docs/closeout/task-issue-1433.md
@@ -1,0 +1,37 @@
+# PR Creation Instructions for Issue #1433
+
+## Context
+- Issue: #1433
+- Branch: task/issue-1433
+- Commit: e690f39d
+- State: merge-ready
+
+## PR Details
+
+**Title**: feat(check): clean physical resources when closed PR has no task issue link
+
+**Body**:
+## Summary
+- Add physical resource cleanup when `vibe3 check` detects a closed PR for a flow without a linked task issue
+- Modify `_reset_issue_after_pr_closed` to return tuple with cleanup warnings
+- Reuse `FlowCleanupService.cleanup_flow_scene()` for consistent cleanup behavior
+
+## Changes
+- `src/vibe3/services/check_service.py`: Add cleanup invocation in no-task-issue-link path
+- `tests/vibe3/services/test_check_pr_status.py`: New test for cleanup behavior
+- `tests/vibe3/services/test_check_service_verify_branch.py`: Update mock return value
+
+## Test plan
+- [x] All 31 tests pass
+- [x] mypy clean
+- [x] ruff clean
+- [x] New test `test_closed_pr_no_task_issue_cleans_physical_resources` verifies cleanup call
+
+Closes #1433
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+## Executor Instructions
+1. Create PR using the title and body above
+2. After PR creation, update flow state to record `pr_ref`
+3. Do NOT push directly — PR creation will handle the push

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -185,16 +185,21 @@ class CheckService(CheckRemote):
 
         if pr.state == PRState.CLOSED:
             # PR closed without merge → clean up and return to READY
-            reset_error = self._reset_issue_after_pr_closed(branch, pr.number)
+            reset_error, reset_warnings = self._reset_issue_after_pr_closed(
+                branch, pr.number
+            )
             self._update_pr_cache(branch, pr)
 
             if reset_error:
                 return CheckResult(is_valid=False, branch=branch, issues=[reset_error])
+            result_issues.extend(reset_warnings)
             return CheckResult(is_valid=True, branch=branch, issues=result_issues)
 
         return None
 
-    def _reset_issue_after_pr_closed(self, branch: str, pr_number: int) -> str | None:
+    def _reset_issue_after_pr_closed(
+        self, branch: str, pr_number: int
+    ) -> tuple[str | None, list[str]]:
         """Reset issue to READY after PR closed without merge.
 
         Cleans up flow scene (worktree, branch, flow record) and
@@ -203,6 +208,10 @@ class CheckService(CheckRemote):
         Args:
             branch: Branch name (e.g., "task/issue-456")
             pr_number: Closed PR number
+
+        Returns:
+            Tuple of (error_str, warnings). error_str is None on success,
+            warnings contains cleanup result messages.
         """
         from vibe3.models.flow import FlowStatusResponse
         from vibe3.services.task_resume_operations import TaskResumeOperations
@@ -226,7 +235,35 @@ class CheckService(CheckRemote):
             self._flow_status_service.mark_flow_aborted(
                 branch, f"PR #{pr_number} closed without merge (no issue link)"
             )
-            return None
+
+            # Clean up physical resources (worktree, branches, flow record)
+            from vibe3.services.flow_cleanup_service import FlowCleanupService
+
+            cleanup_service = FlowCleanupService(
+                store=self.store,
+                git_client=self.git_client,
+            )
+            cleanup_result = cleanup_service.cleanup_flow_scene(
+                branch, include_remote=True, keep_flow_record=False
+            )
+
+            # Build warning message from cleanup results
+            cleaned_items = []
+            if cleanup_result.get("worktree"):
+                cleaned_items.append("worktree")
+            if cleanup_result.get("local_branch"):
+                cleaned_items.append("local branch")
+            if cleanup_result.get("remote_branch"):
+                cleaned_items.append("remote branch")
+            if cleanup_result.get("flow_record"):
+                cleaned_items.append("flow record")
+
+            warning_msg = (
+                f"Flow '{branch}' marked aborted; cleaned: {', '.join(cleaned_items)}"
+                if cleaned_items
+                else f"Flow '{branch}' marked aborted (no cleanup needed)"
+            )
+            return (None, [warning_msg])
 
         # Check if issue already closed
         gh_issue = self.github_client.view_issue(task_issue_number)
@@ -239,7 +276,7 @@ class CheckService(CheckRemote):
                     branch=branch,
                     issue_number=task_issue_number,
                 ).info(f"Issue #{task_issue_number} already closed, skip reset")
-                return None
+                return (None, [])
 
         # Build minimal FlowStatusResponse for task resume
         flow = FlowStatusResponse(
@@ -294,10 +331,11 @@ class CheckService(CheckRemote):
             ).warning(f"Failed to reset issue: {exc}")
             return (
                 f"Failed to reset issue #{task_issue_number} after PR "
-                f"#{pr_number} closed: {exc}"
+                f"#{pr_number} closed: {exc}",
+                [],
             )
 
-        return None
+        return (None, [])
 
     def _check_multiple_state_labels(
         self, issue_number: int, issue_payload: dict

--- a/tests/vibe3/services/test_check_pr_status.py
+++ b/tests/vibe3/services/test_check_pr_status.py
@@ -109,6 +109,7 @@ class TestPRStatusDetection:
             store=store, git_client=git_client, github_client=github_client
         )
         with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
+            mock_reset.return_value = (None, [])
             service.verify_current_flow()
 
             # ASSERT: Should call reset to READY (not mark as aborted)
@@ -280,3 +281,88 @@ class TestMergedPRCacheIntegration:
                 assert result["number"] == 100
                 # Sync should have been called (via list_merged_prs)
                 mock_client.list_merged_prs.assert_called()
+
+
+class TestClosedPRNoTaskIssue:
+    """Test closed-PR cleanup when flow has no task issue link."""
+
+    def test_closed_pr_no_task_issue_cleans_physical_resources(self, tmp_path):
+        """Should mark flow aborted AND clean physical resources when PR closed."""
+        # ARRANGE: Flow with closed PR but no task issue link
+        store = SQLiteClient(db_path=tmp_path / "test.db")
+        store.update_flow_state(
+            "dev/no-task-issue",
+            flow_slug="no_task_issue",
+            flow_status="active",
+        )
+        # No issue link added (no task issue)
+
+        # Mock git client
+        from vibe3.clients.git_client import GitClient
+
+        git_client = MagicMock(spec=GitClient)
+        git_client.get_current_branch.return_value = "dev/no-task-issue"
+        git_client.get_git_common_dir.return_value = tmp_path / ".git"
+
+        # Mock GitHub client to return closed PR (not merged)
+        github_client = MagicMock(spec=GitHubClient)
+        closed_pr = PRResponse(
+            number=42,
+            title="Test PR",
+            state=PRState.CLOSED,
+            head_branch="dev/no-task-issue",
+            base_branch="main",
+            url="https://github.com/test/pr/42",
+            draft=False,
+            is_ready=True,
+            ci_passed=True,
+        )
+        github_client.list_prs_for_branch.return_value = [closed_pr]
+        github_client.list_all_prs.return_value = [closed_pr]
+
+        # Create handoff file
+        from vibe3.utils.git_helpers import get_branch_handoff_dir
+
+        handoff_dir = get_branch_handoff_dir(tmp_path, "dev/no-task-issue")
+        handoff_dir.mkdir(parents=True, exist_ok=True)
+        (handoff_dir / "current.md").touch()
+
+        # ACT: Run check with mocked cleanup service
+        service = CheckService(
+            store=store, git_client=git_client, github_client=github_client
+        )
+
+        from unittest.mock import patch
+
+        with patch(
+            "vibe3.services.flow_cleanup_service.FlowCleanupService"
+        ) as mock_cleanup_class:
+            mock_cleanup = MagicMock()
+            mock_cleanup_class.return_value = mock_cleanup
+            # Mock cleanup result: all steps succeeded
+            mock_cleanup.cleanup_flow_scene.return_value = {
+                "worktree": True,
+                "local_branch": True,
+                "remote_branch": True,
+                "handoff": True,
+                "flow_record": True,
+            }
+
+            result = service.verify_current_flow()
+
+            # ASSERT 1: Flow should be marked as aborted
+            flow = store.get_flow_state("dev/no-task-issue")
+            assert flow["flow_status"] == "aborted"
+
+            # ASSERT 2: cleanup_flow_scene should be called with correct args
+            mock_cleanup.cleanup_flow_scene.assert_called_once_with(
+                "dev/no-task-issue",
+                include_remote=True,
+                keep_flow_record=False,
+            )
+
+            # ASSERT 3: Result should be valid and contain cleanup warning
+            assert result.is_valid is True
+            assert len(result.issues) > 0
+            # Should mention cleanup in the warning
+            assert any("cleaned:" in issue for issue in result.issues)

--- a/tests/vibe3/services/test_check_service_verify_branch.py
+++ b/tests/vibe3/services/test_check_service_verify_branch.py
@@ -212,7 +212,7 @@ def test_verify_branch_handles_closed_pr(tmp_path: Path) -> None:
 
     # Mock _reset_issue_after_pr_closed to avoid side effects
     with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
-        mock_reset.return_value = None
+        mock_reset.return_value = (None, [])
         result = service.verify_branch(branch)
 
         # Should call _reset_issue_after_pr_closed


### PR DESCRIPTION
## Summary
- Add physical resource cleanup when `vibe3 check` detects a closed PR for a flow without a linked task issue
- Modify `_reset_issue_after_pr_closed` to return tuple with cleanup warnings
- Reuse `FlowCleanupService.cleanup_flow_scene()` for consistent cleanup behavior

## Changes
- `src/vibe3/services/check_service.py`: Add cleanup invocation in no-task-issue-link path
- `tests/vibe3/services/test_check_pr_status.py`: New test for cleanup behavior
- `tests/vibe3/services/test_check_service_verify_branch.py`: Update mock return value

## Test plan
- [x] All 31 tests pass
- [x] mypy clean
- [x] ruff clean
- [x] New test `test_closed_pr_no_task_issue_cleans_physical_resources` verifies cleanup call

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
