### PR TITLE
refactor(test): extract shared error-tracking fixtures to conftest.py

### DIFF
--- a/tests/vibe3/exceptions/conftest.py
+++ b/tests/vibe3/exceptions/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for exception tests."""
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from vibe3.clients import SQLiteClient
+from vibe3.services.error_tracking_service import ErrorTrackingService
+
+
+@pytest.fixture(autouse=True)
+def reset_error_tracking() -> Iterator[None]:
+    """Reset ErrorTrackingService singleton between tests to prevent state leakage."""
+    yield
+    ErrorTrackingService.clear_instance()
+
+
+@pytest.fixture
+def temp_store(tmp_path: Path) -> SQLiteClient:
+    """Create a temporary SQLiteClient for testing."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    from vibe3.clients.sqlite_schema import init_schema
+
+    init_schema(conn)
+    conn.close()
+    return SQLiteClient(db_path=str(db_path))

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -1,32 +1,12 @@
 """Tests for ErrorTrackingService cleanup functionality."""
 
 import sqlite3
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from vibe3.clients import SQLiteClient
 from vibe3.services.error_tracking_service import ErrorTrackingService
-
-
-@pytest.fixture(autouse=True)
-def reset_error_tracking() -> Iterator[None]:
-    """Reset ErrorTrackingService singleton between tests to prevent state leakage."""
-    yield
-    ErrorTrackingService.clear_instance()
-
-
-@pytest.fixture
-def temp_store(tmp_path: Path) -> SQLiteClient:
-    """Create a temporary SQLiteClient for testing."""
-    db_path = tmp_path / "test.db"
-    conn = sqlite3.connect(db_path)
-    from vibe3.clients.sqlite_schema import init_schema
-
-    init_schema(conn)
-    conn.close()
-    return SQLiteClient(db_path=str(db_path))
 
 
 def test_cleanup_deletes_old_records(temp_store: SQLiteClient) -> None:

--- a/tests/vibe3/exceptions/test_error_tracking_edge_cases.py
+++ b/tests/vibe3/exceptions/test_error_tracking_edge_cases.py
@@ -1,32 +1,9 @@
 """Tests for ErrorTrackingService.get_all_errors_status() edge cases."""
 
 import sqlite3
-from collections.abc import Iterator
-from pathlib import Path
-
-import pytest
 
 from vibe3.clients import SQLiteClient
 from vibe3.services.error_tracking_service import ErrorTrackingService
-
-
-@pytest.fixture(autouse=True)
-def reset_error_tracking() -> Iterator[None]:
-    """Reset ErrorTrackingService singleton between tests to prevent state leakage."""
-    yield
-    ErrorTrackingService.clear_instance()
-
-
-@pytest.fixture
-def temp_store(tmp_path: Path) -> SQLiteClient:
-    """Create a temporary SQLiteClient for testing."""
-    db_path = tmp_path / "test.db"
-    conn = sqlite3.connect(db_path)
-    from vibe3.clients.sqlite_schema import init_schema
-
-    init_schema(conn)
-    conn.close()
-    return SQLiteClient(db_path=str(db_path))
 
 
 def test_get_all_errors_status_empty_db(temp_store: SQLiteClient) -> None:


### PR DESCRIPTION
Closes #1439

## Summary

Extract `reset_error_tracking` and `temp_store` fixtures from test_error_tracking.py and test_error_tracking_edge_cases.py into a shared conftest.py to reduce duplication.

**Changes**:
- NEW: tests/vibe3/exceptions/conftest.py with shared fixtures
- REMOVE: duplicate fixture definitions from both test files
- CLEANUP: unused imports (Iterator, Path, pytest where applicable)

**Impact**: Pure test refactoring - no source code changes

## Test plan

- [x] All 41 tests pass (no regressions)
- [x] Type checking passes (mypy clean)
- [x] Linting passes (ruff clean)
- [x] Fixture correctness verified (byte-for-byte match with originals)
- [x] Import cleanup verified (unused imports removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
