### PR TITLE
fix(roadmap): correct contradictory label rule in SKILL.md

### DIFF
--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -712,7 +712,8 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 2. **禁止** vibe-roadmap 写 `[governance suggest]`（marker 必须区分 observer / decider）
 3. `[roadmap decision]` marker 同时作为 cron-supervisor / 下次 vibe-roadmap 自身判断"上次审查时间"的锚点
 4. **自动打 `roadmap-reviewed` 标签**：
-   - 每个 `[roadmap decision]` 评论后必须立即打 `roadmap-reviewed` 标签
+   - 写完 `[roadmap decision]` 评论后，如果 decision 不是 `rfc`，**必须**打 `roadmap-reviewed` 标签
+   - 如果 decision 是 `rfc`，**不打** `roadmap-reviewed`（保留 `roadmap/rfc` 标签等待人类决策）
    - 目的：标记已决策，避免 Step 0 重复扫描
    - 命令：`gh issue edit <number> --add-label "roadmap-reviewed"`
 5. 格式：


### PR DESCRIPTION
## Summary

Fixed pre-existing contradiction in `skills/vibe-roadmap/SKILL.md` regarding when to add the `roadmap-reviewed` label.

**Changes**:
- Updated lines 693-697 to match canonical rule at lines 359-363 and 534
- Replaced unconditional "must always add roadmap-reviewed" with conditional rule:
  - Add `roadmap-reviewed` label only when decision is NOT `rfc`
  - Do NOT add label when decision is `rfc` (preserve `roadmap/rfc` for human decision)

**Impact**: Documentation-only fix, ensures consistent label rules across the file.

Fixes #1528

## Test plan

- [x] Read SKILL.md to verify all three references now align
- [x] Check line 693-697 matches canonical rule at 359-363
- [x] Verify conditional logic is correct (only add when not rfc)
- [x] Pre-commit hooks passed
- [x] Smoke tests passed (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
