### PR TITLE
fix(governance): show log path in dispatch message and fix cross-project log location

### DIFF
--- a/src/vibe3/agents/backends/async_launcher.py
+++ b/src/vibe3/agents/backends/async_launcher.py
@@ -271,7 +271,13 @@ def spawn_tmux_command(
 
     project_root = cwd or Path.cwd()
 
-    log_dir = default_log_dir()
+    # Determine log directory: check env first (for cross-project execution),
+    # then fall back to default_log_dir (which checks VIBE3_ASYNC_LOG_DIR env var)
+    if env and "VIBE3_ASYNC_LOG_DIR" in env:
+        log_dir = Path(env["VIBE3_ASYNC_LOG_DIR"]).expanduser().resolve()
+    else:
+        log_dir = default_log_dir()
+
     prefix = execution_name.replace("/", "-")[:50]
 
     # Rule: L3 agent roles (manager/plan/run/review) MUST NOT auto-increment

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -242,6 +242,8 @@ def run_governance_async(
     env = dict(os.environ)
     env["VIBE3_ASYNC_CHILD"] = "1"
     env["VIBE3_ORCHESTRA_EVENT_LOG"] = "1"
+    # Force logs to be written to the target project, not the vibe repo
+    env["VIBE3_ASYNC_LOG_DIR"] = str(root / "temp" / "logs")
 
     request = ExecutionRequest(
         role="governance",
@@ -286,7 +288,11 @@ def run_governance_async(
             f"governance agent launched: tick={tick_count} "
             f"session={result.tmux_session}",
         )
-        echo(f"Governance scan dispatched in tmux session: {result.tmux_session}")
+        log_info = f"Log: {result.log_path}" if result.log_path else ""
+        message = f"Governance scan dispatched in tmux session: {result.tmux_session}"
+        if log_info:
+            message += f"\n{log_info}"
+        echo(message)
     elif result:
         append_governance_event(
             f"governance dispatch skipped: tick={tick_count} "


### PR DESCRIPTION
## Summary

- Show log file path in governance dispatch success message
- Fix cross-project execution: logs now written to calling project, not vibe repo
- Preserve test compatibility via `VIBE3_ASYNC_LOG_DIR` environment variable

## Problem

When running `vibe scan governance -r roadmap-intake` in other projects (e.g., agent-mesh):
1. Output only showed tmux session name, no indication where to find logs
2. Logs were written to vibe repo's `temp/logs/` instead of calling project's directory
3. Impossible to check execution results or debug issues

## Root Cause

1. `governance_sync_runner.py` line 289 only printed tmux session name
2. `async_launcher.py` `default_log_dir()` used `__file__` path, always returning vibe repo root
3. No mechanism to override log location for cross-project execution

## Solution

1. Add log path to success message in `governance_sync_runner.py`
2. Set `VIBE3_ASYNC_LOG_DIR` environment variable in `run_governance_async()` to force logs into target project's `temp/logs/`
3. Preserve `default_log_dir()` for test compatibility (monkeypatch support)

## Testing

- ✅ All existing tests pass
- ✅ Manual testing in agent-mesh project confirmed logs written to correct location
- ✅ Output now shows log path for easy access

## Impact

Users can now:
- See log file location immediately after dispatch
- Find governance logs in the calling project's `temp/logs/orchestra/governance/` directory
- Debug cross-project governance execution more easily

🤖 Generated with [Claude Code](https://claude.com/claude-code)