### PR TITLE
fix(dispatch): 全 blocked 且无新 ready issue 时，dispatch 没有真正停止派发

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -390,6 +390,29 @@ class GlobalDispatchCoordinator:
             )
         )
 
+    def _has_qualifiable_blocked_entries(self) -> bool:
+        """Check if any blocked entries in queue would qualify as ready."""
+        if not self._frozen_queue:
+            return False
+
+        for entry in self._frozen_queue:
+            if entry.waiting_state is not None:
+                continue
+            if entry.collected_state != "blocked":
+                continue
+
+            # Load the issue to check qualification
+            issue = self._load_issue(entry.issue_number)
+            if issue is None:
+                continue
+
+            # Check if this blocked issue would qualify as ready
+            target_state = self._qualify_gate.qualify_blocked_issue(issue)
+            if target_state == IssueState.READY:
+                return True
+
+        return False
+
     async def _probe_for_non_blocked_candidates(self) -> bool:
         """Check if any non-blocked state issue is available after a paused period."""
         for state in (
@@ -624,17 +647,22 @@ class GlobalDispatchCoordinator:
             if self._has_actionable_entries():
                 self._dispatch_paused = False
             elif self._has_pending_blocked_entries():
-                has_non_blocked = await self._probe_for_non_blocked_candidates()
-                if not has_non_blocked:
-                    append_orchestra_event(
-                        "dispatcher",
-                        "GlobalDispatchCoordinator: dispatch paused "
-                        "(blocked entries pending, no non-blocked candidates)",
-                    )
-                    self._queue_persistence.frozen_queue = self._frozen_queue
-                    self._queue_persistence.persist()
-                    return
-                self._dispatch_paused = False
+                # Check if any blocked entries in queue would qualify as ready
+                # before probing for external non-blocked candidates
+                if self._has_qualifiable_blocked_entries():
+                    self._dispatch_paused = False
+                else:
+                    has_non_blocked = await self._probe_for_non_blocked_candidates()
+                    if not has_non_blocked:
+                        append_orchestra_event(
+                            "dispatcher",
+                            "GlobalDispatchCoordinator: dispatch paused "
+                            "(blocked entries pending, no non-blocked candidates)",
+                        )
+                        self._queue_persistence.frozen_queue = self._frozen_queue
+                        self._queue_persistence.persist()
+                        return
+                    self._dispatch_paused = False
             else:
                 has_non_blocked = await self._probe_for_non_blocked_candidates()
                 if not has_non_blocked:

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -616,8 +616,6 @@ class GlobalDispatchCoordinator:
         if self._frozen_queue is None:
             self._frozen_queue = []
 
-        paused_with_pending_blocked = False
-
         # Step 3: Paused mode waits for human task resume to create a
         # non-blocked candidate again. Keep existing waiting entries resident.
         # Blocked-only rebuilds get one dispatch-time qualify pass before the
@@ -626,7 +624,17 @@ class GlobalDispatchCoordinator:
             if self._has_actionable_entries():
                 self._dispatch_paused = False
             elif self._has_pending_blocked_entries():
-                paused_with_pending_blocked = True
+                has_non_blocked = await self._probe_for_non_blocked_candidates()
+                if not has_non_blocked:
+                    append_orchestra_event(
+                        "dispatcher",
+                        "GlobalDispatchCoordinator: dispatch paused "
+                        "(blocked entries pending, no non-blocked candidates)",
+                    )
+                    self._queue_persistence.frozen_queue = self._frozen_queue
+                    self._queue_persistence.persist()
+                    return
+                self._dispatch_paused = False
             else:
                 has_non_blocked = await self._probe_for_non_blocked_candidates()
                 if not has_non_blocked:
@@ -659,16 +667,7 @@ class GlobalDispatchCoordinator:
             self._check_service = None  # Invalidate cache
             if fresh and all(entry.collected_state == "blocked" for entry in fresh):
                 self._dispatch_paused = True
-                if paused_with_pending_blocked:
-                    append_orchestra_event(
-                        "dispatcher",
-                        "GlobalDispatchCoordinator: dispatch paused "
-                        "(blocked candidates unchanged after qualify)",
-                    )
-                else:
-                    self._frozen_queue = self._merge_queue(
-                        self._frozen_queue or [], fresh
-                    )
+                self._frozen_queue = self._merge_queue(self._frozen_queue or [], fresh)
                 append_orchestra_event(
                     "dispatcher",
                     "GlobalDispatchCoordinator: dispatch paused "

--- a/tests/vibe3/orchestra/test_dispatch_actionable_trigger.py
+++ b/tests/vibe3/orchestra/test_dispatch_actionable_trigger.py
@@ -399,34 +399,59 @@ class TestActionableTriggeredCollection:
         ]
 
     @pytest.mark.asyncio
-    async def test_paused_blocked_queue_drops_rechecked_blocked_entries(
+    async def test_paused_blocked_queue_probes_and_returns_early(
         self, mock_coordinator
     ):
-        """After one qualify pass, stable blocked-only queues become quiet."""
+        """Paused with blocked entries: probe for non-blocked candidates
+        and return early if none."""
         mock_coordinator._dispatch_paused = True
         mock_coordinator._frozen_queue = [
             QueueEntry(issue_number=10, collected_state="blocked", waiting_state=None),
         ]
         mock_coordinator._queue_persistence.promote = MagicMock(return_value=False)
         mock_coordinator._queue_persistence.persist = MagicMock()
-        mock_coordinator._probe_for_non_blocked_candidates = AsyncMock()
-
-        def mock_dispatch_loop(_tick_id: int = 0) -> int:
-            mock_coordinator._frozen_queue = []
-            return 0
-
-        mock_coordinator._dispatch_loop = MagicMock(side_effect=mock_dispatch_loop)
-
-        async def mock_collect() -> list[QueueEntry]:
-            return [QueueEntry(issue_number=10, collected_state="blocked")]
-
-        mock_coordinator._collect_frozen_queue = mock_collect
+        mock_coordinator._probe_for_non_blocked_candidates = AsyncMock(
+            return_value=False
+        )
+        mock_coordinator._dispatch_loop = MagicMock(
+            side_effect=AssertionError("Should not call _dispatch_loop")
+        )
+        mock_coordinator._collect_frozen_queue = AsyncMock(
+            side_effect=AssertionError("Should not call _collect_frozen_queue")
+        )
 
         await mock_coordinator.coordinate(tick_id=1)
 
         assert mock_coordinator._dispatch_paused is True
-        assert mock_coordinator._frozen_queue == []
-        mock_coordinator._probe_for_non_blocked_candidates.assert_not_called()
+        assert len(mock_coordinator._frozen_queue) == 1
+        assert mock_coordinator._frozen_queue[0].issue_number == 10
+        mock_coordinator._probe_for_non_blocked_candidates.assert_awaited_once()
+        mock_coordinator._dispatch_loop.assert_not_called()
+        mock_coordinator._collect_frozen_queue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_paused_blocked_queue_resumes_when_probe_finds_non_blocked(
+        self, mock_coordinator
+    ):
+        """Paused with blocked entries but probe finds non-blocked
+        candidates: resume dispatch."""
+        mock_coordinator._dispatch_paused = True
+        mock_coordinator._frozen_queue = [
+            QueueEntry(issue_number=10, collected_state="blocked", waiting_state=None),
+        ]
+        mock_coordinator._queue_persistence.promote = MagicMock(return_value=False)
+        mock_coordinator._queue_persistence.persist = MagicMock()
+        mock_coordinator._probe_for_non_blocked_candidates = AsyncMock(
+            return_value=True
+        )
+        mock_coordinator._dispatch_loop = MagicMock(return_value=0)
+        mock_coordinator._collect_frozen_queue = AsyncMock(return_value=[])
+
+        await mock_coordinator.coordinate(tick_id=1)
+
+        assert mock_coordinator._dispatch_paused is False
+        mock_coordinator._probe_for_non_blocked_candidates.assert_awaited_once()
+        mock_coordinator._dispatch_loop.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_paused_dispatch_skips_recollect_until_non_blocked_probe_hits(


### PR DESCRIPTION
## Summary

Fix coordinate() Step 3 branch 2 to properly handle paused state with pending blocked entries.

### Problem
When `_dispatch_paused` and there are pending blocked entries, the code was:
1. Setting a flag but continuing to dispatch loop
2. Re-qualifying the same blocked entries every tick
3. Re-collecting blocked issues repeatedly
4. Wasting cycles without actually stopping dispatch

### Root Cause
Branch 2 (paused with pending blocked entries) was only setting a flag and falling through to the dispatch loop, instead of probing for non-blocked candidates and returning early like branch 3.

### Solution
1. **Original commit**: Add probe logic to branch 2 matching branch 3 pattern
   - Probe for non-blocked candidates before continuing
   - Return early if none found to stop wasteful dispatch-loop cycles
   
2. **Follow-up fix**: Check qualifiable blocked entries before early return
   - Add `_has_qualifiable_blocked_entries()` to check if blocked issues would qualify as READY
   - Prevents blocking falsely-blocked issues (label says blocked but qualify returns READY)
   - Ensures proper dispatch of issues that should be ready

### Changes
- `global_dispatch_coordinator.py`:
  - Add `_has_qualifiable_blocked_entries()` method
  - Update coordinate() Step 3 branch 2 to check qualifiable entries before returning early
  - Maintain optimization while supporting falsely-blocked scenario

### Test Results
✅ All state transition tests pass (7/7)
✅ All actionable trigger tests pass (9/9)
✅ Pre-commit checks pass (black, ruff, mypy, shellcheck)

Fixes #1483

---

## Contributors

claude/opus
