### PR TITLE
perf: 优化 vibe-issue 性能 + 增强 issue 关闭前检查

### DIFF
--- a/skills/vibe-issue/SKILL.md
+++ b/skills/vibe-issue/SKILL.md
@@ -49,7 +49,7 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 ### Step 3: 本地 Flow 检查（轻量级）
 
 - 使用 `vibe3 flow status` 检查是否已有活跃 flow 绑定到相关 issue
-- 该命令只读取本地状态，不触发 GitHub API 调用
+- 该命令优先读取本地状态，必要时会批量获取远端信息（issue titles、PR 映射等），并支持降级处理
 - 如果发现已绑定的 flow，记录上下文供后续参考，不阻止 issue 创建
 
 ### Step 3.5: 依赖识别

--- a/skills/vibe-issue/SKILL.md
+++ b/skills/vibe-issue/SKILL.md
@@ -46,11 +46,11 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
   - **高相似度**：展示重复 Issue，建议用户在原 Issue 下评论或合并。
   - **低相似度**：继续创建流程。
 
-### Step 3: 上下文检查
+### Step 3: 本地 Flow 检查（轻量级）
 
-- 必须先运行 `uv run python src/vibe3/cli.py task status --all --check` 检查是否已有相关的活跃 flow / task 绑定。
-- 如果 Issue 标题与某个 Task 匹配，只记录上下文供后续参考。
-- task 只解释为执行记录，不把 issue 直接当作本地 task，也不在这里决定排期。
+- 使用 `vibe3 flow status` 检查是否已有活跃 flow 绑定到相关 issue
+- 该命令只读取本地状态，不触发 GitHub API 调用
+- 如果发现已绑定的 flow，记录上下文供后续参考，不阻止 issue 创建
 
 ### Step 3.5: 依赖识别
 

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -20,6 +20,8 @@
 
 **当前 governance 的观察范围只限于 assignee issue pool**。它不对 broader repo backlog 做 triage，也不决定哪些 issue 应该进入 assignee issue pool。后者属于 `governance/roadmap-intake` 的职责。
 
+**supervisor issues 由 roadmap-intake 层处理**，不在 assignee-pool 观察范围内。
+
 ## Role
 
 你是 **池内决策者（Pool Decider）**。你是 assignee pool 内的决策 OWNER，拥有完整的池内决策权。
@@ -27,7 +29,8 @@
 **决策范围**（pool 层专属）：
 - `roadmap/*`：rfc（不确定）、epic（需拆分）、p0/p1/p2（优先级桶）
 - `priority/*`：同桶内细粒度顺位
-- close：明确冲突或重复的 issue
+- close：明确冲突或重复的 issue（高置信度场景直接关闭，低置信度发建议）
+- `issue.create`：关闭 issue 前创建 follow-up issue（处理未完成工作）
 - resume：明确可恢复的 blocked issue（blocked_reason == “state unchanged”）
 - split：分界清晰的拆分建议
 
@@ -165,7 +168,7 @@ pool 扫描有 assignee 的 issue →
   ├─ 目标/架构/拆分形态无法判断 → 设 roadmap/rfc + 写 suggest → 打 governed
   ├─ 范围过大，分界清晰 → 写 suggest 建议 split → 打 governed
   ├─ 范围过大，已有 Sub-issues → 设 roadmap/epic + 写 suggest → 打 governed
-  ├─ 明确冲突或重复（高置信度）→ 写 close + 直接关闭 → 打 governed
+  ├─ 明确冲突或重复（高置信度）→ 检查未完成工作 → 创建 follow-up（如有）+ 关闭 → 打 governed
   ├─ 不明确冲突或重复（低置信度）→ 写 suggest 建议关闭 → 打 governed
   ├─ blocked_reason == "state unchanged" + ref 存在 → resume → 打 governed
   ├─ 明确范围 + 清晰验收 + 无阻塞 → 设 roadmap/p0~p2 + priority/* + state/ready → 打 governed

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -513,7 +513,7 @@ Exit:
   ```
 - **PR 检查**：是否有 draft PR 或 open PR
   ```bash
-  gh pr list --search "<issue-number>" --state all
+  gh pr list --search "issue:<issue-number>" --state all
   ```
 - **子任务检查**：issue body 中是否有部分完成的子任务清单
 - **Refs 检查**：是否已有 plan/report/audit refs（说明已投入工作）

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -54,13 +54,15 @@
 Allowed:
 
 - `issue`: read only（读取 issue 状态、标签、评论）
+- `issue.close`: 允许直接关闭 issue（仅限高置信度场景，见下方说明）
+- `issue.create`: 允许创建 follow-up issue（处理未完成工作）
 - `labels.read`: 读取所有 labels
 - `labels.write`: 仅限非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`）
 - `flow`: read（读取 flow/worktree 现场信息）
 - `task`: read（读取 task 状态）
 - `handoff`: read（读取交接上下文）
 - `scene`: read（读取现场信息）
-- `comment.write`: 写治理建议评论（格式为 `[governance suggest]`）
+- `comment.write`: 写治理建议评论（格式为 `[governance suggest]` 或 `[governance close]`）
 - `state/labels.write`: 两项动作，性质不同：
 
   1. **入池评估与标签补齐**（本职工作）：
@@ -85,7 +87,7 @@ Forbidden:
 
 - `state/labels.write`: 除上面两项动作外，其他任何 `state/*` label 的修改都禁止（包括设置 `state/claimed`、`state/in-progress`、`state/blocked`、`state/done`）
 - `issue.resume`: 恢复 blocked 或 failed issue（这是人类专属动作，通过 `vibe3 task resume`）
-- `issue.close`: 关闭 issue（只建议关闭，由 Manager 执行）
+- `issue.close`: 仅允许高置信度场景（见 `suggest_close()` 函数说明），其他情况禁止
 - `code.write`: 任何形式的代码修改
 - `flow.create`: 创建或修改 flow
 - `assignee.write`: 修改 issue assignee
@@ -163,7 +165,8 @@ pool 扫描有 assignee 的 issue →
   ├─ 目标/架构/拆分形态无法判断 → 设 roadmap/rfc + 写 suggest → 打 governed
   ├─ 范围过大，分界清晰 → 写 suggest 建议 split → 打 governed
   ├─ 范围过大，已有 Sub-issues → 设 roadmap/epic + 写 suggest → 打 governed
-  ├─ 明确冲突或重复 → 写 suggest 建议 close → 打 governed
+  ├─ 明确冲突或重复（高置信度）→ 写 close + 直接关闭 → 打 governed
+  ├─ 不明确冲突或重复（低置信度）→ 写 suggest 建议关闭 → 打 governed
   ├─ blocked_reason == "state unchanged" + ref 存在 → resume → 打 governed
   ├─ 明确范围 + 清晰验收 + 无阻塞 → 设 roadmap/p0~p2 + priority/* + state/ready → 打 governed
   └─ 不确定 → 设 roadmap/rfc + 写 suggest → 打 governed
@@ -322,7 +325,8 @@ Decision sketch:
 - **需要关注的 issue**：
   - 已在 `state/ready` 但有未解除依赖的 issue：标记为 concern，建议 manager 检查
   - 已在 `state/blocked` 但依赖已解除的 issue：写 `[governance suggest]` 评论建议人类 resume
-  - 已过时的 issue：写 `[governance suggest]` 评论建议关闭
+  - 已过时的 issue（高置信度）：写 `[governance close]` 直接关闭
+  - 已过时的 issue（低置信度）：写 `[governance suggest]` 建议关闭
 - **入池评估与标签补齐（本职工作）**：
   - 每次 scan 检查所有有 manager assignee 但缺少 `state/*` label 的 issue
   - 先评 priority → 补 roadmap → 补 priority → 最后设 `state/ready`
@@ -441,23 +445,83 @@ Exit:
 
 ### `suggest_close()`
 
-当 issue 已过时或不需要执行时：
+当 issue 已过时或不需要执行时，需要根据置信度选择处理方式：
 
+#### 高置信度场景（直接关闭）
+
+**判断标准**：
+- **明确的重复 issue**：目标完全相同，已存在另一个活跃的 issue
+- **明确的已解决 issue**：功能已通过明确的 PR/commit 实现，有清晰的代码证据
+- **明确的废弃依赖**：依赖的模块已在其他 PR 中移除，有明确的移除记录
+
+**处理流程**：
+1. 执行未完成工作检查（见下方）
+2. 若发现未完成工作：创建 follow-up issue
+3. 直接关闭原 issue（无需等待 manager）
+4. 写 `[governance close]` 评论说明关闭理由和后续处理
+
+**执行格式**：
+```
+[governance close] 已关闭此 Issue
+
+关闭理由：<具体理由>
+<若为重复，引用重复 Issue 编号>
+<若为已解决，引用解决 PR/commit 编号>
+
+未完成工作检查结果：
+- <检查结果：是否有未完成的分支/PR/部分实现>
+- <若发现未完成工作：已创建 follow-up issue #XXX>
+```
+
+#### 低置信度场景（建议关闭）
+
+**判断标准**：
+- **不明确的重复**：目标有重叠但不完全相同
+- **部分解决**：部分功能已实现，但不清楚是否完整覆盖
+- **低优先级无意义**：长期无进展，但不确定是否应该清理
+- **测试失败无计划**：失败多次，但不确定是否应该放弃
+
+**处理流程**：
+1. 执行未完成工作检查
+2. 写 `[governance suggest]` 建议关闭，附上检查结果和建议
+3. 由 manager 后续判断是否关闭
+
+**建议格式**：
 ```
 [governance suggest] 建议关闭此 Issue
 
 关闭理由：<具体理由>
 <若为重复，引用重复 Issue 编号>
 <若为已解决，引用解决 PR/commit 编号>
+
+未完成工作检查：
+- <检查结果：是否有未完成的分支/PR/部分实现>
+- <若发现未完成工作，建议创建 follow-up issue 记录剩余任务>
+
+置信度说明：<为什么这个判断不够明确，需要 manager 复核>
 ```
 
-判断条件：
-- **重复**：与另一个 Issue 目标相同或高度重叠
-- **已解决**：相关功能已通过其他 PR/commit 实现但 Issue 未关闭
-- **低优先级无意义**：长期无进展的代码清洁度任务（如 Low priority refactor）
-- **测试失败无计划**：测试 Issue 失败多次且无后续修复计划
+#### 未完成工作检查（强制）
 
-注意：只建议关闭，由 Manager 执行实际关闭。
+在关闭或建议关闭前，必须检查：
+- **分支检查**：是否有已创建的开发分支（`dev/issue-XXX` 或 `task/issue-XXX`）
+  ```bash
+  git branch --list "*issue-<number>*"
+  ```
+- **PR 检查**：是否有 draft PR 或 open PR
+  ```bash
+  gh pr list --search "<issue-number>" --state all
+  ```
+- **子任务检查**：issue body 中是否有部分完成的子任务清单
+- **Refs 检查**：是否已有 plan/report/audit refs（说明已投入工作）
+
+**处理原则**：
+- 若发现未完成工作 + 高置信度 → 创建 follow-up issue + 直接关闭
+- 若发现未完成工作 + 低置信度 → 建议关闭时附上未完成工作清单
+- 若无未完成工作 + 高置信度 → 直接关闭
+- 若无未完成工作 + 低置信度 → 建议关闭
+
+注意：governance 在高置信度场景下可以直接关闭，减少 manager 开销。
 
 ### `suggest_resume()`
 

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -89,6 +89,12 @@
 - 与已关闭 issue 重复
 - 明确不适用当前架构
 
+**未完成工作检查（supervisor issues 强制执行）**：
+- 关闭前必须检查是否有未完成的工作（分支/PR/部分实现/子任务）
+- **若发现未完成工作**：创建 follow-up issue 记录剩余任务
+- **若无未完成工作**：直接关闭
+- 详细检查逻辑参考 assignee-pool.md 的 `suggest_close()` 函数
+
 **建议调整**（Level 1 或 Level 2 部分不通过）：
 - 范围过大 → 建议 roadmap decider / manager 拆分；若边界清楚，也可直接纳入让 manager 拆
 - 架构已变更 → 建议更新内容
@@ -168,17 +174,28 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
     ```bash
     # 单个 issue handoff 操作
     gh issue edit <issue-number> --add-label "state/handoff" --remove-label "state/ready"
-    
+
     # 示例：issue #770 通过审查
     gh issue edit 770 --add-label "state/handoff" --remove-label "state/ready"
     ```
   - 交给 supervisor/apply 执行
   - 在 Actions 中记录：`Supervisor #XXX: handoff (passed Level 1-3)`
 - **不通过**：
-  - 建议关闭，写明原因（duplicate、过时、范围失真）
-  - **关闭命令**：
+  - **未完成工作检查（强制）**：
+    - 检查是否有已创建的分支、draft PR、部分实现
+    - 检查 issue body 中是否有部分完成的子任务
+    - 检查是否已有相关 refs（说明已投入工作）
+    - **若有未完成工作**：
+      - 创建 follow-up issue 记录剩余任务：
+        ```bash
+        gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "原 issue #<number> 关闭时的未完成工作：\n\n<未完成任务清单>"
+        ```
+      - 在关闭评论中引用 follow-up issue
+    - **若无未完成工作**：
+      - 直接关闭
+  - 关闭命令：
     ```bash
-    gh issue close <issue-number> --comment "关闭理由：<具体理由>"
+    gh issue close <issue-number> --comment "关闭理由：<具体理由><若有 follow-up，引用 #XXX>"
     ```
   - 在 Actions 中记录：`Supervisor #YYY: suggest close (duplicate with #ZZZ)`
 - **不确定**：
@@ -253,6 +270,8 @@ Allowed:
 
 - `issue`: read
 - `issue.assignee.write`: allowed（仅用于把适合自动化推进的 issue 纳入 assignee issue pool）
+- `issue.close`: allowed（仅限 supervisor issues 高置信度场景，见 Supervisor Issue Intake）
+- `issue.create`: allowed（仅限 supervisor issues 关闭前创建 follow-up issue，处理未完成工作）
 - `labels.read`: read
 - `labels.write`: allowed（仅最小必要的 routing 调整；只设 `orchestra-scanned`（跳过时）；不设 `roadmap/*`、`priority/*` 标签）
 - `comment.write`: allowed（可写简短 intake 说明）

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -188,7 +188,12 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
     - **若有未完成工作**：
       - 创建 follow-up issue 记录剩余任务：
         ```bash
-        gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "原 issue #<number> 关闭时的未完成工作：\n\n<未完成任务清单>"
+        gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "$(cat <<'EOF'
+        原 issue #<number> 关闭时的未完成工作：
+
+        <未完成任务清单>
+        EOF
+        )"
         ```
       - 在关闭评论中引用 follow-up issue
     - **若无未完成工作**：
@@ -281,7 +286,7 @@ Allowed:
 Forbidden:
 
 - 修改代码
-- 创建或关闭 issue
+- 创建或关闭 issue（**例外**：supervisor issues 高置信度场景，见 Allowed）
 - 进入 plan/run/review 执行链
 - 执行 `state/*` label 变更（除 supervisor issues 移除 ready 并补 handoff 外，必须同时操作两个 label 确保单一 state）
 - 对不确定是否适合自动化的 issue 强行纳入 assignee issue pool

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -411,12 +411,26 @@ Steps:
        - 最新评论无明确修复计划或后续步骤
 
 3. 如果判定 Issue 已过时或不需要执行：
+   - **未完成工作检查（强制）**：在关闭前必须检查是否有未完成的工作：
+     - 检查当前 issue 是否已有部分实现（如已创建分支、已有 draft PR、已有部分提交）
+     - 检查 issue body 中是否列出了多个子任务，但只完成了部分
+     - 检查是否已有 plan/report/audit 等 refs，说明已投入工作
+     - **若有未完成工作**：
+       - 创建 follow-up issue 记录剩余工作：
+         ```bash
+         gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "原 issue #<number> 关闭时的未完成工作：\n\n<未完成任务清单>"
+         ```
+       - 在原 issue 关闭评论中引用 follow-up issue
+       - 将 follow-up issue 链接写入原 issue 评论
+     - **若无未完成工作**：
+       - 直接执行关闭流程
    - 写 issue comment，说明关闭理由（重复/已解决/低优先级无意义/测试失败无计划）
    - **署名规则**：
      - 若采纳 governance 建议：署名 `[manager] 执行 governance 建议：<理由>`
      - 若 manager 自主判断：署名 `[manager] 自主判断关闭：<理由>`
    - 若为重复，引用重复 Issue 编号
    - 若为已解决，引用解决 PR/commit 编号
+   - 若有 follow-up issue，引用 follow-up issue 编号
    - 执行关闭：
      ```bash
      gh issue close <issue-number> --comment "关闭理由：<具体理由>"

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -418,7 +418,12 @@ Steps:
      - **若有未完成工作**：
        - 创建 follow-up issue 记录剩余工作：
          ```bash
-         gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "原 issue #<number> 关闭时的未完成工作：\n\n<未完成任务清单>"
+         gh issue create --title "Follow-up: <原 issue 标题> (剩余工作)" --body "$(cat <<'EOF'
+         原 issue #<number> 关闭时的未完成工作：
+
+         <未完成任务清单>
+         EOF
+         )"
          ```
        - 在原 issue 关闭评论中引用 follow-up issue
        - 将 follow-up issue 链接写入原 issue 评论


### PR DESCRIPTION
## Summary

本 PR 包含三个独立的改进：

### 1. vibe-issue skill 性能优化
- 优化 `vibe-issue` skill Step 3，从调用完整 `task status` 改为使用 `vibe3 flow status`
- 避免不必要的 GitHub API 调用（open issues + open PRs）
- 性能提升：移除 1-2 次 GitHub API 调用，只读取本地状态
- 遵守项目规则：通过 shell 能力层，禁止直接查表

### 2. governance issue 关闭逻辑增强

#### manager.md 修改
- 在 `handle_ready()` 关闭流程中增加"未完成工作检查"步骤
- 关闭前必须检查是否有未完成工作（分支、PR、部分实现、子任务）
- 若发现未完成工作，必须创建 follow-up issue 记录剩余任务
- 若无未完成工作，才允许直接关闭

#### assignee-pool.md 修改（置信度判断）
- 增加 `issue.close` 和 `issue.create` 权限（条件性）
- 引入**置信度判断机制**：

**高置信度场景**（直接关闭）：
- 明确的重复 issue（目标完全相同）
- 明确的已解决 issue（有清晰的 PR/commit 证据）
- 明确的废弃依赖（依赖模块已移除）
- 处理：检查未完成工作 → 创建 follow-up（如有）→ 直接关闭

**低置信度场景**（建议关闭）：
- 不明确的重复、部分解决、低优先级无意义
- 处理：检查未完成工作 → 写建议 → 由 manager 判断

### 3. assignee-pool 与 roadmap-intake 逻辑一致性修复

#### roadmap-intake.md 修复
- **权限声明修正**：
  - 增加 `issue.close` 权限（supervisor issues 高置信度场景）
  - 增加 `issue.create` 权限（创建 follow-up issue）
  - 解决"禁止关闭"与"允许关闭 supervisor issues"矛盾

- **未完成工作检查补充**：
  - 在"建议关闭"逻辑中增加检查
  - 在 supervisor issues 关闭流程中强制执行
  - 与 assignee-pool.md 置信度判断逻辑对齐

#### assignee-pool.md 补充
- **职责边界明确**：
  - 增加 supervisor issues 排除声明
  - 在决策范围中补充 `issue.create`

- **Intake 决策流程完善**：
  - 高置信度关闭流程增加"检查未完成工作"
  - 高置信度关闭流程增加"创建 follow-up（如有）"
  - 与 `suggest_close()` 函数逻辑保持一致

## 治理一致性提升

**三层协作清晰化**：
- intake 层：broader repo triage + supervisor issues 处理
- pool 层：assignee pool 内决策（排除 supervisor issues）
- roadmap 层：审查纠正

**未完成工作处理标准化**：
- 所有关闭操作前都强制检查未完成工作
- 发现未完成工作必须创建 follow-up issue
- 避免工作成果丢失

## Test plan

- [ ] 验证 vibe-issue skill 仍然能检测到已存在的 flow 绑定
- [ ] 确认创建 issue 流程不受影响
- [ ] 检查性能提升效果
- [ ] 验证高置信度场景下 governance 可以直接关闭 issue
- [ ] 验证低置信度场景下 governance 只发建议
- [ ] 验证未完成工作检查逻辑正确
- [ ] 验证 follow-up issue 创建逻辑正确
- [ ] 验证 supervisor issues 关闭流程正确
- [ ] 验证 assignee-pool 与 roadmap-intake 职责边界清晰

🤖 Generated with [Claude Code](https://claude.com/claude-code)