### PR TITLE
refactor(orchestra): extract _ensure_load_issue_attribute helper

### DIFF
--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -131,6 +131,10 @@ class GlobalDispatchCoordinator:
         """Load issue snapshot (backward compatibility)."""
         return load_issue(issue_number, self._config, self._github)
 
+    def _ensure_load_issue_attribute(self) -> None:
+        """Ensure persistence service has current _load_issue reference."""
+        self._queue_persistence.load_issue = self._load_issue
+
     async def _collect_frozen_queue(self) -> list[QueueEntry]:
         """Collect a new frozen queue only when the current one is empty."""
         queue: list[QueueEntry] = []
@@ -565,7 +569,7 @@ class GlobalDispatchCoordinator:
         # Step 1: Restore queue from persistence if None
         if self._frozen_queue is None:
             self._queue_persistence.frozen_queue = None
-            self._queue_persistence.load_issue = self._load_issue
+            self._ensure_load_issue_attribute()
             restored = self._queue_persistence.restore()
             self._frozen_queue = restored if restored is not None else []
             self._queue_persistence.frozen_queue = self._frozen_queue
@@ -573,7 +577,7 @@ class GlobalDispatchCoordinator:
 
         # Step 2: Promote progressed entries (state changes)
         self._queue_persistence.frozen_queue = self._frozen_queue
-        self._queue_persistence.load_issue = self._load_issue
+        self._ensure_load_issue_attribute()
         cleared_all = self._queue_persistence.promote()
         if cleared_all:
             self._check_service = None  # Invalidate when queue is cleared


### PR DESCRIPTION
Closes #1496

## Summary

Extracted duplicated `load_issue` assignment protection logic into a private helper method `_ensure_load_issue_attribute()`.

**Changes**:
- Added `_ensure_load_issue_attribute()` method in `global_dispatch_coordinator.py`
- Replaced two duplicate code blocks in `coordinate()` method with helper call

**Motivation**:
- Eliminate code duplication (2 identical 3-line blocks)
- Improve code maintainability
- Pure internal refactor with zero functional change

**Context**:
- Issue: #1496
- Related: #1452 (where the duplication was discovered)
- File: `src/vibe3/orchestra/global_dispatch_coordinator.py`
- Lines affected: 2 call sites in `coordinate()` method

## Technical Details

The assignment must be repeated before `restore()` and `promote()` calls because:
- Tests may monkeypatch `_load_issue` 
- Persistence service needs to receive the current reference
- Extracting to helper preserves this behavior

## Test Plan

- [x] Type check: `uv run mypy src/vibe3/orchestra/global_dispatch_coordinator.py` - ✅ Passed
- [x] Lint: `uv run ruff check src/vibe3/orchestra/global_dispatch_coordinator.py` - ✅ Passed
- [x] Pre-commit: `pre-commit run --all-files` - ✅ All checks passed
- [x] Tests: 124 orchestra tests passed
- [x] Rebased on latest `origin/main` - ✅ No conflicts

## Impact

- **LOC**: +4 lines (minimal)
- **Files changed**: 1 file
- **Functions changed**: +1 (new helper method)
- **Risk**: Zero functional change, pure extract-method refactor

---

## Contributors

claude/opus
