### PR TITLE
feat(check): rebuild flow after PR closed to avoid dangling issue state

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -32,8 +32,8 @@ code_limits:
         limit: 500
         reason: "Qualify gate 域服务，包含 truth-first 决策流程、blocked 对齐、auto-resume、worktree 健康检查、依赖检查、github_state CLOSED guard 等紧密耦合逻辑"
       - path: "src/vibe3/services/handoff_service.py"
-        limit: 590
-        reason: "Handoff 记录管理核心服务，内聚度高，模板函数共生；包含 terminology 统一映射逻辑；--branch 参数统一支持后略微膨胀；新增 blocked_reason 自动清除逻辑（当 plan_ref/report_ref 写入时）"
+        limit: 650
+        reason: "Handoff 记录管理核心服务，内聚度高，模板函数共生；包含 terminology 统一映射逻辑；--branch 参数统一支持后略微膨胀；新增 blocked_reason 自动清除逻辑（当 plan_ref/report_ref 写入时）；新增 event 驱动架构支持（FlowTimelineService 集成，issue_number 查询，event 记录逻辑）"
 
       # Clients 聚合 —— 允许 450-540
       - path: "src/vibe3/clients/sqlite_schema.py"

--- a/src/vibe3/config/timeline_comment_policy.py
+++ b/src/vibe3/config/timeline_comment_policy.py
@@ -41,8 +41,9 @@ class TimelineCommentPolicy(BaseModel):
 
     # Milestone events - WRITE COMMENTS (important progress markers)
     # NOTE: Must be routed through FlowTimelineService.record_timeline_event()
-    # Future events will be added here when producers migrate to FlowTimelineService
+    # handoff_append is now routed through HandoffService.append_current_handoff()
     milestone_events: list[str] = [
+        "handoff_append",  # Important milestone records (routed via HandoffService)
         "milestone_recorded",  # Example: Future milestone event (placeholder)
     ]
 
@@ -57,8 +58,9 @@ class TimelineCommentPolicy(BaseModel):
     # These events are recorded directly with store.add_event() and bypass policy:
     # - pr_created: PRService creates PR (pr_service.py:310-315)
     # - handoff_verdict: VerdictService records verdict (verdict_service.py:140-146)
-    # - handoff_append: BootstrapContextService action (bootstrap_context_service.py)
     # - state_transitioned: NoopGate state transition (noop_gate.py:406-424)
+    #
+    # handoff_append is NOW routed through FlowTimelineService via HandoffService
     # To enable policy filtering, route through FlowTimelineService first
 
     def should_write_comment(self, event_type: str) -> bool:

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -300,6 +300,7 @@ class CheckPRService:
             handoff_service = HandoffService(
                 store=self.store,
                 git_client=self.git_client,
+                github_client=self.github_client,
             )
 
             handoff_service.append_current_handoff(

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -254,6 +254,64 @@ class CheckPRService:
                 f"Reset issue #{task_issue_number} to READY after "
                 f"PR #{pr_number} closed"
             )
+
+            # Rebuild flow after reset to avoid dangling state
+            from vibe3.config.orchestra_config import OrchestraConfig
+            from vibe3.services.flow_orchestrator_service import (
+                FlowOrchestratorService,
+            )
+            from vibe3.services.issue_context_loader import load_issue_info
+
+            config = OrchestraConfig()
+            orchestrator = FlowOrchestratorService(
+                config,
+                store=self.store,
+                git=self.git_client,
+                github=self.github_client,
+            )
+
+            issue_info = load_issue_info(
+                task_issue_number, config=config, github=self.github_client
+            )
+
+            # Create new flow (ensure_worktree=False to delay creation)
+            orchestrator.bootstrap_issue_flow(
+                issue_info,
+                branch=branch,
+                slug=f"issue-{task_issue_number}",
+                source="check:pr_closed",
+                ensure_worktree=False,
+                reactivate_existing=False,
+            )
+
+            logger.bind(
+                domain="check",
+                action="reset_pr_closed_rebuild",
+                branch=branch,
+                issue_number=task_issue_number,
+            ).info(
+                f"Rebuilt flow for issue #{task_issue_number} after "
+                f"PR #{pr_number} closed"
+            )
+
+            # Record handoff milestone (optional but recommended)
+            from vibe3.services.handoff_service import HandoffService
+
+            handoff_service = HandoffService(
+                store=self.store,
+                git_client=self.git_client,
+            )
+
+            handoff_service.append_current_handoff(
+                message=(
+                    f"PR #{pr_number} closed without merge, "
+                    f"flow rebuilt and reset to READY"
+                ),
+                actor="vibe:check",
+                kind="milestone",
+                branch=branch,
+            )
+
         except Exception as exc:
             logger.bind(
                 domain="check",

--- a/src/vibe3/services/flow_timeline_service.py
+++ b/src/vibe3/services/flow_timeline_service.py
@@ -186,6 +186,7 @@ class FlowTimelineService:
                 "flow_failed": "Flow failed",
                 "flow_aborted": "Flow aborted",
                 "resumed": "Flow resumed",
+                "handoff_append": "Handoff update",
                 "milestone_recorded": "Milestone recorded",
                 "user_notification": "User notification",
             }

--- a/src/vibe3/services/flow_timeline_service.py
+++ b/src/vibe3/services/flow_timeline_service.py
@@ -136,6 +136,7 @@ class FlowTimelineService:
             "flow_failed": "Flow failed",
             "flow_aborted": "Flow aborted",
             "resumed": "Flow resumed",
+            "handoff_append": "Handoff update",
             "milestone_recorded": "Milestone recorded",
             "user_notification": "User notification",
         }

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
@@ -21,6 +21,9 @@ from vibe3.services.handoff_storage import HandoffStorage
 from vibe3.services.handoff_validation import validate_authoritative_ref
 from vibe3.services.path_helpers import _SHARED_HANDOFF_PREFIX
 from vibe3.services.signature_service import SignatureService
+
+if TYPE_CHECKING:
+    from vibe3.clients.github_client import GitHubClient
 
 
 class HandoffService:
@@ -90,9 +93,20 @@ class HandoffService:
         self,
         store: SQLiteClient | None = None,
         git_client: GitPathProtocol | None = None,
+        github_client: "GitHubClient | None" = None,
     ) -> None:
+        """Initialize handoff service.
+
+        Args:
+            store: SQLite client for database operations
+            git_client: Git client for branch/worktree operations
+            github_client: GitHub client for API operations (optional)
+        """
+        from vibe3.clients.github_client import GitHubClient
+
         self.store = store or SQLiteClient()
         self.git_client = git_client or GitClient()
+        self.github_client = github_client or GitHubClient()
         self.storage = HandoffStorage(self.git_client)
         self.external_recorder = ExternalEventRecorder(
             self.store,
@@ -181,9 +195,48 @@ class HandoffService:
             target_branch,
             explicit_actor=actor,
         )
-        return self.storage.append_current_handoff(
+
+        # 1. Write to handoff file
+        handoff_path = self.storage.append_current_handoff(
             message, effective_actor, kind, branch
         )
+
+        # 2. Record timeline event for milestone handoff updates
+        # Query issue_number from branch → issue link
+        issue_links = self.store.get_issue_links(target_branch)
+        issue_number: int | None = None
+        for link in issue_links:
+            if link.get("issue_role") == "task":
+                issue_number = link.get("issue_number")
+                if isinstance(issue_number, int):
+                    break
+
+        # 3. Call FlowTimelineService to record event and optionally write comment
+        if issue_number:
+            from vibe3.services.flow_timeline_service import FlowTimelineService
+
+            timeline_service = FlowTimelineService(
+                store=self.store,
+                github_client=self.github_client,
+            )
+
+            timeline_service.record_timeline_event(
+                branch=target_branch,
+                event_type="handoff_append",
+                actor=effective_actor,
+                detail=message,
+                issue_number=issue_number,
+            )
+        else:
+            # No issue_number → only record SQLite event, skip comment
+            self.store.add_event(
+                target_branch,
+                "handoff_append",
+                effective_actor,
+                detail=message,
+            )
+
+        return handoff_path
 
     def _resolve_branch_worktree_root(self, branch: str) -> Path:
         worktree_root = self.git_client.find_worktree_path_for_branch(branch)

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -46,11 +46,30 @@ def test_handle_closed_pr_resets_issue_to_ready() -> None:
         "state": "open",
     }
 
-    with patch(
-        "vibe3.services.task_resume_operations.TaskResumeOperations"
-    ) as mock_resume_ops_cls:
+    with (
+        patch(
+            "vibe3.services.task_resume_operations.TaskResumeOperations"
+        ) as mock_resume_ops_cls,
+        patch(
+            "vibe3.services.flow_orchestrator_service.FlowOrchestratorService"
+        ) as mock_orchestrator_cls,
+        patch("vibe3.services.handoff_service.HandoffService") as mock_handoff_cls,
+        patch("vibe3.services.issue_context_loader.load_issue_info") as mock_load_issue,
+    ):
         mock_resume_ops = MagicMock()
         mock_resume_ops_cls.return_value = mock_resume_ops
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator_cls.return_value = mock_orchestrator
+
+        mock_handoff = MagicMock()
+        mock_handoff_cls.return_value = mock_handoff
+
+        # Mock issue info
+        from vibe3.models.orchestration import IssueInfo
+
+        mock_issue_info = IssueInfo(number=456, title="Test Issue", labels=[])
+        mock_load_issue.return_value = mock_issue_info
 
         handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
 
@@ -59,6 +78,12 @@ def test_handle_closed_pr_resets_issue_to_ready() -> None:
         call_kwargs = mock_resume_ops.reset_issue_to_ready.call_args[1]
         assert call_kwargs["issue_number"] == 456
         assert call_kwargs["resume_kind"] == "pr_closed"
+
+        # Verify flow rebuild was attempted
+        mock_orchestrator.bootstrap_issue_flow.assert_called_once()
+
+        # Verify handoff milestone was recorded
+        mock_handoff.append_current_handoff.assert_called_once()
 
         # Verify result is valid and handled
         assert handled is True


### PR DESCRIPTION
## Summary

- **根因修正**：PR closed 后的 reset 流程会删除 flow record，导致 issue 进入悬空状态（无活跃 flow）
- **改进方案**：reset 时立即重建 flow，通过 `FlowOrchestratorService.bootstrap_issue_flow()` 创建新 flow
- **Event 架构**：两个 events（`resumed` + `handoff_append`），完整接入 flow timeline events
- **Comments 能力**：`handoff_append` 具备 GitHub comments 能力，策略可配置

## Changes

### 1. HandoffService comments capability (Commit 1)

**修改**：
- `HandoffService` 添加 `github_client` 参数
- `append_current_handoff()` 调用 `FlowTimelineService.record_timeline_event()`
- `handoff_append` 加入 `milestone_events`（写 GitHub comments）

**Event 架构**：
- 统一通过 `FlowTimelineService` 记录 events
- Policy 配置化控制哪些 events 写 comments

### 2. Flow rebuild after reset (Commit 2)

**修改**：
- `_reset_issue_after_pr_closed()` 添加 flow 重建逻辑
- 使用 `FlowOrchestratorService.bootstrap_issue_flow()` 创建新 flow
- 记录 handoff milestone（通过 `HandoffService.append_current_handoff()`）

**Event 架构验证**：
- **`resumed` event**：内部状态同步（不写 comments）
- **`handoff_append` event**：里程碑记录（写 comments）
- 分类语义清晰：state_sync vs milestone

### 3. Test fix (Commit 3)

**修改**：
- 添加 mocks for `FlowOrchestratorService`, `HandoffService`, `load_issue_info`
- 验证 flow rebuild 和 handoff milestone 被调用

## Technical Design

### Event Architecture

当前 reset 流程已完整接入 flow timeline events：

**两个 Events 记录**：
1. **`resumed` event**（通过 `BlockedStateService.unblock()`）
   - 调用 `FlowTimelineService.record_timeline_event("resumed", ...)`
   - 记录到 SQLite timeline events 表
   - 不写 GitHub comments（policy: `state_sync_events`）
   - 作用：内部状态同步，标记 flow 从 blocked → active

2. **`handoff_append` event**（通过 `HandoffService.append_current_handoff()`）
   - 记录到 SQLite + handoff file
   - 写 GitHub comments（policy: `milestone_events`）
   - 作用：用户可见的里程碑记录

**Policy 配置**（`timeline_comment_policy.py`）：
```python
state_sync_events = [
    "flow_blocked",
    "resumed",        # ← 不写 comments
    "flow_aborted",
]

milestone_events = [
    "handoff_append",  # ← 写 comments
    "milestone_recorded",
]
```

### Implementation Strategy

**原方案**（issue body）：
- 发布 `flow_reset` 新事件类型
- 需要扩展 `TimelineCommentPolicy`

**实际实现**：
- 复用现有 events：`resumed` + `handoff_append`
- 无需新增 event 类型
- 利用现有 policy 配置机制

**优势**：
- ✅ 更符合现有架构（event 驱动）
- ✅ 减少新增概念（复用 `handoff_append`）
- ✅ Policy 可配置（通过 `TimelineCommentPolicy`）

## Test Plan

- ✅ 运行 `vibe3 check` 在 PR closed 后的分支
- ✅ 检查 SQLite 是否有两个 events（`resumed` + `handoff_append`）
- ✅ 检查 issue comments 中是否有 handoff milestone comment
- ✅ 验证 flow 重建成功（`vibe3 flow show`）
- ✅ 所有单元测试通过（`test_check_service.py`）

## Related

- Issue: #1531
- Related PR: #1537 (timeline comment policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)