### PR TITLE
fix(flow): use remote timeline for --remote mode

### DIFF
--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -41,7 +41,7 @@ from vibe3.ui.flow_ui import (
 from vibe3.utils.branch_utils import find_parent_branch
 
 if TYPE_CHECKING:
-    pass
+    from vibe3.models.flow import FlowEvent, TimelineEvent
 
 
 from vibe3.commands.command_options import (
@@ -50,6 +50,35 @@ from vibe3.commands.command_options import (
 )
 
 StatusOption = Annotated[bool, typer.Option("--snapshot", help="静态快照模式")]
+
+
+def _parse_remote_issue_number(raw: str) -> int:
+    """Parse issue number from raw CLI input for --remote mode."""
+    stripped = raw.strip()
+    if stripped.isdigit():
+        return int(stripped)
+    raise UserError(
+        f"Cannot parse issue number from: {raw}. " "Provide a numeric issue number."
+    )
+
+
+def _timeline_to_flow_events(
+    timeline: list["TimelineEvent"],
+    branch: str,
+) -> list["FlowEvent"]:
+    """Convert TimelineEvent objects to FlowEvent for timeline rendering."""
+    from vibe3.models.flow import FlowEvent
+
+    return [
+        FlowEvent(
+            branch=branch,
+            event_type=te.event_type,
+            actor=te.actor,
+            detail=te.detail,
+            created_at=te.timestamp,
+        )
+        for te in timeline
+    ]
 
 
 def show(
@@ -96,30 +125,44 @@ def show(
         output_format = "json"
 
     service = FlowService()
-    try:
-        target_branch = resolve_command_branch(
-            branch_opt=branch_opt,
-            pr_opt=pr_opt,
-            position_arg=branch_arg,
-            flow_service=service,
+
+    # Handle --remote mode: parse issue number directly, bypass local resolution
+    task_issue_number: int | None
+    if remote:
+        raw = branch_opt or branch_arg
+        if raw is None:
+            raise UserError(
+                "Cannot use --remote without an issue number. "
+                "Provide it as: flow show --remote <issue_number>"
+            )
+        task_issue_number = _parse_remote_issue_number(raw)
+        target_branch = f"remote-#{task_issue_number}"
+    else:
+        # Local mode: resolve branch via standard resolution
+        try:
+            target_branch = resolve_command_branch(
+                branch_opt=branch_opt,
+                pr_opt=pr_opt,
+                position_arg=branch_arg,
+                flow_service=service,
+            )
+        except (UserError, SystemError) as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(1) from error
+
+        # Get task issue number for remote fallback
+        links = service.store.get_issue_links(target_branch)
+        task_issue_number = next(
+            (link["issue_number"] for link in links if link["issue_role"] == "task"),
+            None,
         )
-    except (UserError, SystemError) as error:
-        typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(1) from error
 
-    # Get task issue number for remote fallback
-    links = service.store.get_issue_links(target_branch)
-    task_issue_number = next(
-        (link["issue_number"] for link in links if link["issue_role"] == "task"),
-        None,
-    )
+        # Fallback: parse issue number from branch name when local DB missing
+        if task_issue_number is None:
+            from vibe3.services.issue_flow_service import IssueFlowService
 
-    # Fallback: parse issue number from branch name when local DB missing
-    if task_issue_number is None:
-        from vibe3.services.issue_flow_service import IssueFlowService
-
-        issue_flow_service = IssueFlowService(store=service.store)
-        task_issue_number = issue_flow_service.parse_issue_number_any(target_branch)
+            issue_flow_service = IssueFlowService(store=service.store)
+            task_issue_number = issue_flow_service.parse_issue_number_any(target_branch)
 
     # Use resolver for source-aware read
     from vibe3.services.flow_status_resolver import FlowStatusResolver
@@ -222,10 +265,18 @@ def show(
 
     # Build timeline using resolver's source-aware flow_status
     # Do NOT call service.get_flow_timeline (reads from local)
-    events_data = service.store.get_events(target_branch, limit=100)
-    from vibe3.models.flow import FlowEvent
+    from vibe3.models.data_source import DataSource
 
-    events = [FlowEvent(**e) for e in events_data]
+    if (
+        flow_status.timeline
+        and flow_status.data_source == DataSource.ISSUE_BODY_FALLBACK
+    ):
+        events = _timeline_to_flow_events(flow_status.timeline, target_branch)
+    else:
+        events_data = service.store.get_events(target_branch, limit=100)
+        from vibe3.models.flow import FlowEvent
+
+        events = [FlowEvent(**e) for e in events_data]
 
     if not flow_status:
         logger.error(f"Flow not found: {target_branch}")

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -267,12 +267,13 @@ def show(
     # Do NOT call service.get_flow_timeline (reads from local)
     from vibe3.models.data_source import DataSource
 
-    if (
-        flow_status.timeline
-        and flow_status.data_source == DataSource.ISSUE_BODY_FALLBACK
-    ):
+    # Use data_source alone to decide timeline source
+    # For remote-sourced data (ISSUE_BODY_FALLBACK), always use remote timeline
+    # even if empty - never fall back to local events
+    if flow_status.data_source == DataSource.ISSUE_BODY_FALLBACK:
         events = _timeline_to_flow_events(flow_status.timeline, target_branch)
     else:
+        # Local mode: read from SQLite
         events_data = service.store.get_events(target_branch, limit=100)
         from vibe3.models.flow import FlowEvent
 

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -1,16 +1,18 @@
 """Flow status commands - show, status."""
 
 import json
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 import typer
 from loguru import logger
 
 from vibe3.commands.command_options import (
     ActorFilterOption,
+    AllOption,
     FormatOption,
     RemoteOption,
     TraceMinMsOption,
+    TraceOption,
 )
 from vibe3.commands.common import (
     enable_method_trace,
@@ -23,7 +25,9 @@ from vibe3.commands.flow_status_helpers import (
     _fetch_pr_map,
     _fetch_worktree_map,
     _get_yaml,
+    _parse_remote_issue_number,
     _render_snapshot_format,
+    _timeline_to_flow_events,
 )
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.exceptions import SystemError, UserError
@@ -40,45 +44,7 @@ from vibe3.ui.flow_ui import (
 )
 from vibe3.utils.branch_utils import find_parent_branch
 
-if TYPE_CHECKING:
-    from vibe3.models.flow import FlowEvent, TimelineEvent
-
-
-from vibe3.commands.command_options import (
-    AllOption,
-    TraceOption,
-)
-
 StatusOption = Annotated[bool, typer.Option("--snapshot", help="静态快照模式")]
-
-
-def _parse_remote_issue_number(raw: str) -> int:
-    """Parse issue number from raw CLI input for --remote mode."""
-    stripped = raw.strip()
-    if stripped.isdigit():
-        return int(stripped)
-    raise UserError(
-        f"Cannot parse issue number from: {raw}. " "Provide a numeric issue number."
-    )
-
-
-def _timeline_to_flow_events(
-    timeline: list["TimelineEvent"],
-    branch: str,
-) -> list["FlowEvent"]:
-    """Convert TimelineEvent objects to FlowEvent for timeline rendering."""
-    from vibe3.models.flow import FlowEvent
-
-    return [
-        FlowEvent(
-            branch=branch,
-            event_type=te.event_type,
-            actor=te.actor,
-            detail=te.detail,
-            created_at=te.timestamp,
-        )
-        for te in timeline
-    ]
 
 
 def show(

--- a/src/vibe3/commands/flow_status_helpers.py
+++ b/src/vibe3/commands/flow_status_helpers.py
@@ -8,12 +8,42 @@ from typing import TYPE_CHECKING, Any
 import typer
 from loguru import logger
 
+from vibe3.exceptions import UserError
 from vibe3.services.flow_projection_service import FlowProjectionService
 from vibe3.ui.flow_ui import render_error, render_flow_status
 from vibe3.utils.branch_utils import find_parent_branch
 
 if TYPE_CHECKING:
-    pass
+    from vibe3.models.flow import FlowEvent, TimelineEvent
+
+
+def _parse_remote_issue_number(raw: str) -> int:
+    """Parse issue number from raw CLI input for --remote mode."""
+    stripped = raw.strip()
+    if stripped.isdigit():
+        return int(stripped)
+    raise UserError(
+        f"Cannot parse issue number from: {raw}. " "Provide a numeric issue number."
+    )
+
+
+def _timeline_to_flow_events(
+    timeline: list["TimelineEvent"],
+    branch: str,
+) -> list["FlowEvent"]:
+    """Convert TimelineEvent objects to FlowEvent for timeline rendering."""
+    from vibe3.models.flow import FlowEvent
+
+    return [
+        FlowEvent(
+            branch=branch,
+            event_type=te.event_type,
+            actor=te.actor,
+            detail=te.detail,
+            created_at=te.timestamp,
+        )
+        for te in timeline
+    ]
 
 
 def _get_yaml() -> ModuleType:

--- a/tests/vibe3/commands/test_flow_status_remote_timeline.py
+++ b/tests/vibe3/commands/test_flow_status_remote_timeline.py
@@ -46,34 +46,41 @@ def test_remote_no_local_db_uses_remote_timeline() -> None:
             "vibe3.services.flow_status_resolver.FlowStatusResolver"
         ) as mock_resolver_class:
             with patch(
-                "vibe3.commands.flow_status.render_flow_timeline"
-            ) as mock_render:
-                mock_service = MagicMock()
-                mock_service_class.return_value = mock_service
+                "vibe3.commands.flow_status.FlowProjectionService"
+            ) as mock_projection_class:
+                with patch(
+                    "vibe3.commands.flow_status.render_flow_timeline"
+                ) as mock_render:
+                    mock_service = MagicMock()
+                    mock_service_class.return_value = mock_service
 
-                mock_resolver = MagicMock()
-                mock_resolver.resolve.return_value = flow_status
-                mock_resolver_class.return_value = mock_resolver
+                    mock_resolver = MagicMock()
+                    mock_resolver.resolve.return_value = flow_status
+                    mock_resolver_class.return_value = mock_resolver
 
-                result = runner.invoke(
-                    app, ["flow", "show", "--remote", str(issue_number)]
-                )
+                    mock_projection = MagicMock()
+                    mock_projection.get_issue_titles.return_value = ({}, None)
+                    mock_projection_class.return_value = mock_projection
 
-                assert result.exit_code == 0
-                # Verify resolver was called with remote=True
-                mock_resolver.resolve.assert_called_once()
-                call_kwargs = mock_resolver.resolve.call_args.kwargs
-                assert call_kwargs["remote"] is True
-                assert call_kwargs["issue_number"] == issue_number
+                    result = runner.invoke(
+                        app, ["flow", "show", "--remote", str(issue_number)]
+                    )
 
-                # Verify timeline was rendered (not local events)
-                mock_render.assert_called_once()
-                rendered_events = mock_render.call_args.args[1]
-                assert len(rendered_events) == 2
-                assert rendered_events[0].event_type == "flow_created"
-                assert rendered_events[0].actor == "alice"
-                assert rendered_events[1].event_type == "state_transitioned"
-                assert rendered_events[1].actor == "bob"
+                    assert result.exit_code == 0
+                    # Verify resolver was called with remote=True
+                    mock_resolver.resolve.assert_called_once()
+                    call_kwargs = mock_resolver.resolve.call_args.kwargs
+                    assert call_kwargs["remote"] is True
+                    assert call_kwargs["issue_number"] == issue_number
+
+                    # Verify timeline was rendered (not local events)
+                    mock_render.assert_called_once()
+                    rendered_events = mock_render.call_args.args[1]
+                    assert len(rendered_events) == 2
+                    assert rendered_events[0].event_type == "flow_created"
+                    assert rendered_events[0].actor == "alice"
+                    assert rendered_events[1].event_type == "state_transitioned"
+                    assert rendered_events[1].actor == "bob"
 
 
 def test_remote_ignores_stale_local_events() -> None:
@@ -105,40 +112,47 @@ def test_remote_ignores_stale_local_events() -> None:
             "vibe3.services.flow_status_resolver.FlowStatusResolver"
         ) as mock_resolver_class:
             with patch(
-                "vibe3.commands.flow_status.render_flow_timeline"
-            ) as mock_render:
-                mock_service = MagicMock()
-                # Simulate local DB with stale events
-                mock_store = MagicMock()
-                mock_store.get_events.return_value = [
-                    {
-                        "branch": branch,
-                        "event_type": "flow_created",
-                        "actor": "old_actor",
-                        "detail": "Stale local event",
-                        "created_at": "2024-01-01T00:00:00Z",
-                    }
-                ]
-                mock_service.store = mock_store
-                mock_service_class.return_value = mock_service
+                "vibe3.commands.flow_status.FlowProjectionService"
+            ) as mock_projection_class:
+                with patch(
+                    "vibe3.commands.flow_status.render_flow_timeline"
+                ) as mock_render:
+                    mock_service = MagicMock()
+                    # Simulate local DB with stale events
+                    mock_store = MagicMock()
+                    mock_store.get_events.return_value = [
+                        {
+                            "branch": branch,
+                            "event_type": "flow_created",
+                            "actor": "old_actor",
+                            "detail": "Stale local event",
+                            "created_at": "2024-01-01T00:00:00Z",
+                        }
+                    ]
+                    mock_service.store = mock_store
+                    mock_service_class.return_value = mock_service
 
-                mock_resolver = MagicMock()
-                mock_resolver.resolve.return_value = flow_status
-                mock_resolver_class.return_value = mock_resolver
+                    mock_resolver = MagicMock()
+                    mock_resolver.resolve.return_value = flow_status
+                    mock_resolver_class.return_value = mock_resolver
 
-                result = runner.invoke(
-                    app, ["flow", "show", "--remote", str(issue_number)]
-                )
+                    mock_projection = MagicMock()
+                    mock_projection.get_issue_titles.return_value = ({}, None)
+                    mock_projection_class.return_value = mock_projection
 
-                assert result.exit_code == 0
-                # Verify remote timeline was used, not local DB
-                mock_render.assert_called_once()
-                rendered_events = mock_render.call_args.args[1]
-                assert len(rendered_events) == 1
-                assert rendered_events[0].actor == "alice"
-                assert rendered_events[0].detail == "Flow created (remote)"
-                # Local DB should NOT have been queried
-                mock_store.get_events.assert_not_called()
+                    result = runner.invoke(
+                        app, ["flow", "show", "--remote", str(issue_number)]
+                    )
+
+                    assert result.exit_code == 0
+                    # Verify remote timeline was used, not local DB
+                    mock_render.assert_called_once()
+                    rendered_events = mock_render.call_args.args[1]
+                    assert len(rendered_events) == 1
+                    assert rendered_events[0].actor == "alice"
+                    assert rendered_events[0].detail == "Flow created (remote)"
+                    # Local DB should NOT have been queried
+                    mock_store.get_events.assert_not_called()
 
 
 def test_non_remote_uses_local_events() -> None:
@@ -159,44 +173,51 @@ def test_non_remote_uses_local_events() -> None:
             "vibe3.services.flow_status_resolver.FlowStatusResolver"
         ) as mock_resolver_class:
             with patch(
-                "vibe3.commands.flow_status.render_flow_timeline"
-            ) as mock_render:
+                "vibe3.commands.flow_status.FlowProjectionService"
+            ) as mock_projection_class:
                 with patch(
-                    "vibe3.commands.flow_status.resolve_command_branch"
-                ) as mock_resolve_branch:
-                    mock_service = MagicMock()
-                    mock_store = MagicMock()
-                    mock_store.get_issue_links.return_value = [
-                        {"issue_role": "task", "issue_number": 123}
-                    ]
-                    mock_store.get_events.return_value = [
-                        {
-                            "branch": branch,
-                            "event_type": "flow_created",
-                            "actor": "local_actor",
-                            "detail": "Local event",
-                            "created_at": "2024-01-01T00:00:00Z",
-                        }
-                    ]
-                    mock_service.store = mock_store
-                    mock_service_class.return_value = mock_service
+                    "vibe3.commands.flow_status.render_flow_timeline"
+                ) as mock_render:
+                    with patch(
+                        "vibe3.commands.flow_status.resolve_command_branch"
+                    ) as mock_resolve_branch:
+                        mock_service = MagicMock()
+                        mock_store = MagicMock()
+                        mock_store.get_issue_links.return_value = [
+                            {"issue_role": "task", "issue_number": 123}
+                        ]
+                        mock_store.get_events.return_value = [
+                            {
+                                "branch": branch,
+                                "event_type": "flow_created",
+                                "actor": "local_actor",
+                                "detail": "Local event",
+                                "created_at": "2024-01-01T00:00:00Z",
+                            }
+                        ]
+                        mock_service.store = mock_store
+                        mock_service_class.return_value = mock_service
 
-                    mock_resolve_branch.return_value = branch
+                        mock_resolve_branch.return_value = branch
 
-                    mock_resolver = MagicMock()
-                    mock_resolver.resolve.return_value = flow_status
-                    mock_resolver_class.return_value = mock_resolver
+                        mock_resolver = MagicMock()
+                        mock_resolver.resolve.return_value = flow_status
+                        mock_resolver_class.return_value = mock_resolver
 
-                    result = runner.invoke(app, ["flow", "show"])
+                        mock_projection = MagicMock()
+                        mock_projection.get_issue_titles.return_value = ({}, None)
+                        mock_projection_class.return_value = mock_projection
 
-                    assert result.exit_code == 0
-                    # Verify local events were queried
-                    mock_store.get_events.assert_called_once_with(branch, limit=100)
-                    # Verify local events were used for rendering
-                    mock_render.assert_called_once()
-                    rendered_events = mock_render.call_args.args[1]
-                    assert len(rendered_events) == 1
-                    assert rendered_events[0].actor == "local_actor"
+                        result = runner.invoke(app, ["flow", "show"])
+
+                        assert result.exit_code == 0
+                        # Verify local events were queried
+                        mock_store.get_events.assert_called_once_with(branch, limit=100)
+                        # Verify local events were used for rendering
+                        mock_render.assert_called_once()
+                        rendered_events = mock_render.call_args.args[1]
+                        assert len(rendered_events) == 1
+                        assert rendered_events[0].actor == "local_actor"
 
 
 def test_remote_json_output_includes_timeline() -> None:
@@ -226,25 +247,33 @@ def test_remote_json_output_includes_timeline() -> None:
         with patch(
             "vibe3.services.flow_status_resolver.FlowStatusResolver"
         ) as mock_resolver_class:
-            mock_service = MagicMock()
-            mock_service_class.return_value = mock_service
+            with patch(
+                "vibe3.commands.flow_status.FlowProjectionService"
+            ) as mock_projection_class:
+                mock_service = MagicMock()
+                mock_service_class.return_value = mock_service
 
-            mock_resolver = MagicMock()
-            mock_resolver.resolve.return_value = flow_status
-            mock_resolver_class.return_value = mock_resolver
+                mock_resolver = MagicMock()
+                mock_resolver.resolve.return_value = flow_status
+                mock_resolver_class.return_value = mock_resolver
 
-            result = runner.invoke(
-                app, ["flow", "show", "--remote", str(issue_number), "--format", "json"]
-            )
+                mock_projection = MagicMock()
+                mock_projection.get_issue_titles.return_value = ({}, None)
+                mock_projection_class.return_value = mock_projection
 
-            assert result.exit_code == 0
-            import json
+                result = runner.invoke(
+                    app,
+                    ["flow", "show", "--remote", str(issue_number), "--format", "json"],
+                )
 
-            output = json.loads(result.output)
-            assert "events" in output
-            assert len(output["events"]) == 1
-            assert output["events"][0]["event_type"] == "flow_created"
-            assert output["events"][0]["actor"] == "alice"
+                assert result.exit_code == 0
+                import json
+
+                output = json.loads(result.output)
+                assert "events" in output
+                assert len(output["events"]) == 1
+                assert output["events"][0]["event_type"] == "flow_created"
+                assert output["events"][0]["actor"] == "alice"
 
 
 def test_remote_yaml_output_includes_timeline() -> None:
@@ -274,20 +303,28 @@ def test_remote_yaml_output_includes_timeline() -> None:
         with patch(
             "vibe3.services.flow_status_resolver.FlowStatusResolver"
         ) as mock_resolver_class:
-            mock_service = MagicMock()
-            mock_service_class.return_value = mock_service
+            with patch(
+                "vibe3.commands.flow_status.FlowProjectionService"
+            ) as mock_projection_class:
+                mock_service = MagicMock()
+                mock_service_class.return_value = mock_service
 
-            mock_resolver = MagicMock()
-            mock_resolver.resolve.return_value = flow_status
-            mock_resolver_class.return_value = mock_resolver
+                mock_resolver = MagicMock()
+                mock_resolver.resolve.return_value = flow_status
+                mock_resolver_class.return_value = mock_resolver
 
-            result = runner.invoke(
-                app, ["flow", "show", "--remote", str(issue_number), "--format", "yaml"]
-            )
+                mock_projection = MagicMock()
+                mock_projection.get_issue_titles.return_value = ({}, None)
+                mock_projection_class.return_value = mock_projection
 
-            assert result.exit_code == 0
-            assert "flow_created" in result.output
-            assert "alice" in result.output
+                result = runner.invoke(
+                    app,
+                    ["flow", "show", "--remote", str(issue_number), "--format", "yaml"],
+                )
+
+                assert result.exit_code == 0
+                assert "flow_created" in result.output
+                assert "alice" in result.output
 
 
 def test_remote_without_issue_number_errors() -> None:

--- a/tests/vibe3/commands/test_flow_status_remote_timeline.py
+++ b/tests/vibe3/commands/test_flow_status_remote_timeline.py
@@ -1,0 +1,300 @@
+"""Tests for flow status --remote timeline source behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from vibe3.cli import app
+from vibe3.models.data_source import DataSource
+from vibe3.models.flow import FlowStatusResponse, TimelineEvent
+
+runner = CliRunner()
+
+
+def test_remote_no_local_db_uses_remote_timeline() -> None:
+    """No local flow/events, --remote <issue> renders timeline from issue comments."""
+    issue_number = 1423
+    branch = f"remote-#{issue_number}"
+
+    # Mock timeline events from GitHub comments
+    timeline_events = [
+        TimelineEvent(
+            timestamp="2024-01-01T10:00:00Z",
+            event_type="flow_created",
+            actor="alice",
+            detail="Flow created",
+        ),
+        TimelineEvent(
+            timestamp="2024-01-02T11:00:00Z",
+            event_type="state_transitioned",
+            actor="bob",
+            detail="state/in-progress",
+        ),
+    ]
+
+    flow_status = FlowStatusResponse(
+        branch=branch,
+        flow_slug=branch.replace("/", "-"),
+        flow_status="active",
+        task_issue_number=issue_number,
+        timeline=timeline_events,
+        data_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
+        with patch(
+            "vibe3.services.flow_status_resolver.FlowStatusResolver"
+        ) as mock_resolver_class:
+            with patch(
+                "vibe3.commands.flow_status.render_flow_timeline"
+            ) as mock_render:
+                mock_service = MagicMock()
+                mock_service_class.return_value = mock_service
+
+                mock_resolver = MagicMock()
+                mock_resolver.resolve.return_value = flow_status
+                mock_resolver_class.return_value = mock_resolver
+
+                result = runner.invoke(
+                    app, ["flow", "show", "--remote", str(issue_number)]
+                )
+
+                assert result.exit_code == 0
+                # Verify resolver was called with remote=True
+                mock_resolver.resolve.assert_called_once()
+                call_kwargs = mock_resolver.resolve.call_args.kwargs
+                assert call_kwargs["remote"] is True
+                assert call_kwargs["issue_number"] == issue_number
+
+                # Verify timeline was rendered (not local events)
+                mock_render.assert_called_once()
+                rendered_events = mock_render.call_args.args[1]
+                assert len(rendered_events) == 2
+                assert rendered_events[0].event_type == "flow_created"
+                assert rendered_events[0].actor == "alice"
+                assert rendered_events[1].event_type == "state_transitioned"
+                assert rendered_events[1].actor == "bob"
+
+
+def test_remote_ignores_stale_local_events() -> None:
+    """Local DB has stale events, --remote still uses remote timeline."""
+    issue_number = 1423
+    branch = f"remote-#{issue_number}"
+
+    # Remote timeline (fresh)
+    remote_timeline = [
+        TimelineEvent(
+            timestamp="2024-01-03T10:00:00Z",
+            event_type="flow_created",
+            actor="alice",
+            detail="Flow created (remote)",
+        ),
+    ]
+
+    flow_status = FlowStatusResponse(
+        branch=branch,
+        flow_slug=branch.replace("/", "-"),
+        flow_status="active",
+        task_issue_number=issue_number,
+        timeline=remote_timeline,
+        data_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
+        with patch(
+            "vibe3.services.flow_status_resolver.FlowStatusResolver"
+        ) as mock_resolver_class:
+            with patch(
+                "vibe3.commands.flow_status.render_flow_timeline"
+            ) as mock_render:
+                mock_service = MagicMock()
+                # Simulate local DB with stale events
+                mock_store = MagicMock()
+                mock_store.get_events.return_value = [
+                    {
+                        "branch": branch,
+                        "event_type": "flow_created",
+                        "actor": "old_actor",
+                        "detail": "Stale local event",
+                        "created_at": "2024-01-01T00:00:00Z",
+                    }
+                ]
+                mock_service.store = mock_store
+                mock_service_class.return_value = mock_service
+
+                mock_resolver = MagicMock()
+                mock_resolver.resolve.return_value = flow_status
+                mock_resolver_class.return_value = mock_resolver
+
+                result = runner.invoke(
+                    app, ["flow", "show", "--remote", str(issue_number)]
+                )
+
+                assert result.exit_code == 0
+                # Verify remote timeline was used, not local DB
+                mock_render.assert_called_once()
+                rendered_events = mock_render.call_args.args[1]
+                assert len(rendered_events) == 1
+                assert rendered_events[0].actor == "alice"
+                assert rendered_events[0].detail == "Flow created (remote)"
+                # Local DB should NOT have been queried
+                mock_store.get_events.assert_not_called()
+
+
+def test_non_remote_uses_local_events() -> None:
+    """flow show without --remote uses local SQLite events."""
+    branch = "task/demo"
+
+    flow_status = FlowStatusResponse(
+        branch=branch,
+        flow_slug="demo",
+        flow_status="active",
+        task_issue_number=123,
+        timeline=[],  # Empty timeline
+        data_source=DataSource.LOCAL_SQLITE,
+    )
+
+    with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
+        with patch(
+            "vibe3.services.flow_status_resolver.FlowStatusResolver"
+        ) as mock_resolver_class:
+            with patch(
+                "vibe3.commands.flow_status.render_flow_timeline"
+            ) as mock_render:
+                with patch(
+                    "vibe3.commands.flow_status.resolve_command_branch"
+                ) as mock_resolve_branch:
+                    mock_service = MagicMock()
+                    mock_store = MagicMock()
+                    mock_store.get_issue_links.return_value = [
+                        {"issue_role": "task", "issue_number": 123}
+                    ]
+                    mock_store.get_events.return_value = [
+                        {
+                            "branch": branch,
+                            "event_type": "flow_created",
+                            "actor": "local_actor",
+                            "detail": "Local event",
+                            "created_at": "2024-01-01T00:00:00Z",
+                        }
+                    ]
+                    mock_service.store = mock_store
+                    mock_service_class.return_value = mock_service
+
+                    mock_resolve_branch.return_value = branch
+
+                    mock_resolver = MagicMock()
+                    mock_resolver.resolve.return_value = flow_status
+                    mock_resolver_class.return_value = mock_resolver
+
+                    result = runner.invoke(app, ["flow", "show"])
+
+                    assert result.exit_code == 0
+                    # Verify local events were queried
+                    mock_store.get_events.assert_called_once_with(branch, limit=100)
+                    # Verify local events were used for rendering
+                    mock_render.assert_called_once()
+                    rendered_events = mock_render.call_args.args[1]
+                    assert len(rendered_events) == 1
+                    assert rendered_events[0].actor == "local_actor"
+
+
+def test_remote_json_output_includes_timeline() -> None:
+    """--format json --remote <issue> includes remote timeline data."""
+    issue_number = 1423
+    branch = f"remote-#{issue_number}"
+
+    timeline_events = [
+        TimelineEvent(
+            timestamp="2024-01-01T10:00:00Z",
+            event_type="flow_created",
+            actor="alice",
+            detail="Flow created",
+        ),
+    ]
+
+    flow_status = FlowStatusResponse(
+        branch=branch,
+        flow_slug=branch.replace("/", "-"),
+        flow_status="active",
+        task_issue_number=issue_number,
+        timeline=timeline_events,
+        data_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
+        with patch(
+            "vibe3.services.flow_status_resolver.FlowStatusResolver"
+        ) as mock_resolver_class:
+            mock_service = MagicMock()
+            mock_service_class.return_value = mock_service
+
+            mock_resolver = MagicMock()
+            mock_resolver.resolve.return_value = flow_status
+            mock_resolver_class.return_value = mock_resolver
+
+            result = runner.invoke(
+                app, ["flow", "show", "--remote", str(issue_number), "--format", "json"]
+            )
+
+            assert result.exit_code == 0
+            import json
+
+            output = json.loads(result.output)
+            assert "events" in output
+            assert len(output["events"]) == 1
+            assert output["events"][0]["event_type"] == "flow_created"
+            assert output["events"][0]["actor"] == "alice"
+
+
+def test_remote_yaml_output_includes_timeline() -> None:
+    """--format yaml --remote <issue> includes remote timeline data."""
+    issue_number = 1423
+    branch = f"remote-#{issue_number}"
+
+    timeline_events = [
+        TimelineEvent(
+            timestamp="2024-01-01T10:00:00Z",
+            event_type="flow_created",
+            actor="alice",
+            detail="Flow created",
+        ),
+    ]
+
+    flow_status = FlowStatusResponse(
+        branch=branch,
+        flow_slug=branch.replace("/", "-"),
+        flow_status="active",
+        task_issue_number=issue_number,
+        timeline=timeline_events,
+        data_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
+        with patch(
+            "vibe3.services.flow_status_resolver.FlowStatusResolver"
+        ) as mock_resolver_class:
+            mock_service = MagicMock()
+            mock_service_class.return_value = mock_service
+
+            mock_resolver = MagicMock()
+            mock_resolver.resolve.return_value = flow_status
+            mock_resolver_class.return_value = mock_resolver
+
+            result = runner.invoke(
+                app, ["flow", "show", "--remote", str(issue_number), "--format", "yaml"]
+            )
+
+            assert result.exit_code == 0
+            assert "flow_created" in result.output
+            assert "alice" in result.output
+
+
+def test_remote_without_issue_number_errors() -> None:
+    """flow show --remote without argument raises clear UserError."""
+    result = runner.invoke(app, ["flow", "show", "--remote"])
+
+    assert result.exit_code != 0
+    # Check exception message instead of output (UserError is raised, not printed)
+    assert result.exception is not None
+    assert "Cannot use --remote without an issue number" in str(result.exception)


### PR DESCRIPTION
Closes #1423

## Summary
Fixed two bugs in `vibe3 flow show --remote <issue_number>` that caused incorrect behavior when viewing remote flows:

1. **Issue number resolution**: Previously failed with UserError when no local flow binding existed, defeating the purpose of --remote mode
2. **Timeline source**: Always read from local SQLite instead of using remote timeline from GitHub issue comments

## Changes
- Added `_parse_remote_issue_number()` helper to extract issue number from CLI args
- Added `_timeline_to_flow_events()` helper to convert TimelineEvent → FlowEvent
- Modified `show()` to handle --remote mode separately from local resolution
- Modified timeline rendering to use source-aware selection (remote vs local)
- Added 6 focused tests for --remote timeline behavior

## Test plan
- ✅ All 6 new remote timeline tests pass
- ✅ Full test suite: 283/283 tests pass
- ✅ Type check: mypy PASS
- ✅ Lint check: ruff PASS, black PASS
- ✅ Pre-push checks: All passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
