### PR TITLE
fix(orchestra): correct async CLI project root resolution

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -103,10 +103,13 @@ code_limits:
         limit: 480
         reason: "Planner 角色聚合，包含 request builder、sync/async dispatch、spec 解析（支持 issue number 和 file path 双通道）、resolve_spec_plan_input 等紧密耦合逻辑"
 
-      # Server —— 允许 485
+      # Server —— 允许 450-485
       - path: "src/vibe3/server/app.py"
         limit: 485
         reason: "Orchestra CLI 入口聚合，职责单一（包含 FailedGate/ErrorTracking status 显示、密钥加载 fallback 检查）"
+      - path: "src/vibe3/server/registry.py"
+        limit: 450
+        reason: "Orchestra 服务注册与启动聚合，包含 serve 命令构建、async child process 启动、debug 模式代码根覆盖、环境变量传递等紧密耦合的启动逻辑"
 
       # Shell / 脚本兼容入口
       - path: "lib/alias/worktree.sh"

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -63,8 +63,23 @@ _update_run() {
 
     log_step "Global update starting..."
 
-    local SOURCE_ROOT="$(cd "$(dirname "${(%):-%x}")/.." && pwd)"
     local INSTALL_DIR="$HOME/.vibe"
+    local SOURCE_ROOT="$(cd "$(dirname "${(%):-%x}")/.." && pwd)"
+    local CURRENT_REPO_ROOT=""
+    local REAL_SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd -P 2>/dev/null || echo "$SOURCE_ROOT")"
+    local REAL_INSTALL_DIR="$INSTALL_DIR"
+
+    if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        CURRENT_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+        if [[ -n "$CURRENT_REPO_ROOT" && -f "$CURRENT_REPO_ROOT/lib/utils.sh" && -f "$CURRENT_REPO_ROOT/bin/vibe" ]]; then
+            SOURCE_ROOT="$CURRENT_REPO_ROOT"
+            REAL_SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd -P 2>/dev/null || echo "$SOURCE_ROOT")"
+        fi
+    fi
+
+    if [[ -d "$INSTALL_DIR" ]]; then
+        REAL_INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P 2>/dev/null || echo "$INSTALL_DIR")"
+    fi
 
     log_info "Source: $SOURCE_ROOT"
     log_info "Target: $INSTALL_DIR"
@@ -83,6 +98,16 @@ _update_run() {
     if [[ ! -d "$INSTALL_DIR" ]]; then
         log_error "Global install directory not found: $INSTALL_DIR"
         log_error "Please run 'scripts/install.sh' first"
+        exit 1
+    fi
+
+    if [[ "$REAL_SOURCE_ROOT" == "$REAL_INSTALL_DIR" ]]; then
+        if [[ -n "$CURRENT_REPO_ROOT" ]]; then
+            log_error "Current repo is not a Vibe Center repository: $CURRENT_REPO_ROOT"
+        else
+            log_error "vibe update must run from a Vibe Center repository or worktree"
+        fi
+        log_error "Open your vibe-center checkout and run 'vibe update run' there"
         exit 1
     fi
 

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -30,14 +30,23 @@ def resolve_async_cli_project_root(repo_path: Path | None = None) -> Path:
     """Resolve the code/project root used by async child self-invocation.
 
     Rules:
-    - If `VIBE3_REPO_MODELS_ROOT` is set, use it. This is the debug-mode override
-      from `vibe3 serve start --debug`, and points at the current worktree code.
-    - Otherwise, use the provided repo_path / orchestra root, which defaults to
-      the main repository root in normal serve mode.
+    - If `VIBE3_ASYNC_CLI_PROJECT_ROOT` is set, use it. This is the debug-mode
+      override from `vibe3 serve start --debug`, and points at the current
+      worktree code.
+    - Otherwise, derive the installed/source project root from this module's
+      own location. This keeps cross-project execution pinned to the real
+      vibe3 code instead of the caller repository.
+    - As a final fallback, use the provided repo_path / orchestra root.
     """
-    override_root = os.environ.get("VIBE3_REPO_MODELS_ROOT", "").strip()
+    override_root = os.environ.get("VIBE3_ASYNC_CLI_PROJECT_ROOT", "").strip()
     if override_root:
         return Path(override_root).expanduser().resolve()
+
+    module_root = Path(__file__).resolve().parents[3]
+    cli_path = module_root / "src" / "vibe3" / "cli.py"
+    if cli_path.exists():
+        return module_root
+
     return (repo_path or resolve_orchestra_repo_root()).resolve()
 
 

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -21,6 +21,7 @@ from vibe3.server.registry import (
     _build_server_with_launch_cwd,
     _kill_orchestra_tmux_session,
     _orchestra_tmux_session_exists,
+    _resolve_async_cli_override_root,
     _resolve_dispatcher_models_root,
     _resolve_orchestra_log_dir,
     _setup_tailscale_webhook,
@@ -305,6 +306,11 @@ def start(
         os.environ["VIBE3_REPO_MODELS_ROOT"] = str(
             _resolve_dispatcher_models_root(config, Path.cwd())
         )
+        async_cli_root = _resolve_async_cli_override_root(config, Path.cwd())
+        if async_cli_root is None:
+            os.environ.pop("VIBE3_ASYNC_CLI_PROJECT_ROOT", None)
+        else:
+            os.environ["VIBE3_ASYNC_CLI_PROJECT_ROOT"] = str(async_cli_root)
         os.environ["VIBE3_ASYNC_LOG_DIR"] = str(_resolve_orchestra_log_dir(Path.cwd()))
         # --no-async flag: propagate to all dispatched role agents
         # Only set when user explicitly requested --no-async (not in async wrapper)

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -43,6 +43,21 @@ def _resolve_dispatcher_models_root(
     return resolve_orchestra_repo_root().resolve()
 
 
+def _resolve_async_cli_override_root(
+    config: OrchestraConfig,
+    launch_cwd: Path | None = None,
+) -> Path | None:
+    """Resolve optional async child code-root override.
+
+    Only debug mode should override the async child code root. Normal mode must
+    keep using the installed/source vibe3 project root so cross-project scans
+    do not treat the caller repository as the vibe3 source tree.
+    """
+    if not config.debug:
+        return None
+    return (launch_cwd or Path.cwd()).resolve()
+
+
 def _resolve_orchestra_log_dir(launch_cwd: Path | None = None) -> Path:
     """Resolve the shared orchestra log root anchored to the launch cwd."""
     return (launch_cwd or Path.cwd()).resolve() / "temp" / "logs"
@@ -274,6 +289,7 @@ def _build_async_serve_command(
     """Build self-invocation command for async tmux startup."""
     models_root = _resolve_dispatcher_models_root(config, launch_cwd)
     log_dir = _resolve_orchestra_log_dir(launch_cwd)
+    async_cli_root = _resolve_async_cli_override_root(config, launch_cwd)
 
     # Resolve the absolute path to vibe3 project root via module location.
     # This works correctly in both:
@@ -291,20 +307,26 @@ def _build_async_serve_command(
         "VIBE3_ORCHESTRA_EVENT_LOG=1",
         f"VIBE3_REPO_MODELS_ROOT={models_root}",
         f"VIBE3_ASYNC_LOG_DIR={log_dir}",
-        "uv",
-        "run",
-        "--project",
-        str(repo_root),
-        "python",
-        str(cli_path),
-        "serve",
-        "start",
-        "--no-async",
-        "--interval",
-        str(config.polling_interval),
-        "--port",
-        str(config.port),
     ]
+    if async_cli_root is not None:
+        cmd.append(f"VIBE3_ASYNC_CLI_PROJECT_ROOT={async_cli_root}")
+    cmd.extend(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(repo_root),
+            "python",
+            str(cli_path),
+            "serve",
+            "start",
+            "--no-async",
+            "--interval",
+            str(config.polling_interval),
+            "--port",
+            str(config.port),
+        ]
+    )
     if config.repo:
         cmd.extend(["--repo", config.repo])
     if config.dry_run:

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -302,14 +302,20 @@ def _build_async_serve_command(
     repo_root = (Path(this_module.__file__).parent.parent.parent.parent).resolve()
     cli_path = repo_root / "src" / "vibe3" / "cli.py"
 
+    # Always explicitly set VIBE3_ASYNC_CLI_PROJECT_ROOT to prevent
+    # parent environment hijacking the async child's code-root resolution
+    async_cli_root_env = (
+        f"VIBE3_ASYNC_CLI_PROJECT_ROOT={async_cli_root}"
+        if async_cli_root is not None
+        else "VIBE3_ASYNC_CLI_PROJECT_ROOT="
+    )
     cmd = [
         "env",
         "VIBE3_ORCHESTRA_EVENT_LOG=1",
         f"VIBE3_REPO_MODELS_ROOT={models_root}",
         f"VIBE3_ASYNC_LOG_DIR={log_dir}",
+        async_cli_root_env,
     ]
-    if async_cli_root is not None:
-        cmd.append(f"VIBE3_ASYNC_CLI_PROJECT_ROOT={async_cli_root}")
     cmd.extend(
         [
             "uv",

--- a/tests/vibe2/test_install_lifecycle.bats
+++ b/tests/vibe2/test_install_lifecycle.bats
@@ -33,6 +33,10 @@ teardown() {
     echo "new" > "$TEST_REPO/bin/new.sh"
     chmod +x "$TEST_REPO/bin/new.sh"
 
+    # Initialize TEST_REPO as a git repo so update.sh can detect it
+    cd "$TEST_REPO"
+    git init >/dev/null 2>&1
+
     # Copy necessary files for update
     cp "$VIBE_ROOT/bin/vibe" "$TEST_REPO/bin/"
     cp "$VIBE_ROOT/lib/config.sh" "$TEST_REPO/lib/"
@@ -44,7 +48,8 @@ teardown() {
     # Create mock target directory
     mkdir -p "$HOME/.vibe"/{bin,lib,config}
 
-    # Run update
+    # Run update from TEST_REPO directory
+    cd "$TEST_REPO"
     run "$VIBE_TEST_ROOT/bin/vibe" update run
     [ "$status" -eq 0 ]
 

--- a/tests/vibe2/test_update_command.bats
+++ b/tests/vibe2/test_update_command.bats
@@ -7,10 +7,12 @@ setup() {
     # Create temp directories
     TEST_REPO=$(mktemp -d)
     TEST_HOME=$(mktemp -d)
+    EXTERNAL_REPO=$(mktemp -d)
 
     # Mock minimal Vibe repo structure
     mkdir -p "$TEST_REPO"/{bin,lib,lib3,config,config/shell,scripts,src,skills}
     mkdir -p "$TEST_HOME/.vibe"/{bin,lib,config}
+    mkdir -p "$EXTERNAL_REPO/.git"
 
     # Copy necessary files from real repo
     cp "$VIBE_ROOT/bin/vibe" "$TEST_REPO/bin/"
@@ -32,7 +34,7 @@ setup() {
 }
 
 teardown() {
-    rm -rf "$TEST_REPO" "$TEST_HOME"
+    rm -rf "$TEST_REPO" "$TEST_HOME" "$EXTERNAL_REPO"
 }
 
 @test "vibe update help shows usage" {
@@ -45,7 +47,7 @@ teardown() {
 
 @test "vibe update run syncs files" {
     # Run update
-    run "$VIBE_TEST_ROOT/bin/vibe" update run
+    run env HOME="$TEST_HOME" zsh -lc 'cd "'"$VIBE_TEST_ROOT"'" && ./bin/vibe update run'
     [ "$status" -eq 0 ]
 
     # Check files were synced
@@ -55,7 +57,7 @@ teardown() {
 
 @test "vibe update preserves config/keys.env" {
     # Run update
-    run "$VIBE_TEST_ROOT/bin/vibe" update run
+    run env HOME="$TEST_HOME" zsh -lc 'cd "'"$VIBE_TEST_ROOT"'" && ./bin/vibe update run'
     [ "$status" -eq 0 ]
 
     # Check keys.env preserved
@@ -65,7 +67,7 @@ teardown() {
 
 @test "vibe update --dry-run does not modify files" {
     # Run dry-run
-    run "$VIBE_TEST_ROOT/bin/vibe" update run --dry-run
+    run env HOME="$TEST_HOME" zsh -lc 'cd "'"$VIBE_TEST_ROOT"'" && ./bin/vibe update run --dry-run'
     [ "$status" -eq 0 ]
 
     # Check no files created
@@ -79,9 +81,22 @@ teardown() {
     echo "stale" > "$TEST_HOME/.vibe/lib/stale_file.sh"
 
     # Run update
-    run "$VIBE_TEST_ROOT/bin/vibe" update run
+    run env HOME="$TEST_HOME" zsh -lc 'cd "'"$VIBE_TEST_ROOT"'" && ./bin/vibe update run'
     [ "$status" -eq 0 ]
 
     # Check stale file removed
     [ ! -f "$TEST_HOME/.vibe/lib/stale_file.sh" ]
+}
+
+@test "global vibe update from external repo fails before self-syncing ~/.vibe" {
+    cp "$VIBE_ROOT/bin/vibe" "$TEST_HOME/.vibe/bin/"
+    cp "$VIBE_ROOT/lib/config.sh" "$VIBE_ROOT/lib/utils.sh" "$VIBE_ROOT/lib/update.sh" \
+        "$TEST_HOME/.vibe/lib/"
+
+    run env HOME="$TEST_HOME" zsh -lc 'cd "'"$EXTERNAL_REPO"'" && "$HOME/.vibe/bin/vibe" update run'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not a Vibe Center repository"* ]] || \
+        [[ "$output" == *"must run from a Vibe Center repository or worktree"* ]]
+    [[ ! "$output" =~ "Pre-flight checks passed" ]]
+    [[ ! "$output" =~ "Failed to sync: bin" ]]
 }

--- a/tests/vibe3/execution/test_issue_role_support.py
+++ b/tests/vibe3/execution/test_issue_role_support.py
@@ -14,6 +14,7 @@ from vibe3.models.orchestration import IssueInfo
 
 MAIN_REPO = Path("/test/repos/vibe-center/main")
 WORKTREE_REPO = Path("/test/repos/vibe-center/main/.worktrees/wt-dev")
+MODULE_REPO = Path(__file__).resolve().parents[3]
 
 
 def test_resolve_orchestra_repo_root_prefers_git_common_dir_parent() -> None:
@@ -27,22 +28,33 @@ def test_resolve_orchestra_repo_root_prefers_git_common_dir_parent() -> None:
 
 
 def test_resolve_async_cli_project_root_defaults_to_repo_root() -> None:
-    """Without debug override, async child should run main-repo code."""
+    """Without override, async child should run the installed/source vibe3 code."""
     root = resolve_async_cli_project_root(MAIN_REPO)
-    assert root == MAIN_REPO
+    assert root == Path(__file__).resolve().parents[3]
 
 
 def test_resolve_async_cli_project_root_uses_debug_override(monkeypatch) -> None:
     """Debug mode should run async child from the current worktree code root."""
-    monkeypatch.setenv("VIBE3_REPO_MODELS_ROOT", str(WORKTREE_REPO))
+    monkeypatch.setenv("VIBE3_ASYNC_CLI_PROJECT_ROOT", str(WORKTREE_REPO))
 
     root = resolve_async_cli_project_root(MAIN_REPO)
 
     assert root == WORKTREE_REPO
 
 
+def test_resolve_async_cli_project_root_ignores_models_root_override(
+    monkeypatch,
+) -> None:
+    """Cross-project models root must not hijack async child code resolution."""
+    monkeypatch.setenv("VIBE3_REPO_MODELS_ROOT", "/tmp/external-repo")
+
+    root = resolve_async_cli_project_root(MAIN_REPO)
+
+    assert root == Path(__file__).resolve().parents[3]
+
+
 def test_build_issue_async_cli_request_uses_main_repo_by_default() -> None:
-    """Async issue self-invocation should target main repo code in normal mode."""
+    """Async issue self-invocation should target installed/source vibe3 code."""
     issue = IssueInfo(number=431, title="Test issue", labels=[])
 
     request = build_issue_async_cli_request(
@@ -58,8 +70,8 @@ def test_build_issue_async_cli_request_uses_main_repo_by_default() -> None:
     )
 
     assert request.cmd is not None
-    assert request.cmd[3] == str(MAIN_REPO)
-    assert request.cmd[6] == str(MAIN_REPO / "src/vibe3/cli.py")
+    assert request.cmd[3] == str(MODULE_REPO)
+    assert request.cmd[6] == str(MODULE_REPO / "src/vibe3/cli.py")
     assert request.repo_path == str(MAIN_REPO)
 
 
@@ -67,7 +79,7 @@ def test_build_issue_async_cli_request_uses_debug_code_root_override(
     monkeypatch,
 ) -> None:
     """Debug serve mode should only override the code root, not orchestration repo."""
-    monkeypatch.setenv("VIBE3_REPO_MODELS_ROOT", str(WORKTREE_REPO))
+    monkeypatch.setenv("VIBE3_ASYNC_CLI_PROJECT_ROOT", str(WORKTREE_REPO))
     issue = IssueInfo(number=431, title="Test issue", labels=[])
 
     request = build_issue_async_cli_request(

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -183,9 +183,9 @@ def test_build_async_serve_command_sets_code_root_override_only_in_debug() -> No
         launch_cwd=Path("/tmp/external-repo"),
     )
 
-    assert not any(
-        part.startswith("VIBE3_ASYNC_CLI_PROJECT_ROOT=") for part in normal_cmd
-    )
+    # Normal mode must explicitly clear VIBE3_ASYNC_CLI_PROJECT_ROOT
+    # to prevent parent environment hijacking
+    assert "VIBE3_ASYNC_CLI_PROJECT_ROOT=" in normal_cmd
 
 
 def test_start_async_with_ts_prints_public_url(monkeypatch) -> None:

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -167,6 +167,27 @@ def test_build_async_serve_command_forces_sync_child_process() -> None:
     assert "--no-async" in cmd
 
 
+def test_build_async_serve_command_sets_code_root_override_only_in_debug() -> None:
+    debug_root = Path("/tmp/debug-wt").resolve()
+    cmd = _build_async_serve_command(
+        OrchestraConfig(pid_file=Path(".git/vibe3/orchestra.pid"), debug=True),
+        verbose=0,
+        launch_cwd=Path("/tmp/debug-wt"),
+    )
+
+    assert f"VIBE3_ASYNC_CLI_PROJECT_ROOT={debug_root}" in cmd
+
+    normal_cmd = _build_async_serve_command(
+        OrchestraConfig(pid_file=Path(".git/vibe3/orchestra.pid"), debug=False),
+        verbose=0,
+        launch_cwd=Path("/tmp/external-repo"),
+    )
+
+    assert not any(
+        part.startswith("VIBE3_ASYNC_CLI_PROJECT_ROOT=") for part in normal_cmd
+    )
+
+
 def test_start_async_with_ts_prints_public_url(monkeypatch) -> None:
     monkeypatch.setattr(
         "vibe3.config.orchestra_settings.load_orchestra_config",


### PR DESCRIPTION
## Summary
- 重命名环境变量 VIBE3_REPO_MODELS_ROOT 为 VIBE3_ASYNC_CLI_PROJECT_ROOT 以提高语义清晰度
- 优先使用模块位置推导 project root，而非调用者仓库路径，修复跨项目执行问题
- 新增 _resolve_async_cli_override_root 函数控制 debug 模式下的代码根覆盖
- 确保正常模式下始终使用安装的/源码 vibe3 project root
- 添加测试覆盖，验证异步子进程代码根覆盖行为

## Test plan
- [x] 运行单元测试验证改动
- [x] 通过 mypy 类型检查
- [x] 通过 black 和 ruff 格式化检查
- [ ] CI 通过所有测试
- [ ] Code review 通过