### PR TITLE
chore(config): update LOC limit for test_noop_gate_unit.py

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -168,6 +168,9 @@ code_limits:
       - path: "tests/vibe3/execution/test_noop_gate_transition_count.py"
         limit: 480
         reason: "Transition count 测试集，14 个测试围绕 transition_count 功能（全局计数、pair 追踪、事件记录），共享 fixture，拆分收益低"
+      - path: "tests/vibe3/execution/test_noop_gate_unit.py"
+        limit: 480
+        reason: "No-op gate 单元测试集，覆盖 verdict-aware ref 检查、transition count 检查、state 验证、retry counter、error/block 分离、before_issue_is_closed 检测等紧密耦合场景，新增测试后略微超标"
       - path: "tests/vibe3/services/test_check_cleanup_service.py"
         limit: 540
         reason: "Check cleanup 服务测试集，覆盖 aborted flow 清理、issue resume、comment 引导等紧密耦合场景，新增 2 个测试后略微超标"


### PR DESCRIPTION
## Summary

更新 LOC limits 配置以支持 PR #1554 的测试文件。

## Changes

- **test_noop_gate_unit.py**: 新增例外 480 行
  - 新增 `before_issue_is_closed` 检测测试

## Related PRs

- #1554 - fix(check): terminalize closed issues before PR-closed reset/no-op block

🤖 Generated with [Claude Code](https://claude.com/claude-code)