### PR TITLE
feat(dispatch): add scope validation gate for .claude/.codex paths

### DIFF
--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -120,7 +120,13 @@ Output a structured plan in this format:
 - [Risk description]
 
 ## Notes
-[Optional additional context]"""
+[Optional additional context]
+
+**File scope restriction**: Do NOT include files under .claude/ or .codex/ directories
+in the Files list. These contain agent and team definitions that cannot be modified
+by automated execution. If your task conceptually requires changes to these
+directories, note this in the Risks section instead — those changes require manual
+intervention."""
 
 
 def _plan_variant(mode: PlanPromptMode, context_mode: PromptContextMode) -> str:

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -7,6 +7,8 @@ through role request builders from src/vibe3/roles/.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from typing import Callable
 
 from loguru import logger
@@ -24,9 +26,53 @@ from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.roles.plan import build_plan_request
 from vibe3.roles.review import build_review_request
 from vibe3.roles.run import build_run_request
+from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_context_loader import load_issue_info
 
 _RequestBuilder = Callable[..., ExecutionRequest]
+
+_BLOCKED_SCOPE_PREFIXES = (".claude/", ".codex/")
+_FILES_LINE_RE = re.compile(r"^\s*-?\s*Files:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+
+
+def _validate_plan_scope(plan_ref: str | None) -> list[str]:
+    """Parse plan Files: lines and return any .claude/ or .codex/ paths found.
+
+    Returns empty list if plan_ref is None, plan file is unreadable,
+    or no blocked paths are found.
+    """
+    if not plan_ref:
+        return []
+
+    plan_path = _resolve_plan_path(plan_ref)
+    if plan_path is None:
+        return []
+
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    blocked: list[str] = []
+    for match in _FILES_LINE_RE.finditer(content):
+        files_text = match.group(1).strip()
+        for raw in files_text.split(","):
+            path = raw.strip().strip("[]").strip().strip("'\"")
+            if path and path.startswith(_BLOCKED_SCOPE_PREFIXES):
+                blocked.append(path)
+
+    return blocked
+
+
+def _resolve_plan_path(plan_ref: str) -> Path | None:
+    """Resolve plan_ref to an absolute file path. Returns None on failure."""
+    plan_path = Path(plan_ref)
+    if plan_path.is_absolute() and plan_path.is_file():
+        return plan_path
+    cwd_path = Path.cwd() / plan_ref
+    if cwd_path.is_file():
+        return cwd_path
+    return None
 
 
 def _dispatch_role_intent(
@@ -195,6 +241,27 @@ def handle_executor_dispatch_intent(event: ExecutorDispatchIntent, /) -> None:
         plan_ref=plan_ref,
         commit_mode=commit_mode,
     ).info("Executor dispatch triggered")
+
+    # Validate plan scope before dispatch
+    blocked_paths = _validate_plan_scope(plan_ref)
+    if blocked_paths:
+        logger.bind(
+            domain="executor_handler",
+            issue_number=event.issue_number,
+            branch=event.branch,
+            blocked_paths=blocked_paths,
+        ).warning("Plan references blocked .claude/.codex paths, blocking flow")
+
+        FlowService().block_flow(
+            event.branch,
+            reason=(
+                "Plan modifies .claude/.codex files: "
+                + ", ".join(blocked_paths)
+                + ". Executor sandbox cannot write to agent definition directories."
+            ),
+            actor="orchestra:scope-gate",
+        )
+        return
 
     try:
         _dispatch_role_intent(

--- a/tests/vibe3/domain/handlers/test_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_dispatch.py
@@ -325,3 +325,507 @@ class TestDispatchNotLaunched:
         )
 
         mock_coordinator.dispatch_execution.assert_called_once()
+
+
+class TestExecutorScopeValidation:
+    """Executor dispatch should block when plan references .claude/.codex paths."""
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_blocks_on_claude_paths(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with .claude/ files should block flow and not dispatch."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        # Create temporary plan file with .claude/ path
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Modify agent
+   - Files: .claude/agents/foo.md
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        with patch(
+            "vibe3.domain.handlers.dispatch.FlowService"
+        ) as mock_flow_service_cls:
+            mock_flow_service = MagicMock()
+            mock_flow_service_cls.return_value = mock_flow_service
+
+            handle_executor_dispatch_intent(
+                ExecutorDispatchIntent(
+                    issue_number=42,
+                    branch="task/issue-42",
+                    trigger_state="in-progress",
+                )
+            )
+
+            # Verify FlowService.block_flow was called
+            mock_flow_service.block_flow.assert_called_once()
+            call_args = mock_flow_service.block_flow.call_args
+            assert call_args[0][0] == "task/issue-42"
+            assert ".claude/agents/foo.md" in call_args[1]["reason"]
+            assert call_args[1]["actor"] == "orchestra:scope-gate"
+
+        # Verify dispatch was NOT attempted
+        mock_build_request.assert_not_called()
+        mock_coordinator.dispatch_execution.assert_not_called()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_blocks_on_codex_paths(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with .codex/ files should block flow and not dispatch."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Modify codex
+   - Files: .codex/agents/bar.toml
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        with patch(
+            "vibe3.domain.handlers.dispatch.FlowService"
+        ) as mock_flow_service_cls:
+            mock_flow_service = MagicMock()
+            mock_flow_service_cls.return_value = mock_flow_service
+
+            handle_executor_dispatch_intent(
+                ExecutorDispatchIntent(
+                    issue_number=42,
+                    branch="task/issue-42",
+                    trigger_state="in-progress",
+                )
+            )
+
+            mock_flow_service.block_flow.assert_called_once()
+            call_args = mock_flow_service.block_flow.call_args
+            assert ".codex/agents/bar.toml" in call_args[1]["reason"]
+
+        mock_build_request.assert_not_called()
+        mock_coordinator.dispatch_execution.assert_not_called()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_blocks_on_multiple_blocked_paths(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with both .claude/ and .codex/ paths should list all in reason."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Modify agent
+   - Files: .claude/agents/foo.md, .codex/agents/bar.toml
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        with patch(
+            "vibe3.domain.handlers.dispatch.FlowService"
+        ) as mock_flow_service_cls:
+            mock_flow_service = MagicMock()
+            mock_flow_service_cls.return_value = mock_flow_service
+
+            handle_executor_dispatch_intent(
+                ExecutorDispatchIntent(
+                    issue_number=42,
+                    branch="task/issue-42",
+                    trigger_state="in-progress",
+                )
+            )
+
+            mock_flow_service.block_flow.assert_called_once()
+            call_args = mock_flow_service.block_flow.call_args
+            reason = call_args[1]["reason"]
+            assert ".claude/agents/foo.md" in reason
+            assert ".codex/agents/bar.toml" in reason
+
+        mock_build_request.assert_not_called()
+        mock_coordinator.dispatch_execution.assert_not_called()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_passes_on_normal_paths(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with normal files should proceed with dispatch."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Modify code
+   - Files: src/foo.py, tests/bar.py
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        expected_request = _make_mock_request("executor", 42)
+        mock_build_request.return_value = expected_request
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True,
+            tmux_session="vibe3-executor-issue-42",
+            log_path="/tmp/test.log",
+        )
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        handle_executor_dispatch_intent(
+            ExecutorDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="in-progress",
+            )
+        )
+
+        # Verify dispatch proceeded normally
+        mock_build_request.assert_called_once()
+        mock_coordinator.dispatch_execution.assert_called_once()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_passes_when_plan_ref_none(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+    ) -> None:
+        """No plan_ref should proceed with dispatch (graceful degradation)."""
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {}  # No plan_ref
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        expected_request = _make_mock_request("executor", 42)
+        mock_build_request.return_value = expected_request
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True,
+            tmux_session="vibe3-executor-issue-42",
+            log_path="/tmp/test.log",
+        )
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        handle_executor_dispatch_intent(
+            ExecutorDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="in-progress",
+            )
+        )
+
+        # Verify dispatch proceeded normally
+        mock_build_request.assert_called_once()
+        mock_coordinator.dispatch_execution.assert_called_once()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_passes_when_plan_file_unreadable(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+    ) -> None:
+        """Nonexistent plan file should proceed with dispatch (graceful degradation)."""
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {
+            "plan_ref": "nonexistent.md"
+        }  # File doesn't exist
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        expected_request = _make_mock_request("executor", 42)
+        mock_build_request.return_value = expected_request
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True,
+            tmux_session="vibe3-executor-issue-42",
+            log_path="/tmp/test.log",
+        )
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        handle_executor_dispatch_intent(
+            ExecutorDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="in-progress",
+            )
+        )
+
+        # Verify dispatch proceeded normally
+        mock_build_request.assert_called_once()
+        mock_coordinator.dispatch_execution.assert_called_once()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_blocks_on_bracketed_file_list(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with bracketed file list should still detect .claude/ path."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Modify agent
+   - Files: [.claude/rules/custom.md, src/foo.py]
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        with patch(
+            "vibe3.domain.handlers.dispatch.FlowService"
+        ) as mock_flow_service_cls:
+            mock_flow_service = MagicMock()
+            mock_flow_service_cls.return_value = mock_flow_service
+
+            handle_executor_dispatch_intent(
+                ExecutorDispatchIntent(
+                    issue_number=42,
+                    branch="task/issue-42",
+                    trigger_state="in-progress",
+                )
+            )
+
+            # Should block on .claude/ path, but not src/foo.py
+            mock_flow_service.block_flow.assert_called_once()
+            call_args = mock_flow_service.block_flow.call_args
+            reason = call_args[1]["reason"]
+            assert ".claude/rules/custom.md" in reason
+            assert "src/foo.py" not in reason
+
+        mock_build_request.assert_not_called()
+        mock_coordinator.dispatch_execution.assert_not_called()
+
+    @patch("vibe3.domain.handlers.dispatch.build_run_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_no_block_on_files_none(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """Plan with 'Files: none' should proceed with dispatch."""
+        from pathlib import Path
+
+        from vibe3.domain.handlers.dispatch import handle_executor_dispatch_intent
+
+        plan_file = Path(str(tmp_path)) / "plan.md"
+        plan_file.write_text("""## Plan Summary
+Test plan
+
+## Steps
+1. Research only
+   - Files: none
+   - Effort: S
+   - Dependencies: none
+""")
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = {"plan_ref": str(plan_file)}
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        expected_request = _make_mock_request("executor", 42)
+        mock_build_request.return_value = expected_request
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=True,
+            tmux_session="vibe3-executor-issue-42",
+            log_path="/tmp/test.log",
+        )
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        handle_executor_dispatch_intent(
+            ExecutorDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="in-progress",
+            )
+        )
+
+        # Verify dispatch proceeded normally
+        mock_build_request.assert_called_once()
+        mock_coordinator.dispatch_execution.assert_called_once()


### PR DESCRIPTION
Closes #1480

## Summary
- Add programmatic scope validation in executor dispatch handler to block flows that reference `.claude/` or `.codex/` directories in plan `Files:` lines
- Update output contract in plan_prompt.py to warn planners not to include `.claude/.codex` files in `Files:` lists
- Add comprehensive test coverage (8 new test cases) covering blocked paths, normal paths, and edge cases

This prevents the systemic waste pattern from issue #898 where executor sandbox restrictions caused repeated blocked/resumed cycles.

## Test plan
- [x] 13 dispatch tests pass (including 8 new scope validation tests)
- [x] 4 plan_prompt tests pass
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] All tests pass after rebase onto latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
