### PR TITLE
[codex] install shared uv env via direnv

### DIFF
--- a/config/shell/loader.sh
+++ b/config/shell/loader.sh
@@ -37,9 +37,3 @@ _keys_load() {
     return 0
 }
 _keys_load "${HOME}/.vibe/config/keys.env"
-
-# ---------- UV_PROJECT_ENVIRONMENT ----------
-# Fallback so `uv run` from external project dirs doesn't create .venv in $PWD.
-if [[ -z "$UV_PROJECT_ENVIRONMENT" && -d "$HOME/.venvs/vibe-center" ]]; then
-    export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/vibe-center"
-fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -82,8 +82,8 @@ if [[ -z "$UV_PROJECT_ENVIRONMENT" ]]; then
   echo -e "\033[1;33m⚠️  Warning: UV_PROJECT_ENVIRONMENT is not set\033[0m"
   echo "   Vibe Center uses a shared virtual environment at: ~/.venvs/vibe-center"
   echo ""
-  echo "   Please add the following to your shell config (~/.zshrc or ~/.bashrc):"
-  echo "   export UV_PROJECT_ENVIRONMENT=\"\$HOME/.venvs/vibe-center\""
+  echo "   Please enter the repo directory through direnv, or run:"
+  echo "   direnv allow"
   echo ""
   echo "   Or run: scripts/install.sh to set it up automatically"
 elif [[ ! -d "$UV_PROJECT_ENVIRONMENT" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,8 +246,8 @@ if [[ -f "$RC_FILE" ]]; then
         sed -i '' '/# Load Vibe keys/,+5 d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/# Vibe Coding Control Center - Loader/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/source .*\/loader.sh/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '' '/VIBE_ROOT/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '' '/UV_PROJECT_ENVIRONMENT/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/^export VIBE_ROOT=/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/# Vibe Local Bin/,+1 d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/# Vibe Direnv Hook/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/direnv hook /d' "$RC_FILE" 2>/dev/null || true
@@ -256,8 +256,8 @@ if [[ -f "$RC_FILE" ]]; then
         sed -i '/# Load Vibe keys/,+5 d' "$RC_FILE" 2>/dev/null || true
         sed -i '/# Vibe Coding Control Center - Loader/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/source .*\/loader.sh/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '/VIBE_ROOT/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '/UV_PROJECT_ENVIRONMENT/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/^export VIBE_ROOT=/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/# Vibe Local Bin/,+1 d' "$RC_FILE" 2>/dev/null || true
         sed -i '/# Vibe Direnv Hook/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/direnv hook /d' "$RC_FILE" 2>/dev/null || true
@@ -270,9 +270,9 @@ _append_to_rc "$RC_FILE" $'if [[ -f ~/.vibe/config/keys.env ]]; then\n    set -a
 _append_to_rc "$RC_FILE" "[ -f \"$INSTALL_DIR/loader.sh\" ] && source \"$INSTALL_DIR/loader.sh\"" "Vibe Coding Control Center - Loader"
 _append_to_rc "$RC_FILE" 'export PATH="$HOME/.local/bin:$PATH"' "Vibe Local Bin"
 if [[ "$SHELL" == */bash ]]; then
-    _append_to_rc "$RC_FILE" 'eval "$(direnv hook bash)"' "Vibe Direnv Hook"
+    _append_to_rc "$RC_FILE" 'command -v direnv >/dev/null 2>&1 && eval "$(direnv hook bash)"' "Vibe Direnv Hook"
 else
-    _append_to_rc "$RC_FILE" 'eval "$(direnv hook zsh)"' "Vibe Direnv Hook"
+    _append_to_rc "$RC_FILE" 'command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"' "Vibe Direnv Hook"
 fi
 
 if command -v gh >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,16 @@ _append_to_rc() {
     fi
 }
 
+_write_file_if_changed() {
+    local path="$1"
+    local content="$2"
+    local current=""
+    [[ -f "$path" ]] && current="$(<"$path")"
+    if [[ "$current" != "$content" ]]; then
+        printf '%s\n' "$content" > "$path"
+    fi
+}
+
 _get_shell_rc() {
     case "$SHELL" in
         */zsh) echo "$HOME/.zshrc" ;;
@@ -232,24 +242,43 @@ log_info "Updating $RC_FILE..."
 if [[ -f "$RC_FILE" ]]; then
     # 兼容macOS和Linux的sed语法
     if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' '/# Vibe Coding Control Center/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/# Vibe Center - codeagent-wrapper PATH/,+1 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/# Load Vibe keys/,+5 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/# Vibe Coding Control Center - Loader/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/source .*\/loader.sh/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/VIBE_ROOT/d' "$RC_FILE" 2>/dev/null || true
         sed -i '' '/UV_PROJECT_ENVIRONMENT/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '' '/Vibe Local Bin/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/# Vibe Local Bin/,+1 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/# Vibe Direnv Hook/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '' '/direnv hook /d' "$RC_FILE" 2>/dev/null || true
     else
-        sed -i '/# Vibe Coding Control Center/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/# Vibe Center - codeagent-wrapper PATH/,+1 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/# Load Vibe keys/,+5 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/# Vibe Coding Control Center - Loader/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/source .*\/loader.sh/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/VIBE_ROOT/d' "$RC_FILE" 2>/dev/null || true
         sed -i '/UV_PROJECT_ENVIRONMENT/d' "$RC_FILE" 2>/dev/null || true
-        sed -i '/Vibe Local Bin/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/# Vibe Local Bin/,+1 d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/# Vibe Direnv Hook/d' "$RC_FILE" 2>/dev/null || true
+        sed -i '/direnv hook /d' "$RC_FILE" 2>/dev/null || true
     fi
 fi
 
 # 添加环境变量
-_append_to_rc "$RC_FILE" "export VIBE_ROOT=\"$SOURCE_ROOT\"" "Vibe Coding Control Center - Root"
+_append_to_rc "$RC_FILE" 'export PATH="$HOME/.claude/bin:$PATH"' "Vibe Center - codeagent-wrapper PATH"
+_append_to_rc "$RC_FILE" $'if [[ -f ~/.vibe/config/keys.env ]]; then\n    set -a\n    source ~/.vibe/config/keys.env 2>/dev/null || true\n    set +a\nfi' "Load Vibe keys"
 _append_to_rc "$RC_FILE" "[ -f \"$INSTALL_DIR/loader.sh\" ] && source \"$INSTALL_DIR/loader.sh\"" "Vibe Coding Control Center - Loader"
 _append_to_rc "$RC_FILE" 'export PATH="$HOME/.local/bin:$PATH"' "Vibe Local Bin"
+if [[ "$SHELL" == */bash ]]; then
+    _append_to_rc "$RC_FILE" 'eval "$(direnv hook bash)"' "Vibe Direnv Hook"
+else
+    _append_to_rc "$RC_FILE" 'eval "$(direnv hook zsh)"' "Vibe Direnv Hook"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+    gh config set prompt disabled >/dev/null 2>&1 || true
+    gh config set pager cat >/dev/null 2>&1 || true
+fi
 
 # 7. uv环境与Python依赖安装
 _setup_uv_environment() {
@@ -269,9 +298,16 @@ _setup_uv_environment() {
         log_info "Global venv already exists at $venv_path"
     fi
 
-    local uv_env_export='export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/vibe-center"'
-    _append_to_rc "$RC_FILE" "$uv_env_export" "UV_PROJECT_ENVIRONMENT"
     export UV_PROJECT_ENVIRONMENT="$venv_path"
+
+    local envrc_content='export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/vibe-center"'
+    _write_file_if_changed "$SOURCE_ROOT/.envrc" "$envrc_content"
+    if command -v direnv >/dev/null 2>&1; then
+        (
+            cd "$SOURCE_ROOT" &&
+                direnv allow . >/dev/null 2>&1 || true
+        )
+    fi
 
     # 安装项目依赖
     log_info "Installing Python dependencies..."
@@ -281,7 +317,7 @@ _setup_uv_environment() {
 
     # 安装项目本身
     log_info "Installing Vibe CLI package..."
-    "$VIBE_UV_BIN" pip install -e .
+    "$VIBE_UV_BIN" tool install --editable .
     log_success "Vibe CLI installed successfully"
 }
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -154,24 +154,24 @@ _clean_rc_file() {
     # Remove Vibe-related lines using markers as anchors
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS sed
-        # Delete line following Vibe marker (loader.sh source)
-        sed -i '' '/# Vibe Coding Control Center/,+1 d' "$rc_file" 2>/dev/null || true
-        # Delete VIBE_ROOT export
-        sed -i '' '/^export VIBE_ROOT=/d' "$rc_file" 2>/dev/null || true
-        # Delete UV_PROJECT_ENVIRONMENT for vibe-center
-        sed -i '' '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/# Vibe Center - codeagent-wrapper PATH/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/# Load Vibe keys/,+5 d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/# Vibe Coding Control Center - Loader/,+1 d' "$rc_file" 2>/dev/null || true
         # Delete PATH export following Vibe Local Bin marker
         sed -i '' '/# Vibe Local Bin/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/# Vibe Direnv Hook/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/^export VIBE_ROOT=/d' "$rc_file" 2>/dev/null || true
+        sed -i '' '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$rc_file" 2>/dev/null || true
     else
         # Linux sed
-        # Delete line following Vibe marker (loader.sh source)
-        sed -i '/# Vibe Coding Control Center/,+1 d' "$rc_file" 2>/dev/null || true
-        # Delete VIBE_ROOT export
-        sed -i '/^export VIBE_ROOT=/d' "$rc_file" 2>/dev/null || true
-        # Delete UV_PROJECT_ENVIRONMENT for vibe-center
-        sed -i '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$rc_file" 2>/dev/null || true
+        sed -i '/# Vibe Center - codeagent-wrapper PATH/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '/# Load Vibe keys/,+5 d' "$rc_file" 2>/dev/null || true
+        sed -i '/# Vibe Coding Control Center - Loader/,+1 d' "$rc_file" 2>/dev/null || true
         # Delete PATH export following Vibe Local Bin marker
         sed -i '/# Vibe Local Bin/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '/# Vibe Direnv Hook/,+1 d' "$rc_file" 2>/dev/null || true
+        sed -i '/^export VIBE_ROOT=/d' "$rc_file" 2>/dev/null || true
+        sed -i '/^export UV_PROJECT_ENVIRONMENT=.*vibe-center/d' "$rc_file" 2>/dev/null || true
     fi
 
     log_success "Cleaned $rc_file (backup: $rc_file.vibe-backup)"

--- a/tests/vibe2/integration/test_install_gh_noninteractive.bats
+++ b/tests/vibe2/integration/test_install_gh_noninteractive.bats
@@ -154,7 +154,7 @@ EOF
   grep -q 'export PATH="\$HOME/.claude/bin:\$PATH"' "$rc_file"
   grep -q '# Load Vibe keys' "$rc_file"
   grep -q '\[ -f "'"$home_dir"'/.vibe/loader.sh" \] && source "'"$home_dir"'/.vibe/loader.sh"' "$rc_file"
-  grep -q 'direnv hook zsh' "$rc_file"
+  grep -q 'command -v direnv >/dev/null 2>&1 && eval "\$(direnv hook zsh)"' "$rc_file"
 }
 
 @test "install bootstraps uv into ~/.local/bin and remains idempotent" {
@@ -173,6 +173,11 @@ EOF
   cp -R "$VIBE_ROOT/lib" "$source_root/lib"
   cp -R "$VIBE_ROOT/config" "$source_root/config"
   cp -R "$VIBE_ROOT/scripts" "$source_root/scripts"
+  cat > "$rc_file" <<'EOF'
+export VIBE_ROOT_CUSTOM="/tmp/keep-me"
+# mention UV_PROJECT_ENVIRONMENT but keep this comment
+export UV_PROJECT_ENVIRONMENT_CUSTOM="/tmp/keep-me"
+EOF
 
   cat > "$bin_dir/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -193,6 +198,8 @@ EOF
   [ "$(grep -c '# Load Vibe keys' "$rc_file")" -eq 1 ]
   [ "$(grep -c 'Vibe Coding Control Center - Loader' "$rc_file")" -eq 1 ]
   [ "$(grep -c 'Vibe Direnv Hook' "$rc_file")" -eq 1 ]
+  grep -q '^export VIBE_ROOT_CUSTOM="/tmp/keep-me"$' "$rc_file"
+  grep -q '^export UV_PROJECT_ENVIRONMENT_CUSTOM="/tmp/keep-me"$' "$rc_file"
 
   run env HOME="$home_dir" SHELL="/bin/zsh" TEST_UV_LOG="$uv_log" PATH="$bin_dir:$PATH" zsh "$install_script"
   [ "$status" -eq 0 ]
@@ -202,6 +209,8 @@ EOF
   [ "$(grep -c 'Vibe Coding Control Center - Loader' "$rc_file")" -eq 1 ]
   [ "$(grep -c 'Vibe Direnv Hook' "$rc_file")" -eq 1 ]
   [ "$(grep -c '^tool install --editable \.$' "$uv_log")" -eq 2 ]
+  grep -q '^export VIBE_ROOT_CUSTOM="/tmp/keep-me"$' "$rc_file"
+  grep -q '^export UV_PROJECT_ENVIRONMENT_CUSTOM="/tmp/keep-me"$' "$rc_file"
 }
 
 @test "install writes bash direnv hook when current shell is bash" {
@@ -249,6 +258,6 @@ EOF
   run env HOME="$home_dir" SHELL="/bin/bash" PATH="$bin_dir:$PATH" zsh "$install_script"
 
   [ "$status" -eq 0 ]
-  grep -q 'direnv hook bash' "$rc_file"
+  grep -q 'command -v direnv >/dev/null 2>&1 && eval "\$(direnv hook bash)"' "$rc_file"
   ! grep -q 'direnv hook zsh' "$rc_file"
 }

--- a/tests/vibe2/integration/test_install_gh_noninteractive.bats
+++ b/tests/vibe2/integration/test_install_gh_noninteractive.bats
@@ -4,6 +4,57 @@ setup() {
   export VIBE_ROOT="$BATS_TEST_DIRNAME/../../.."
 }
 
+_write_common_noninteractive_stubs() {
+  local bin_dir="$1"
+
+  cat > "$bin_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+cat <<'INSTALLER'
+#!/usr/bin/env sh
+set -e
+mkdir -p "${UV_INSTALL_DIR:?}"
+cat > "${UV_INSTALL_DIR}/uv" <<'UVEOF'
+#!/usr/bin/env sh
+if [ "$1" = "venv" ]; then
+  mkdir -p "$2/bin"
+  touch "$2/bin/activate"
+  [ -n "${TEST_UV_LOG:-}" ] && echo "$*" >> "${TEST_UV_LOG}"
+  exit 0
+fi
+if [ "$1" = "sync" ] || [ "$1" = "tool" ]; then
+  [ -n "${TEST_UV_LOG:-}" ] && echo "$*" >> "${TEST_UV_LOG}"
+  exit 0
+fi
+[ -n "${TEST_UV_LOG:-}" ] && echo "$*" >> "${TEST_UV_LOG}"
+exit 0
+UVEOF
+chmod +x "${UV_INSTALL_DIR}/uv"
+INSTALLER
+EOF
+
+  cat > "$bin_dir/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$bin_dir/pre-commit" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$bin_dir/openspec" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$bin_dir/jq" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+  chmod +x "$bin_dir/curl" "$bin_dir/npx" "$bin_dir/pre-commit" "$bin_dir/openspec" "$bin_dir/jq"
+}
+
 @test "install configures gh non-interactive defaults when gh is available" {
   local fixture home_dir bin_dir gh_log
 
@@ -38,6 +89,7 @@ exit 0
 EOF
 
   chmod +x "$bin_dir/gh" "$bin_dir/direnv" "$bin_dir/uv"
+  _write_common_noninteractive_stubs "$bin_dir"
 
   run env HOME="$home_dir" SHELL="/bin/zsh" TEST_GH_LOG="$gh_log" PATH="$bin_dir:$PATH" zsh "$VIBE_ROOT/scripts/install.sh"
 
@@ -48,7 +100,7 @@ EOF
 }
 
 @test "install writes stable envrc path and installs alias loader assets" {
-  local fixture home_dir bin_dir source_root install_script envrc_path
+  local fixture home_dir bin_dir source_root install_script envrc_path rc_file
 
   fixture="$(mktemp -d)"
   home_dir="$fixture/home"
@@ -56,6 +108,7 @@ EOF
   source_root="$fixture/source"
   install_script="$source_root/scripts/install.sh"
   envrc_path="$source_root/.envrc"
+  rc_file="$home_dir/.zshrc"
 
   mkdir -p "$home_dir" "$bin_dir" "$source_root"
   cp -R "$VIBE_ROOT/bin" "$source_root/bin"
@@ -87,18 +140,25 @@ exit 0
 EOF
 
   chmod +x "$bin_dir/gh" "$bin_dir/direnv" "$bin_dir/uv"
+  _write_common_noninteractive_stubs "$bin_dir"
 
   run env HOME="$home_dir" SHELL="/bin/zsh" PATH="$bin_dir:$PATH" zsh "$install_script"
 
   [ "$status" -eq 0 ]
   [ -f "$envrc_path" ]
   [ -f "$home_dir/.vibe/lib/alias/loader.sh" ]
-  grep -Fx 'source "$HOME/.venvs/vibe-center/bin/activate"' "$envrc_path"
+  grep -Fx 'export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/vibe-center"' "$envrc_path"
   [[ "$(cat "$envrc_path")" != *"$fixture"* ]]
+  ! grep -q '^export UV_PROJECT_ENVIRONMENT=' "$rc_file"
+  grep -q 'Vibe Center - codeagent-wrapper PATH' "$rc_file"
+  grep -q 'export PATH="\$HOME/.claude/bin:\$PATH"' "$rc_file"
+  grep -q '# Load Vibe keys' "$rc_file"
+  grep -q '\[ -f "'"$home_dir"'/.vibe/loader.sh" \] && source "'"$home_dir"'/.vibe/loader.sh"' "$rc_file"
+  grep -q 'direnv hook zsh' "$rc_file"
 }
 
 @test "install bootstraps uv into ~/.local/bin and remains idempotent" {
-  local fixture home_dir bin_dir source_root install_script rc_file
+  local fixture home_dir bin_dir source_root install_script rc_file uv_log
 
   fixture="$(mktemp -d)"
   home_dir="$fixture/home"
@@ -106,6 +166,7 @@ EOF
   source_root="$fixture/source"
   install_script="$source_root/scripts/install.sh"
   rc_file="$home_dir/.zshrc"
+  uv_log="$fixture/uv.log"
 
   mkdir -p "$home_dir" "$bin_dir" "$source_root"
   cp -R "$VIBE_ROOT/bin" "$source_root/bin"
@@ -118,38 +179,29 @@ EOF
 exit 0
 EOF
 
-  cat > "$bin_dir/curl" <<'EOF'
-#!/usr/bin/env bash
-cat <<'INSTALLER'
-#!/usr/bin/env sh
-set -e
-mkdir -p "${UV_INSTALL_DIR:?}"
-cat > "${UV_INSTALL_DIR}/uv" <<'UVEOF'
-#!/usr/bin/env sh
-if [ "$1" = "venv" ]; then
-  mkdir -p "$2/bin"
-  touch "$2/bin/activate"
-  exit 0
-fi
-exit 0
-UVEOF
-chmod +x "${UV_INSTALL_DIR}/uv"
-INSTALLER
-EOF
+  chmod +x "$bin_dir/gh"
+  _write_common_noninteractive_stubs "$bin_dir"
 
-  chmod +x "$bin_dir/gh" "$bin_dir/curl"
-
-  run env HOME="$home_dir" SHELL="/bin/zsh" PATH="$bin_dir:$PATH" zsh "$install_script"
+  run env HOME="$home_dir" SHELL="/bin/zsh" TEST_UV_LOG="$uv_log" PATH="$bin_dir:$PATH" zsh "$install_script"
   [ "$status" -eq 0 ]
   [ -x "$home_dir/.local/bin/uv" ]
   [ -d "$home_dir/.venvs/vibe-center" ]
   grep -q 'Vibe Local Bin' "$rc_file"
-  grep -q '^export UV_PROJECT_ENVIRONMENT=' "$rc_file"
+  ! grep -q '^export UV_PROJECT_ENVIRONMENT=' "$rc_file"
+  grep -q '^tool install --editable \.$' "$uv_log"
+  [ "$(grep -c 'Vibe Center - codeagent-wrapper PATH' "$rc_file")" -eq 1 ]
+  [ "$(grep -c '# Load Vibe keys' "$rc_file")" -eq 1 ]
+  [ "$(grep -c 'Vibe Coding Control Center - Loader' "$rc_file")" -eq 1 ]
+  [ "$(grep -c 'Vibe Direnv Hook' "$rc_file")" -eq 1 ]
 
-  run env HOME="$home_dir" SHELL="/bin/zsh" PATH="$bin_dir:$PATH" zsh "$install_script"
+  run env HOME="$home_dir" SHELL="/bin/zsh" TEST_UV_LOG="$uv_log" PATH="$bin_dir:$PATH" zsh "$install_script"
   [ "$status" -eq 0 ]
   [ "$(grep -c 'Vibe Local Bin' "$rc_file")" -eq 1 ]
-  [ "$(grep -c '^export UV_PROJECT_ENVIRONMENT=' "$rc_file")" -eq 1 ]
+  [ "$(grep -c 'Vibe Center - codeagent-wrapper PATH' "$rc_file")" -eq 1 ]
+  [ "$(grep -c '# Load Vibe keys' "$rc_file")" -eq 1 ]
+  [ "$(grep -c 'Vibe Coding Control Center - Loader' "$rc_file")" -eq 1 ]
+  [ "$(grep -c 'Vibe Direnv Hook' "$rc_file")" -eq 1 ]
+  [ "$(grep -c '^tool install --editable \.$' "$uv_log")" -eq 2 ]
 }
 
 @test "install writes bash direnv hook when current shell is bash" {
@@ -192,6 +244,7 @@ exit 0
 EOF
 
   chmod +x "$bin_dir/gh" "$bin_dir/direnv" "$bin_dir/uv"
+  _write_common_noninteractive_stubs "$bin_dir"
 
   run env HOME="$home_dir" SHELL="/bin/bash" PATH="$bin_dir:$PATH" zsh "$install_script"
 


### PR DESCRIPTION
## Summary
- switch global Python CLI install from editable package install to `uv tool install --editable .`
- move shared `UV_PROJECT_ENVIRONMENT` setup into repo-local `.envrc` with `direnv` instead of shell-global export
- keep only the required global shell injections for `~/.claude/bin`, `~/.vibe/config/keys.env`, and `~/.vibe/loader.sh`
- update installer/uninstaller behavior and integration tests to keep repeated installs idempotent

## Why
The previous installer exported `UV_PROJECT_ENVIRONMENT` globally, which leaked the vibe-center shared environment into unrelated directories. This change preserves `uv run` inside the repo and `.worktrees/` while avoiding global `uv` pollution elsewhere.

## Validation
- `uv run bats tests/vibe2/integration/test_install_gh_noninteractive.bats`
- `zsh -n scripts/install.sh config/shell/loader.sh scripts/uninstall.sh`
- `bash -n scripts/init.sh`
- `uv run pre-commit run --all-files`
- pre-push smoke checks during `git push`

## Contributors
- jacobcy (Codex)
