### PR TITLE
refactor(environment): remove upward dependencies on services/orchestra

### DIFF
--- a/src/vibe3/environment/worktree.py
+++ b/src/vibe3/environment/worktree.py
@@ -20,7 +20,6 @@ from vibe3.exceptions import SystemError
 
 if TYPE_CHECKING:
     from vibe3.models.orchestra_config import OrchestraConfig
-    from vibe3.orchestra.flow_dispatch import FlowManager
 
 
 class WorktreeManager(WorktreePRMixin):
@@ -40,18 +39,15 @@ class WorktreeManager(WorktreePRMixin):
         self,
         config: "OrchestraConfig",
         repo_path: Path,
-        flow_manager: Optional["FlowManager"] = None,
     ):
         """Initialize WorktreeManager.
 
         Args:
             config: Orchestra configuration
             repo_path: Path to the main repository
-            flow_manager: Optional FlowManager for flow state binding
         """
         self.config = config
         self.repo_path = repo_path
-        self.flow_manager = flow_manager
         self.lifecycle = WorktreeLifecycle(config, repo_path)
 
     # --- Issue Worktree Methods (L3) ---

--- a/src/vibe3/environment/worktree_lifecycle.py
+++ b/src/vibe3/environment/worktree_lifecycle.py
@@ -21,10 +21,14 @@ from vibe3.environment.worktree_support import (
     recycle_worktree_path,
 )
 from vibe3.exceptions import SystemError
-from vibe3.services.status_query_service import is_auto_task_branch
 
 if TYPE_CHECKING:
     from vibe3.models.orchestra_config import OrchestraConfig
+
+
+def _is_auto_task_branch(branch: str) -> bool:
+    """Check if branch follows auto-managed task naming convention."""
+    return branch.startswith("task/issue-")
 
 
 class WorktreeLifecycle:
@@ -403,7 +407,7 @@ class WorktreeLifecycle:
                 ).error("Existing worktree branch name does not match issue number")
                 return None
             # Record worktree path for auto task branches only
-            if check_recorded_path and is_auto_task_branch(flow_branch):
+            if check_recorded_path and _is_auto_task_branch(flow_branch):
                 self.record_worktree_path(flow_branch, str(existing))
             return WorktreeContext(
                 path=existing,
@@ -416,7 +420,7 @@ class WorktreeLifecycle:
         try:
             ctx = acquire_issue_worktree_func(issue_number, flow_branch)
             # Record worktree path for auto task branches only
-            if check_recorded_path and is_auto_task_branch(flow_branch):
+            if check_recorded_path and _is_auto_task_branch(flow_branch):
                 self.record_worktree_path(flow_branch, str(ctx.path))
             return ctx
         except Exception as exc:


### PR DESCRIPTION
## Summary

Fix two layering violations in environment module:

1. **worktree_lifecycle.py → services/status_query_service**
   - Define `_is_auto_task_branch()` locally instead of importing
   - Function is a pure string check (`branch.startswith("task/issue-")`)
   - Update 2 call sites to use local version

2. **worktree.py → orchestra/flow_dispatch**
   - Remove unused `flow_manager` parameter from `WorktreeManager.__init__`
   - Zero callers pass this parameter (verified all 41 references)
   - Dead code removal, no functional change

## Verification

- ✅ All environment tests pass (29 tests)
- ✅ All affected services tests pass (27 tests)
- ✅ No upward imports remain (rg confirms clean)
- ✅ Type checking passes (mypy on environment/)
- ✅ No new lint issues

## Test Plan

- [x] Run environment tests: `pytest tests/vibe3/environment/`
- [x] Run services tests: `pytest tests/vibe3/services/`
- [x] Verify no upward imports: `rg "from.*services" src/vibe3/environment/`
- [x] Type check: `mypy src/vibe3/environment/`

Fixes #1581

---

## Contributors

claude/opus
