### PR TITLE
fix(governance): 修正标签生命周期管理，明确职责边界

### DIFF
--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -62,7 +62,9 @@ Allowed:
 - `issue.close`: 允许直接关闭 issue（仅限高置信度场景，见下方说明）
 - `issue.create`: 允许创建 follow-up issue（处理未完成工作）
 - `labels.read`: 读取所有 labels
-- `labels.write`: 仅限非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`）
+- `labels.write`: 允许设置和移除非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`、`orchestra-scanned`）
+  - **设置**：决策后的标签添加（如 `roadmap/rfc`、`roadmap/epic`、`priority/*`、`orchestra-governed`）
+  - **移除**：标签验证失败时的清理（如移除过时的 `orchestra-governed`、`roadmap/rfc`）
 - `flow`: read（读取 flow/worktree 现场信息）
 - `task`: read（读取 task 状态）
 - `handoff`: read（读取交接上下文）
@@ -121,6 +123,76 @@ Forbidden:
 - orchestra heartbeat status
 - epic issues（有 `roadmap/epic` 标签的 open issue，用于收口检查）
 - epic sub-issues 状态（通过 `gh issue view <number> --json state,stateReason,labels` 查询）
+
+## 标签验证与清理（强制执行）
+
+**每次 scan 时必须先执行标签验证，确保治理标签的正确性**。
+
+### `orchestra-governed` 标签验证
+
+**验证条件**（必须同时满足）：
+- Issue 有 assignee
+- Assignee 在 `manager_usernames` 配置列表中
+- Issue 是 open 状态
+
+**验证失败处理**：
+```bash
+# 移除不合理的标签
+gh issue edit <issue-number> --remove-label "orchestra-governed"
+
+# 写清理评论
+gh issue comment <issue-number> --body "[governance auto-cleanup] 移除 orchestra-governed 标签：issue 不再满足持有条件（原因：无 assignee / assignee 非 manager / issue 已关闭）"
+```
+
+**记录到 Actions**：
+```
+Cleanup: #XXX removed orchestra-governed (no manager assignee)
+```
+
+### `roadmap/rfc` 标签验证
+
+**验证条件**（任一满足即应保留）：
+- Issue 涉及 `.claude/` 或 `.codex/` 目录（Level 0 阻塞）
+- Issue 需要人类讨论决定架构/产品方向（通过 issue 内容判断）
+
+**验证失败处理**：
+```bash
+# 移除过时的 RFC 标签
+gh issue edit <issue-number> --remove-label "roadmap/rfc"
+
+# 写清理评论
+gh issue comment <issue-number> --body "[governance auto-cleanup] 移除 roadmap/rfc 标签：issue 不再需要 RFC 讨论（原因：已不再涉及受限目录 / 架构决策已完成）"
+```
+
+**记录到 Actions**：
+```
+Cleanup: #XXX removed roadmap/rfc (restriction resolved)
+```
+
+### 执行时机
+
+**在 Step 1 过滤前必须先执行标签验证**：
+
+```bash
+# 伪代码流程
+for issue in all_open_issues:
+    if has_label(issue, "orchestra-governed"):
+        if not verify_governed_label(issue):
+            cleanup_governed_label(issue)
+    
+    if has_label(issue, "roadmap/rfc"):
+        if not verify_rfc_label(issue):
+            cleanup_rfc_label(issue)
+
+# 然后继续正常的过滤逻辑
+issues = filter_by_assignee_and_labels(issues)
+...
+```
+
+**目的**：
+- 防止标签永久残留导致过滤失效
+- 确保治理标签反映真实状态
+- 让过时 issue 能被重新处理
 
 ## Issue Intake 策略
 

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -41,10 +41,10 @@
 **触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
 
 **处理动作**：
-- 写 `[governance suggest]` comment：涉及 agent 权限配置目录，无法自动化执行
-- 添加 `roadmap/rfc` 标签
+- 写 `[governance suggest]` comment：建议标记 `roadmap/rfc`（涉及 agent 权限配置目录，无法自动化执行）
 - **禁止**纳入 assignee issue pool
 - 记录到 `Skipped`，原因为 `blocked: .claude/.codex directory permission issue`
+- **注意**：intake 只负责建议，标签实际添加由 roadmap decider 或 assignee-pool 执行
 
 **Level 1-3 审查框架详见 [../../supervisor/roadmap-common.md](../../supervisor/roadmap-common.md#三级审查框架)**。
 
@@ -247,7 +247,7 @@ Allowed:
 - `issue.close`: allowed（仅限 supervisor issues 高置信度场景，见 Supervisor Issue Intake）
 - `issue.create`: allowed（仅限 supervisor issues 关闭前创建 follow-up issue，处理未完成工作）
 - `labels.read`: read
-- `labels.write`: allowed（仅最小必要的 routing 调整；只设 `orchestra-scanned`（跳过时）；不设 `roadmap/*`、`priority/*` 标签）
+- `labels.write`: allowed（仅最小必要的 routing 调整；只设 `orchestra-scanned`（跳过时）；**禁止设置 `roadmap/*`、`priority/*` 标签**，这些由 assignee-pool 或 roadmap decider 决策执行）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
 - `state/labels.write`: allowed（仅限 supervisor issues：移除 `state/ready` 并补 `state/handoff`，确保单一 state label）


### PR DESCRIPTION
## 问题

### 问题1：roadmap-intake Permission Contract 矛盾
- **行250禁止**：`不设 roadmap/*、priority/* 标签`
- **行44-46要求**：Level 0 添加 `roadmap/rfc` 标签
- **后果**：Agent 无法同时遵守两个规则，Level 0 逻辑无法正确执行

### 问题2：assignee-pool 只决策不验证
**缺失的验证环节导致标签永久残留**：

- `orchestra-governed` 标签：assignee 被移除后仍存在 → issue 永久被过滤
- `roadmap/rfc` 标签：问题已修改不再涉及 `.claude/`，但标签仍存在 → issue 永久被标记为"需要 RFC"

### 问题3：治理标签的生命周期不完整
**只有"设置"，没有"清理"**：
```
orchestra-scanned: 设置✓ 清理❌
orchestra-governed: 设置✓ 清理❌  
roadmap/rfc: 设置✓ 清理❌
```

## 解决方案

### 修正1：明确 roadmap-intake 职责边界
- **只负责建议和设定 assignee**，不做决策执行
- Level 0 只写建议评论，不直接添加 `roadmap/rfc` 标签
- 明确禁止设置 `roadmap/*`、`priority/*` 标签（由 assignee-pool 决策执行）

### 修正2：扩展 assignee-pool 职责，增加标签验证与清理
- 新增"标签验证与清理（强制执行）" section
- 每次 scan 前必须先验证标签正确性
- `orchestra-governed` 验证：必须有 manager assignee 且 open
- `roadmap/rfc` 验证：必须仍涉及受限目录或需要 RFC 讨论
- 验证失败自动清理标签并写评论

### 修正3：补全标签生命周期
- Permission Contract 明确允许"设置"和"移除"操作
- 在过滤前先执行标签验证和清理
- 防止标签永久残留

## 测试计划

- [ ] 验证 roadmap-intake 不再直接设置 `roadmap/rfc` 标签
- [ ] 验证 assignee-pool 能正确验证和清理过时标签
- [ ] 验证过滤逻辑不会被残留标签阻塞
- [ ] 验证过时 issue 能被重新处理

## 后续工作

需要在 `src/vibe3/roles/governance_utils.py` 增加验证函数实现：
- `verify_governed_label(issue, config)` - 验证 orchestra-governed 标签合理性
- `verify_rfc_label(issue)` - 验证 roadmap/rfc 标签合理性
- 在 `build_broader_repo_entries()` 调用验证逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)