### PR TITLE
fix(check/cleanup): 修复 PR-closed soft-delete 三连坑导致 orchestra 派发污染

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -87,6 +87,9 @@ code_limits:
       - path: "src/vibe3/services/expired_resource_cleanup_service.py"
         limit: 540
         reason: "过期资源清理服务聚合，包含 agent worktree、远程分支、本地分支清理等三个紧密耦合的过期资源清理逻辑，新增 quiet 模式和颜色高亮输出后略微超标"
+      - path: "src/vibe3/services/flow_cleanup_service.py"
+        limit: 420
+        reason: "Flow 现场清理服务，包含 worktree/branch/handoff/flow record 等多步清理编排、live session 终端处理、prune worktree 兜底逻辑等紧密耦合的清理步骤"
       - path: "src/vibe3/services/check_cleanup_service.py"
         limit: 540
         reason: "终端 flow 清理 + detached worktree 清理聚合，包含 done/aborted 处理、live session 过滤、issue resume、detached worktree 安全清理（worktree root 比较、flow-managed scope 检查）等紧密耦合逻辑"

--- a/src/vibe3/clients/git_worktree_ops.py
+++ b/src/vibe3/clients/git_worktree_ops.py
@@ -256,3 +256,32 @@ def remove_worktree(wt_path: Path, force: bool = False) -> None:
         action="remove_worktree",
         path=str(wt_path),
     ).info("Removed worktree")
+
+
+def prune_worktrees() -> None:
+    """Prune stale worktree metadata for worktrees whose directories no longer exist.
+
+    When a worktree directory is removed externally (e.g. rm -rf) but
+    .git/worktrees/<name>/ metadata remains, git worktree remove fails.
+    This prunes those orphan metadata entries so subsequent worktree
+    operations succeed.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "worktree", "prune"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        logger.bind(
+            domain="git",
+            action="prune_worktrees",
+            stderr=result.stderr,
+        ).warning("Failed to prune worktrees")
+    else:
+        logger.bind(
+            domain="git",
+            action="prune_worktrees",
+        ).info("Pruned stale worktree metadata")

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -255,6 +255,11 @@ class SQLiteFlowStateRepo(_HasConnection):
 
         The flow_status is normalized to 'aborted' (terminal state) to
         distinguish tombstones from active flows in audits/debugging.
+
+        Also cascade-deletes non-audit associated records (runtime_session,
+        flow_issue_links, flow_context_cache) to prevent zombie state from
+        polluting subsequent orchestra dispatch. flow_events is preserved
+        as audit trail.
         """
         now = datetime.datetime.now().isoformat()
         conn = self._get_connection()
@@ -291,6 +296,9 @@ class SQLiteFlowStateRepo(_HasConnection):
                 WHERE branch = ?""",
                 (now, now, branch),
             )
+            cursor.execute("DELETE FROM runtime_session WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_issue_links WHERE branch = ?", (branch,))
+            cursor.execute("DELETE FROM flow_context_cache WHERE branch = ?", (branch,))
         logger.bind(
             external="sqlite",
             operation="soft_delete_flow",

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -172,12 +172,24 @@ class FlowCleanupService:
         return results
 
     def _remove_worktree(self, branch: str, results: dict[str, bool]) -> None:
-        """Remove worktree if exists."""
+        """Remove worktree if exists, with prune fallback for orphan metadata."""
         try:
             worktree_path = self.git_client.find_worktree_path_for_branch(branch)
             if worktree_path:
-                self.git_client.remove_worktree(str(worktree_path), force=True)
-                logger.bind(domain="cleanup", branch=branch).debug("Removed worktree")
+                try:
+                    self.git_client.remove_worktree(str(worktree_path), force=True)
+                    logger.bind(domain="cleanup", branch=branch).debug(
+                        "Removed worktree"
+                    )
+                except Exception as exc:
+                    logger.bind(domain="cleanup", branch=branch).warning(
+                        f"Failed to remove worktree, trying prune: {exc}"
+                    )
+                    from vibe3.clients.git_worktree_ops import prune_worktrees
+
+                    prune_worktrees()
+                    # Mark as failed even after prune - prune is just cleanup
+                    results["worktree"] = False
         except Exception as exc:
             logger.bind(domain="cleanup", branch=branch).warning(
                 f"Failed to remove worktree: {exc}"

--- a/src/vibe3/services/flow_write_mixin.py
+++ b/src/vibe3/services/flow_write_mixin.py
@@ -90,7 +90,8 @@ class FlowWriteMixin(FlowReadMixin):
         # update_flow_state silently fails on the existing tombstone row and
         # create_flow leaves a zombie with deleted_at set.
         tombstone = self.store.get_flow_state_include_deleted(branch)
-        if tombstone and tombstone.get("deleted_at") is not None:
+        was_tombstone = tombstone and tombstone.get("deleted_at") is not None
+        if was_tombstone:
             logger.bind(
                 domain="flow",
                 action="create",
@@ -99,26 +100,30 @@ class FlowWriteMixin(FlowReadMixin):
             self.store.restore_flow(branch)
             self.store.update_flow_state(branch, flow_status="active")
 
-        # Idempotency: if flow already exists, return existing
-        existing_state = self.store.get_flow_state(branch)
-        if existing_state:
-            existing_slug = existing_state.get("flow_slug", slug)
-            logger.bind(
-                domain="flow",
-                action="create",
-                branch=branch,
-                source=source,
-                existing_slug=existing_slug,
-            ).warning(
-                f"Flow already exists for '{branch}' "
-                f"(slug={existing_slug}, source={source}). "
-                f"Returning existing — use reactivate_flow to reset."
-            )
-            existing = self.get_flow_status(branch)
-            if existing is not None:
-                return existing
-            # get_flow_state found a row but get_flow_status returned None;
-            # fall through to recreate (should not happen in practice).
+        # Idempotency: if flow already exists, return existing.
+        # Skip when we just restored from a tombstone so the normal create
+        # path updates slug/initiated_by/latest_actor and records a
+        # flow_created event.
+        if not was_tombstone:
+            existing_state = self.store.get_flow_state(branch)
+            if existing_state:
+                existing_slug = existing_state.get("flow_slug", slug)
+                logger.bind(
+                    domain="flow",
+                    action="create",
+                    branch=branch,
+                    source=source,
+                    existing_slug=existing_slug,
+                ).warning(
+                    f"Flow already exists for '{branch}' "
+                    f"(slug={existing_slug}, source={source}). "
+                    f"Returning existing — use reactivate_flow to reset."
+                )
+                existing = self.get_flow_status(branch)
+                if existing is not None:
+                    return existing
+                # get_flow_state found a row but get_flow_status returned None;
+                # fall through to recreate (should not happen in practice).
 
         logger.bind(
             domain="flow",

--- a/src/vibe3/services/flow_write_mixin.py
+++ b/src/vibe3/services/flow_write_mixin.py
@@ -85,6 +85,20 @@ class FlowWriteMixin(FlowReadMixin):
                 "Switch to a feature branch first."
             )
 
+        # Handle soft-deleted tombstone: restore and reactivate before
+        # idempotency check. Without this, INSERT OR IGNORE in
+        # update_flow_state silently fails on the existing tombstone row and
+        # create_flow leaves a zombie with deleted_at set.
+        tombstone = self.store.get_flow_state_include_deleted(branch)
+        if tombstone and tombstone.get("deleted_at") is not None:
+            logger.bind(
+                domain="flow",
+                action="create",
+                branch=branch,
+            ).info("Restoring soft-deleted tombstone before flow creation")
+            self.store.restore_flow(branch)
+            self.store.update_flow_state(branch, flow_status="active")
+
         # Idempotency: if flow already exists, return existing
         existing_state = self.store.get_flow_state(branch)
         if existing_state:

--- a/tests/vibe3/clients/test_sqlite_flow_state_repo.py
+++ b/tests/vibe3/clients/test_sqlite_flow_state_repo.py
@@ -107,6 +107,137 @@ def test_soft_delete_flow_clears_refs_from_active_flow() -> None:
         assert deleted["audit_ref"] is None
 
 
+def test_soft_delete_flow_cascades_to_runtime_session() -> None:
+    """soft_delete_flow must delete runtime_session rows for the branch."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("task/issue-123", flow_slug="issue_123")
+
+        # Insert a runtime_session row
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO runtime_session "
+            "(role, target_type, target_id, branch, session_name, status, "
+            "created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
+            ("planner", "issue", "123", "task/issue-123", "vibe3-plan-123", "running"),
+        )
+        conn.commit()
+
+        # Verify session exists before soft delete
+        cursor.execute(
+            "SELECT COUNT(*) FROM runtime_session WHERE branch = ?",
+            ("task/issue-123",),
+        )
+        assert cursor.fetchone()[0] == 1
+
+        store.soft_delete_flow("task/issue-123")
+
+        # Verify session is deleted
+        cursor.execute(
+            "SELECT COUNT(*) FROM runtime_session WHERE branch = ?",
+            ("task/issue-123",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+
+def test_soft_delete_flow_cascades_to_flow_issue_links() -> None:
+    """soft_delete_flow must delete flow_issue_links rows for the branch."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("task/issue-456", flow_slug="issue_456")
+
+        # Insert a flow_issue_links row
+        store.add_issue_link("task/issue-456", 456, "task")
+
+        # Verify link exists before soft delete
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_issue_links WHERE branch = ?",
+            ("task/issue-456",),
+        )
+        assert cursor.fetchone()[0] == 1
+
+        store.soft_delete_flow("task/issue-456")
+
+        # Verify link is deleted
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_issue_links WHERE branch = ?",
+            ("task/issue-456",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+
+def test_soft_delete_flow_cascades_to_flow_context_cache() -> None:
+    """soft_delete_flow must delete flow_context_cache rows for the branch."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("task/issue-789", flow_slug="issue_789")
+
+        # Insert a flow_context_cache row
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_context_cache (branch, task_issue_number, updated_at) "
+            "VALUES (?, ?, datetime('now'))",
+            ("task/issue-789", 789),
+        )
+        conn.commit()
+
+        # Verify cache exists before soft delete
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_context_cache WHERE branch = ?",
+            ("task/issue-789",),
+        )
+        assert cursor.fetchone()[0] == 1
+
+        store.soft_delete_flow("task/issue-789")
+
+        # Verify cache is deleted
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_context_cache WHERE branch = ?",
+            ("task/issue-789",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+
+def test_soft_delete_flow_preserves_flow_events() -> None:
+    """soft_delete_flow must NOT delete flow_events (audit trail)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        store.update_flow_state("task/issue-999", flow_slug="issue_999")
+
+        # Insert a flow_events row
+        store.add_event("task/issue-999", "flow_created", "test-actor", "created")
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_events WHERE branch = ?",
+            ("task/issue-999",),
+        )
+        assert cursor.fetchone()[0] == 1
+
+        store.soft_delete_flow("task/issue-999")
+
+        # Verify events are preserved
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_events WHERE branch = ?",
+            ("task/issue-999",),
+        )
+        assert cursor.fetchone()[0] == 1
+
+
 def test_get_task_issue_number_returns_int_when_link_exists() -> None:
     """Test get_task_issue_number returns int when flow_issue_links has task."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/vibe3/services/test_flow_cleanup_service.py
+++ b/tests/vibe3/services/test_flow_cleanup_service.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vibe3.exceptions import GitError
 from vibe3.models.pr import PRResponse, PRState
 from vibe3.services.flow_cleanup_service import (
     FlowCleanupService,
@@ -95,3 +96,30 @@ def test_delete_remote_branch_skips_when_open_pr_exists() -> None:
 
     service.git_client.delete_remote_branch.assert_not_called()
     assert results["remote_branch"] is True
+
+
+def test_remove_worktree_falls_back_to_prune_on_failure() -> None:
+    """When remove_worktree raises GitError, _remove_worktree must try prune."""
+    service = FlowCleanupService(
+        git_client=MagicMock(),
+        store=MagicMock(),
+        issue_flow_service=MagicMock(),
+    )
+
+    # Simulate: find_worktree_path_for_branch returns a path,
+    # but remove_worktree raises GitError (orphan metadata)
+    service.git_client.find_worktree_path_for_branch.return_value = (
+        "/tmp/stale-worktree"
+    )
+    service.git_client.remove_worktree.side_effect = GitError(
+        "worktree remove", "fatal: validation failed"
+    )
+
+    with patch("vibe3.clients.git_worktree_ops.prune_worktrees") as mock_prune:
+        results: dict[str, bool] = {"worktree": True}
+        service._remove_worktree("task/issue-123", results)
+
+        # Prune must be called as fallback
+        mock_prune.assert_called_once()
+        # Worktree step should still be marked as failed
+        assert results["worktree"] is False

--- a/tests/vibe3/services/test_flow_service.py
+++ b/tests/vibe3/services/test_flow_service.py
@@ -55,12 +55,17 @@ class TestFlowServiceCreate:
         assert kwargs["flow_slug"] == "test-flow"
 
     def test_create_flow_restores_tombstone_row(self, mock_store, mock_git):
-        """create_flow must restore and reactivate a soft-deleted tombstone row."""
+        """create_flow must restore and reactivate a soft-deleted tombstone row.
+
+        After restoration, the idempotency check is skipped so the normal
+        create path runs: update_flow_state with slug/actor/initiated_by,
+        add_event for flow_created, and get_flow_status for the return value.
+        """
         service = FlowService(store=mock_store, git_client=mock_git)
         mock_git.get_current_branch.return_value = "task/issue-123"
 
-        # Simulate tombstone: get_flow_state returns None (deleted_at filter),
-        # but get_flow_state_include_deleted finds the tombstone.
+        # Simulate tombstone: get_flow_state_include_deleted finds the
+        # soft-deleted row with deleted_at set.
         tombstone = {
             "branch": "task/issue-123",
             "flow_slug": "issue-123",
@@ -68,21 +73,19 @@ class TestFlowServiceCreate:
             "deleted_at": "2026-05-27T00:00:00",
             "updated_at": "2026-05-27T00:00:00",
         }
-        mock_store.get_flow_state.return_value = None
         mock_store.get_flow_state_include_deleted.return_value = tombstone
-        mock_store.get_issue_links.return_value = []
 
-        # After restore, get_flow_state returns the active flow (idempotency check)
-        mock_store.get_flow_state.side_effect = [
-            None,  # First call: idempotency check -> None (tombstone not visible)
-            {  # Second call (after restore+reactivate): returns active flow
-                "branch": "task/issue-123",
-                "flow_slug": "issue-123",
-                "flow_status": "active",
-                "updated_at": "2026-05-27T18:00:00",
-                "initiated_by": "manual",
-            },
-        ]
+        # Normal create path calls get_flow_status which internally calls
+        # get_flow_state. Return the active flow for that chain.
+        mock_store.get_flow_state.return_value = {
+            "branch": "task/issue-123",
+            "flow_slug": "issue-123",
+            "flow_status": "active",
+            "updated_at": "2026-05-27T18:00:00",
+            "initiated_by": "manual",
+        }
+        mock_store.get_issue_links.return_value = []
+        mock_git.find_worktree_path_for_branch.return_value = None
 
         with patch("vibe3.services.flow_read_mixin.GitHubClient") as mock_gh:
             mock_gh.return_value.get_pr.return_value = None
@@ -94,12 +97,17 @@ class TestFlowServiceCreate:
         assert status is not None
         # Must have called restore_flow
         mock_store.restore_flow.assert_called_once_with("task/issue-123")
-        # Must have reset flow_status to 'active'
+        # Must have reset flow_status to 'active' (tombstone reactivation)
         update_calls = mock_store.update_flow_state.call_args_list
         status_updates = [
             c for c in update_calls if c.kwargs.get("flow_status") == "active"
         ]
         assert len(status_updates) >= 1
+        # Normal create path must record flow_created event
+        mock_store.add_event.assert_called_once()
+        add_event_args = mock_store.add_event.call_args[0]
+        assert add_event_args[0] == "task/issue-123"
+        assert add_event_args[1] == "flow_created"
 
 
 class TestFlowServiceAbort:

--- a/tests/vibe3/services/test_flow_service.py
+++ b/tests/vibe3/services/test_flow_service.py
@@ -24,6 +24,9 @@ class TestFlowServiceCreate:
         service = FlowService(store=mock_store, git_client=mock_git)
         mock_git.get_current_branch.return_value = "feature/test"
 
+        # No tombstone exists
+        mock_store.get_flow_state_include_deleted.return_value = None
+
         # First call (idempotency check) returns None; subsequent calls
         # return the created state.
         mock_store.get_flow_state.side_effect = [
@@ -50,6 +53,53 @@ class TestFlowServiceCreate:
         args, kwargs = mock_store.update_flow_state.call_args
         assert kwargs["initiated_by"] == "manual"
         assert kwargs["flow_slug"] == "test-flow"
+
+    def test_create_flow_restores_tombstone_row(self, mock_store, mock_git):
+        """create_flow must restore and reactivate a soft-deleted tombstone row."""
+        service = FlowService(store=mock_store, git_client=mock_git)
+        mock_git.get_current_branch.return_value = "task/issue-123"
+
+        # Simulate tombstone: get_flow_state returns None (deleted_at filter),
+        # but get_flow_state_include_deleted finds the tombstone.
+        tombstone = {
+            "branch": "task/issue-123",
+            "flow_slug": "issue-123",
+            "flow_status": "aborted",
+            "deleted_at": "2026-05-27T00:00:00",
+            "updated_at": "2026-05-27T00:00:00",
+        }
+        mock_store.get_flow_state.return_value = None
+        mock_store.get_flow_state_include_deleted.return_value = tombstone
+        mock_store.get_issue_links.return_value = []
+
+        # After restore, get_flow_state returns the active flow (idempotency check)
+        mock_store.get_flow_state.side_effect = [
+            None,  # First call: idempotency check -> None (tombstone not visible)
+            {  # Second call (after restore+reactivate): returns active flow
+                "branch": "task/issue-123",
+                "flow_slug": "issue-123",
+                "flow_status": "active",
+                "updated_at": "2026-05-27T18:00:00",
+                "initiated_by": "manual",
+            },
+        ]
+
+        with patch("vibe3.services.flow_read_mixin.GitHubClient") as mock_gh:
+            mock_gh.return_value.get_pr.return_value = None
+
+            status = service.create_flow(
+                slug="issue-123", branch="task/issue-123", initiated_by="manual"
+            )
+
+        assert status is not None
+        # Must have called restore_flow
+        mock_store.restore_flow.assert_called_once_with("task/issue-123")
+        # Must have reset flow_status to 'active'
+        update_calls = mock_store.update_flow_state.call_args_list
+        status_updates = [
+            c for c in update_calls if c.kwargs.get("flow_status") == "active"
+        ]
+        assert len(status_updates) >= 1
 
 
 class TestFlowServiceAbort:

--- a/tests/vibe3/services/test_task_resume_reset_scene.py
+++ b/tests/vibe3/services/test_task_resume_reset_scene.py
@@ -104,3 +104,72 @@ def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
             terminate_sessions=True,
             keep_flow_record=False,
         )
+
+
+def test_soft_delete_then_create_flow_produces_clean_state() -> None:
+    """Full cycle: soft_delete -> create_flow must produce a clean active flow.
+
+    Simulates the orchestra dispatch after PR-closed reset:
+    1. Soft-delete the flow (as cleanup does)
+    2. Create a new flow (as orchestra dispatch does)
+    3. Verify: deleted_at is NULL, flow_status is 'active', no zombie links
+    """
+    import tempfile
+    from pathlib import Path
+
+    from vibe3.clients.sqlite_client import SQLiteClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Setup: create flow with links and session
+        store.update_flow_state(
+            "task/issue-100",
+            flow_slug="issue-100",
+            flow_status="active",
+        )
+        store.add_issue_link("task/issue-100", 100, "task")
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO runtime_session "
+            "(role, target_type, target_id, branch, session_name, status, "
+            "created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
+            ("planner", "issue", "100", "task/issue-100", "sess-1", "running"),
+        )
+        conn.commit()
+
+        # Step 1: Soft delete (as cleanup does)
+        store.soft_delete_flow("task/issue-100")
+
+        # Verify tombstone
+        tombstone = store.get_flow_state_include_deleted("task/issue-100")
+        assert tombstone is not None
+        assert tombstone["deleted_at"] is not None
+        assert tombstone["flow_status"] == "aborted"
+
+        # Verify cascade: runtime_session and flow_issue_links are gone
+        cursor.execute(
+            "SELECT COUNT(*) FROM runtime_session WHERE branch = ?",
+            ("task/issue-100",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+        cursor.execute(
+            "SELECT COUNT(*) FROM flow_issue_links WHERE branch = ?",
+            ("task/issue-100",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+        # Step 2: Simulate what create_flow does with tombstone
+        store.restore_flow("task/issue-100")
+        store.update_flow_state("task/issue-100", flow_status="active")
+
+        # Step 3: Verify clean state
+        active = store.get_flow_state("task/issue-100")
+        assert active is not None, "get_flow_state must find the restored flow"
+        assert active["deleted_at"] is None
+        assert active["flow_status"] == "active"


### PR DESCRIPTION
## Summary

修复 issue #1535 中描述的 PR-closed reset 后 soft-delete 残留的三类僵尸状态：

- **Pit 1** — `soft_delete_flow` 级联删除 `runtime_session`、`flow_issue_links`、`flow_context_cache`，保留 `flow_events` 作为 audit trail
- **Pit 2** — `create_flow` 在幂等检查前检测并恢复 tombstone 行，避免 `INSERT OR IGNORE` 静默失败导致 deleted_at 残留
- **Pit 3** — `_remove_worktree` 在 `git worktree remove` 失败后兜底 `git worktree prune`，清理孤儿元数据

## Test Plan

- [x] 6 个 `soft_delete_flow` 相关测试（含 4 个新增级联删除测试）
- [x] 6 个 `FlowService` 测试（含新增 tombstone 恢复测试）
- [x] 4 个 `FlowCleanupService` 测试（含新增 prune 兜底测试）
- [x] 4 个 `task_resume_reset_scene` 测试（含新增端到端集成测试）
- [x] 全部 23 个测试通过，无回归

Closes #1535

## Contributors

- Yi Chen
- Claude (Anthropic, claude-opus-4-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)