### PR TITLE
fix(check): terminalize closed issues before PR-closed reset/no-op block

### DIFF
--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -224,28 +224,8 @@ class CodeagentExecutionService:
 
         # Capture before_state_label from GitHub for unified no-op gate.
         # Remote source of truth: GitHub issue labels, not local SQLite cache.
+        # Also capture whether the issue is closed before agent execution.
         before_state_label: str | None = None
-        if command.issue_number is not None:
-            try:
-                from vibe3.clients.github_client import GitHubClient
-
-                issue_payload = GitHubClient().view_issue(
-                    command.issue_number,
-                    repo=getattr(self.config, "repo", None),
-                )
-                if isinstance(issue_payload, dict):
-                    labels = issue_payload.get("labels", [])
-                    if isinstance(labels, list):
-                        for label in labels:
-                            if isinstance(label, dict):
-                                name = label.get("name")
-                                if isinstance(name, str) and name.startswith("state/"):
-                                    before_state_label = name
-                                    break
-            except Exception as exc:
-                log.warning(f"Cannot read issue state for no-op gate: {exc}")
-
-        # Capture whether the issue is closed before agent execution
         before_issue_is_closed = False
         if command.issue_number is not None:
             try:
@@ -256,10 +236,20 @@ class CodeagentExecutionService:
                     repo=getattr(self.config, "repo", None),
                 )
                 if isinstance(issue_payload, dict):
+                    # Extract state label
+                    labels = issue_payload.get("labels", [])
+                    if isinstance(labels, list):
+                        for label in labels:
+                            if isinstance(label, dict):
+                                name = label.get("name")
+                                if isinstance(name, str) and name.startswith("state/"):
+                                    before_state_label = name
+                                    break
+                    # Check if issue is closed
                     if str(issue_payload.get("state", "")).upper() == "CLOSED":
                         before_issue_is_closed = True
             except Exception as exc:
-                log.warning(f"Cannot read issue state for closed detection: {exc}")
+                log.warning(f"Cannot read issue state for no-op gate: {exc}")
 
         execution_cwd = self._resolve_command_cwd(command.cwd)
 

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -54,6 +54,7 @@ class SyncExecutionContext:
     before_state_label: str | None
     execution_cwd: Path
     commit_count_before: int | None = None
+    before_issue_is_closed: bool = False
 
 
 class CodeagentExecutionService:
@@ -244,6 +245,22 @@ class CodeagentExecutionService:
             except Exception as exc:
                 log.warning(f"Cannot read issue state for no-op gate: {exc}")
 
+        # Capture whether the issue is closed before agent execution
+        before_issue_is_closed = False
+        if command.issue_number is not None:
+            try:
+                from vibe3.clients.github_client import GitHubClient
+
+                issue_payload = GitHubClient().view_issue(
+                    command.issue_number,
+                    repo=getattr(self.config, "repo", None),
+                )
+                if isinstance(issue_payload, dict):
+                    if str(issue_payload.get("state", "")).upper() == "CLOSED":
+                        before_issue_is_closed = True
+            except Exception as exc:
+                log.warning(f"Cannot read issue state for closed detection: {exc}")
+
         execution_cwd = self._resolve_command_cwd(command.cwd)
 
         # Record commit count before execution (for planner commit detection)
@@ -266,6 +283,7 @@ class CodeagentExecutionService:
             before_state_label=before_state_label,
             execution_cwd=execution_cwd,
             commit_count_before=commit_count_before,
+            before_issue_is_closed=before_issue_is_closed,
         )
 
     def _finalize_sync_execution(
@@ -329,6 +347,7 @@ class CodeagentExecutionService:
                     required_ref_key=required_ref_key,
                     flow_state=flow_state,
                     tick_id=command.tick_id,
+                    before_issue_is_closed=ctx.before_issue_is_closed,
                 )
 
                 # Persist transition_count after gate call

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -81,14 +81,73 @@ def apply_unified_noop_gate(
         ).info("No-op gate SKIP: issue has no state/ label")
         return
 
-    verifier = StateVerificationService(store=store)
-    after_state_label = verifier.get_issue_state_label(
-        issue_number=issue_number,
-        repo=repo,
-        branch=branch,
-        flow_state=flow_state,
-        tick_id=tick_id,
-    )
+    # If the issue was open before agent execution but is now closed,
+    # treat this as a meaningful terminal transition regardless of state label.
+    # Also fetch after_state_label from the same payload to avoid redundant API call.
+    after_state_label: str | None = None
+    if not before_issue_is_closed:
+        try:
+            from vibe3.clients.github_client import GitHubClient
+
+            after_payload = GitHubClient().view_issue(issue_number, repo=repo)
+            if isinstance(after_payload, dict):
+                # Check if issue is now closed (terminal transition)
+                if str(after_payload.get("state", "")).upper() == "CLOSED":
+                    logger.bind(
+                        domain="codeagent",
+                        role=role,
+                        issue_number=issue_number,
+                        branch=branch,
+                    ).info(
+                        f"No-op gate PASS: issue #{issue_number} closed by {role} "
+                        "(terminal transition)"
+                    )
+                    store.add_event(
+                        branch,
+                        EVENT_STATE_TRANSITIONED,
+                        actor,
+                        detail=(
+                            f"Issue #{issue_number} closed by {role} "
+                            "(terminal transition)"
+                        ),
+                        refs={
+                            "before_state": str(before_state_label or ""),
+                            "issue": str(issue_number),
+                        },
+                    )
+                    return
+                # Extract after_state_label from the same payload
+                labels = after_payload.get("labels", [])
+                if isinstance(labels, list):
+                    for label in labels:
+                        if isinstance(label, dict):
+                            name = label.get("name")
+                            if isinstance(name, str) and name.startswith("state/"):
+                                after_state_label = name
+                                break
+        except Exception as exc:
+            # Log warning instead of silent pass for diagnose
+            logger.bind(
+                domain="codeagent",
+                role=role,
+                issue_number=issue_number,
+                branch=branch,
+            ).warning(
+                f"Failed to check issue closed state: {exc}; "
+                "falling through to normal no-op gate logic"
+            )
+
+    # If we didn't fetch after_state_label above (issue was already closed before
+    # or the API call failed), use StateVerificationService
+    if after_state_label is None:
+        verifier = StateVerificationService(store=store)
+        after_state_label = verifier.get_issue_state_label(
+            issue_number=issue_number,
+            repo=repo,
+            branch=branch,
+            flow_state=flow_state,
+            tick_id=tick_id,
+        )
 
     if flow_state is not None:
         store.update_flow_state(
@@ -344,43 +403,6 @@ def apply_unified_noop_gate(
                 actor=actor,
             )
             return
-
-    # If the issue was open before agent execution but is now closed,
-    # treat this as a meaningful terminal transition regardless of state label.
-    if not before_issue_is_closed:
-        try:
-            from vibe3.clients.github_client import GitHubClient
-
-            after_payload = GitHubClient().view_issue(issue_number, repo=repo)
-            if (
-                isinstance(after_payload, dict)
-                and str(after_payload.get("state", "")).upper() == "CLOSED"
-            ):
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).info(
-                    f"No-op gate PASS: issue #{issue_number} closed by {role} "
-                    "(terminal transition)"
-                )
-                store.add_event(
-                    branch,
-                    EVENT_STATE_TRANSITIONED,
-                    actor,
-                    detail=(
-                        f"Issue #{issue_number} closed by {role} "
-                        "(terminal transition)"
-                    ),
-                    refs={
-                        "before_state": str(before_state_label or ""),
-                        "issue": str(issue_number),
-                    },
-                )
-                return
-        except Exception:
-            pass  # Fail-open: fall through to normal no-op gate logic
 
     if before_state_label == after_state_label:
         state_desc = before_state_label or "(no state)"

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -52,6 +52,7 @@ def apply_unified_noop_gate(
     required_ref_key: str | None = None,
     flow_state: dict | None = None,
     tick_id: int = 0,
+    before_issue_is_closed: bool = False,
 ) -> None:
     """Apply the single hard no-op gate after agent completion.
 
@@ -343,6 +344,43 @@ def apply_unified_noop_gate(
                 actor=actor,
             )
             return
+
+    # If the issue was open before agent execution but is now closed,
+    # treat this as a meaningful terminal transition regardless of state label.
+    if not before_issue_is_closed:
+        try:
+            from vibe3.clients.github_client import GitHubClient
+
+            after_payload = GitHubClient().view_issue(issue_number, repo=repo)
+            if (
+                isinstance(after_payload, dict)
+                and str(after_payload.get("state", "")).upper() == "CLOSED"
+            ):
+                logger.bind(
+                    domain="codeagent",
+                    role=role,
+                    issue_number=issue_number,
+                    branch=branch,
+                ).info(
+                    f"No-op gate PASS: issue #{issue_number} closed by {role} "
+                    "(terminal transition)"
+                )
+                store.add_event(
+                    branch,
+                    EVENT_STATE_TRANSITIONED,
+                    actor,
+                    detail=(
+                        f"Issue #{issue_number} closed by {role} "
+                        "(terminal transition)"
+                    ),
+                    refs={
+                        "before_state": str(before_state_label or ""),
+                        "issue": str(issue_number),
+                    },
+                )
+                return
+        except Exception:
+            pass  # Fail-open: fall through to normal no-op gate logic
 
     if before_state_label == after_state_label:
         state_desc = before_state_label or "(no state)"

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -43,6 +43,72 @@ class CheckPRService:
         self.github_client = github_client
         self._flow_status_service = flow_status_service
 
+    def _abort_and_cleanup(
+        self,
+        branch: str,
+        reason: str,
+        extra_warning_suffix: str = "",
+    ) -> tuple[None, list[str]]:
+        """Mark flow as aborted and clean up physical resources.
+
+        Args:
+            branch: Branch name
+            reason: Reason for abort (e.g., "issue #123 already closed")
+            extra_warning_suffix: Optional suffix for warning message
+
+        Returns:
+            Tuple of (None, warning_messages)
+        """
+        self._flow_status_service.mark_flow_aborted(branch, reason)
+
+        # Clean up physical resources (worktree, branches, flow record)
+        from vibe3.services.flow_cleanup_service import (
+            FlowCleanupService,
+            LiveSessionsDetectedError,
+        )
+
+        cleanup_service = FlowCleanupService(
+            store=self.store,
+            git_client=self.git_client,
+        )
+
+        try:
+            cleanup_result = cleanup_service.cleanup_flow_scene(
+                branch, include_remote=True, keep_flow_record=False
+            )
+
+            # Build warning message from cleanup results
+            cleaned_items = []
+            if cleanup_result.get("worktree") is True:
+                cleaned_items.append("worktree")
+            if cleanup_result.get("local_branch") is True:
+                cleaned_items.append("local branch")
+            if cleanup_result.get("remote_branch") is True:
+                cleaned_items.append("remote branch")
+            if cleanup_result.get("flow_record") is True:
+                cleaned_items.append("flow record")
+
+            warning_msg = (
+                f"Flow '{branch}' marked aborted ({reason}); "
+                f"cleaned: {', '.join(cleaned_items)}"
+                if cleaned_items
+                else f"Flow '{branch}' marked aborted ({reason}, no cleanup needed)"
+            )
+            if extra_warning_suffix:
+                warning_msg += f"; {extra_warning_suffix}"
+            return (None, [warning_msg])
+
+        except LiveSessionsDetectedError as exc:
+            warning_msg = (
+                f"Flow '{branch}' marked aborted ({reason}); " f"cleanup skipped: {exc}"
+            )
+            logger.bind(
+                domain="check",
+                action="reset_pr_closed",
+                branch=branch,
+            ).warning(warning_msg)
+            return (None, [warning_msg])
+
     def handle_closed_pr(
         self,
         branch: str,
@@ -147,55 +213,10 @@ class CheckPRService:
                 branch=branch,
             ).debug("No task issue linked, marking flow as aborted instead")
             # No issue link → just mark flow as aborted (PR abandoned)
-            self._flow_status_service.mark_flow_aborted(
-                branch, f"PR #{pr_number} closed without merge (no issue link)"
+            return self._abort_and_cleanup(
+                branch,
+                f"PR #{pr_number} closed without merge (no issue link)",
             )
-
-            # Clean up physical resources (worktree, branches, flow record)
-            from vibe3.services.flow_cleanup_service import (
-                FlowCleanupService,
-                LiveSessionsDetectedError,
-            )
-
-            cleanup_service = FlowCleanupService(
-                store=self.store,
-                git_client=self.git_client,
-            )
-
-            try:
-                cleanup_result = cleanup_service.cleanup_flow_scene(
-                    branch, include_remote=True, keep_flow_record=False
-                )
-
-                # Build warning message from cleanup results
-                # Only report items that were actually cleaned (True means removed)
-                cleaned_items = []
-                if cleanup_result.get("worktree") is True:
-                    cleaned_items.append("worktree")
-                if cleanup_result.get("local_branch") is True:
-                    cleaned_items.append("local branch")
-                if cleanup_result.get("remote_branch") is True:
-                    cleaned_items.append("remote branch")
-                if cleanup_result.get("flow_record") is True:
-                    cleaned_items.append("flow record")
-
-                warning_msg = (
-                    f"Flow '{branch}' marked aborted; "
-                    f"cleaned: {', '.join(cleaned_items)}"
-                    if cleaned_items
-                    else f"Flow '{branch}' marked aborted (no cleanup needed)"
-                )
-                return (None, [warning_msg])
-
-            except LiveSessionsDetectedError as exc:
-                # Live sessions detected - skip cleanup but continue
-                warning_msg = f"Flow '{branch}' marked aborted; cleanup skipped: {exc}"
-                logger.bind(
-                    domain="check",
-                    action="reset_pr_closed",
-                    branch=branch,
-                ).warning(warning_msg)
-                return (None, [warning_msg])
 
         # Check if issue already closed
         gh_issue = self.github_client.view_issue(task_issue_number)
@@ -213,66 +234,11 @@ class CheckPRService:
                 )
 
                 # Issue already closed → mark flow as aborted and clean up
-                self._flow_status_service.mark_flow_aborted(
+                return self._abort_and_cleanup(
                     branch,
-                    (
-                        f"Issue #{task_issue_number} already closed; "
-                        f"PR #{pr_number} closed without merge"
-                    ),
+                    f"Issue #{task_issue_number} already closed; "
+                    f"PR #{pr_number} closed without merge",
                 )
-
-                # Clean up physical resources (worktree, branches, flow record)
-                from vibe3.services.flow_cleanup_service import (
-                    FlowCleanupService,
-                    LiveSessionsDetectedError,
-                )
-
-                cleanup_service = FlowCleanupService(
-                    store=self.store,
-                    git_client=self.git_client,
-                )
-
-                try:
-                    cleanup_result = cleanup_service.cleanup_flow_scene(
-                        branch, include_remote=True, keep_flow_record=False
-                    )
-
-                    # Build warning message from cleanup results
-                    cleaned_items = []
-                    if cleanup_result.get("worktree") is True:
-                        cleaned_items.append("worktree")
-                    if cleanup_result.get("local_branch") is True:
-                        cleaned_items.append("local branch")
-                    if cleanup_result.get("remote_branch") is True:
-                        cleaned_items.append("remote branch")
-                    if cleanup_result.get("flow_record") is True:
-                        cleaned_items.append("flow record")
-
-                    warning_msg = (
-                        f"Flow '{branch}' marked aborted "
-                        f"(issue #{task_issue_number} closed); "
-                        f"cleaned: {', '.join(cleaned_items)}"
-                        if cleaned_items
-                        else (
-                            f"Flow '{branch}' marked aborted "
-                            f"(issue #{task_issue_number} closed, "
-                            "no cleanup needed)"
-                        )
-                    )
-                    return (None, [warning_msg])
-
-                except LiveSessionsDetectedError as exc:
-                    warning_msg = (
-                        f"Flow '{branch}' marked aborted "
-                        f"(issue #{task_issue_number} closed); "
-                        f"cleanup skipped: {exc}"
-                    )
-                    logger.bind(
-                        domain="check",
-                        action="reset_pr_closed",
-                        branch=branch,
-                    ).warning(warning_msg)
-                    return (None, [warning_msg])
 
         # Build minimal FlowStatusResponse for task resume
         flow = FlowStatusResponse(

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -207,8 +207,72 @@ class CheckPRService:
                     action="reset_pr_closed",
                     branch=branch,
                     issue_number=task_issue_number,
-                ).info(f"Issue #{task_issue_number} already closed, skip reset")
-                return (None, [])
+                ).info(
+                    f"Issue #{task_issue_number} already closed, "
+                    "marking flow as aborted"
+                )
+
+                # Issue already closed → mark flow as aborted and clean up
+                self._flow_status_service.mark_flow_aborted(
+                    branch,
+                    (
+                        f"Issue #{task_issue_number} already closed; "
+                        f"PR #{pr_number} closed without merge"
+                    ),
+                )
+
+                # Clean up physical resources (worktree, branches, flow record)
+                from vibe3.services.flow_cleanup_service import (
+                    FlowCleanupService,
+                    LiveSessionsDetectedError,
+                )
+
+                cleanup_service = FlowCleanupService(
+                    store=self.store,
+                    git_client=self.git_client,
+                )
+
+                try:
+                    cleanup_result = cleanup_service.cleanup_flow_scene(
+                        branch, include_remote=True, keep_flow_record=False
+                    )
+
+                    # Build warning message from cleanup results
+                    cleaned_items = []
+                    if cleanup_result.get("worktree") is True:
+                        cleaned_items.append("worktree")
+                    if cleanup_result.get("local_branch") is True:
+                        cleaned_items.append("local branch")
+                    if cleanup_result.get("remote_branch") is True:
+                        cleaned_items.append("remote branch")
+                    if cleanup_result.get("flow_record") is True:
+                        cleaned_items.append("flow record")
+
+                    warning_msg = (
+                        f"Flow '{branch}' marked aborted "
+                        f"(issue #{task_issue_number} closed); "
+                        f"cleaned: {', '.join(cleaned_items)}"
+                        if cleaned_items
+                        else (
+                            f"Flow '{branch}' marked aborted "
+                            f"(issue #{task_issue_number} closed, "
+                            "no cleanup needed)"
+                        )
+                    )
+                    return (None, [warning_msg])
+
+                except LiveSessionsDetectedError as exc:
+                    warning_msg = (
+                        f"Flow '{branch}' marked aborted "
+                        f"(issue #{task_issue_number} closed); "
+                        f"cleanup skipped: {exc}"
+                    )
+                    logger.bind(
+                        domain="check",
+                        action="reset_pr_closed",
+                        branch=branch,
+                    ).warning(warning_msg)
+                    return (None, [warning_msg])
 
         # Build minimal FlowStatusResponse for task resume
         flow = FlowStatusResponse(

--- a/tests/vibe3/execution/test_noop_gate_unit.py
+++ b/tests/vibe3/execution/test_noop_gate_unit.py
@@ -406,12 +406,13 @@ class TestApplyUnifiedNoopGate:
                 "vibe3.services.issue_failure_service.block_planner_noop_issue"
             ) as mock_block,
         ):
-            # First call: for after_state_label (returns same state)
-            # Second call: for issue closed check (returns closed state)
-            mock_gh.return_value.view_issue.side_effect = [
-                _make_github_issue_payload("state/plan"),  # after_state_label check
-                {"state": "CLOSED"},  # issue closed check
-            ]
+            # Single call: check issue closed state (returns closed)
+            # Also extracts after_state_label from same payload
+            # (not used since issue closed)
+            mock_gh.return_value.view_issue.return_value = {
+                "state": "CLOSED",
+                "labels": [{"name": "state/plan"}],  # State label unchanged
+            }
             apply_unified_noop_gate(
                 store=store,
                 issue_number=42,

--- a/tests/vibe3/execution/test_noop_gate_unit.py
+++ b/tests/vibe3/execution/test_noop_gate_unit.py
@@ -390,3 +390,43 @@ class TestApplyUnifiedNoopGate:
         # Gate should skip, not block
         mock_block.assert_not_called()
         store.add_event.assert_not_called()
+
+    def test_issue_closed_during_execution_bypasses_state_unchanged_block(
+        self,
+    ) -> None:
+        """Issue closed during execution is a terminal transition.
+
+        Bypasses state unchanged block even when state label is unchanged.
+        """
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.issue_failure_service.block_planner_noop_issue"
+            ) as mock_block,
+        ):
+            # First call: for after_state_label (returns same state)
+            # Second call: for issue closed check (returns closed state)
+            mock_gh.return_value.view_issue.side_effect = [
+                _make_github_issue_payload("state/plan"),  # after_state_label check
+                {"state": "CLOSED"},  # issue closed check
+            ]
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=42,
+                branch="task/issue-42",
+                actor="agent:plan",
+                role="planner",
+                before_state_label="state/plan",
+                before_issue_is_closed=False,  # Issue was open before execution
+            )
+
+        # Should NOT block, even though state label is unchanged
+        mock_block.assert_not_called()
+        # Should record terminal transition event
+        store.add_event.assert_called_once()
+        event_args = store.add_event.call_args
+        assert event_args[0][1] == "state_transitioned"
+        assert "closed" in event_args[1]["detail"]
+        assert "terminal transition" in event_args[1]["detail"]

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -123,8 +123,8 @@ def test_handle_closed_pr_reports_reset_failure() -> None:
     ]
 
 
-def test_handle_closed_pr_skips_already_closed_issue() -> None:
-    """When issue already closed, skip reset."""
+def test_handle_closed_pr_with_closed_issue_marks_flow_aborted() -> None:
+    """When PR closed and issue already closed, mark flow as aborted and cleanup."""
     service = _make_check_pr_service()
 
     mock_pr = MagicMock()
@@ -142,14 +142,37 @@ def test_handle_closed_pr_skips_already_closed_issue() -> None:
     }
 
     with patch(
-        "vibe3.services.task_resume_operations.TaskResumeOperations"
-    ) as mock_resume_ops_cls:
-        mock_resume_ops = MagicMock()
-        mock_resume_ops_cls.return_value = mock_resume_ops
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup = MagicMock()
+        mock_cleanup_cls.return_value = mock_cleanup
+        # Mock cleanup result
+        mock_cleanup.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": False,
+            "flow_record": True,
+        }
 
         handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
 
-        # Should not try to reset closed issue
-        mock_resume_ops.reset_issue_to_ready.assert_not_called()
+        # Verify flow was marked as aborted
+        service._flow_status_service.mark_flow_aborted.assert_called_once()
+        call_args = service._flow_status_service.mark_flow_aborted.call_args
+        assert call_args[0][0] == "task/issue-456"
+        assert "Issue #456 already closed" in call_args[0][1]
+        assert "PR #123 closed without merge" in call_args[0][1]
+
+        # Verify cleanup was called
+        mock_cleanup.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-456",
+            include_remote=True,
+            keep_flow_record=False,
+        )
+
+        # Verify result includes warning about cleanup
         assert handled is True
         assert len(issues) == 0
+        assert len(warnings) == 1
+        assert "marked aborted" in warnings[0]
+        assert "issue #456 closed" in warnings[0]

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -175,4 +175,4 @@ def test_handle_closed_pr_with_closed_issue_marks_flow_aborted() -> None:
         assert len(issues) == 0
         assert len(warnings) == 1
         assert "marked aborted" in warnings[0]
-        assert "issue #456 closed" in warnings[0]
+        assert "Issue #456 already closed" in warnings[0]


### PR DESCRIPTION
Closes #1522

Fixes two bugs in check/dispatch health handling:

1. **Closed-issue + closed-PR flows**: Now properly terminalized as aborted with cleanup instead of silently skipped

2. **No-op gate issue-closed transition**: Now detects open→closed transitions as terminal transitions and passes without blocking

## Changes
- check_pr_service.py: Replace no-op return with flow abort + cleanup
- codeagent_runner.py: Capture before_issue_is_closed in sync context
- noop_gate.py: Add issue-closed detection before state unchanged check
- test_check_service.py: Update test for new abort + cleanup behavior
- test_noop_gate_unit.py: Add test for issue-closed transition bypass

## Test Plan
- [x] All verification tests pass (17/17)
- [x] mypy: no type errors
- [x] ruff: all checks passed
- [x] Pre-push checks passed (104 tests)

---

## Contributors

claude/opus
