### PR TITLE
feat(orchestra): adopt Protocol-based DI for orchestra layer

### DIFF
--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -16,13 +16,13 @@ from vibe3.models.coordination_truth import CoordinationTruth
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.orchestra.protocols import FlowManagerPort
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.coordination_resolver import CoordinationResolver
 from vibe3.services.flow_resume_resolver import infer_resume_label
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.orchestra.flow_dispatch import FlowManager
 
 
 class QualifyGateService:
@@ -37,7 +37,7 @@ class QualifyGateService:
         config: OrchestraConfig,
         github: GitHubClient,
         store: "SQLiteClient",
-        flow_manager: "FlowManager",
+        flow_manager: FlowManagerPort,
     ) -> None:
         """Initialize qualify gate service.
 

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -7,8 +7,11 @@ Primary entry point: HeartbeatServer (vibe3 serve start)
 
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
+from vibe3.orchestra.protocols import FlowManagerPort, QueuePersistencePort
 
 __all__ = [
     "OrchestraConfig",
     "IssueInfo",
+    "FlowManagerPort",
+    "QueuePersistencePort",
 ]

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -23,19 +23,18 @@ from vibe3.execution.capacity_service import CapacityService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.observability.degraded_mode import get_degraded_manager
-from vibe3.orchestra.flow_dispatch import FlowManager
 from vibe3.orchestra.issue_loader import (
     find_role_for_state,
     get_flow_context,
     load_issue,
 )
 from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.orchestra.protocols import FlowManagerPort, QueuePersistencePort
 from vibe3.orchestra.queue_entry import QueueEntry
 from vibe3.orchestra.queue_operations import (
     collect_raw_issues_without_qualify,
     select_ready_issues,
 )
-from vibe3.orchestra.queue_persistence_service import QueuePersistenceService
 from vibe3.roles.registry import build_label_dispatch_event
 from vibe3.services.check_service import CheckService
 from vibe3.services.flow_service import FlowService
@@ -62,15 +61,16 @@ class GlobalDispatchCoordinator:
         capacity: CapacityService,
         github: GitHubClient,
         store: "SQLiteClient",
-        flow_manager: FlowManager,
+        flow_manager: FlowManagerPort,
         registry: "SessionRegistryService | None" = None,
         executor: ThreadPoolExecutor | None = None,
+        queue_persistence: QueuePersistencePort | None = None,
     ) -> None:
         self._config = config
         self._capacity = capacity
         self._github = github
         self._store = store
-        self._flow_manager = flow_manager
+        self._flow_manager: FlowManagerPort = flow_manager
         self._registry = registry
         self._executor = executor or ThreadPoolExecutor(
             max_workers=config.max_concurrent_flows
@@ -83,14 +83,23 @@ class GlobalDispatchCoordinator:
         self._supervisor_label = config.supervisor_handoff.issue_label
 
         # Initialize queue persistence service
-        self._queue_persistence = QueuePersistenceService(
-            store=store,
-            config=config,
-            github=github,
-            registry=registry,
-            supervisor_label=self._supervisor_label,
-            load_issue=self._load_issue,
-        )
+        # Allow injection for testability; default to concrete implementation
+        if queue_persistence is None:
+            # Import concrete implementation only when needed
+            from vibe3.orchestra.queue_persistence_service import (
+                QueuePersistenceService,
+            )
+
+            self._queue_persistence: QueuePersistencePort = QueuePersistenceService(
+                store=store,
+                config=config,
+                github=github,
+                registry=registry,
+                supervisor_label=self._supervisor_label,
+                load_issue=self._load_issue,
+            )
+        else:
+            self._queue_persistence = queue_persistence
 
         # Queue is lazily restored on first coordinate() call
         # (not eagerly in __init__ to avoid startup I/O and keep
@@ -597,7 +606,10 @@ class GlobalDispatchCoordinator:
         # Step 1: Restore queue from persistence if None
         if self._frozen_queue is None:
             self._queue_persistence.frozen_queue = None
-            self._queue_persistence.load_issue = self._load_issue
+            # load_issue is set on construction for Protocol instances
+            # Only reassign for concrete QueuePersistenceService
+            if hasattr(self._queue_persistence, "load_issue"):
+                self._queue_persistence.load_issue = self._load_issue  # type: ignore[attr-defined]
             restored = self._queue_persistence.restore()
             self._frozen_queue = restored if restored is not None else []
             self._queue_persistence.frozen_queue = self._frozen_queue
@@ -605,7 +617,10 @@ class GlobalDispatchCoordinator:
 
         # Step 2: Promote progressed entries (state changes)
         self._queue_persistence.frozen_queue = self._frozen_queue
-        self._queue_persistence.load_issue = self._load_issue
+        # load_issue is set on construction for Protocol instances
+        # Only reassign for concrete QueuePersistenceService
+        if hasattr(self._queue_persistence, "load_issue"):
+            self._queue_persistence.load_issue = self._load_issue  # type: ignore[attr-defined]
         cleared_all = self._queue_persistence.promote()
         if cleared_all:
             self._check_service = None  # Invalidate when queue is cleared

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -8,13 +8,13 @@ from loguru import logger
 
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState
+from vibe3.orchestra.protocols import FlowManagerPort
 from vibe3.roles.registry import LABEL_DISPATCH_ROLES
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.models.orchestration import IssueInfo
-    from vibe3.orchestra.flow_dispatch import FlowManager
     from vibe3.roles.definitions import TriggerableRoleDefinition
 
 
@@ -45,7 +45,7 @@ def get_flow_context(
     config: OrchestraConfig,
     github: "GitHubClient",
     store: "SQLiteClient",
-    flow_manager: "FlowManager",
+    flow_manager: FlowManagerPort,
 ) -> tuple[str, dict[str, object] | None]:
     """Get flow context (branch and state) for an issue.
 

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -1,0 +1,66 @@
+"""Protocol definitions for orchestra layer."""
+
+from typing import Protocol
+
+from vibe3.clients.git_client import GitClient
+from vibe3.orchestra.queue_entry import QueueEntry
+
+
+class FlowManagerPort(Protocol):
+    """Protocol for flow management operations.
+
+    Used for dependency injection in GlobalDispatchCoordinator to decouple
+    from concrete FlowManager implementation. Enables testability via
+    structural typing — any object with matching attributes satisfies this.
+    """
+
+    git: GitClient
+
+    def get_flow_for_issue(self, issue_number: int) -> dict | None:
+        """Get flow context for an issue.
+
+        Args:
+            issue_number: GitHub issue number
+
+        Returns:
+            Flow context dict or None if no flow found
+        """
+        ...
+
+
+class QueuePersistencePort(Protocol):
+    """Protocol for queue persistence operations.
+
+    Used for dependency injection in GlobalDispatchCoordinator to decouple
+    from concrete QueuePersistenceService implementation.
+    """
+
+    frozen_queue: list[QueueEntry] | None
+
+    def restore(self) -> list[QueueEntry] | None:
+        """Load persisted queue from database on restart.
+
+        Returns:
+            Restored queue entries or None if restore failed
+        """
+        ...
+
+    def persist(self) -> None:
+        """Persist current frozen queue to database."""
+        ...
+
+    def promote(self) -> bool:
+        """Promote progressed queue entries.
+
+        Returns:
+            True if promotion succeeded
+        """
+        ...
+
+    def get_queued_issue_numbers(self) -> set[int]:
+        """Get set of queued issue numbers.
+
+        Returns:
+            Set of issue numbers currently in queue
+        """
+        ...

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -14,6 +14,7 @@ from vibe3.orchestra.issue_loader import (
     load_issue,
 )
 from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.orchestra.protocols import FlowManagerPort
 from vibe3.orchestra.queue_entry import QueueEntry
 from vibe3.orchestra.queue_ordering import sort_ready_issues
 from vibe3.services.label_utils import normalize_labels, should_skip_from_queue
@@ -22,7 +23,6 @@ if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
-    from vibe3.orchestra.flow_dispatch import FlowManager
 
 
 def collect_raw_issues_without_qualify(
@@ -60,7 +60,7 @@ def select_ready_issues(
     config: OrchestraConfig,
     github: "GitHubClient",
     store: "SQLiteClient",
-    flow_manager: "FlowManager",
+    flow_manager: FlowManagerPort,
     qualify_gate: QualifyGateService,
     supervisor_label: str,
 ) -> list[IssueInfo]:


### PR DESCRIPTION
## Summary

Implement Protocol-based dependency injection for the orchestra layer by defining `FlowManagerPort` and `QueuePersistencePort` structural Protocols and accepting them via constructor injection in `GlobalDispatchCoordinator`. This breaks tight coupling without changing the `FlowManager` concrete class or its 11 importers, leveraging Python's structural typing for backward compatibility.

## Changes

### New Files
- `src/vibe3/orchestra/protocols.py` — Define `FlowManagerPort` and `QueuePersistencePort` Protocols

### Modified Files
- `src/vibe3/orchestra/global_dispatch_coordinator.py` — Accept Protocol types in `__init__`, maintain backward compatibility via optional `queue_persistence` parameter
- `src/vibe3/domain/qualify_gate.py` — Update to accept `FlowManagerPort`
- `src/vibe3/orchestra/issue_loader.py` — Update to accept `FlowManagerPort`
- `src/vibe3/orchestra/queue_operations.py` — Update to accept `FlowManagerPort`
- `src/vibe3/orchestra/__init__.py` — Re-export Protocol symbols

## Tests

- All 127 orchestra tests pass
- mypy clean on 348 source files (including `src/vibe3/orchestra/` and `src/vibe3/domain/`)
- Pre-push checks passed (coverage, incremental tests, LOC checks)

## Design Notes

1. **Structural typing**: `FlowManager` (concrete) structurally satisfies `FlowManagerPort` without modification. This allows all 11 existing importers to continue working without changes.

2. **Backward compatibility**: The optional `queue_persistence` parameter defaults to None, preserving existing behavior in production code.

3. **`load_issue` exclusion**: The `load_issue` Callable field is intentionally excluded from `QueuePersistencePort` as it's an implementation detail. The `hasattr()` guard in `coordinate()` handles concrete implementations that need it.

## Audit Findings

Verdict: **MINOR** (non-blocking)

Two minor findings:
1. Duplicate `hasattr` + `load_issue` reassignment in `coordinate()` — recommend extracting into helper method in follow-up
2. Test fixtures not updated for `queue_persistence` injection — DI path works but lacks explicit test coverage (low impact)

## Verification

- [x] All tests pass
- [x] Type checking clean (mypy)
- [x] No lint errors (ruff/black)
- [x] Pre-commit hooks passed
- [x] Backward compatibility maintained

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
