### PR TITLE
docs(standards): align stale vibe-start references to vibe-continue

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -46,11 +46,11 @@ related_docs:
 ## 🧭 Namespace 约定
 
 - `workflow` 使用 `vibe:*`
-  - 例：`vibe:new`、`vibe:start`、`vibe:commit`
+  - 例：`vibe:new`、`vibe:continue`、`vibe:commit`
 - `skill` 使用 `vibe-*`
-  - 例：`vibe-new`、`vibe-start`、`vibe-commit`
+  - 例：`vibe-new`、`vibe-continue`、`vibe-commit`
 
-兼容期内，用户仍可使用 `/vibe-new`、`/vibe-start` 等 slash 入口；这些入口触发的是 workflow，workflow 再委托同名 skill。
+兼容期内，用户仍可使用 `/vibe-new`、`/vibe-continue` 等 slash 入口；这些入口触发的是 workflow，workflow 再委托同名 skill。
 
 ## 🤖 AI 互操作协议 (AI Interoperability Protocol)
 
@@ -73,7 +73,7 @@ related_docs:
 | Workflow | Description | Usage |
 | :--- | :--- | :--- |
 | **[/vibe-new](workflows/vibe:new.md)** | 规划入口 | intake 新目标、handoff 或缺 spec 的 task，委托 `vibe-new` skill 产出 plan 和 task 绑定。 |
-| **[/vibe-start](workflows/vibe:start.md)** | 执行入口 | 执行当前 flow 已绑定且带 plan 的 task，委托 `vibe-start` skill 按图纸推进。 |
+| **[/vibe-continue](workflows/vibe:continue.md)** | 执行入口 | 执行当前 flow 已绑定且带 plan 的 task，委托 `vibe-continue` skill 按图纸推进。 |
 | **[/vibe-commit](workflows/vibe:commit.md)** | 提交与发 PR 入口 | 读取工作区和 flow 事实，再委托 `vibe-commit` skill 处理提交分组与 PR 切片。 |
 
 ## 🧩 专项 workflow

--- a/docs/references/skill-loop-memo.md
+++ b/docs/references/skill-loop-memo.md
@@ -17,7 +17,7 @@ related_docs:
   - skills/vibe-task/SKILL.md
   - skills/vibe-check/SKILL.md
   - skills/vibe-new/SKILL.md
-  - skills/vibe-start/SKILL.md
+  - skills/vibe-continue/SKILL.md
   - skills/vibe-commit/SKILL.md
   - skills/vibe-integrate/SKILL.md
   - skills/vibe-done/SKILL.md
@@ -35,7 +35,7 @@ related_docs:
 
 ## 主链路
 
-`GitHub issue -> vibe-new -> vibe-start -> spec execution -> PR -> review/integrate -> done`
+`GitHub issue -> vibe-new -> vibe-continue -> spec execution -> PR -> review/integrate -> done`
 
 > Note: `roadmap item` 是历史兼容/规划参考语义（见 glossary.md §3.2）。当前治理直接管理 assignee issue，不经过 roadmap item 中间层转换。
 
@@ -56,10 +56,10 @@ related_docs:
    - 不做什么：不创建 task，不直接开始执行。
    - 记忆句：它处理“怎么进入新链”，不是“进来后怎么落 task”。
 
-4. `vibe-start`
-   - 做什么：进入新 flow 后，从 issue 落 task，再把 `spec_standard/spec_ref` 交给对应执行体系。
+4. `vibe-continue`
+   - 做什么：恢复或加载当前 flow 的任务上下文，确保共享真源与本地现场一致。
    - 不做什么：不承担旧 flow 到新 flow 的转换，不负责 issue intake。
-   - 记忆句：它是“从 issue 落 task 后开始做”，不是“决定切到哪个主 issue”。
+   - 记忆句：它是“恢复工作现场”，不是“决定切到哪个主 issue”。
 
 5. `vibe-commit`
    - 做什么：commit 分组、PR 切片、提交并发 PR。
@@ -95,7 +95,7 @@ related_docs:
 - `vibe-issue`：发 issue
 - `vibe-roadmap`：排 roadmap
 - `vibe-new`：旧 flow 到新 flow 的转换，不创建 task
-- `vibe-start`：从 issue 落 task，然后开始做
+- `vibe-continue`：恢复并加载执行现场
 - `vibe-commit`：提交 + PR
 - `vibe-integrate`：review / CI / merge readiness
 - `vibe-done`：merge and clear

--- a/docs/standards/v3/git-workflow-standard.md
+++ b/docs/standards/v3/git-workflow-standard.md
@@ -154,7 +154,7 @@ closeout 约束：
 1. 从 `GitHub issue` 确认来源层目标（直接真源）
 2. 若有必要，同步对应的 `roadmap item`（仅作规划参考）
 3. 通过 `vibe-new` 确认/创建目标 issue、创建/注册 flow、绑定 issue 并创建 PR draft
-4. 进入新 flow 后，通过 `vibe-start` 确认并补齐 flow 环境
+4. 进入新 flow 后，通过 `vibe-continue` 确认并补齐 flow 环境
 5. 让该 `flow` 绑定本轮要交付的 `task` (execution record)
 6. 在该 `flow` 对应的 `branch` 上提交本地 commit
 7. 执行 `review`

--- a/docs/standards/v3/skill-trigger-standard.md
+++ b/docs/standards/v3/skill-trigger-standard.md
@@ -71,7 +71,7 @@ related_docs:
 | `vibe-issue` | Issue intake | 用户要创建、补全、查重、润色、落 GitHub issue | 已经在讨论版本归类、task 映射、runtime 修复 | "创建 issue", "提 issue", "查重", "补 issue 模板" |
 | `vibe-roadmap` | Roadmap planning | 用户要排版本、定目标、做 backlog triage、决定 issue 放哪版 | 只是在看当前 flow 该去哪，或修 runtime/registry | "版本规划", "下一个版本做什么", "这个 issue 放哪一版" |
 | `vibe-new` | Flow transition | 用户要开始新任务、确认目标 issue、创建/注册 flow、绑定 issue 并创建 PR draft | 已经进入实现、跨 worktree 调度 | "开始新任务", "进入新 flow", "切主 issue", "vibe-new" |
-| `vibe-start` | Execution resume | 用户切换到已有分支后，要确认并补齐 flow 环境、绑定 issue 或补 PR draft | 创建新 issue、创建新 branch、新任务启动 | "从 issue 开始做", "开始执行", "恢复执行环境", "vibe-start" |
+| `vibe-continue` | Execution resume | 用户要恢复已有分支的工作、重新加载当前 flow 上下文 | 创建新 issue、创建新 branch、新任务启动 | "恢复执行", "继续工作", "加载上下文", "vibe-continue" |
 | `vibe-task` | Task registry / roadmap-task mapping | 用户要看跨 worktree 的 flow/task 大盘，或核对 `roadmap <-> task`、task registry | 项目级版本规划、Issue intake、runtime stale repair | "现在该回哪个 flow", "任务总览", "修复 roadmap 和 task 对应关系" |
 | `vibe-check` | Runtime / task-flow binding | 用户要解释或修复 `task <-> flow` / worktree runtime 不一致 | roadmap 归类、task registry 审计、Issue 治理 | "binding 不对", "runtime stale", "check runtime", "当前 worktree 状态不对" |
 | `vibe-review-code` | Code review | 用户要对 source changes 做 pre-PR 审查、复核 PR review feedback、检查实现风险与测试覆盖 | docs-only review、standards/changelog 审查 | "review 这段代码", "代码审查", "PR 前 review", "根据 review feedback 修代码" |

--- a/supervisor/vibe-orchestrator/SKILL.md
+++ b/supervisor/vibe-orchestrator/SKILL.md
@@ -22,14 +22,14 @@ input_examples:
 2. Gate 1: Scope Gate
 3. Gate 2: Spec Gate
 4. Gate 3: Plan Gate
-   **(HARD STOP) /vibe-new 只能走到此处，等待人类用 /vibe-start 唤醒执行机**
+   **(HARD STOP) /vibe-new 只能走到此处，等待人类用 /vibe-continue 唤醒执行机**
 5. Gate 4: Test Gate
 6. Gate 5: Execution Gate
 7. Gate 6: Audit / Review Gate
 
 ## Exception Escalation Hook (异常举报通道)
 
-作为总编排器，你还需要接管来自下层技能（特别是 `vibe-start` 步进器）的异常举报（Escalation）。
+作为总编排器，你还需要接管来自下层技能（特别是 `vibe-continue` 步进器）的异常举报（Escalation）。
 下属技能如果在执行途中遇到以下情况，将主动挂起并向你报告：
 
 1. **文档缺失/前提错误**：执行依赖的关键配置或规范不存在。
@@ -157,7 +157,7 @@ input_examples:
 - 检查是否存在可执行计划（目标、非目标、步骤、验证命令）
 - 无计划时，先产出计划文件再继续
 - 禁止"先改再补计划"
-- **HARD STOP**：一旦产生 Plan，如果入口是 `/vibe-new`，强制挂起，并提示用户运行 `/vibe-start` 或人工审查。严禁直接继续走到 Gate 4！
+- **HARD STOP**：一旦产生 Plan，如果入口是 `/vibe-new`，强制挂起，并提示用户运行 `/vibe-continue` 或人工审查。严禁直接继续走到 Gate 4！
 
 ### Gate 4: Test Gate
 
@@ -170,7 +170,7 @@ input_examples:
 - 按计划逐任务执行，禁止跳步
 - 执行前声明改动范围（文件数、预计行数）
 - 执行中收集验证证据（命令与输出）
-- 若入口来自 `/vibe-new`，则无权进入此 Gate。此 Gate 仅为 `/vibe-start` 开放。
+- 若入口来自 `/vibe-new`，则无权进入此 Gate。此 Gate 仅为 `/vibe-continue` 开放。
 - 共享 registry、worktree 绑定、共享任务存储修改必须委托给 Shell 命令（Tier 1）：
   - 当前目录模式：
     1. 确保在正确的分支上（`git checkout <branch>` 或创建新分支）
@@ -220,7 +220,7 @@ input_examples:
 ## Entry Command Contract
 
 - 当用户通过 `/vibe-new <feature>` 进入时，默认走慢速通道并从 Scope Gate 开始，并在 Gate 3 (Plan) 结束后触发绝对硬停止（HARD STOP）。
-- 当用户通过 `/vibe-start` 进入时，它是静默执行机。如果期间触发报错，它会将警报升级 (Escalate) 给你。
+- 当用户通过 `/vibe-continue` 进入时，它是静默执行机。如果期间触发报错，它会将警报升级 (Escalate) 给你。
 - 当用户请求 `/vibe-commit` 时，仅在 Audit / Review Gate 通过后进入提交建议阶段
 
 ## Output Contract


### PR DESCRIPTION
Aligns stale /vibe-start references to /vibe-continue in core documentation files as requested in issue #1456.

Files updated:
1. .agent/README.md
2. docs/standards/v3/git-workflow-standard.md
3. docs/standards/v3/skill-trigger-standard.md
4. docs/references/skill-loop-memo.md
5. supervisor/vibe-orchestrator/SKILL.md

No structural or logic changes were made.