### PR TITLE
refactor(pr): use GitHub client wrapper for PR body update

### DIFF
--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -12,7 +12,7 @@ from loguru import logger
 from vibe3.commands.common import enable_method_trace
 from vibe3.commands.pr_helpers import build_base_resolution_usecase
 from vibe3.exceptions import UserError
-from vibe3.models.pr import PRResponse
+from vibe3.models.pr import PRResponse, UpdatePRRequest
 from vibe3.observability.logger import setup_logging
 from vibe3.services.flow_service import FlowService
 from vibe3.services.pr_create_usecase import PRCreateUsecase
@@ -234,13 +234,15 @@ def register_create_command(app: typer.Typer) -> None:
         if behind_info:
             behind_warning = format_branch_behind_body(behind_info)
             updated_body = f"{behind_warning}\n\n---\n\n{pr.body}"
-            # Update PR body via gh CLI
-            subprocess.run(
-                ["gh", "pr", "edit", str(pr.number), "--body", updated_body],
-                check=True,
-                capture_output=True,
+            # Update PR body via GitHub client wrapper
+            pr = pr_service.github_client.update_pr(
+                UpdatePRRequest(
+                    number=pr.number,
+                    title=None,
+                    body=updated_body,
+                    draft=None,
+                    base_branch=None,
+                )
             )
-            # Update local PR object
-            pr = pr.model_copy(update={"body": updated_body})
 
         _emit_pr_result(pr, json_output, yaml_output)


### PR DESCRIPTION
Closes #1471

Replace direct subprocess.run(["gh", "pr", "edit", ...]) call with pr_service.github_client.update_pr(UpdatePRRequest(...)), which provides consistent error handling via raise_gh_pr_error and returns a refreshed PRResponse.

## Changes
- Add UpdatePRRequest import to pr_create.py
- Replace subprocess.run + model_copy pattern with update_pr wrapper
- Matches existing codebase patterns (github_pr_write_ops.py)

## Testing
- All PR create tests pass (7 tests)
- All PR service tests pass (13 tests)
- MyPy and Ruff clean
- Pre-push checks passed

---

## Contributors

claude/opus
