### PR TITLE
fix(orchestra): log warning when block_manager_noop cannot find flow

### DIFF
--- a/src/vibe3/services/issue_failure_service.py
+++ b/src/vibe3/services/issue_failure_service.py
@@ -188,10 +188,28 @@ def block_manager_noop_issue(
         # Find any flow for this issue
         flows = store.get_flows_by_issue(issue_number, role="task")
         if not flows:
+            logger.bind(
+                domain="flow",
+                action="block_manager_noop",
+                issue_number=issue_number,
+                reason=reason,
+            ).warning(
+                f"No flow found for issue #{issue_number},"
+                " cannot block — possible flow creation failure"
+            )
             return
 
         branch = str(flows[0].get("branch") or "").strip()
         if not branch:
+            logger.bind(
+                domain="flow",
+                action="block_manager_noop",
+                issue_number=issue_number,
+                reason=reason,
+            ).warning(
+                f"Flow has no branch for issue #{issue_number},"
+                " cannot block — possible flow creation failure"
+            )
             return
 
         # Reuse block_flow() - eliminates ALL duplication


### PR DESCRIPTION
## Summary

Fix silent error logging in `block_manager_noop_issue()`. Previously, when flow creation failed and no flow/branch existed yet, the function silently returned without any log — making dispatch failure debugging difficult.

## Changes

- `src/vibe3/services/issue_failure_service.py` (+18 lines)
  - Add WARNING log when `get_flows_by_issue()` returns no flow
  - Add WARNING log when flow exists but has no branch
  - Both logs include `issue_number` and `reason` for traceability

## Test Plan

- [x] Manager dispatch failure during flow creation now visible in logs
- [x] No behavior change — only adds logging before existing early returns
- [x] ruff/mypy clean

Closes #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)