### PR TITLE
docs(governance): block .claude/.codex directory modifications due to permission issues

### DIFF
--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -232,6 +232,7 @@ pool 扫描有 assignee 的 issue →
 
 - **只观察 assignee issue pool；不观察 broader repo backlog 或 supervisor issue 池**
 - **不负责决定哪些 issue 应进入 assignee issue pool（属于 `governance/roadmap-intake` 职责）**
+- **不接手涉及 `.claude/` 目录的 issue**（见下方 `.claude` 目录阻塞规则）
 - 不负责 task registry 或 task 数据质量审计
 - 不负责 runtime 绑定修复
 - 不负责 roadmap 规划或版本目标
@@ -244,6 +245,17 @@ pool 扫描有 assignee 的 issue →
 - **允许两项 state 动作**：
   1. **入池评估与标签补齐**：有 manager assignee 但缺少 state label → 先评 priority/roadmap，再设 `state/ready`
   2. **漏改 blocked 恢复**：`state/blocked` + `blocked_reason == "state unchanged"` + authoritative ref 已存在 → 自动恢复
+
+### `.claude/` 和 `.codex/` 目录阻塞规则
+
+**禁止接手涉及 `.claude/` 或 `.codex/` 目录的 issue**
+
+- **原因**：这些目录涉及 agent 权限配置，自动化流程无法修改
+- **触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
+- **处理动作**：
+  - 写 `[governance suggest]` comment 说明：涉及 agent 权限配置目录，无法自动化执行
+  - 添加 `roadmap/rfc` 标签
+  - **禁止**设置 `state/ready` 或纳入 assignee pool
 
 ## Execution Pattern
 

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -232,7 +232,7 @@ pool 扫描有 assignee 的 issue →
 
 - **只观察 assignee issue pool；不观察 broader repo backlog 或 supervisor issue 池**
 - **不负责决定哪些 issue 应进入 assignee issue pool（属于 `governance/roadmap-intake` 职责）**
-- **不接手涉及 `.claude/` 目录的 issue**（见下方 `.claude` 目录阻塞规则）
+- **不接手涉及 `.claude/` 或 `.codex/` 目录的 issue**（见下方阻塞规则）
 - 不负责 task registry 或 task 数据质量审计
 - 不负责 runtime 绑定修复
 - 不负责 roadmap 规划或版本目标

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -34,6 +34,18 @@
 
 ### 三级审查
 
+**Level 0: `.claude/` 和 `.codex/` 目录检查**（优先级最高）
+
+**原因**：这些目录涉及 agent 权限配置，自动化流程无法修改
+
+**触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
+
+**处理动作**：
+- 写 `[governance suggest]` comment：涉及 agent 权限配置目录，无法自动化执行
+- 添加 `roadmap/rfc` 标签
+- **禁止**纳入 assignee issue pool
+- 记录到 `Skipped`，原因为 `blocked: .claude/.codex directory permission issue`
+
 **Level 1: 基础条件**
 - 问题边界明确、验收口径清楚、无需额外产品讨论
 - 改动范围可控、依赖关系简单

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -106,7 +106,7 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
 - 依赖未就绪 → suggest 中说明等待依赖
 
 **intake 不设以下标签**（属于 assignee-pool 层决策范围）：
-- `roadmap/rfc`、`roadmap/epic`
+- `roadmap/rfc`、`roadmap/epic`（**例外**：Level 0 检查阻塞时，intake 需要添加 `roadmap/rfc` 标签以路由该 issue）
 - `roadmap/p0`、`roadmap/p1`、`roadmap/p2`
 - `priority/*`
 

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -193,6 +193,22 @@ This performs the same three actions as `--reason`, plus:
   可以直接关闭 issue。只允许在 `state/ready` 时执行 close。
   Close 后不再执行任何状态转换或后续流程。
 
+## Hard Boundary
+
+**禁止接手涉及 `.claude/` 或 `.codex/` 目录的 issue**（见下方阻塞规则）
+
+### `.claude/` 和 `.codex/` 目录阻塞规则
+
+**原因**：这些目录涉及 agent 权限配置，自动化流程无法修改
+
+**触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
+
+**处理动作**：
+1. 写 issue comment：`[manager] 涉及 agent 权限配置目录，无法自动化执行`
+2. 调用 `vibe3 flow blocked --reason "涉及 .claude/.codex 目录，权限问题"`
+3. 添加 `roadmap/rfc` 标签
+4. `exit()`
+
 ## Core Rules
 
 1. 先读最新评论，再判断现场
@@ -205,6 +221,7 @@ This performs the same three actions as `--reason`, plus:
 8. `state/claimed` 就表示可以进入 plan；你在 claimed 后必须停止本轮判断
 9. **主动 block 是合法决策**：`state/blocked` 不仅用于被动卡住，也用于你主动请求人类判断。当判断依据不足、风险不确定、或业务决策超出你的权限时，你应该 block 并说明原因，而不是强行推进。执行器报错由对应 agent 标记为 `state/failed`
 10. `state/ready` 本轮必须落下明确状态结果：要么 `claimed`，要么 `blocked`，要么关闭
+11. **权限目录检查优先**：在任何处理前，先检查是否涉及 `.claude/` 或 `.codex/` 目录，若涉及则立即 block
 
 ## `exit()` 语义
 - 文中出现的 `exit()` 只是**语义停止标记**，不是可执行函数


### PR DESCRIPTION
## Summary

- 在 `roadmap-intake.md` 添加 Level 0 检查：涉及 `.claude/` 或 `.codex/` 目录的 issue 不纳入自动化流程
- 在 `assignee-pool.md` 和 `manager.md` 添加阻塞规则：检测到权限配置目录时主动 block
- 核心原因：这些目录涉及 agent 权限配置，自动化流程无法修改

## 修改内容

**supervisor/governance/roadmap-intake.md**：
- 新增 Level 0 检查（优先级最高）
- 触发条件：改动范围包含 `.claude/` 或 `.codex/` 目录
- 处理：标记 `roadmap/rfc`，禁止纳入 assignee pool

**supervisor/governance/assignee-pool.md**：
- 新增 `.claude/` 和 `.codex/` 目录阻塞规则
- 处理：写 `[governance suggest]` comment，添加 `roadmap/rfc` 标签

**supervisor/manager.md**：
- 新增 Hard Boundary 说明
- 处理：调用 `vibe3 flow blocked`，添加 `roadmap/rfc` 标签
- 新增 Core Rule 11：权限目录检查优先

## Test plan

- [x] 文档修改完成，无功能变更
- [x] 三个文件修改一致，逻辑完整
- [x] 提交信息清晰

Closes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet-4.5