### PR TITLE
fix: preserve tick ids in error-log fallback paths

### DIFF
--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -36,6 +36,7 @@ def _dispatch_role_intent(
     issue_number: int,
     request_builder: _RequestBuilder,
     actor: str,
+    tick_id: int = 0,
     **builder_kwargs: object,
 ) -> None:
     """Dispatch a role intent through role request builder + ExecutionCoordinator."""
@@ -112,6 +113,7 @@ def _dispatch_role_intent(
                 record_error(
                     error_code="E_DISPATCH_FAILURE",
                     error_message=error_message,
+                    tick_id=tick_id,
                     issue_number=issue_number,
                     branch=branch,
                     store=store,

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -328,6 +328,7 @@ class CodeagentExecutionService:
                     repo=getattr(self.config, "repo", None),
                     required_ref_key=required_ref_key,
                     flow_state=flow_state,
+                    tick_id=command.tick_id,
                 )
 
                 # Persist transition_count after gate call

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -51,6 +51,7 @@ def apply_unified_noop_gate(
     repo: str | None = None,
     required_ref_key: str | None = None,
     flow_state: dict | None = None,
+    tick_id: int = 0,
 ) -> None:
     """Apply the single hard no-op gate after agent completion.
 
@@ -85,6 +86,7 @@ def apply_unified_noop_gate(
         repo=repo,
         branch=branch,
         flow_state=flow_state,
+        tick_id=tick_id,
     )
 
     if flow_state is not None:

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -50,6 +50,8 @@ class StateVerificationService:
             repo: Repository (defaults to current repo)
             branch: Branch for retry counter persistence
             flow_state: Flow state dict for retry counter
+            tick_id: Current heartbeat tick, preserved when retry-limit failures
+                are recorded to error_log
 
         Returns:
             State label string (e.g., "state/in-progress") or None

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -41,6 +41,7 @@ class StateVerificationService:
         repo: str | None = None,
         branch: str | None = None,
         flow_state: dict | None = None,
+        tick_id: int = 0,
     ) -> str | None:
         """Get current state label from GitHub issue.
 
@@ -61,17 +62,19 @@ class StateVerificationService:
         try:
             issue_payload = GitHubClient().view_issue(issue_number, repo=repo)
         except Exception as exc:
-            self._handle_github_api_failure(exc, issue_number, branch, flow_state)
+            self._handle_github_api_failure(
+                exc, issue_number, branch, flow_state, tick_id
+            )
 
         if not isinstance(issue_payload, dict):
             self._handle_malformed_response(
-                issue_payload, issue_number, branch, flow_state
+                issue_payload, issue_number, branch, flow_state, tick_id
             )
 
         labels = issue_payload.get("labels", [])
         if not isinstance(labels, list):
             self._handle_malformed_response(
-                issue_payload, issue_number, branch, flow_state
+                issue_payload, issue_number, branch, flow_state, tick_id
             )
 
         for label in labels:
@@ -92,6 +95,7 @@ class StateVerificationService:
         issue_number: int,
         branch: str | None,
         flow_state: dict | None,
+        tick_id: int,
     ) -> NoReturn:
         retry_count = (
             flow_state.get("noop_gate_github_retry_count", 0) if flow_state else 0
@@ -103,6 +107,7 @@ class StateVerificationService:
                 branch,
                 f"GitHub API failed after {retry_count} retries: {exc}",
                 retry_count,
+                tick_id,
             )
             raise GitHubAPIError(
                 f"Cannot verify remote state for #{issue_number} "
@@ -127,6 +132,7 @@ class StateVerificationService:
         issue_number: int,
         branch: str | None,
         flow_state: dict | None,
+        tick_id: int,
     ) -> NoReturn:
         retry_count = (
             flow_state.get("noop_gate_malformed_retry_count", 0) if flow_state else 0
@@ -138,6 +144,7 @@ class StateVerificationService:
                 branch,
                 f"Malformed GitHub response after {retry_count} retries",
                 retry_count,
+                tick_id,
             )
             raise GitHubAPIError(
                 f"Malformed GitHub response for #{issue_number} "
@@ -173,6 +180,7 @@ class StateVerificationService:
         branch: str | None,
         error_message: str,
         retry_count: int,
+        tick_id: int,
     ) -> None:
         """Record API error to error_log."""
         if not self.store:
@@ -184,6 +192,7 @@ class StateVerificationService:
             record_error(
                 error_code="E_API_UNAVAILABLE",
                 error_message=error_message,
+                tick_id=tick_id,
                 issue_number=issue_number,
                 branch=branch,
                 store=self.store,

--- a/tests/vibe3/domain/handlers/test_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_dispatch.py
@@ -96,6 +96,57 @@ class TestPlannerDispatchHandler:
         assert request.role == "planner"
         assert request.target_id == 42
 
+    @patch("vibe3.services.error_helpers.record_error")
+    @patch("vibe3.domain.handlers.dispatch.build_plan_request")
+    @patch("vibe3.domain.handlers.dispatch.ExecutionCoordinator")
+    @patch("vibe3.domain.handlers.dispatch.get_store")
+    @patch("vibe3.domain.handlers.dispatch.load_issue_info")
+    @patch("vibe3.domain.handlers.dispatch.load_orchestra_config")
+    def test_planner_dispatch_failure_records_event_tick_id(
+        self,
+        mock_config_cls: MagicMock,
+        mock_load_issue: MagicMock,
+        mock_get_store: MagicMock,
+        mock_coordinator_cls: MagicMock,
+        mock_build_request: MagicMock,
+        mock_record_error: MagicMock,
+    ) -> None:
+        from vibe3.domain.handlers.dispatch import handle_planner_dispatch_intent
+
+        config = MagicMock(dry_run=False, repo="owner/repo")
+        mock_config_cls.return_value = config
+
+        mock_issue = MagicMock(number=42, title="Test issue")
+        mock_load_issue.return_value = mock_issue
+
+        mock_store = MagicMock()
+        mock_store.get_flow_state.return_value = None
+        mock_get_store.return_value.__enter__ = MagicMock(return_value=mock_store)
+        mock_get_store.return_value.__exit__ = MagicMock(return_value=None)
+
+        mock_build_request.return_value = _make_mock_request("planner", 42)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.dispatch_execution.return_value = ExecutionLaunchResult(
+            launched=False,
+            skipped=False,
+            reason="Failed to start session",
+            reason_code="launch_failed",
+        )
+        mock_coordinator_cls.return_value = mock_coordinator
+
+        handle_planner_dispatch_intent(
+            PlannerDispatchIntent(
+                issue_number=42,
+                branch="task/issue-42",
+                trigger_state="claimed",
+                tick_id=17,
+            )
+        )
+
+        mock_record_error.assert_called_once()
+        assert mock_record_error.call_args.kwargs["tick_id"] == 17
+
 
 class TestExecutorDispatchHandler:
     """Executor dispatch should delegate to build_run_request + coordinator."""

--- a/tests/vibe3/execution/test_retry_counter_persistence.py
+++ b/tests/vibe3/execution/test_retry_counter_persistence.py
@@ -5,6 +5,7 @@ Verifies that retry counters are persisted to database correctly:
 - Success path: retry count is cleared to 0 immediately
 """
 
+import sqlite3
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -177,3 +178,40 @@ class TestRetryCounterPersistence:
         # Verify: error recorded to error_log (FailedGate will control dispatch)
         # Note: error_log verification requires ErrorTrackingService query
         # which is tested in test_error_tracking.py
+
+    def test_retry_limit_records_current_tick_id(self, temp_db):
+        """Retry-limit error should preserve the heartbeat tick id in error_log."""
+        branch = "test-branch"
+        issue_number = 123
+
+        temp_db.update_flow_state(
+            branch, flow_slug="test", noop_gate_github_retry_count=3
+        )
+        flow_state = temp_db.get_flow_state(branch)
+
+        with patch("vibe3.clients.github_client.GitHubClient") as mock_gh:
+            mock_gh.return_value.view_issue.side_effect = Exception("GitHub API failed")
+
+            with pytest.raises(
+                GitHubAPIError, match="Cannot verify remote state.*after 3 retries"
+            ):
+                apply_unified_noop_gate(
+                    store=temp_db,
+                    issue_number=issue_number,
+                    branch=branch,
+                    actor="test",
+                    role="executor",
+                    before_state_label="state/running",
+                    repo="owner/repo",
+                    flow_state=flow_state,
+                    tick_id=9,
+                )
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            rows = conn.execute("""
+                SELECT tick_id, error_code
+                FROM error_log
+                ORDER BY id DESC
+                LIMIT 1
+                """).fetchall()
+        assert rows == [(9, "E_API_UNAVAILABLE")]


### PR DESCRIPTION
Closes #1558

## Summary
- preserve heartbeat tick ids when noop-gate GitHub verification records retry-limit errors
- preserve event tick ids when dispatch-intent failures are recorded to error_log
- add regression tests covering both fallback paths

## Testing
- uv run pytest tests/vibe3/execution/test_retry_counter_persistence.py -q
- uv run pytest tests/vibe3/domain/handlers/test_dispatch.py -q
- pre-push incremental checks (131 passed)

## Contributors
- Codex

---

## Contributors

AI Agent
