### PR TITLE
feat(pr): add branch behind base check with reusable utilities

### DIFF
--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -19,6 +19,7 @@ from vibe3.services.pr_create_usecase import PRCreateUsecase
 from vibe3.services.pr_service import PRService
 from vibe3.services.task_binding_guard import MissingTaskIssueError
 from vibe3.ui.pr_ui import render_pr_confirmed, render_pr_created
+from vibe3.utils.branch_compare import check_branch_behind, format_branch_behind_body
 
 
 def _is_interactive(json_output: bool, yaml_output: bool) -> bool:
@@ -210,6 +211,18 @@ def register_create_command(app: typer.Typer) -> None:
             raise typer.Exit(1)
 
         pr_body = ai_body if ai_body else body
+
+        # Check if branch is behind base and add warning to PR body
+        behind_info = check_branch_behind(
+            git_client=pr_service.git_client,
+            head_branch=branch,
+            base_branch=resolved_base,
+        )
+        if behind_info:
+            behind_warning = format_branch_behind_body(behind_info)
+            # Prepend warning to PR body
+            pr_body = f"{behind_warning}\n\n---\n\n{pr_body}"
+
         # Actor determination:
         # - AI suggestion mode: "ai-assistant"
         # - Agent mode: None (will be resolved by PRService from flow state)

--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -212,17 +212,6 @@ def register_create_command(app: typer.Typer) -> None:
 
         pr_body = ai_body if ai_body else body
 
-        # Check if branch is behind base and add warning to PR body
-        behind_info = check_branch_behind(
-            git_client=pr_service.git_client,
-            head_branch=branch,
-            base_branch=resolved_base,
-        )
-        if behind_info:
-            behind_warning = format_branch_behind_body(behind_info)
-            # Prepend warning to PR body
-            pr_body = f"{behind_warning}\n\n---\n\n{pr_body}"
-
         # Actor determination:
         # - AI suggestion mode: "ai-assistant"
         # - Agent mode: None (will be resolved by PRService from flow state)
@@ -235,5 +224,23 @@ def register_create_command(app: typer.Typer) -> None:
             base_branch=resolved_base,
             actor=actor,
         )
+
+        # Check if branch is behind base and update PR body
+        behind_info = check_branch_behind(
+            git_client=pr_service.git_client,
+            head_branch=pr.head_branch,
+            base_branch=pr.base_branch,
+        )
+        if behind_info:
+            behind_warning = format_branch_behind_body(behind_info)
+            updated_body = f"{behind_warning}\n\n---\n\n{pr.body}"
+            # Update PR body via gh CLI
+            subprocess.run(
+                ["gh", "pr", "edit", str(pr.number), "--body", updated_body],
+                check=True,
+                capture_output=True,
+            )
+            # Update local PR object
+            pr = pr.model_copy(update={"body": updated_body})
 
         _emit_pr_result(pr, json_output, yaml_output)

--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -32,7 +32,7 @@ from vibe3.commands.output_format import (
     create_trace_output,
     output_result,
 )
-from vibe3.models.pr import PRResponse
+from vibe3.models.pr import PRResponse, PRState
 from vibe3.models.trace import TraceOutput
 from vibe3.services.branch_resolver import resolve_branch_from_pr
 from vibe3.services.flow_service import FlowService
@@ -40,6 +40,7 @@ from vibe3.services.handoff_service import HandoffService
 from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
 from vibe3.services.pr_service import PRService
 from vibe3.ui.pr_ui import render_local_review_summary, render_pr_details
+from vibe3.utils.branch_compare import check_branch_behind, format_branch_behind_console
 
 
 def _resolve_task_from_flow(pr_svc: PRService, branch: str) -> list[int]:
@@ -447,6 +448,21 @@ def register_query_commands(app: typer.Typer) -> None:
         else:
             # Human-readable output
             render_pr_details(pr)
+
+            # Check if PR branch is behind base branch (only for OPEN PRs)
+            console = Console()
+            if pr.state == PRState.OPEN:
+                behind_info = check_branch_behind(
+                    git_client=pr_svc.git_client,
+                    head_branch=pr.head_branch,
+                    base_branch=pr.base_branch,
+                )
+                if behind_info:
+                    console.print()
+                    console.rule("[bold red]⚠️  Branch Behind Base[/]", style="red")
+                    console.print()
+                    console.print(format_branch_behind_console(behind_info))
+                    console.print()
 
             # Show bound tasks from flow truth
             # Fallback chain:

--- a/src/vibe3/utils/branch_compare.py
+++ b/src/vibe3/utils/branch_compare.py
@@ -1,0 +1,108 @@
+"""Branch comparison utilities for PR operations."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
+
+
+@dataclass(frozen=True)
+class BranchBehindInfo:
+    """Information about how far a branch is behind its base."""
+
+    head_branch: str
+    base_branch: str
+    behind_count: int
+    behind_commits: list[str]
+
+
+def check_branch_behind(
+    git_client: "GitClient",
+    head_branch: str,
+    base_branch: str,
+) -> BranchBehindInfo | None:
+    """Check if a branch is behind its base branch.
+
+    Args:
+        git_client: GitClient instance
+        head_branch: PR head branch name
+        base_branch: PR base branch name
+
+    Returns:
+        BranchBehindInfo if behind, None if up-to-date or error
+    """
+    try:
+        # origin/head_branch..origin/base_branch = commits in base
+        # that are NOT in head (i.e., behind count)
+        behind_commits = git_client.get_commit_subjects(
+            base_ref=f"origin/{head_branch}",
+            head_ref=f"origin/{base_branch}",
+        )
+
+        if not behind_commits:
+            return None
+
+        return BranchBehindInfo(
+            head_branch=head_branch,
+            base_branch=base_branch,
+            behind_count=len(behind_commits),
+            behind_commits=behind_commits,
+        )
+    except Exception as e:
+        logger.bind(
+            domain="pr",
+            action="check_branch_behind",
+            head_branch=head_branch,
+            base_branch=base_branch,
+            error_type=type(e).__name__,
+            error_msg=str(e),
+        ).debug(f"Failed to check branch behind: {e}")
+        return None
+
+
+def format_branch_behind_body(info: BranchBehindInfo) -> str:
+    """Format branch behind info as markdown for PR body.
+
+    Args:
+        info: BranchBehindInfo instance
+
+    Returns:
+        Markdown formatted warning block
+    """
+    return f"""## ⚠️ Branch Behind Base
+
+The PR branch `{info.head_branch}` is behind `{info.base_branch}` \
+by **{info.behind_count} commit(s)**.
+
+### Recommended Actions
+
+```bash
+git fetch origin {info.base_branch}
+git rebase origin/{info.base_branch}
+git push --force-with-lease origin {info.head_branch}
+```
+"""
+
+
+def format_branch_behind_console(info: BranchBehindInfo) -> str:
+    """Format branch behind info for console display (Rich markup).
+
+    Args:
+        info: BranchBehindInfo instance
+
+    Returns:
+        Rich markup formatted string
+    """
+    return f"""[bold red]⚠️  Branch Behind Base[/]
+
+  [bold red]PR branch[/] [yellow]{info.head_branch}[/]
+  [bold red]is behind[/] [cyan]{info.base_branch}[/]
+  [bold red]by[/] [bold yellow]{info.behind_count} commit(s)[/]
+
+[bold cyan]Recommended actions:[/]
+  [green]1.[/] git fetch origin {info.base_branch}
+  [green]2.[/] git rebase origin/{info.base_branch}
+  [green]3.[/] git push --force-with-lease origin {info.head_branch}"""

--- a/src/vibe3/utils/branch_compare.py
+++ b/src/vibe3/utils/branch_compare.py
@@ -52,7 +52,18 @@ def check_branch_behind(
         output = git_client._run(
             ["rev-list", "--count", f"origin/{head_branch}..origin/{base_branch}"]
         )
-        behind_count = int(output.strip())
+
+        try:
+            behind_count = int(output.strip())
+        except ValueError:
+            logger.bind(
+                domain="pr",
+                action="check_branch_behind_parse",
+                output=output,
+                head_branch=head_branch,
+                base_branch=base_branch,
+            ).warning(f"Unexpected git rev-list output: {output}")
+            return None
 
         if behind_count == 0:
             return None

--- a/src/vibe3/utils/branch_compare.py
+++ b/src/vibe3/utils/branch_compare.py
@@ -16,7 +16,6 @@ class BranchBehindInfo:
     head_branch: str
     base_branch: str
     behind_count: int
-    behind_commits: list[str]
 
 
 def check_branch_behind(
@@ -34,24 +33,36 @@ def check_branch_behind(
     Returns:
         BranchBehindInfo if behind, None if up-to-date or error
     """
+    from vibe3.clients.git_client import GitError
+
     try:
+        # Fetch base branch to ensure up-to-date refs
+        try:
+            git_client._run(["fetch", "origin", base_branch])
+        except GitError as fetch_err:
+            logger.bind(
+                domain="pr",
+                action="check_branch_behind_fetch",
+                base_branch=base_branch,
+                error=str(fetch_err),
+            ).warning("Failed to fetch base branch, refs may be stale")
+
         # origin/head_branch..origin/base_branch = commits in base
         # that are NOT in head (i.e., behind count)
-        behind_commits = git_client.get_commit_subjects(
-            base_ref=f"origin/{head_branch}",
-            head_ref=f"origin/{base_branch}",
+        output = git_client._run(
+            ["rev-list", "--count", f"origin/{head_branch}..origin/{base_branch}"]
         )
+        behind_count = int(output.strip())
 
-        if not behind_commits:
+        if behind_count == 0:
             return None
 
         return BranchBehindInfo(
             head_branch=head_branch,
             base_branch=base_branch,
-            behind_count=len(behind_commits),
-            behind_commits=behind_commits,
+            behind_count=behind_count,
         )
-    except Exception as e:
+    except GitError as e:
         logger.bind(
             domain="pr",
             action="check_branch_behind",

--- a/tests/vibe3/commands/test_pr_create_ai.py
+++ b/tests/vibe3/commands/test_pr_create_ai.py
@@ -82,6 +82,9 @@ class TestPRCreateCommandAI:
             ),
             patch("vibe3.services.pr_create_usecase.PRCreateUsecase.check_flow_task"),
             patch("vibe3.commands.pr_create.PRService") as mock_service,
+            patch(
+                "vibe3.commands.pr_create.check_branch_behind", return_value=None
+            ),  # Mock branch behind check
         ):
             mock_service.return_value.get_open_pr_for_branch.return_value = None
             mock_service.return_value.create_pr.return_value = MagicMock(
@@ -155,6 +158,10 @@ class TestPRCreateCommandAI:
                                 patch(
                                     "vibe3.commands.pr_create.PRService"
                                 ) as mock_service,
+                                patch(
+                                    "vibe3.commands.pr_create.check_branch_behind",
+                                    return_value=None,
+                                ),  # Mock branch behind check
                             ):
                                 pr_service = mock_service.return_value
                                 pr_service.get_open_pr_for_branch.return_value = None

--- a/tests/vibe3/commands/test_task_binding.py
+++ b/tests/vibe3/commands/test_task_binding.py
@@ -73,11 +73,12 @@ def test_pr_create_requires_human_confirmation(
     mock_pr_service.create_pr.assert_not_called()
 
 
+@patch("vibe3.commands.pr_create.check_branch_behind", return_value=None)
 @patch("vibe3.commands.pr_create.render_pr_created")
 @patch("vibe3.commands.pr_create.PRService")
 @patch("vibe3.commands.pr_create.FlowService")
 def test_pr_create_allows_yes_when_task_issue_missing(
-    mock_flow_service_cls, mock_pr_service_cls, _render_pr_created
+    mock_flow_service_cls, mock_pr_service_cls, _render_pr_created, _check_behind
 ) -> None:
     """pr create --yes should bypass gates."""
     flow_service = MagicMock()

--- a/tests/vibe3/utils/test_branch_compare.py
+++ b/tests/vibe3/utils/test_branch_compare.py
@@ -42,7 +42,11 @@ class TestCheckBranchBehind:
         from vibe3.clients.git_client import GitError
 
         mock_git = MagicMock()
-        mock_git._run.side_effect = GitError("rev-list", "fatal: bad revision")
+        # First call (fetch) succeeds, second call (rev-list) fails
+        mock_git._run.side_effect = [
+            "",  # fetch succeeds
+            GitError("rev-list", "fatal: bad revision"),  # rev-list fails
+        ]
 
         result = check_branch_behind(mock_git, "nonexistent", "main")
 
@@ -63,6 +67,19 @@ class TestCheckBranchBehind:
 
         assert result is not None
         assert result.behind_count == 3
+
+    def test_invalid_output_returns_none(self) -> None:
+        """When git rev-list returns invalid output, return None."""
+        mock_git = MagicMock()
+        # First call (fetch) succeeds, second call (rev-list) returns invalid output
+        mock_git._run.side_effect = [
+            "",  # fetch succeeds
+            "not-a-number",  # rev-list returns invalid output
+        ]
+
+        result = check_branch_behind(mock_git, "feature", "main")
+
+        assert result is None
 
 
 class TestFormatBranchBehindBody:

--- a/tests/vibe3/utils/test_branch_compare.py
+++ b/tests/vibe3/utils/test_branch_compare.py
@@ -1,0 +1,158 @@
+"""Tests for branch_compare utilities."""
+
+from unittest.mock import MagicMock
+
+from vibe3.utils.branch_compare import (
+    BranchBehindInfo,
+    check_branch_behind,
+    format_branch_behind_body,
+    format_branch_behind_console,
+)
+
+
+class TestCheckBranchBehind:
+    """Tests for check_branch_behind function."""
+
+    def test_up_to_date_returns_none(self) -> None:
+        """When branch is up-to-date, return None."""
+        mock_git = MagicMock()
+        mock_git._run.return_value = "0"
+
+        result = check_branch_behind(mock_git, "feature", "main")
+
+        assert result is None
+        mock_git._run.assert_called()
+
+    def test_behind_n_commits_returns_info(self) -> None:
+        """When branch is behind N commits, return BranchBehindInfo with count."""
+        mock_git = MagicMock()
+        # First call for fetch, second for rev-list
+        mock_git._run.side_effect = ["", "5"]
+
+        result = check_branch_behind(mock_git, "feature", "main")
+
+        assert result is not None
+        assert isinstance(result, BranchBehindInfo)
+        assert result.head_branch == "feature"
+        assert result.base_branch == "main"
+        assert result.behind_count == 5
+
+    def test_origin_head_not_exists_returns_none(self) -> None:
+        """When origin/{head} doesn't exist, return None (git error)."""
+        from vibe3.clients.git_client import GitError
+
+        mock_git = MagicMock()
+        mock_git._run.side_effect = GitError("rev-list", "fatal: bad revision")
+
+        result = check_branch_behind(mock_git, "nonexistent", "main")
+
+        assert result is None
+
+    def test_fetch_failure_continues_with_warning(self) -> None:
+        """When fetch fails, continue with stale refs (log warning)."""
+        from vibe3.clients.git_client import GitError
+
+        mock_git = MagicMock()
+        # First call (fetch) fails, second call (rev-list) succeeds
+        mock_git._run.side_effect = [
+            GitError("fetch", "network error"),
+            "3",
+        ]
+
+        result = check_branch_behind(mock_git, "feature", "main")
+
+        assert result is not None
+        assert result.behind_count == 3
+
+
+class TestFormatBranchBehindBody:
+    """Tests for format_branch_behind_body function."""
+
+    def test_output_contains_branch_names(self) -> None:
+        """Output should contain head and base branch names."""
+        info = BranchBehindInfo(
+            head_branch="feature-branch",
+            base_branch="main",
+            behind_count=5,
+        )
+
+        result = format_branch_behind_body(info)
+
+        assert "feature-branch" in result
+        assert "main" in result
+        assert "5" in result
+
+    def test_output_is_markdown(self) -> None:
+        """Output should be formatted as markdown."""
+        info = BranchBehindInfo(
+            head_branch="feature",
+            base_branch="main",
+            behind_count=3,
+        )
+
+        result = format_branch_behind_body(info)
+
+        assert "## ⚠️" in result
+        assert "```bash" in result
+        assert "git fetch" in result
+        assert "git rebase" in result
+
+    def test_output_contains_recommended_actions(self) -> None:
+        """Output should contain recommended git commands."""
+        info = BranchBehindInfo(
+            head_branch="feature",
+            base_branch="main",
+            behind_count=10,
+        )
+
+        result = format_branch_behind_body(info)
+
+        assert "git fetch origin main" in result
+        assert "git rebase origin/main" in result
+        assert "git push --force-with-lease" in result
+
+
+class TestFormatBranchBehindConsole:
+    """Tests for format_branch_behind_console function."""
+
+    def test_output_contains_branch_names(self) -> None:
+        """Output should contain head and base branch names."""
+        info = BranchBehindInfo(
+            head_branch="feature-branch",
+            base_branch="main",
+            behind_count=5,
+        )
+
+        result = format_branch_behind_console(info)
+
+        assert "feature-branch" in result
+        assert "main" in result
+        assert "5" in result
+
+    def test_output_is_rich_markup(self) -> None:
+        """Output should contain Rich markup tags."""
+        info = BranchBehindInfo(
+            head_branch="feature",
+            base_branch="main",
+            behind_count=3,
+        )
+
+        result = format_branch_behind_console(info)
+
+        assert "[bold red]" in result
+        assert "[yellow]" in result
+        assert "[cyan]" in result
+
+    def test_output_contains_recommended_actions(self) -> None:
+        """Output should contain recommended git commands."""
+        info = BranchBehindInfo(
+            head_branch="feature",
+            base_branch="main",
+            behind_count=10,
+        )
+
+        result = format_branch_behind_console(info)
+
+        assert "git fetch origin main" in result
+        assert "git rebase origin/main" in result
+        assert "git push --force-with-lease" in result


### PR DESCRIPTION
## Summary

- 新增分支落后检查功能，当 PR 分支落后 base branch 时显示醒目提醒
- `vibe3 pr show`：OPEN 状态 PR 显示红色分隔线 + 颜色高亮警告
- `vibe3 pr create`：落后时自动在 PR body 开头添加 Markdown 警告块
- 核心逻辑提取为可复用模块 `src/vibe3/utils/branch_compare.py`

## Changes

### New Module
- `src/vibe3/utils/branch_compare.py`：可复用分支比较工具
  - `check_branch_behind()`：检查分支落后情况，返回 `BranchBehindInfo` dataclass
  - `format_branch_behind_body()`：格式化为 PR body Markdown
  - `format_branch_behind_console()`：格式化为 Console Rich markup

### PR Show Enhancement
- 仅对 OPEN 状态 PR 检查（已合并/已关闭不检查，避免误导）
- 使用 `console.rule()` 创建醒目红色分隔线
- 多颜色布局：红色关键词、黄色分支名/数量、青色 base、绿色步骤编号
- 编号步骤，易于执行 rebase

### PR Create Enhancement
- 创建 PR 前检查分支是否落后 base
- 落后时在 PR body 开头自动添加 Markdown 警告块
- 警告块包含落后数量和 rebase 命令代码块

## Reusability

| 功能 | 复用函数 | 调用位置 |
|------|---------|---------|
| 检查落后 | `check_branch_behind()` | pr_query.py, pr_create.py |
| Console 显示 | `format_branch_behind_console()` | pr_query.py |
| PR body 显示 | `format_branch_behind_body()` | pr_create.py |

核心逻辑只写一次，两处共享，复用率 100%。

## Test plan
- [x] `vibe3 pr show <OPEN_PR>` 落后时显示警告
- [x] `vibe3 pr show <MERGED_PR>` 不显示警告
- [x] `format_branch_behind_body()` 输出正确 Markdown
- [x] `format_branch_behind_console()` 输出正确 Rich markup
- [x] pre-commit 检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)