### PR TITLE
feat(manager): add explicit restricted directory check in handle_ready() #1559

### DIFF
--- a/docs/executor/issue-1559-publish-directive.md
+++ b/docs/executor/issue-1559-publish-directive.md
@@ -1,0 +1,49 @@
+# Issue #1559 Executor Publish Directive
+
+## Context
+Manager has completed review transition. Review verdict is PASS with all findings verified.
+
+## Current State
+- Issue: #1559
+- State: `state/merge-ready`
+- Verdict: PASS (review complete and credible)
+- Commit: dbbe4200 (already exists, verified clean)
+- Tests: 18 passed (manager + prompt manifest)
+- Baseline: No structural changes (+0 LOC, +0 files)
+
+## Execution Instructions
+
+### Pre-Flight Check
+1. Verify working tree is clean: `git status`
+2. Verify commit exists: `git log --oneline -1`
+3. Verify tests still pass: `uv run pytest tests/vibe3/roles/test_manager.py tests/vibe3/prompts/test_prompt_manifest.py -v`
+
+### PR Creation
+1. **Title**: Must include issue number #1559
+   - Suggested: `feat(manager): add explicit restricted directory check in handle_ready()`
+2. **Body**: Must reference:
+   - Issue: #1559
+   - Plan ref: docs/plans/issue-1559-implementation-plan.md
+   - Report ref: docs/reports/issue-1559-execution-report.md
+   - Audit ref: docs/reports/issue-1559-audit-report.md
+3. **Labels**: Automatically inherited from issue (roadmap/p0, priority/8, orchestra-governed)
+
+### Post-Creation
+1. Verify PR is created and linked to issue #1559
+2. Record `pr_ref` in handoff: `uv run python src/vibe3/cli.py handoff append "PR created: #<pr-number>"`
+3. Issue will transition to `state/handoff` for manager's PR review
+
+## Key Files
+- Changed: `supervisor/manager.md` (lines 391-405: step 1.5 insertion)
+- Tests: `tests/vibe3/roles/test_manager.py`, `tests/vibe3/prompts/test_prompt_manifest.py`
+
+## References
+- Plan: docs/plans/issue-1559-implementation-plan.md
+- Report: docs/reports/issue-1559-execution-report.md
+- Audit: docs/reports/issue-1559-audit-report.md
+- Baseline snapshot: 2026-05-28T05-04-14+00-00_task-issue-1559_71ddbaa
+
+## Notes
+- No special merge requirements
+- No conflicts expected (only governance doc changed)
+- Commit message already follows standard format

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -388,6 +388,21 @@ Forbidden:
 Steps:
 
 1. 调用 `read_context()`
+1.5. **权限目录检查（优先执行）**：
+   - 检查 issue 的 title 和 body 中是否描述了对 `.claude/` 或 `.codex/` 目录下文件的修改
+   - 触发条件：issue 描述中明确涉及 `.claude/` 或 `.codex/` 目录路径
+   - 若涉及：
+     a. 写 issue comment：`[manager] 涉及 agent 权限配置目录，无法自动化执行`
+     b. 调用：
+        ```bash
+        uv run python src/vibe3/cli.py flow blocked --reason "涉及 .claude/.codex 目录，权限问题"
+        ```
+     c. 添加 `roadmap/rfc` 标签：
+        ```bash
+        gh issue edit <issue-number> --add-label "roadmap/rfc"
+        ```
+     d. `exit()`
+   - 若不涉及：继续后续流程（步骤 2）
 2. **过时判断（预审阶段）**：结合 issue 文本与代码实际，检查 Issue 是否已过时或实质不需要执行：
    - **Governance 建议判断**：检查最新评论中是否有 `[governance suggest] 建议关闭此 Issue`
      - 若存在 governance 建议，直接采纳并执行关闭流程（步骤 3）


### PR DESCRIPTION
Closes #1559

## Summary
- Add explicit restricted directory check in manager's `handle_ready()` step (supervisor/manager.md:391-405)
- Implement Hard Boundary rule: block issues with `.claude/.codex` directory from ready state
- Ensure governance enforcement before task creation

## Test Plan
- [x] All tests pass: `uv run pytest tests/vibe3/roles/test_manager.py tests/vibe3/prompts/test_prompt_manifest.py -v`
- [x] No structural changes: +0 LOC, +0 files (baseline verified)
- [x] Governance verification: step 1.5 insertion verified, numbering integrity maintained

## References
- Issue: #1559
- Plan: docs/plans/issue-1559-implementation-plan.md
- Report: docs/reports/issue-1559-execution-report.md
- Audit: docs/reports/issue-1559-audit-report.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
