### PR TITLE
refactor(governance): extract duplicated content to supervisor/roadmap-common.md

### DIFF
--- a/docs/governance/governance-roadmap-closed-loop.md
+++ b/docs/governance/governance-roadmap-closed-loop.md
@@ -6,6 +6,11 @@
 
 ---
 
+> **真源指针**: 三层架构、标签语义、过滤逻辑和 comment marker 的权威定义位于 [supervisor/roadmap-common.md](../../supervisor/roadmap-common.md)。
+> 本文档是面向人类的说明性文档，供理解整体机制使用。agent 治理材料应优先读取 supervisor/roadmap-common.md。
+
+---
+
 ## 概述
 
 Governance 分为两层，加上上层的 roadmap 审查，共三层。每层有独立的标签实现闭环，防止重复处理。

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -269,32 +269,14 @@ vibe-roadmap 作为治理-决策双轨中的**决策者**，使用独立的 `[ro
 
 #### 治理闭环标签
 
-三层标签各自闭环，由不同角色在不同阶段打上：
+> 三层标签的完整定义、过滤逻辑和闭环机制见 [supervisor/roadmap-common.md](../../supervisor/roadmap-common.md)。
 
-| 标签名称 | 角色 | 打标签时机 | 语义 |
-| -------- | ---- | ---------- | ---- |
-| `orchestra-scanned` | roadmap-intake（入口层） | intake 审查后**跳过**时 | "已审查，不纳入"——下次 intake 自动跳过 |
-| `orchestra-governed` | assignee-pool（池内层） | pool 决策完成后 | "已决策"——下次 pool 扫描自动跳过 |
-| `roadmap-reviewed` | vibe-roadmap（审查层） | roadmap 审查完成后 | "已审查"——下次 Step 0 自动跳过 |
+本节补充 roadmap 层特有规则：
 
-**闭环流程（三层）**：
-```
-broader repo ──→ intake 扫描 ──→ 接受(assignee) ──→ pool 扫描 ──→ 决策(rfc/epic/ready)
-                     │ 跳过                               │
-                     ▼                                    ▼
-              orchestra-scanned                   orchestra-governed
-              (下次 intake 跳过)                  (下次 pool 跳过)
-                                                        │
-                                                        ▼
-                                        vibe-roadmap Step 0 ──→ 审查
-                                                                    │
-                                                                    ▼
-                                                            roadmap-reviewed
-                                                            (下次 roadmap 跳过)
-                                                                    │
-                                                                    ▼
-                                                              memory.md 缓存
-```
+**roadmap-reviewed 标签使用**：
+- 在写完 `[roadmap decision]` 评论后，如果 decision 不是 `rfc`，**必须**打 `roadmap-reviewed` 标签
+- 如果 decision 是 `rfc`，**不打** `roadmap-reviewed`（保留 `roadmap/rfc` 标签等待人类决策）
+- 命令：`gh issue edit <issue-number> --add-label "roadmap-reviewed"`
 
 ### Milestone 管理
 
@@ -675,6 +657,9 @@ Agent 应通过以下方式使用标签触发机制：
 - 不要自行 fallback 到直接修改数据库
 
 ## Comment Marker Contract
+
+> Comment marker 通用规范见 [supervisor/roadmap-common.md](../../supervisor/roadmap-common.md#comment-marker-规范)。
+> 本节补充 roadmap-decider 特有规则。
 
 ### 角色定位
 

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -449,15 +449,17 @@ Exit:
 如果当前没有合适的建议 issue，明确写无，并说明原因。
 
 **orchestra-governed 标签要求**：
+
+> 三层标签的完整定义和过滤逻辑见 [supervisor/roadmap-common.md](../roadmap-common.md)。
+
 - 完成 issue 决策后（不管结论是 rfc/epic/ready/close），**必须**立即添加 `orchestra-governed` 标签
 - `orchestra-governed` 标签表示该 issue 已经过 assignee-pool 层决策，作为"已决策"标记
 - 如果需要重新决策某个 issue，应先移除 `orchestra-governed` 标签（人类也可以手动移除）
-- 与三层标签配合实现治理闭环：
-  - `orchestra-scanned`：intake 层已审查，不接受（跳过）
-  - `orchestra-governed`：assignee-pool 层已决策（不管 rfc/epic/ready）
-  - `roadmap-reviewed`：roadmap decider 已审查
 
 ## Comment Contract
+
+> Comment marker 通用规范见 [supervisor/roadmap-common.md](../roadmap-common.md#comment-marker-规范)。
+> 本节补充 pool 层特有的 suggest 类型定义。
 
 治理建议以 `[governance suggest]` 署名写入 issue comment。
 

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -124,22 +124,12 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
 
 ### 与 Assignee Pool 的职责边界
 
-**Roadmap Intake（入口层）**：
-- 决策范围：**只决定 accept（分配 assignee）或 skip（打 scanned）**
-- 检查：生命周期、依赖、API、模块
-- 输出：`[governance suggest]` 建议纳入或跳过，附带原因
-- 不设 `roadmap/*`、`priority/*` 标签
-- 边界：intake 不自称 decider；跳过原因写在 suggest 中，由 pool 或 roadmap 做进一步决策
+> 三层决策范围边界见 [supervisor/roadmap-common.md](../roadmap-common.md#三层决策范围边界)。
+> 本节补充 intake 层特有规则。
 
-**Assignee Pool（池内决策层）**：
-- 决策范围：`roadmap/*`(rfc/epic/p0/p1/p2)、`priority/*`、close（明确冲突/重复）、`roadmap/rfc`（不确定）、resume（明确可恢复）、split（清晰分界）
-- 所有决策完成后打 `orchestra-governed`
-- 边界：pool 是 assignee pool 内的决策 OWNER
-
-**Vibe Roadmap（审查纠正层）**：
-- 审查范围：`roadmap/rfc`、`state/blocked`、未 reviewed 的 issue
-- 可覆盖 pool 的决策（rfc → continue、epic → split 等）
-- 审查完打 `roadmap-reviewed`，写 memory.md
+**Roadmap Intake（入口层）特有约束**：
+- 不设 `roadmap/*`、`priority/*` 标签（属于 pool 层决策范围）
+- Level 0 检查阻塞时，intake 需要添加 `roadmap/rfc` 标签以路由该 issue
 
 ### Supervisor Issue Intake
 
@@ -356,9 +346,11 @@ Forbidden:
 
 ## Comment Contract
 
-任何 intake 类 routing 评论必须遵循 marker 规则：
+> Comment marker 通用规范见 [supervisor/roadmap-common.md](../roadmap-common.md#comment-marker-规范)。
+> 本节补充 intake 特有 marker 用法。
 
-- 第一行行首必须是 `[governance]` 或更具体的 `[governance suggest]`（前面只允许空白字符）
+**intake 特有规则**：
+- 第一行行首必须是 `[governance]` 或更具体的 `[governance suggest]`
 - intake 决策建议用 `[governance suggest]`，因为本材料只产出 routing 信号、不做强制结论
 - 不要把 intake 说明嵌入到自由文本中而不带 marker；缺失 marker 会被人类指令解析器误读为人类指令
 
@@ -412,6 +404,9 @@ Supervisor issues:
 
 ## 治理闭环标签
 
+> 标签定义、过滤逻辑和闭环机制见 [supervisor/roadmap-common.md](../roadmap-common.md)。
+> 本节补充 intake 层特有规则。
+
 **两种结果，不同处理**：
 
 **接受（分配 assignee）**：不设标签。assignee 本身就是信号——issue 进入 pool，由 assignee-pool 层接手。
@@ -425,11 +420,6 @@ gh issue edit <issue-number> --add-label "orchestra-scanned"
 **目的**：
 - `orchestra-scanned`：intake 层已审查，决定不接受 → 下次扫描自动跳过
 - 接受进入 pool 的 issue 不打 scanned，靠 assignee 信号自然流入 assignee-pool 层
-
-**三层标签协作**：
-- `orchestra-scanned`：intake 层审查通过但**不接**（跳过）
-- `orchestra-governed`：assignee-pool 层已决策（不管 rfc/epic/ready）
-- `roadmap-reviewed`：roadmap decider 已审查
 
 ## Stop Point
 

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -1,0 +1,230 @@
+# Roadmap 治理闭环共享定义
+
+**维护者**: Vibe Team  
+**创建时间**: 2026-05-27  
+**状态**: Active  
+
+---
+
+> 本文件是三层治理架构的权威定义源。所有治理材料应引用此文件，而非重复定义。
+
+---
+
+## 三层架构与角色分工
+
+```
+broader repo --> Layer 1: roadmap-intake (入口层)
+                    扫描范围: 无 assignee 的 issue
+                    过滤: 无 orchestra-scanned
+                    接受 -> 分配 assignee -> 流入 Layer 2
+                    跳过 -> 打 orchestra-scanned -> 不再看
+                          |
+                          v
+                 Layer 2: assignee-pool (池内决策层)
+                    扫描范围: 有 assignee 的 issue
+                    过滤: 无 orchestra-governed
+                    决策(rfc/epic/ready) -> 打 orchestra-governed -> 不再看
+                          |
+                          v
+                 Layer 3: vibe-roadmap (上层审查层)
+                    扫描范围: 所有 [governance suggest] 评论
+                    过滤: 无 roadmap-reviewed
+                    审查 -> 打 roadmap-reviewed -> 写入 memory.md
+```
+
+| 角色 | 文件 | Marker | 职责 | 标签 |
+|------|------|--------|------|------|
+| **roadmap-intake** | supervisor/governance/roadmap-intake.md | `[governance suggest]` | 入口观察者：扫描 broader repo，决定是否纳入 pool | 跳过时打 `orchestra-scanned` |
+| **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest]` | 池内决策者：对 pool 中 issue 做 rfc/epic/ready 决策 | 决策后打 `orchestra-governed` |
+| **vibe-roadmap** | skills/vibe-roadmap/SKILL.md | `[roadmap decision]` | 上层审查者：审查 governance 决策，纠正和补全 | 审查后打 `roadmap-reviewed` |
+
+---
+
+## 三标签定义与语义
+
+### 1. orchestra-scanned（入口层闭环）
+
+**谁打**：roadmap-intake  
+**何时打**：审查后**决定不接受**（不分配 assignee）时  
+**不打的情况**：接受并分配 assignee 时——assignee 本身就是信号，issue 自然流入 assignee-pool  
+
+**语义**："已审查，不纳入"  
+
+**命令**：
+```bash
+gh issue edit <issue-number> --add-label "orchestra-scanned"
+```
+
+**颜色**：FF9933（橙色）
+
+**过滤逻辑**：
+```
+intake 扫描 -> 跳过有 orchestra-scanned 的 issue
+intake 扫描 -> 跳过有 assignee 的 issue（已在 pool 中）
+```
+
+---
+
+### 2. orchestra-governed（池内层闭环）
+
+**谁打**：assignee-pool  
+**何时打**：完成决策后（不管结论是 rfc、epic、ready、建议关闭）  
+
+**语义**："已决策，不再重复检查"  
+
+**命令**：
+```bash
+gh issue edit <issue-number> --add-label "orchestra-governed"
+```
+
+**颜色**：9933FF（蓝紫色）
+
+**过滤逻辑**：
+```
+pool 扫描 -> 跳过有 orchestra-governed 的 issue
+pool 扫描 -> 跳过无 assignee 的 issue（不在 pool 中，由 intake 负责）
+```
+
+---
+
+### 3. roadmap-reviewed（审查层闭环）
+
+**谁打**：vibe-roadmap  
+**何时打**：写完 `[roadmap decision]` 评论后，**但 decision 不是 `rfc` 时**  
+**不打的情况**：decision 是 `rfc` 时——rfc 表示需要人类决策，未完成决策闭环  
+
+**语义**："已审查，下次 Step 0 跳过"  
+
+**与 `roadmap/rfc` 的互斥规则**：
+- `roadmap/rfc` 和 `roadmap-reviewed` **不能共存**
+- 带 `roadmap/rfc` 的 issue 表示"未完成决策"，不应打 `roadmap-reviewed`
+- 人类移除 `roadmap/rfc` 后，下次 roadmap 扫描会重新捡起该 issue，完成审查后打 `roadmap-reviewed`
+
+**命令**：
+```bash
+gh issue edit <issue-number> --add-label "roadmap-reviewed"
+```
+
+**过滤逻辑**：
+```
+Step 0 搜索 -> 过滤掉有 roadmap-reviewed 的 issue
+Step 0 搜索 -> 过滤掉有 roadmap/rfc 的 issue（等待人类决策）
+```
+
+**颜色**：CC99FF（淡紫色）
+
+---
+
+## 各层过滤逻辑
+
+### Layer 1: roadmap-intake
+
+**扫描前过滤（强制）**：
+- 跳过有 `orchestra-scanned` 标签的 issue（已审查过，不重复扫描）
+- 跳过有 assignee 的 issue（已在 pool 中，由 assignee-pool 负责）
+
+**处理动作**：
+- 接受（分配 assignee）：不设 scanned 标签，自然流入 pool
+- 跳过（不接受）：打 `orchestra-scanned` 标签
+
+---
+
+### Layer 2: assignee-pool
+
+**扫描前过滤（强制）**：
+- 跳过无 assignee 的 issue（不在 pool 中，由 roadmap-intake 负责）
+- 跳过有 `orchestra-governed` 标签的 issue（pool 已决策过，不重复检查）
+
+**处理动作**：
+- 决策完成（rfc/epic/ready/close）：打 `orchestra-governed` 标签
+
+---
+
+### Layer 3: vibe-roadmap
+
+**Step 0 过滤（强制）**：
+- 跳过有 `roadmap-reviewed` 标签的 issue（已审查过）
+- 跳过有 `roadmap/rfc` 标签的 issue（等待人类决策）
+
+**处理动作**：
+- 审查完成：写 `[roadmap decision]` + 打 `roadmap-reviewed` 标签（decision 不是 rfc 时）
+- 结果写入 memory.md 缓存
+
+---
+
+## 三层决策范围边界
+
+| 层级 | 决策范围 | 输出 | 边界 |
+|------|----------|------|------|
+| **Layer 1: roadmap-intake** | 只决定 accept（分配 assignee）或 skip（打 scanned） | `[governance suggest]` 建议纳入或跳过，附带原因 | intake 不自称 decider；跳过原因写在 suggest 中，由 pool 或 roadmap 做进一步决策 |
+| **Layer 2: assignee-pool** | `roadmap/*`(rfc/epic/p0/p1/p2)、`priority/*`、close（明确冲突/重复）、`roadmap/rfc`（不确定）、resume（明确可恢复）、split（清晰分界） | `[governance suggest]` 决策建议 + `orchestra-governed` 标签 | pool 是 assignee pool 内的决策 OWNER |
+| **Layer 3: vibe-roadmap** | 审查 `roadmap/rfc`、`state/blocked`、未 reviewed 的 issue；可覆盖 pool 的决策（rfc → continue、epic → split 等） | `[roadmap decision]` 决策结论 + `roadmap-reviewed` 标签 + memory.md 缓存 | roadmap 是上层审查纠正者，拥有最终决策权 |
+
+**关键原则**：
+- intake 不设 `roadmap/*`、`priority/*` 标签（属于 pool 层决策范围）
+- pool 决策完成后一律打 `orchestra-governed`，不管结论是什么
+- roadmap 审查完成后打 `roadmap-reviewed`（decision 不是 rfc 时），结果写入 memory.md
+
+---
+
+## Comment Marker 规范
+
+### 角色与 Marker 映射
+
+| 角色 | Marker | 性质 | 适用场景 |
+|------|--------|------|----------|
+| roadmap-intake / assignee-pool（observer） | `[governance suggest]` | 观察者意见，无强制力 | 入口观察、池内决策建议 |
+| vibe-roadmap（decider） | `[roadmap decision]` | 决策者结论，覆盖 governance 建议 | 上层审查、纠正、最终决策 |
+
+### 强制规则
+
+1. **Marker 必须在行首**：所有 agent 写出的 issue / PR comment 必须以角色 marker 开头（行首，方括号包裹），前面只允许空白字符
+2. **Marker 与正文分隔**：marker 与正文之间至少一个空格或换行
+3. **禁止混用**：
+   - vibe-roadmap **禁止**写 `[governance suggest]`
+   - roadmap-intake / assignee-pool **禁止**写 `[roadmap decision]`
+4. **缺失 marker 的后果**：会被人类指令解析器误读为人类指令
+
+### 合规示例
+
+```
+[governance suggest] Intake: assigned to @vibe-manager-agent (manager-pool); scope=bugfix.
+[governance suggest] Skipped: scope unclear, needs pool or roadmap review before automation.
+[governance suggest] 入池评估：评估依据=重构范围明确，已设置 roadmap/p2 + priority/5 + state/ready.
+[governance auto-recover] 已自动恢复 state：检测到 blocked 原因是 state unchanged，但 authoritative ref 已存在。
+[roadmap decision] split epic into #42, #43, #44; reason: scope exceeds single-iteration threshold.
+[roadmap decision] continue #78; reason: bounded enough for manager to plan inside one issue.
+[roadmap decision] close #99; reason: dependency removed in #123, API deprecated.
+[roadmap decision] hold #55 until #56 completes; reason: dependency graph constraint.
+[roadmap decision] rfc #77; reason: cannot determine split shape without architecture input.
+```
+
+### 不合规示例
+
+```
+✗ "Manager: moving to in-progress"        # 无 marker，会被识别为人类
+✗ "请尽快合并 [manager]"                  # marker 不在行首
+✗ "评论里嵌入 [run] 字样作引用"           # 装饰性使用，会触发 agent 过滤
+✗ [governance suggest] vibe-roadmap 写的  # vibe-roadmap 禁止使用此 marker
+✗ [roadmap decision] intake 写的          # intake 禁止使用此 marker
+```
+
+---
+
+## 验证方法
+
+```bash
+# 验证 intake 层：被跳过的 issue 应有 orchestra-scanned
+gh issue view <N> --json labels --jq '.labels | map(.name)'
+
+# 验证 pool 层：被决策的 issue 应有 orchestra-governed
+gh issue view <N> --json labels --jq '.labels | map(.name)'
+
+# 验证 roadmap 层：被审查的 issue 应有 roadmap-reviewed
+gh issue view <N> --json labels --jq '.labels | map(.name)'
+```
+
+---
+
+**维护者**: Vibe Team  
+**最后更新**: 2026-05-27


### PR DESCRIPTION
## Summary

Created centralized shared definition for three-layer roadmap governance architecture to eliminate duplicated content across four consumer files.

## Changes

- **NEW**: `supervisor/roadmap-common.md` - centralized definitions for:
  * Three-layer architecture and role division
  * Three-label semantics (orchestra-scanned, orchestra-governed, roadmap-reviewed)
  * Per-layer filtering logic
  * Decision scope boundaries
  * Comment marker contract

- **MODIFIED**: Four consumer files now reference the shared source instead of duplicating content:
  * `supervisor/governance/roadmap-intake.md`
  * `supervisor/governance/assignee-pool.md`
  * `skills/vibe-roadmap/SKILL.md`
  * `docs/governance/governance-roadmap-closed-loop.md`

## Impact

- No code changes, no tests affected
- Documentation refactor only
- Reduces risk of inconsistencies when updating label semantics or governance rules

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
