### PR TITLE
docs(comment_utils): add [flow] and [roadmap decision] markers to docstring

### DIFF
--- a/src/vibe3/utils/comment_utils.py
+++ b/src/vibe3/utils/comment_utils.py
@@ -19,6 +19,7 @@ def is_human_comment(comment: dict[str, Any]) -> bool:
     Markers that indicate automated comments
     (see vibe3.utils.constants.AUTOMATED_MARKERS):
     - [manager]: Manager agent reports
+    - [flow]: Unified flow timeline marker
     - [resume]: Task resume operations
     - [plan]: Plan phase completion / scope clarification
     - [run]: Run phase completion / blocker
@@ -28,6 +29,7 @@ def is_human_comment(comment: dict[str, Any]) -> bool:
     - [handoff]: Handoff operations
     - [governance], [governance suggest], [governance auto-recover],
       [governance apply]: Governance routing
+    - [roadmap decision]: Roadmap decisions / mandatory split / dependency orchestration
     - [agent], [agent:<role>]: Generic agent fallback markers
 
     These markers prevent automated systems from interpreting their own


### PR DESCRIPTION
Update is_human_comment docstring to document [flow] and [roadmap decision] markers that were already present in AUTOMATED_MARKERS but missing from the human-readable documentation.

- Add [flow] marker after [manager], before [resume]
- Add [roadmap decision] marker after governance group
- Maintain alphabetical/logical ordering consistent with AUTOMATED_MARKERS

No functional changes - documentation-only update.

Fixes #1448

---

## Contributors

claude/opus
