### PR TITLE
fix(dispatch): improve orphan flow diagnostics

### DIFF
--- a/skills/vibe-check/SKILL.md
+++ b/skills/vibe-check/SKILL.md
@@ -25,6 +25,27 @@ description: Use when the user wants to inspect the current runtime scene with v
 
 - 任何修复都必须先读 shell 审计输出，再决定动作
 
+## 故障归类边界
+
+`vibe-check` 必须先判断现场是否是 flow/block 问题，还是 serve/system 问题。
+
+属于 flow/block 问题：
+
+- business blocked reason、dependency block、human block
+- task / flow / branch / worktree 绑定缺失或残留
+- terminal flow 仍残留 runtime binding
+- orphan auto task scene 需要 `task resume` 或 cleanup 回到可恢复起点
+
+属于 serve/system 问题：
+
+- dispatcher / heartbeat / frozen queue 行为异常
+- role handler 或 ExecutionCoordinator 派发失败
+- worktree 创建异常发生在 serve dispatch 链路中
+- FailedGate、error_log、`serve status` 中的系统错误
+
+如果证据指向 serve/system，`vibe-check` 只报告边界并转交 `/vibe-debug-serve`；
+不要把系统错误写成 business blocked reason，也不要在 flow repair 中扩展新机制。
+
 **Announce at start:** "我正在使用 vibe-check 技能读取 runtime 现场与审计结果，并在可确定时通过 Shell API 修复共享状态问题。"
 
 > 项目命令参考见 `skills/vibe-instruction/SKILL.md`

--- a/skills/vibe-debug-serve/SKILL.md
+++ b/skills/vibe-debug-serve/SKILL.md
@@ -24,6 +24,28 @@ description: Use when checking whether a new vibe3 serve debugging round is read
 - 所有状态写入只通过真实 `vibe3` 命令完成，不直接改 `.git/vibe3/` 底层文件。
 - `debug/*` 只是临时调试分支，不是 canonical flow 分支，不替代 `dev/issue-*` 或 `task/issue-*` 的正式语义。
 
+## Dispatch 故障模型
+
+serve 派发链路按这个顺序排查：
+
+1. frozen queue 保留跨 tick 候选
+2. health check 处理结构性和 terminal 条件
+3. qualify gate 对齐远程 body truth 与本地 blocked cache
+4. role handler 构造 execution request
+5. ExecutionCoordinator 解析 worktree 并启动角色执行
+6. FailedGate / error_log 控制系统性错误后的全局派发
+
+可见性规则：
+
+- 业务 block 写 blocked reason，应该在 `task status` 可见。
+- 系统 error 写 error_log，应该在 `serve status` / FailedGate 可见。
+- `temp/logs/orchestra/events.log` 是 tick、queue、dispatch 的时间线证据。
+
+先判断故障是单点历史残留还是全局机制问题：
+
+- 单点残留：优先做最小防御或 cleanup，不扩展状态机。
+- 全局重复：再提高 dispatch / health check / error tracking 的容错度。
+
 ## 调试分支规则
 
 当当前工作树已经是 `task/issue-*` 自动化分支，且该分支上已有活跃 PR 时：

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -157,10 +157,6 @@ class QualifyGateService:
 
         return result
 
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
-
     def _align_blocked_state(
         self,
         issue_number: int,
@@ -177,6 +173,7 @@ class QualifyGateService:
         from vibe3.services.blocked_state_service import BlockedStateService
 
         blocked_label = self._convention.state_label(self._convention.blocked_label)
+        label_blocked = blocked_label in labels
 
         if not flow_state or flow_state.get("flow_status") != "blocked":
             service = BlockedStateService(
@@ -206,16 +203,19 @@ class QualifyGateService:
                     actor="orchestra:qualify_gate",
                     force=True,
                 )
+                label_blocked = True
             except Exception as exc:
                 logger.bind(domain="orchestra").warning(
                     f"Failed to add {blocked_label} during alignment: {exc}"
                 )
 
-        append_orchestra_event(
-            "dispatcher",
-            f"qualify_gate skip #{issue_number}: "
-            "blocked per body truth (projection state or payload)",
+        event = self._format_blocked_skip_event(
+            issue_number=issue_number,
+            truth=truth,
+            flow_state=flow_state,
+            label_blocked=label_blocked,
         )
+        append_orchestra_event("dispatcher", event)
 
     def _has_stale_blocked_state(
         self,
@@ -241,6 +241,36 @@ class QualifyGateService:
         )
 
         return label_blocked or local_blocked
+
+    @staticmethod
+    def _source_value(source: object | None) -> str:
+        return str(value) if (value := getattr(source, "value", None)) else "none"
+
+    @classmethod
+    def _format_blocked_skip_event(
+        cls,
+        *,
+        issue_number: int,
+        truth: CoordinationTruth,
+        flow_state: dict[str, object] | None,
+        label_blocked: bool,
+    ) -> str:
+        blocked_by = f"#{truth.blocked_by_issue}" if truth.blocked_by_issue else "none"
+        local_flow_status = (
+            str(flow_state.get("flow_status") or "none") if flow_state else "none"
+        )
+        return (
+            f"qualify_gate skip #{issue_number}: blocked per body truth "
+            f"(projection_state={truth.projection_state or 'none'}, "
+            f"projection_source={cls._source_value(truth.projection_state_source)}, "
+            f"blocked_reason={truth.blocked_reason or 'none'}, "
+            f"blocked_reason_source={cls._source_value(truth.blocked_reason_source)}, "
+            f"blocked_by_issue={blocked_by}, "
+            "blocked_by_issue_source="
+            f"{cls._source_value(truth.blocked_by_issue_source)}, "
+            f"local_flow_status={local_flow_status}, "
+            f"label_blocked={label_blocked})"
+        )
 
     def _auto_resume_blocked(
         self,

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -254,8 +254,20 @@ class GlobalDispatchCoordinator:
         # Get the canonical branch for this issue
         branch, _ = self._flow_context(issue.number)
 
-        # If no branch exists, fail open (allow dispatch for new issues)
+        # If no branch exists, fail open only for manager entry states that
+        # can create a fresh task scene. Worker states require an existing flow
+        # context; otherwise role builders fall back to a canonical branch that
+        # may not exist, causing invalid worktree dispatch.
         if not branch:
+            issue_state = issue.state
+            if issue_state not in {IssueState.READY, IssueState.HANDOFF}:
+                state_value = issue_state.value if issue_state else "unknown"
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: skipped #{issue.number} "
+                    f"(missing flow context for {state_value})",
+                )
+                return False
             return True
 
         # Use CheckService for unified health check
@@ -536,11 +548,6 @@ class GlobalDispatchCoordinator:
 
             # === NEW: Pre-dispatch health check ===
             if not self._health_check_before_dispatch(issue):
-                append_orchestra_event(
-                    "dispatcher",
-                    f"GlobalDispatchCoordinator: skipped #{issue.number} "
-                    "(health check failed)",
-                )
                 self._frozen_queue.pop(index)
                 continue
             # === END health check ===

--- a/tests/vibe3/domain/test_qualify_gate_logging.py
+++ b/tests/vibe3/domain/test_qualify_gate_logging.py
@@ -1,0 +1,103 @@
+"""Regression tests for qualify gate operator-facing logs."""
+
+from unittest.mock import Mock, patch
+
+from vibe3.domain.qualify_gate import QualifyGateService
+from vibe3.models.coordination_truth import CoordinationTruth
+from vibe3.models.data_source import DataSource
+from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models.orchestration import IssueInfo, IssueState
+
+
+def test_blocked_skip_log_includes_truth_details() -> None:
+    store = Mock(db_path=":memory:")
+    service = QualifyGateService(
+        config=OrchestraConfig(repo="test/repo"),
+        github=Mock(),
+        store=store,
+        flow_manager=Mock(),
+    )
+    issue = IssueInfo(
+        number=123,
+        title="Test Issue",
+        state=IssueState.IN_PROGRESS,
+        labels=["state/in-progress"],
+        assignees=["alice"],
+    )
+    truth = CoordinationTruth(
+        projection_state="blocked",
+        projection_state_source=DataSource.ISSUE_BODY_FALLBACK,
+        blocked_reason="needs human approval",
+        blocked_reason_source=DataSource.ISSUE_BODY_FALLBACK,
+        blocked_by_issue=456,
+        blocked_by_issue_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with (
+        patch.object(
+            service._coordination_resolver,
+            "resolve_coordination",
+            return_value=truth,
+        ),
+        patch("vibe3.domain.qualify_gate.append_orchestra_event") as append_event,
+    ):
+        result = service.run_qualify_gate(
+            issue=issue,
+            branch="task/issue-123-test",
+            flow_state={"flow_status": "blocked", "blocked_reason": "stale"},
+            labels=["state/blocked"],
+            trigger_state=IssueState.IN_PROGRESS,
+        )
+
+    assert result is None
+    message = append_event.call_args[0][1]
+    expected_parts = [
+        "blocked_reason=needs human approval",
+        "blocked_by_issue=#456",
+        "projection_state=blocked",
+        "projection_source=fallback",
+        "blocked_reason_source=fallback",
+        "local_flow_status=blocked",
+        "label_blocked=True",
+    ]
+    assert all(part in message for part in expected_parts)
+
+
+def test_blocked_skip_log_reports_aligned_label_state() -> None:
+    service = QualifyGateService(
+        config=OrchestraConfig(repo="test/repo"),
+        github=Mock(),
+        store=Mock(db_path=":memory:"),
+        flow_manager=Mock(),
+    )
+    truth = CoordinationTruth(
+        blocked_reason="remote block",
+        blocked_reason_source=DataSource.ISSUE_BODY_FALLBACK,
+    )
+
+    with (
+        patch.object(
+            service._coordination_resolver,
+            "resolve_coordination",
+            return_value=truth,
+        ),
+        patch("vibe3.services.label_service.LabelService") as label_service,
+        patch("vibe3.domain.qualify_gate.append_orchestra_event") as append_event,
+    ):
+        result = service.run_qualify_gate(
+            issue=IssueInfo(
+                number=123,
+                title="Test Issue",
+                state=IssueState.IN_PROGRESS,
+                labels=["state/in-progress"],
+                assignees=["alice"],
+            ),
+            branch="task/issue-123-test",
+            flow_state={"flow_status": "active"},
+            labels=["state/in-progress"],
+            trigger_state=IssueState.IN_PROGRESS,
+        )
+
+    assert result is None
+    label_service.return_value.confirm_issue_state.assert_called_once()
+    assert "label_blocked=True" in append_event.call_args[0][1]

--- a/tests/vibe3/orchestra/test_dispatch_orphan_flow_context.py
+++ b/tests/vibe3/orchestra/test_dispatch_orphan_flow_context.py
@@ -1,0 +1,76 @@
+"""Regression tests for orphan flow dispatch health checks."""
+
+from unittest.mock import MagicMock, patch
+
+from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.orchestra.global_dispatch_coordinator import GlobalDispatchCoordinator
+from vibe3.orchestra.queue_entry import QueueEntry
+
+
+def test_health_check_skips_non_ready_issue_without_flow_context() -> None:
+    config = MagicMock(repo="owner/repo")
+    config.max_concurrent_flows = 10
+    config.supervisor_handoff.issue_label = "supervisor"
+    store = MagicMock(db_path=":memory:")
+    coordinator = GlobalDispatchCoordinator(
+        config=config,
+        capacity=MagicMock(),
+        github=MagicMock(),
+        store=store,
+        flow_manager=MagicMock(),
+    )
+    issue = IssueInfo(
+        number=1013,
+        title="Orphan claimed issue",
+        state=IssueState.CLAIMED,
+        labels=["state/claimed"],
+        github_state="OPEN",
+    )
+    coordinator._flow_context = MagicMock(return_value=("", None))
+
+    with patch(
+        "vibe3.orchestra.global_dispatch_coordinator.append_orchestra_event"
+    ) as append_event:
+        result = coordinator._health_check_before_dispatch(issue)
+
+    assert result is False
+    append_event.assert_called_once()
+    assert "missing flow context" in append_event.call_args[0][1]
+
+
+def test_dispatch_loop_logs_missing_flow_context_once() -> None:
+    config = MagicMock(repo="owner/repo")
+    config.max_concurrent_flows = 10
+    config.supervisor_handoff.issue_label = "supervisor"
+    config.get_manager_usernames.return_value = []
+    coordinator = GlobalDispatchCoordinator(
+        config=config,
+        capacity=MagicMock(),
+        github=MagicMock(),
+        store=MagicMock(db_path=":memory:"),
+        flow_manager=MagicMock(),
+    )
+    coordinator._capacity.get_capacity_status.return_value = {"remaining": 1}
+    coordinator._frozen_queue = [
+        QueueEntry(issue_number=1013, collected_state="claimed")
+    ]
+    coordinator._load_issue = MagicMock(
+        return_value=IssueInfo(
+            number=1013,
+            title="Orphan claimed issue",
+            state=IssueState.CLAIMED,
+            labels=["state/claimed"],
+            github_state="OPEN",
+        )
+    )
+    coordinator._flow_context = MagicMock(return_value=("", None))
+
+    with patch(
+        "vibe3.orchestra.global_dispatch_coordinator.append_orchestra_event"
+    ) as append_event:
+        dispatched = coordinator._dispatch_loop()
+
+    messages = [call.args[1] for call in append_event.call_args_list]
+    assert dispatched == 0
+    assert len([msg for msg in messages if "missing flow context" in msg]) == 1
+    assert all("(health check failed)" not in msg for msg in messages)


### PR DESCRIPTION
## Summary
- Prevent non-entry issue states with missing flow context from dispatching into a nonexistent canonical worktree.
- Enrich qualify gate blocked skip events with remote body truth, source fields, local flow status, and label state so audit reviewers can tell business block from system error.
- Document the diagnostic boundary between `vibe-check` flow/block checks and `vibe-debug-serve` serve/system dispatch checks.

## Root Cause
Historical orphan flow residue could leave an issue in a non-manager state without resolvable flow context. The health check fail-open path then allowed dispatch to continue and later failed at worktree resolution. Separately, qualify gate block logs collapsed remote body truth into a vague message, which made #1495 look like a system dispatch fault instead of a remote blocked-reason synchronization result.

## Behavior
- `READY` and `HANDOFF` still fail open when no flow context exists, preserving manager task-scene creation.
- Non-entry states without flow context are skipped defensively and logged as missing flow context.
- Qualify gate blocked skips now report `projection_state`, `projection_source`, `blocked_reason`, `blocked_reason_source`, `blocked_by_issue`, `blocked_by_issue_source`, `local_flow_status`, and `label_blocked`.
- The skills now explain when to use `vibe-check` for flow/block state and when to use `vibe-debug-serve` for dispatcher/system failures.

## Validation
- `uv run pytest tests/vibe3/domain/test_qualify_gate.py tests/vibe3/orchestra/test_dispatch_health_checks.py tests/vibe3/orchestra/test_dispatch_state_transitions.py -q`
- `uv run ruff check src/vibe3/domain/qualify_gate.py src/vibe3/orchestra/global_dispatch_coordinator.py tests/vibe3/domain/test_qualify_gate.py tests/vibe3/orchestra/test_dispatch_health_checks.py`
- Commit hooks: ShellCheck skipped, custom lint passed, Ruff passed, Black passed, MyPy passed, temp debug check passed.
- Pre-push hooks: type check passed; incremental test suite passed with `82 passed in 58.58s`; LOC warning only.

## Operational Note
Do not reset the current #1013/#1269 residue sample until patched serve has run at least one tick and confirmed the skip/log behavior. If it disrupts active serve before then, stop serve temporarily rather than clearing the evidence.

Closes #1503
Closes #1495
Closes #1504

Contributors: Yi Chen, Codex (OpenAI).
