### PR TITLE
feat(governance): close Level 0 roadmap/rfc loop + label lifecycle

### DIFF
--- a/docs/governance/governance-roadmap-closed-loop.md
+++ b/docs/governance/governance-roadmap-closed-loop.md
@@ -34,8 +34,8 @@ Issue 创建（无 assignee，无标签）
   |- 无 assignee? -> 跳过（不在 pool）
   |- 有 orchestra-governed? -> 跳过
   |- 有 assignee、无 governed -> 决策
-       |- roadmap/rfc -> 跳过执行，等人类决策
-       |- roadmap/epic -> 跳过执行，需拆分
+       |- roadmap/rfc -> 不进 ready，等人类决策（标签是信号，非执行门禁）
+       |- roadmap/epic -> 不进 ready，需拆分
        |- state/ready -> 可执行
        |- 建议关闭
        打完标签后 -> 打 orchestra-governed --> 不再看
@@ -56,6 +56,31 @@ Issue 创建（无 assignee，无标签）
 | **打标签** | 只对跳过的打 `orchestra-scanned` | 对所有决策完的打 `orchestra-governed` |
 | **不打的含义** | 接受 -> assignee 是信号 -> 流入 pool | 无——所有决策完都打 |
 | **过滤例外** | 无 | `roadmap/epic` 收口检查独立扫描所有 epic，不受 governed 过滤 |
+
+---
+
+## roadmap/rfc 语义与 Level 0 闭环
+
+### roadmap/rfc 是人类规划信号，不是执行门禁
+
+自动执行的真正门禁是 **manager assignee + `state/ready`**：orchestra 派发队列恒定 `require_manager_assignee=True`（见 `src/vibe3/orchestra/queue_operations.py`），并要求 state 进入 ready。`roadmap/rfc` 本身**不被派发队列消费**，它是给人类规划层和治理 scan 过滤用的可见性信号，语义为"需要人类设计决策"。
+
+推论：一个 issue 只要没有 manager assignee + ready，就不会被自动执行，无论是否带 `roadmap/rfc`。因此对**人类 assignee** 的 issue 而言，`roadmap/rfc` 不充当门禁，但仍作为"需设计讨论"的可查询规划信号保留其价值。
+
+### Level 0 闭环：intake 直接打 roadmap/rfc
+
+`.claude/` / `.codex/` 目录改动（Level 0）是**机械可判定**的硬阻塞，自动化无法修改这些目录。intake 在 skip 该类 issue 时，除打 `orchestra-scanned` 外，**直接打 `roadmap/rfc`**——这是 intake 唯一允许设置 `roadmap/*` 的机械例外（非 intake 自称 decider，而是路由一个确定性硬阻塞）。
+
+闭环路径（不经过 pool，因为 Level 0 issue 无 assignee，pool 只扫 has-assignee）：
+
+```
+intake 检测 Level 0 -> 打 orchestra-scanned + roadmap/rfc（无 assignee）
+   -> task status Rule 1（roadmap/rfc「始终展示」，不管 assignee）
+   -> /vibe-task surface 给人类
+   -> 人类决策（分配 assignee / 移除 roadmap/rfc / 关闭）
+```
+
+**为什么必须由 intake 打**：[task-status-filtering.md](../v3/orchestra/task-status-filtering.md) 的 Rule 4 会把"无 state + 无 assignee"的 issue 隐藏（SKIP）。若 intake 只写 suggest 而不打 `roadmap/rfc`，Level 0 issue 会落入 Rule 4 被永久隐藏；pool 又只扫 has-assignee，永远看不到它。只有 intake 直接打 `roadmap/rfc` 命中 Rule 1 才能让它可见、被 vibe-task 捡起。`roadmap/rfc` 的后续清理由 vibe-roadmap（Layer 3，两个群体都可见）或人类（经 vibe-task）负责；**pool 不清理 `roadmap/rfc`**——pool 只清理自己域内的 `orchestra-governed`。
 
 ---
 
@@ -80,6 +105,7 @@ Issue 创建（无 assignee，无标签）
 - [x] 扫描前过滤：跳过有 `orchestra-scanned`、`orchestra-governed`（防御）或有 assignee 的 issue
 - [x] 接受（分配 assignee）：不设 scanned 标签，自然流入 pool
 - [x] 跳过（不接受）：打 `orchestra-scanned` 标签
+- [x] Level 0（`.claude/`/`.codex/`）skip：除 `orchestra-scanned` 外**直接打 `roadmap/rfc`**（机械例外），让 task-status Rule 1 始终展示、vibe-task 可捡起
 - [x] Stop Point Checklist 区分接受/跳过两种情况
 
 ### Layer 2: assignee-pool

--- a/skills/vibe-orchestra/SKILL.md
+++ b/skills/vibe-orchestra/SKILL.md
@@ -131,7 +131,7 @@ vibe3 task show <issue-number>
 ```
 
 审查要点（参考 roadmap-intake 三级框架）：
-- Level 0: 是否涉及 `.claude/` 或 `.codex/`（权限问题）→ 跳过
+- Level 0: 是否涉及 `.claude/` 或 `.codex/`（权限问题）→ 跳过并打 `roadmap/rfc`（机械阻塞，需人类；与自动 intake 一致，见 Step 6）
 - Level 1: 问题是否明确？范围是否可控？
 - Level 2: 架构是否仍相关？引用的代码/文档是否存在？
 - Level 3: 是否过时/重复？是否有未完成工作？
@@ -154,6 +154,12 @@ gh issue edit <issue-number> --add-label "orchestra-scanned"
 
 # 写跳过原因
 gh issue comment <issue-number> --body "[governance suggest] Skipped: <原因>"
+```
+
+**跳过 Level 0（`.claude/`/`.codex/` 机械阻塞）**：除 `orchestra-scanned` 外**直接打 `roadmap/rfc`**（与 roadmap-intake 的机械例外一致）。Level 0 issue 无 assignee，pool 扫不到；只有 `roadmap/rfc` 能命中 task-status Rule 1 被 `/vibe-task` surface，否则永久隐藏。
+```bash
+gh issue edit <issue-number> --add-label "orchestra-scanned" --add-label "roadmap/rfc"
+gh issue comment <issue-number> --body "[governance suggest] Skipped: 涉及 .claude/.codex 权限配置，机械阻塞需人类决策（已打 roadmap/rfc 供 /vibe-task surface）"
 ```
 
 **关闭过时 issue**：
@@ -229,13 +235,13 @@ Agent:
 Agent:
   1. 运行 vibe3 task show 456
   2. 发现 Level 0 检查失败（涉及 .claude/ 目录）
-  3. 建议："跳过，涉及权限配置，打 orchestra-scanned"
+  3. 建议："跳过，涉及权限配置，打 orchestra-scanned + roadmap/rfc（机械阻塞，需人类）"
 
 用户: 确认跳过
 Agent:
-  1. 执行 gh issue edit 456 --add-label "orchestra-scanned"
+  1. 执行 gh issue edit 456 --add-label "orchestra-scanned" --add-label "roadmap/rfc"
   2. 写 [governance suggest] comment 说明原因
-  3. 确认完成
+  3. 确认完成（roadmap/rfc 让 /vibe-task 后续可 surface 给人类）
 ```
 
 ## Stop Point

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-roadmap
-description: Use when the user wants project-level roadmap planning, version goals, or backlog triage. Do not use for assignee pool governance or single-flow execution.
+description: Use when the user wants project-level roadmap planning, version goals, backlog triage, or to review and correct assignee-pool's automated roadmap/priority/rfc decisions. Do not use for entry intake/assignment (use vibe-orchestra) or single-flow execution.
 ---
 
 # /vibe-roadmap - 版本规划与 Backlog Triage
@@ -20,11 +20,12 @@ description: Use when the user wants project-level roadmap planning, version goa
 - Issue 分类与 milestone 分配
 - Roadmap/priority labels 设置
 - Backlog triage（哪些 issue 进入规划）
+- **对标 assignee-pool**：审查并纠正其自动决策（`roadmap/*`、`priority/*`、rfc/split 的错漏），作为 pool 的人类纠偏层（可 override pool 的决策）
 
 **不做**：
-- 执行层管理（由 `vibe-orchestra` 负责）
-- RFC issues 处理（由 `vibe-task` 负责）
-- Blocked issues 处理（由 `vibe-task` 负责）
+- 入口 intake 与 serve 监控（由 `vibe-orchestra` 负责，对标 `roadmap-intake`）
+- 单 flow 执行
+- RFC/blocked 的只读 surface 提醒（由 `vibe-task` 负责）——但 vibe-roadmap **可纠正** pool 对 rfc 的决策（见上）
 
 ## Workflow
 
@@ -87,13 +88,13 @@ RFC (需讨论)
 
 ## 与其他 Skills 的区别
 
-- **vibe-roadmap**: 版本规划和 backlog triage
-- **vibe-orchestra**: assignee issue pool 管理（运行中的 issues）
-- **vibe-task**: RFC 和 blocked issues 检查（问题 issue）
+- **vibe-roadmap**: 版本规划 + 纠正 assignee-pool 的自动决策（pool 的人类对标）
+- **vibe-orchestra**: 入口 intake（筛 broader repo 打 assignee）+ serve 监控（roadmap-intake 的人类对标）
+- **vibe-task**: surface RFC/blocked，提请人类关注（只读，不做决策）
 
 ## Restrictions
 
-- 不处理执行层管理
-- 不看 RFC 或 blocked issues（转给 `vibe-task`）
+- 不处理入口 intake / serve 监控（由 `vibe-orchestra` 负责）
+- 不做 RFC/blocked 的只读 surface（由 `vibe-task` 负责）；但可纠正 pool 的 rfc/决策
 - 不根据当前 runtime 现场做即时抢占排序（由 `vibe-orchestra` 负责）
 - 所有操作通过 GitHub labels，不在本地存储

--- a/skills/vibe-task/SKILL.md
+++ b/skills/vibe-task/SKILL.md
@@ -75,9 +75,11 @@ Blocked Issues (有依赖阻塞)
 
 ## 与其他 Skills 的区别
 
-- **vibe-task**: 看 RFC 和 blocked issues（问题 issue）
-- **vibe-orchestra**: 管理 assignee issue pool（运行中的 issues）
-- **vibe-roadmap**: 版本规划和 backlog triage（规划）
+- **vibe-task**: 只读 surface RFC/blocked（提请人类关注，不做决策）
+- **vibe-orchestra**: 入口 intake（筛选打 assignee）+ serve 监控
+- **vibe-roadmap**: 版本规划 + 纠正 assignee-pool 决策（含 rfc 的 override）
+
+**职责分工**：vibe-task 只**发现并提请**（rfc/blocked）；真正的**决策/纠正**去 vibe-roadmap（rfc/roadmap）或 vibe-orchestra（assign/入池）。Level 0 issue 由 intake/vibe-orchestra 打上 `roadmap/rfc` 后，vibe-task 通过 task-status Rule 1 自动 surface。
 
 ## Restrictions
 

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -62,7 +62,10 @@ Allowed:
 - `issue.close`: 允许直接关闭 issue（仅限高置信度场景，见下方说明）
 - `issue.create`: 允许创建 follow-up issue（处理未完成工作）
 - `labels.read`: 读取所有 labels
-- `labels.write`: 仅限非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`）
+- `labels.write`: 非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`）
+  - **设置**：决策后打标签（如 `roadmap/rfc`、`roadmap/epic`、`priority/*`、`orchestra-governed`）
+  - **移除**：仅限 `orchestra-governed` 的验证清理（见「标签验证与清理」）
+  - **不移除 `roadmap/rfc`**：rfc 的清理是人类/vibe-roadmap 职责，不在 pool
 - `flow`: read（读取 flow/worktree 现场信息）
 - `task`: read（读取 task 状态）
 - `handoff`: read（读取交接上下文）
@@ -121,6 +124,46 @@ Forbidden:
 - orchestra heartbeat status
 - epic issues（有 `roadmap/epic` 标签的 open issue，用于收口检查）
 - epic sub-issues 状态（通过 `gh issue view <number> --json state,stateReason,labels` 查询）
+
+## 标签验证与清理（强制执行）
+
+**每次 scan 时，在 Step 1 过滤前，必须先验证 `orchestra-governed` 标签的正确性**，防止标签永久残留导致 issue 被过滤后无法被重新处理。
+
+### `orchestra-governed` 标签验证
+
+**验证条件**（必须全部满足，否则标签过时）：
+- Issue 有 assignee
+- Assignee 在 `manager_usernames` 配置列表中
+- Issue 是 open 状态
+
+**验证失败处理**：
+
+```bash
+gh issue edit <issue-number> --remove-label "orchestra-governed"
+gh issue comment <issue-number> --body "[governance auto-cleanup] 移除 orchestra-governed：issue 不再满足持有条件（无 assignee / assignee 非 manager / 已关闭），允许重新进入评估"
+```
+
+记录到 Actions：`Cleanup: #XXX removed orchestra-governed (no manager assignee)`
+
+### pool 不清理 `roadmap/rfc`
+
+pool **不**验证或移除 `roadmap/rfc`。原因：
+- pool 只扫 has-assignee；Level 0 的 no-assignee rfc 它根本看不到。
+- 移除 `roadmap/rfc` 是"该 issue 不再需要人类设计决策"的判断，属 vibe-roadmap（Layer 3，两个群体都可见）或人类（经 /vibe-task），不是 pool 的自动动作。
+- pool 误删 rfc 会把真正需要人类的 issue 重新放回自动流。
+
+### 执行时机
+
+在 Execution Pattern 的 Step 1（标签过滤）**之前**先跑本验证：
+
+```
+for issue in all_open_issues_with_orchestra_governed:
+    if not (has_assignee and assignee in manager_usernames and is_open):
+        remove orchestra-governed + write [governance auto-cleanup] comment
+# 然后才进入 Step 1 的正常过滤
+```
+
+**目的**：防止标签永久残留导致过滤失效；让 assignee 漂移/决策半完成的 issue 能被重新处理。
 
 ## Issue Intake 策略
 
@@ -284,6 +327,7 @@ pool 扫描有 assignee 的 issue →
 
 Steps:
 
+0. **标签验证（强制，先于过滤）**：先执行「标签验证与清理」段——校验所有带 `orchestra-governed` 的 open issue 是否仍满足持有条件，不满足则移除并写 cleanup comment。然后才进入下面的标签过滤。
 1. **标签过滤（强制）**：只处理有 manager assignee 但无 `orchestra-governed` 标签的 issue：
    - 无 assignee → 跳过（不在 pool 中，由 roadmap-intake 负责）
    - 有 `orchestra-governed` 标签 → 跳过（pool 已决策过，不重复检查）

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -46,6 +46,8 @@
 - **禁止**纳入 assignee issue pool
 - 记录到 `Skipped`，原因为 `blocked: .claude/.codex directory permission issue`
 
+**为什么 intake 直接打 `roadmap/rfc`**：Level 0 issue 被 skip 后无 assignee，assignee-pool 只扫 has-assignee 永远看不到它。只有 intake 此刻打 `roadmap/rfc` 才能命中 task-status Rule 1（始终展示）被 /vibe-task surface；否则落入 Rule 4（无 state 无 assignee）被永久隐藏。这是 intake 唯一允许设 `roadmap/*` 的机械例外。
+
 **Level 1-3 审查框架详见 [../../supervisor/roadmap-common.md](../../supervisor/roadmap-common.md#三级审查框架)**。
 
 ### 决策逻辑
@@ -98,7 +100,7 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
 - 依赖未就绪 → suggest 中说明等待依赖
 
 **intake 不设以下标签**（属于 assignee-pool 层决策范围）：
-- `roadmap/rfc`、`roadmap/epic`（**例外**：Level 0 检查阻塞时，intake 需要添加 `roadmap/rfc` 标签以路由该 issue）
+- `roadmap/rfc`、`roadmap/epic`（**唯一例外**：Level 0 机械阻塞时 intake 直接打 `roadmap/rfc` 路由该 issue；其余 rfc 判断属 pool）
 - `roadmap/p0`、`roadmap/p1`、`roadmap/p2`
 - `priority/*`
 
@@ -247,7 +249,10 @@ Allowed:
 - `issue.close`: allowed（仅限 supervisor issues 高置信度场景，见 Supervisor Issue Intake）
 - `issue.create`: allowed（仅限 supervisor issues 关闭前创建 follow-up issue，处理未完成工作）
 - `labels.read`: read
-- `labels.write`: allowed（仅最小必要的 routing 调整；只设 `orchestra-scanned`（跳过时）；不设 `roadmap/*`、`priority/*` 标签）
+- `labels.write`: allowed（routing 标签）：
+  - 跳过时设 `orchestra-scanned`
+  - **唯一 `roadmap/*` 例外**：Level 0（`.claude/`/`.codex/`）机械阻塞 skip 时，**直接打 `roadmap/rfc`**（路由确定性硬阻塞，使其命中 task-status Rule 1 被 /vibe-task surface）
+  - 除该例外外，**禁止**设置 `roadmap/*`、`priority/*` 标签（由 assignee-pool 或 roadmap decider 决策执行）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
 - `state/labels.write`: allowed（仅限 supervisor issues：移除 `state/ready` 并补 `state/handoff`，确保单一 state label）

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -66,6 +66,7 @@ broader repo --> Layer 1: roadmap-intake (入口层)
 **谁打**：roadmap-intake
 **何时打**：审查后**决定不接受**（不分配 assignee）时
 **不打的情况**：接受并分配 assignee 时——assignee 本身就是信号，issue 自然流入 assignee-pool
+**Level 0 联动**：`.claude/`/`.codex/` 机械阻塞 skip 时，除 `orchestra-scanned` 外**同时打 `roadmap/rfc`**，使其命中 task-status Rule 1 被 `/vibe-task` surface（详见 [governance-roadmap-closed-loop.md](../docs/governance/governance-roadmap-closed-loop.md) 的 "Level 0 闭环"）
 
 **语义**："已审查，不纳入"（intake 层的结论，后续层可推翻）
 
@@ -215,10 +216,10 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 ### Roadmap Intake（入口层）
 
 **决策范围**：**只决定 accept（分配 assignee）或 skip（打 scanned）**
-**检查**：生命周期、依赖、API、模块
+**检查**：生命周期、依赖、API、模块（含 Level 0：`.claude/`/`.codex/` 目录机械检查）
 **输出**：`[governance suggest]` 建议纳入或跳过，附带原因
-**标签**：不设 `roadmap/*`、`priority/*` 标签
-**边界**：intake 不自称 decider；跳过原因写在 suggest 中，由 pool 或 roadmap 做进一步决策
+**标签**：不设 `roadmap/*`、`priority/*` 标签。**唯一例外**——Level 0 机械阻塞 skip 时直接打 `roadmap/rfc`：这是路由一个确定性硬阻塞（diff 是否碰 `.claude/`/`.codex/`，yes/no 机械可判），不是 intake 自称 decider。理由：Level 0 issue 无 assignee，pool 永远扫不到；只有 intake 打 `roadmap/rfc` 才能命中 task-status Rule 1 被 `/vibe-task` surface（否则落入 Rule 4 永久隐藏）。
+**边界**：intake 不自称 decider；除 Level 0 机械例外外，跳过原因写在 suggest 中，由 pool 或 roadmap 做进一步决策
 
 ### Assignee Pool（池内决策层）
 


### PR DESCRIPTION
## Summary

- 修复 **Level 0**（`.claude/`/`.codex/`）issue 的 `roadmap/rfc` 闭环缺口：intake skip 时**直接打 `roadmap/rfc`**（机械例外），命中 task-status Rule 1 被 `/vibe-task` surface；否则落入 Rule 4（无 state 无 assignee）永久隐藏，pool 又只扫 has-assignee 永远看不到。
- 明确 **`roadmap/rfc` 是人类规划信号，不是执行门禁**——真正门禁是 manager-assignee + `state/ready`，orchestra 派发队列（`queue_operations.py` 恒定 `require_manager_assignee=True`）不消费 `roadmap/rfc`。
- 补全 assignee-pool 的 **`orchestra-governed` 验证清理**（限 has-assignee）；**pool 不清理 `roadmap/rfc`**（归 vibe-roadmap/人类）。
- 对齐人机 skill 与治理材料职责：**vibe-orchestra ↔ intake**（入口筛选+assign+serve 监控）、**vibe-roadmap ↔ pool**（纠正自动决策）、**vibe-task** 只读 surface RFC/blocked。

## 设计依据（决定性）

`docs/v3/orchestra/task-status-filtering.md`：Rule 1（`roadmap/rfc` 始终展示，不管 assignee）vs Rule 4（无 state 无 assignee → 隐藏）。Level 0 issue 无 assignee，唯有 intake 直接打 `roadmap/rfc` 才能让它可见 → 这是唯一能闭环的方案。新 repo 冷启动靠现有 `vibe3 scan governance` 跑修正后的材料建立标签基线，**无需新命令**。

## Changes

- **P1（docs + skills）** `84811ec8`：closed-loop.md、roadmap-common.md、vibe-orchestra/roadmap/task SKILL
- **P2（治理材料 / scan prompts）** `39247df7`：roadmap-intake.md（permission contract 例外一致性）、assignee-pool.md（orchestra-governed 验证清理）

## 关联决策

- 替代并关闭了 #1596（其"intake 停打 roadmap/rfc、交给 pool"方向会破坏 Level 0 可见性——pool 看不到 no-assignee）
- 基于已合并的 #1599（vibe-orchestra 手动 intake 入口）

## Test plan

- [x] 跨文件一致性人工核对（"pool 不清 roadmap/rfc" 在 closed-loop.md 与 assignee-pool.md 一致）
- [x] 纯 prompt 材料 + skill 文本，无代码改动
- [ ] CI：markdown / LOC 门禁
- [ ] 新 repo 冷启动实测：`sync-labels.sh` → `vibe3 scan governance` → Level 0 issue 拿到 `roadmap/rfc` → `/vibe-task` 可见

## 已知遗留（另开清理）

- assignee-pool.md 第 215-222 行决策流程图用了线框字符（预存于 `8a511c5b`，违反 HARD RULE 11），已 flag 作独立清理，不在本 PR 范围。

Closes #1595

## Contributors

- 设计 / P1 / Review：AI Agent (Claude Opus 4.7)
- P2 执行：AI Agent (vibe3 run executor)