### PR TITLE
fix(orchestra): three small fixes for dispatch and health check loops

### DIFF
--- a/.claude/hooks/block-destructive.sh
+++ b/.claude/hooks/block-destructive.sh
@@ -12,8 +12,15 @@ PATTERNS=(
   "rm\s+-rf\s+.*\s+(/|~)"
   "git\s+commit\s+.*--no-verify"
   "(DROP|TRUNCATE)\s+(TABLE|DATABASE)"
-  "task\s+resume\s+(?!.*--label).*(-y\b|--yes\b)"
 )
+
+# Block task resume -y without --label (grep -E lacks lookahead)
+if echo "$CMD" | grep -qiE "task\s+resume\s+.*(-y\b|--yes\b)" && \
+   ! echo "$CMD" | grep -qiE "task\s+resume\s+.*--label"; then
+  echo "[security] BLOCKED: unsafe task resume without --label" >&2
+  echo "[security] Command: $CMD" >&2
+  exit 2
+fi
 
 for pattern in "${PATTERNS[@]}"; do
   if echo "$CMD" | grep -qiE "$pattern"; then

--- a/.claude/hooks/block-destructive.sh
+++ b/.claude/hooks/block-destructive.sh
@@ -12,6 +12,7 @@ PATTERNS=(
   "rm\s+-rf\s+.*\s+(/|~)"
   "git\s+commit\s+.*--no-verify"
   "(DROP|TRUNCATE)\s+(TABLE|DATABASE)"
+  "task\s+resume\s+(?!.*--label).*(-y\b|--yes\b)"
 )
 
 for pattern in "${PATTERNS[@]}"; do

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -197,6 +197,12 @@ class GitClient:
         for wt_path, wt_branch in self._worktree_list_cache:
             if wt_branch == ref:
                 return Path(wt_path)
+        # Cache miss: refresh and retry (worktrees may have been created
+        # after the cache was populated).
+        self._worktree_list_cache = self.list_worktrees()
+        for wt_path, wt_branch in self._worktree_list_cache:
+            if wt_branch == ref:
+                return Path(wt_path)
         return None
 
     def get_worktrees_for_branch(self, branch_name: str) -> list[str]:

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -191,18 +191,22 @@ class GitClient:
 
     def find_worktree_path_for_branch(self, branch: str) -> Path | None:
         """Find worktree path whose checked-out branch matches ``branch``."""
-        if self._worktree_list_cache is None:
-            self._worktree_list_cache = self.list_worktrees()
+        cache = self._worktree_list_cache
+        is_stale = cache is not None
+        if cache is None:
+            cache = self.list_worktrees()
+            self._worktree_list_cache = cache
         ref = f"refs/heads/{branch}"
-        for wt_path, wt_branch in self._worktree_list_cache:
+        for wt_path, wt_branch in cache:
             if wt_branch == ref:
                 return Path(wt_path)
-        # Cache miss: refresh and retry (worktrees may have been created
-        # after the cache was populated).
-        self._worktree_list_cache = self.list_worktrees()
-        for wt_path, wt_branch in self._worktree_list_cache:
-            if wt_branch == ref:
-                return Path(wt_path)
+        # Only refresh if cache was populated before this call
+        # (worktrees may have been created after the snapshot).
+        if is_stale:
+            self._worktree_list_cache = self.list_worktrees()
+            for wt_path, wt_branch in self._worktree_list_cache:
+                if wt_branch == ref:
+                    return Path(wt_path)
         return None
 
     def get_worktrees_for_branch(self, branch_name: str) -> list[str]:

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -46,7 +46,9 @@ async def execute_periodic_check(
         # Offload blocking I/O work to a thread to avoid blocking the event loop
         import asyncio
 
-        results = await asyncio.to_thread(service.verify_all_flows, "active")
+        results = await asyncio.to_thread(
+            service.verify_all_flows, ["active", "blocked"]
+        )
 
         # Summary logging
         total = len(results)

--- a/src/vibe3/services/label_utils.py
+++ b/src/vibe3/services/label_utils.py
@@ -66,6 +66,8 @@ def should_skip_from_queue(
     Issues are skipped if:
     1. They have the supervisor label (managed by supervisor, not auto-dispatch)
     2. They don't have a manager assignee (when required for this queue stage)
+    3. They are roadmap/rfc (human discussion, not ready for execution)
+    4. They are roadmap/epic (scope too large, needs decomposition)
 
     Args:
         issue: Issue information
@@ -80,6 +82,10 @@ def should_skip_from_queue(
     """
     # Skip supervisor-managed issues
     if supervisor_label in issue.labels:
+        return True
+
+    # Skip roadmap/rfc (human discussion) and roadmap/epic (needs decomposition)
+    if "roadmap/rfc" in issue.labels or "roadmap/epic" in issue.labels:
         return True
 
     # Skip issues without manager assignee

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -18,7 +18,7 @@
 - 被 orchestra/governance 视为运行池或 ready queue 候选
 - **不是** repo 全量 open issues，**不是** supervisor issue 池
 
-**当前 governance 的观察范围只限于 assignee issue pool**。它不对 broader repo backlog 做 triage，也不决定哪些 issue 应该进入 assignee issue pool。后者属于未来 `governance/roadmap` 的职责。
+**当前 governance 的观察范围只限于 assignee issue pool**。它不对 broader repo backlog 做 triage，也不决定哪些 issue 应该进入 assignee issue pool。后者属于 `governance/roadmap-intake` 的职责。
 
 ## Role
 
@@ -135,6 +135,7 @@ Forbidden:
   - 不把普通拆分选择升级为人类阻塞
 - 若目标、架构方向或拆分形态都无法判断：
   - 写 `[governance suggest]` 建议标记 `roadmap/rfc`
+  - 命令：`gh issue edit <issue-number> --add-label "roadmap/rfc"`
 
 **队列偏浅时的保守边界**：
 - 如果当前 ready queue 只剩少量候选，或 blocked / in-progress 已经占住大部分池子，不要机械地把所有灰区 issue 都归入“保守等待”
@@ -147,12 +148,13 @@ Forbidden:
 
 ```
 issue 是否可纳入？
-  - Epic 主 issue：主 issue 保持治理容器；检查 sub-issues 是否完整，建议补齐或选择具体 sub-issue
-  - 明确范围 + 清晰验收：可纳入（包括重构）
-  - 范围过大但边界可拆：建议 manager 拆分，或由 roadmap decider 先拆
-  - 范围偏大但 manager 可收敛：放行给 manager 继续单 issue
-  - 确定不适用：建议关闭（附原因）
-  - 目标/架构/拆分形态无法判断：建议 `roadmap/rfc`
+  ├─ Epic 主 issue（roadmap/epic）：主 issue 保持治理容器；检查 sub-issues 是否完整，建议补齐或选择具体 sub-issue
+  ├─ RFC（roadmap/rfc）：目标/验收口径不明确，需要人类讨论；不纳入，跳过
+  ├─ 明确范围 + 清晰验收：可纳入（包括重构）
+  ├─ 范围过大但边界可拆：建议 manager 拆分，或由 roadmap decider 先拆
+  ├─ 范围偏大但 manager 可收敛：放行给 manager 继续单 issue
+  ├─ 确定不适用：建议关闭（附原因）
+  └─ 目标/架构/拆分形态无法判断：建议 `roadmap/rfc`
 ```
 
 ### 例子
@@ -211,7 +213,7 @@ issue 是否可纳入？
 ## Hard Boundary
 
 - **只观察 assignee issue pool；不观察 broader repo backlog 或 supervisor issue 池**
-- **不负责决定哪些 issue 应进入 assignee issue pool（属于 future roadmap governance）**
+- **不负责决定哪些 issue 应进入 assignee issue pool（属于 `governance/roadmap-intake` 职责）**
 - 不负责 task registry 或 task 数据质量审计
 - 不负责 runtime 绑定修复
 - 不负责 roadmap 规划或版本目标

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -82,6 +82,41 @@
 - 架构已变更 → 建议更新内容
 - 依赖未就绪 → 建议等依赖完成后重新提出
 
+### RFC / Epic 识别与标记
+
+在三级审查过程中，识别不应直接进入执行链的 issue 类型，并**打上对应 label**。
+
+**RFC（人类讨论）**：
+
+识别特征：
+- 验收口径不明确，无法确定"做完算什么"
+- 需要先决定架构方向、产品策略或跨团队边界
+- 尚无明确实现方案，讨论多于执行描述
+- 标题/body 语气偏向"讨论/探索/要不要做"
+
+动作：
+```bash
+gh issue edit <issue-number> --add-label "roadmap/rfc"
+```
+
+**Epic（范围过大需拆解）**：
+
+识别特征：
+- 范围横跨多个模块，单次执行无法覆盖
+- body 中包含 `## Sub-issues` 或明确的子任务列表
+- 标题包含 `[Meta]`、`Epic`、`总览`、`整体` 等关键词
+- 已有 `roadmap/epic` 标签，或 issue 本身就是拆解容器
+
+动作：
+```bash
+gh issue edit <issue-number> --add-label "roadmap/epic"
+```
+
+**跳过后处理**：
+- RFC 和 Epic 不进入 assignee issue pool
+- 在 `Skipped` 中分别记录 `rfc` 或 `epic`，注明原因
+- 不要强行 assign manager 给 RFC/Epic issue
+
 **跳过（保守等待 / RFC）**：
 - issue 的目标/验收口径本身不明确，无法确定做完算什么
 - 需要先决定架构方向、产品策略或跨团队边界

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -117,13 +117,10 @@ gh issue edit <issue-number> --add-label "roadmap/epic"
 - 在 `Skipped` 中分别记录 `rfc` 或 `epic`，注明原因
 - 不要强行 assign manager 给 RFC/Epic issue
 
-**跳过（保守等待 / RFC）**：
-- issue 的目标/验收口径本身不明确，无法确定做完算什么
-- 需要先决定架构方向、产品策略或跨团队边界
+**跳过（其他）**：
+- 目标/验收口径不明确但又不到 RFC 级别时保守等待
 - 不确定是否过时
-- **Epic 主 issue**（有 `roadmap/epic` 标签且 body 包含 `## Sub-issues`）：
-  - 主 issue 是治理容器，不直接作为执行任务纳入 assignee pool
-  - 优先检查 sub-issues 是否已经覆盖拆分；不完整时建议补齐，而不是把 epic 当成失败状态
+- Epic 主 issue 已有 `roadmap/epic` 标签且 body 包含 `## Sub-issues`：主 issue 是治理容器，不直接纳入；优先检查 sub-issues 是否完整
 
 **不要误判为 `needs human decision` 的情况**：
 - 同一目标下有 2-3 个局部实现路径，但 issue 本身已说明要修什么、验收看什么
@@ -277,7 +274,7 @@ Allowed:
 - `issue`: read
 - `issue.assignee.write`: allowed（仅用于把适合自动化推进的 issue 纳入 assignee issue pool）
 - `labels.read`: read
-- `labels.write`: allowed（仅最小必要的 routing / priority / roadmap 类调整；避免扩大动作）
+- `labels.write`: allowed（仅最小必要的 routing / priority / roadmap 类调整；包括 `roadmap/rfc`、`roadmap/epic` 识别标记；避免扩大动作）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
 - `state/labels.write`: allowed（仅限 supervisor issues：移除 `state/ready` 并补 `state/handoff`，确保单一 state label）


### PR DESCRIPTION
## Summary

三个小修：

### 1. git_client: refresh stale worktree cache on miss

`_worktree_list_cache` 只填一次、永不刷新。新创建的 worktree 不在快照中，导致 health check 误报 "no worktree"。

Fixes #1428, #1441, #1452, #1462, #1471 — 五个 issue 的 worktree 和 plan 文件都实际存在。

### 2. periodic_check: include "blocked" flows

`verify_all_flows("active")` 过滤掉了 blocked flow。一旦 flow 被标为 blocked，check_pr_service 的 reset 逻辑永远无法触达。

Closes #1482

### 3. should_skip_from_queue: exclude roadmap/rfc and roadmap/epic

`roadmap/rfc`（人类讨论）和 `roadmap/epic`（需拆解）不应进入 dispatch 队列。

Closes #1481

Closes #1486
Closes #1487

## Test

- 已有 worktree 仍能正确查到
- 不存在的 branch 正确返回 None

## Contributors

Co-Authored-By: Claude Opus 4.6<noreply@anthropic.com>