### PR TITLE
fix(vibe-issue): 移除错误添加 vibe-task 标签的误导性表述

### DIFF
--- a/skills/vibe-issue/SKILL.md
+++ b/skills/vibe-issue/SKILL.md
@@ -76,7 +76,8 @@ description: Use when the user wants to create, draft, deduplicate, or refine a 
 
 - 引导用户补充模板中缺失的关键信息。
 - 基于 AI 建议合适的 Labels。
-- 为保证后续 intake 链路可识别该 Issue，按当前仓库约定补充最小必要标签；`bug`、`enhancement`、`vibe-task` 等标签按模板和场景决定。
+- 按当前仓库约定补充最小必要类型标签（`bug`、`enhancement` 等），以及优先级标签（如 `priority/*`）。
+- **禁止添加 `vibe-task` 标签**：该标签是 `vibe3 flow bind` 成功后的自动镜像，不应在 issue 创建时手动添加。
 - intake 标签不等于已完成 roadmap placement；是否进入版本窗口、如何排序，仍由 `vibe-roadmap` / `vibe-orchestra` 在后续阶段处理。
 
 ### Step 4.5: Scope 自检与主/子 Issue 结构判断


### PR DESCRIPTION
## Summary

修复 `skills/vibe-issue/SKILL.md` 中关于 `vibe-task` 标签的错误表述。

**问题根源**：
- 第79行错误地建议在 issue 创建时添加 `vibe-task` 标签
- 导致 issue #1570 和 #1571 在创建时就带有此标签

**违背的标准**：
- `docs/standards/github-labels-reference.md`: `vibe-task` 是 `flow bind` 的自动镜像（副作用）
- `docs/standards/glossary.md`: `vibe-task` 标签不作为治理判定依据
- `docs/standards/issue-standard.md`: `vibe-task` 由 `vibe3 flow bind` 自动镜像，不应手动添加

**正确的语义**：
- `vibe-task` 标签**不应该**在 issue 创建时添加
- 只有当执行 `vibe3 flow bind <issue> --role task` 成功后，系统才会自动添加
- 这个标签是执行关系的镜像，不是 intake 标签，也不是真源
- 标签表示"本地有 flow 绑定"，应该由系统自动管理

**修复内容**：
- 删除 vibe-issue skill 中关于 `vibe-task` 的错误表述
- 明确禁止在 issue 创建时添加 `vibe-task` 标签
- 说明 `vibe-task` 是 `flow bind` 成功后的自动镜像

**影响**：
- 已移除 issue #1570 和 #1571 上错误添加的 `vibe-task` 标签
- vibe-issue skill 现在正确遵循项目标签治理标准

## Test plan

- [x] 验证标准文档一致性（所有标准文档都正确定义 `vibe-task`）
- [x] 移除 issue #1570 和 #1571 的错误标签
- [x] 本地测试：vibe-issue skill 文案已修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)