### PR TITLE
fix(orchestra): use absolute path for cross-project serve start

### DIFF
--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -274,6 +274,18 @@ def _build_async_serve_command(
     """Build self-invocation command for async tmux startup."""
     models_root = _resolve_dispatcher_models_root(config, launch_cwd)
     log_dir = _resolve_orchestra_log_dir(launch_cwd)
+
+    # Resolve the absolute path to vibe3 project root via module location.
+    # This works correctly in both:
+    # - Local development: points to source repo
+    # - Global install: points to ~/.vibe
+    # Important: Do NOT use resolve_orchestra_repo_root() which returns
+    # the current working project root, not the vibe3 tool's source root.
+    import vibe3.server.registry as this_module
+
+    repo_root = (Path(this_module.__file__).parent.parent.parent.parent).resolve()
+    cli_path = repo_root / "src" / "vibe3" / "cli.py"
+
     cmd = [
         "env",
         "VIBE3_ORCHESTRA_EVENT_LOG=1",
@@ -281,8 +293,10 @@ def _build_async_serve_command(
         f"VIBE3_ASYNC_LOG_DIR={log_dir}",
         "uv",
         "run",
+        "--project",
+        str(repo_root),
         "python",
-        "src/vibe3/cli.py",
+        str(cli_path),
         "serve",
         "start",
         "--no-async",


### PR DESCRIPTION
## 问题说明

vibe3 serve start 在全局安装模式下，在其他项目中运行时失败。

### 错误现象
```
/Users/chenyi/.venvs/vibe-center/bin/python3: can't open file '/Users/chenyi/src/agent-mesh/src/vibe3/cli.py': [Errno 2] No such file or directory
```

## 根本原因

1. `_build_async_serve_command` 使用相对路径 `"src/vibe3/cli.py"`
2. `resolve_orchestra_repo_root()` 返回当前项目根目录（agent-mesh），而不是 vibe3 源代码位置（~/.vibe）
3. tmux 尝试执行 `/path/to/other/project/src/vibe3/cli.py` → 文件不存在 → 失败

## 解决方案

使用模块的 `__file__` 属性定位 vibe3 源代码：
- 向上导航 4 层：`registry.py` → `server/` → `vibe3/` → `src/` → `repo_root`
- 本地开发：`repo_root` = `/Users/chenyi/src/vibe-coding-control-center`
- 全局安装：`repo_root` = `/Users/chenyi/.vibe`

## 测试验证

在 `~/src/agent-mesh` 中测试：
- ✅ orchestra server 成功启动
- ✅ 无 "can't open file" 错误
- ✅ FailedGate 保持 OPEN 状态（正常）

## 影响范围

- **影响**：全局安装模式下在其他项目中运行 `vibe3 serve start` 的场景
- **风险**：低。修改仅影响启动命令的路径解析逻辑
- **兼容性**：完全兼容本地开发模式

## Checklist

- [x] 代码已自测
- [x] 提交信息符合规范
- [x] 测试跨项目场景通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)