### PR TITLE
refactor: remove dead code get_supervisor_prompt

### DIFF
--- a/src/vibe3/config/orchestra_config.py
+++ b/src/vibe3/config/orchestra_config.py
@@ -31,7 +31,6 @@ __all__ = [
     "_default_pid_file",
     "get_handoff_state_label",
     "get_manager_usernames",
-    "get_supervisor_prompt",
 ]
 
 
@@ -79,26 +78,3 @@ def get_manager_usernames(config: OrchestraConfig) -> tuple[str, ...]:
     resolver = ConventionResolver.from_repo()
     convention = resolver.resolve()
     return convention.manager_usernames
-
-
-def get_supervisor_prompt(config: OrchestraConfig) -> str:
-    """Resolve supervisor prompt template with fallback to ConventionResolver.
-
-    Args:
-        config: OrchestraConfig instance
-
-    Returns:
-        Dotted prompt template path (e.g., 'orchestra.supervisor.apply').
-
-    Example:
-        >>> config = OrchestraConfig()
-        >>> get_supervisor_prompt(config)
-        'orchestra.supervisor.apply'
-    """
-    if config.supervisor_handoff.prompt_template:
-        return config.supervisor_handoff.prompt_template
-    from vibe3.services.convention_resolver import ConventionResolver
-
-    resolver = ConventionResolver.from_repo()
-    convention = resolver.resolve()
-    return convention.supervisor_prompt


### PR DESCRIPTION
## Summary
移除死代码 `get_supervisor_prompt`，这是一个未被任何代码调用的函数。

## Changes
- 删除 `src/vibe3/config/orchestra_config.py` 中的 `get_supervisor_prompt` 函数定义
- 从 `__all__` 中移除函数导出
- 代码行数：-24 LOC

## Verification
✅ **静态检查通过**：
- mypy 类型检查：Success
- ruff 代码检查：All checks passed

✅ **测试验证通过**：
- 198 个测试全部通过（pre-push 检查）
- 原有测试套件无影响

✅ **引用检查通过**：
- 使用 `rg` 全局搜索确认无任何调用
- 其他符号导入验证成功

## Related
Closes #1520

## Risk Assessment
- **零风险**：无调用者、无测试依赖、纯删除操作
- 相关函数 `get_supervisor_*` 仍在使用（不同函数）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
