### PR TITLE
refactor(prompts): 统一 handoff append 与 comment 为单一通道，消除双写冗余

### DIFF
--- a/.agent/policies/common.md
+++ b/.agent/policies/common.md
@@ -166,23 +166,20 @@ uv run python src/vibe3/cli.py handoff append "<message>" --kind finding --actor
 
 Issue / PR 评论和 handoff 是两条互补但不可替换的通道。
 
-### 何时用 issue / PR comment
+**关键事实**：`handoff append` 会自动同步到 GitHub comment，兼具内外可见性。
 
-适合需要**外部可见性**的内容：
-- 阶段性里程碑通报（plan 完成、run 完成、review 裁决）
-- 需要人类介入的 blocker（凭证缺失、依赖未就绪、范围争议）
-- 跨角色协作公告（人类、其他 agent、PR reviewer 都可能看到）
-- 与 GitHub issue / PR 状态机直接相关的事件
+### 统一规则
 
-### 何时用 handoff append
+| 场景 | 使用方式 | 原因 |
+|------|---------|------|
+| **执行过程记录** | `handoff append` | 自动同步到 comment |
+| **状态切换中间过程** | `handoff append` | 自动同步到 comment |
+| **finding/观察记录** | `handoff append` | 自动同步到 comment |
+| **关键里程碑** | 独立 comment + handoff | claim/block/close/done 等关键节点 |
+| **人类介入 blocker** | 独立 comment + handoff | 明确请求人类决策或行动 |
+| **响应人类指令** | 独立 comment | 正式回复人类明确要求 |
 
-适合 **agent 之间的内部交接**：
-- 执行过程中的 finding、临时观察、调试线索
-- 仅供下一步 agent 消费的上下文
-- 不需要人类即刻知晓的次要信息
-- 与当前 flow 主体输出无直接关联但需要留痕的事项
-
-判断准则：**看一眼 issue 评论区就需要知道的事 → comment；只有同 flow 内的下一个 agent 需要的事 → handoff append**。
+判断准则：**大部分情况用 handoff append，只有关键决策点和人类介入才写独立 comment**。
 
 ### 强制 marker 格式
 

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -109,13 +109,15 @@ Forbidden:
 规则：
 
 - 如果某个动作没有被明确允许，视为 forbidden
-- 如果需要反馈给人类，写 **issue comment**
-- 如果需要交给后续 agent：
-  - **结构化指令文件**（plan/audit/PR directive）：写 **handoff indicate**（`vibe3 handoff indicate <path>`）
-  - **轻量级记录**（状态更新、发现问题、注意事项）：写 **handoff append**（`vibe3 handoff append "message"`）
-  - **查看交接记录**：用 **handoff show**（`vibe3 handoff show @current` 查看当前 flow 的完整交接链路）
-- handoff 不代替 issue comment
-- **使用原则**：大部分情况用 `handoff append`，只有在需要传递完整指令文件给下游 agent 时才用 `handoff indicate`
+- **Comment vs Handoff 统一规则**：
+  - **大部分场景**：使用 `handoff append`，它会自动同步到 GitHub comment，兼具内外可见性
+  - **关键里程碑**（claim/block/close/done）：独立 comment + handoff append
+  - **人类介入 blocker**：独立 comment + handoff append
+  - **响应人类指令**：独立 comment
+- **Handoff 使用原则**：
+  - **handoff append**：轻量级记录（状态更新、发现问题、注意事项）
+  - **handoff indicate**：传递完整指令文件给下游 agent（plan/audit/PR directive）
+  - **handoff show**：查看交接记录（`vibe3 handoff show @current`）
 
 ## Setting Blocked State
 
@@ -580,10 +582,10 @@ Steps:
        git log HEAD..origin/main --oneline -- src/vibe3/<target-module>/
        ```
      - **若 main 分支存在架构变化**：
+       - 写 handoff append：说明架构冲突风险、main 分支变化详情、建议人工判断是否需要 rebase 或调整 scope
        - comment: `[manager] main 分支架构已演进，目标模块有新提交。建议先同步再规划。`
        - 列出具体变化文件和 commit 数量
        - 进入 `state/blocked`
-       - 写 handoff append: 说明架构冲突风险，建议人工判断是否需要 rebase 或调整 scope
        - `exit()`
 3. 复述当前已进入 claimed
 4. 明确记录：拆分窗口已关闭，后续 plan/run/review 不得再改变为 sub-issue 拆分；若 plan agent 发现 scope 无法执行，应 blocked 回 manager/人类，而不是自行拆分
@@ -685,8 +687,7 @@ Decision sketch:
   - 进入 `state/in-progress`
 - 已有 `spec_ref`，无 `plan_ref`：
   - 将当前 issue 调整回 `state/claimed`
-  - 写 issue comment：plan 产物缺失，需重新进入 planning
-  - 写 handoff append：等待 plan agent 重新接手
+  - 写 handoff append：说明 plan 产物缺失，需重新进入 planning，等待 plan agent 重新接手
   - `exit()`
 - 已有 `report_ref`，无 `audit_ref`：
   - **实质审查执行结果**: 读 report_ref，判断代码质量是否达标


### PR DESCRIPTION
## Summary

统一 handoff append 与 comment 为单一通道，消除双写冗余。

**核心原则**：handoff append 为主通道，comment 仅用于非内部交接场景。

## 修改内容

### 1. supervisor/manager.md

- **Line 112-117**: 改为统一规则表格，明确大部分场景用 handoff append
- **Line 585-589**: 架构风险评估，保留 blocker 的独立 comment（人类介入）
- **Line 688-692**: plan 产物缺失，改为只用 handoff append（非关键里程碑）

### 2. .agent/policies/common.md

- 补充说明 **handoff append 会自动同步到 GitHub comment**
- 添加统一规则表格，明确何时用 handoff append、何时用独立 comment

## 统一规则

| 场景 | 使用方式 | 原因 |
|------|---------|------|
| **执行过程记录** | `handoff append` | 自动同步到 comment |
| **状态切换中间过程** | `handoff append` | 自动同步到 comment |
| **finding/观察记录** | `handoff append` | 自动同步到 comment |
| **关键里程碑** | 独立 comment + handoff | claim/block/close/done 等关键节点 |
| **人类介入 blocker** | 独立 comment + handoff | 明确请求人类决策或行动 |
| **响应人类指令** | 独立 comment | 正式回复人类明确要求 |

## 预期效果

1. ✅ 减少重复工作（不再要求既写 comment 又写 handoff）
2. ✅ 保持 handoff append 为单一真源
3. ✅ 保留必要的独立 comment（关键里程碑、人类介入等）
4. ✅ 符合"单一真源"和"最小必要"原则

## Test plan

- [x] 验证修改后的规则表格完整且清晰
- [x] 确认关键里程碑场景保留了独立 comment
- [x] 确认中间过程场景改为只用 handoff append
- [x] 补充说明 handoff append 自动同步机制

Closes #1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)