### PR TITLE
docs(governance): expand vibe-roadmap and vibe-task scope for Level 3 governance

### DIFF
--- a/docs/governance/governance-roadmap-closed-loop.md
+++ b/docs/governance/governance-roadmap-closed-loop.md
@@ -120,7 +120,7 @@ intake 检测 Level 0 -> 打 orchestra-scanned + roadmap/rfc（无 assignee）
 - [x] Step 0 过滤：跳过有 `roadmap-reviewed` 标签的 issue
 - [x] 审查完成：写 `[roadmap decision]` + 打 `roadmap-reviewed` 标签
 - [x] 结果写入 memory.md 缓存
-- [x] **推翻 intake skip 时**：移除 `orchestra-scanned` + 分配 assignee + 打 `roadmap-reviewed`（明示规则见 [`skills/vibe-roadmap/SKILL.md`](../../skills/vibe-roadmap/SKILL.md) Step 0 闭环要求第 6 项）
+- [x] **推翻 intake skip 时**：移除 `orchestra-scanned` + 分配 assignee + 打 `roadmap-reviewed`（明示规则见 [`skills/vibe-roadmap/SKILL.md`](../../skills/vibe-roadmap/SKILL.md) Step 0 第 5 步）
 
 ---
 

--- a/skills/vibe-debug-serve/SKILL.md
+++ b/skills/vibe-debug-serve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-debug-serve
-description: Use when checking whether a new vibe3 serve debugging round is ready, debugging vibe3 serve (orchestra server), inspecting agent execution logs in temp/logs/, diagnosing governance or manager chain failures, or identifying bugs in the heartbeat/dispatch pipeline. Do not use for flow/task metadata repair (use vibe-check) or issue pool governance (use vibe-orchestra).
+description: Use when checking orchestra service health, viewing serve running status, debugging vibe3 serve (orchestra server), checking whether a new serve debugging round is ready, inspecting agent execution logs in temp/logs/, diagnosing governance or manager chain failures, or identifying bugs in the heartbeat/dispatch pipeline. Triggered by "serve status", "orchestra service running", "FailedGate", "heartbeat", "serve health". Do not use for flow/task metadata repair (use vibe-check) or issue pool governance (use vibe-orchestra).
 ---
 
 # /vibe-debug-serve - vibe3 serve 自动化调试

--- a/skills/vibe-orchestra/SKILL.md
+++ b/skills/vibe-orchestra/SKILL.md
@@ -1,257 +1,113 @@
 ---
 name: vibe-orchestra
-description: Use when the user wants to manually review issues, assign issues to managers, or check orchestra service status. Human-collaboration entrypoint for issue pool governance and service monitoring.
+description: Use when the user wants heartbeat-style governance over the issue pool. inspect running issues, judge which issue is worth starting next, backfill assignee-triggered candidates, and propose non-state label or routing actions. Do not use for single-flow execution governance, coding, or implementation work.
 ---
 
-# /vibe-orchestra - Orchestra 服务监控与 Issue 治理入口
+# Vibe Orchestra
 
-人机协作的 orchestra 服务监控和 issue pool 治理入口。
+> 项目命令参考见 `skills/vibe-instruction/SKILL.md`
 
-## 核心原则
+`vibe-orchestra` 负责 orchestra 心跳层的 **assignee issue pool** 治理。它关心的范围仅限于 assignee issue pool：现在有哪些 issue 正在运行、哪些已满足 assignee 触发条件但尚未进入调度，以及在人机协作环节接下来哪个 assignee issue 值得优先处理。它不负责单 flow 执行，也不负责 broader repo backlog 的 triage。
 
-- **人机协作**：提供交互式 issue 治理，不自动执行
-- **基于真源**：只读 `vibe3 serve status` 和 `vibe3 task status` 输出
-- **手动决策**：用户决定是否分配 assignee 或添加标签
+## 概念区别
+
+- **governance**：无临时 worktree 的 scan agent，只观察和建议，不执行代码修改。
+- **supervisor/apply**：有临时 worktree 的治理执行 agent，负责实际治理执行动作。
+- **`supervisor/governance/assignee-pool.md`（原 orchestra.md）**：governance supervisor material，是 governance agent 的角色材料，不是 runtime orchestra 本体。
+- **runtime orchestra / governance supervisor material / supervisor apply 是三个独立概念，不可混淆。**
+
+优先级判断口径必须对齐 `supervisor/governance/assignee-pool.md`。可以把 `vibe-orchestra` 视为自动治理 supervisor 在人机协作环节的落地判断器：它不发明另一套优先级规则，只读取当前现场并按 supervisor 已定义的排序模型，指导人类如何找到下一个需要处理的 issue。
+
+术语、对象边界与触发分流以以下标准为准：
+
+- `docs/standards/glossary.md`
+- `docs/standards/action-verbs.md`
+- `docs/standards/v3/skill-standard.md`
+- `docs/standards/v3/command-standard.md`
+- `docs/standards/v3/python-capability-design.md`
+- `docs/standards/v3/worktree-lifecycle-standard.md`
+- `docs/standards/v3/skill-trigger-standard.md`
 
 ## Scope
 
-**两大职责**：
+`vibe-orchestra` 只回答两类问题，且均以 **assignee issue pool** 为前提：
 
-### 1. Service 监控
-- serve 运行状态（running/stopped）
-- FailedGate 检查
-- error_log 分析
-- heartbeat 状态
-- dispatcher 状态
-- 最近活动和事件
+- assignee issue pool 中现在有哪些 issue 正在运行
+- 在当前现场下，assignee issue pool 中接下来哪个 issue 值得建议优先处理
 
-### 2. Issue Pool 治理（手动）
-- 查看 assignee issue pool 状态
-- 扫描候选 issue（无 assignee 的 open issues）
-- 手动分配 issue 给 manager bot
-- 添加治理标签（如 `orchestra-scanned`）
-- 关闭明显过时的 issue
+这里的"建议 issue"只是参考，不是强制调度结果；最终仍需结合 flow / PR / 人类当前上下文判断。
 
-**不做**：
-- 自动化 issue triage（由 `vibe scan governance -r roadmap-intake` 负责）
-- 版本规划（由 `vibe-roadmap` 负责）
-- RFC issues 处理（由 `vibe-task` 负责）
+补充说明：
 
-## Workflow
+- assignee 是启动事实源
+- `state/*` label 只反映 flow 实际状态，不是主触发源
+- 常驻 server 与定时巡检只是运行模式差异，不改变本 skill 的职责边界
+- 自动 ready queue 的建议顺序按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 理解，仅作用于 assignee issue pool 内部
+- 人机协作时，若某个 assignee issue 已被人类明确接手、已有活跃 PR、或当前上下文要求先收口 follow-up，可临时覆盖自动顺序，但必须说明理由
+- **不处理 supervisor issue，也不对 broader repo backlog 做 triage**
 
-### Part 1: Service 监控
+## What It Reads
 
-#### Step 1: 查看 serve 状态
+以下观察面均以 **assignee issue pool** 为范围：
 
-```bash
-vibe3 serve status
-```
+- running issues（assignee issue pool 中正在运行的 issue）
+- assignee issue pool 中尚未启动但可被考虑的候选 issues
+- `uv run python src/vibe3/cli.py task status` 中 assignee issue 的 active / ready / blocked 现场与 ready queue rank
+- 当前是否已有人工明确接手的 assignee issue / PR follow-up / review 收口上下文
+- assignee 与 queue / flow 现场事实
+- assignee issue pool 中 issue 的 state labels
+- dependency information such as blocked_by
+- orchestra heartbeat status 与相关文档
+- `supervisor/governance/assignee-pool.md` 中的 queue guidance 与治理边界
 
-#### Step 2: 解析状态
+## What It Produces
 
-从输出中提炼：
+- running issues summary
+- backfill candidates summary
+- next-issue recommendation
+- ready queue ordering judgment
+- 最小 non-state label actions 或 routing suggestions
+- start / wait / defer recommendations with short reasons
 
-**运行状态**：
-- Service 状态（running/stopped）
-- PID 信息
-- Port 绑定
-- Uptime
+## Hard Boundary
 
-**错误检查**：
-- FailedGate 是否存在
-- error_log 内容
-- 系统错误
+- 不负责 task registry 或 task 数据质量审计
+- 不负责 runtime 绑定修复
+- 不负责 roadmap 规划或版本目标
+- 不负责 GitHub issue intake、模板补全或查重
+- 不负责单个 flow 的 plan / run / review
+- 不负责决定单个 issue 一定要先 plan、run、review 还是直接人工操作
+- 不负责把 `state/*` label 当作启动执行的主驱动
+- 不负责写代码
+- 不负责替代人类做最终业务优先级拍板；它只给出基于 supervisor 语义和当前现场的建议
+- 不负责 orchestra service 运行健康监控（转给 `vibe-debug-serve`）
 
-**最近活动**：
-- Heartbeat 时间
-- Dispatcher 状态
-- 最近事件
+当请求跨出这些边界时，按 `docs/standards/v3/skill-trigger-standard.md` 分流，不在本 skill 中重写职责矩阵。
 
-#### Step 3: 报告问题
+## Execution Pattern
 
-```text
-📋 Orchestra Service 状态
+1. 查看当前 assignee issue pool 中的 running issues 与 queue / flow 现场
+2. 补捞 assignee issue pool 中已满足 assignee 条件但尚未进入调度的候选 issue
+3. 判断 assignee issue pool 中是否已经存在足够明确的执行现场
+4. 参考 `supervisor/governance/assignee-pool.md`，按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 对 assignee issue pool 的自动 ready queue 做人机治理判断
+5. 结合当前人工上下文，识别 assignee issue pool 中哪些 issue 虽然不在自动顺位最前，但更适合现在先处理
+6. 如有必要，提出最小 non-state label 调整建议（仅作用于 assignee issue pool 内）
+7. 在治理结论处停止
 
-运行状态
-- Status: running
-- PID: 12345
-- Port: 8765
-- Uptime: 2 hours
+## Output Contract
 
-健康检查
-- FailedGate: None ✅
-- Error Log: Empty ✅
-- Heartbeat: Normal ✅
+输出至少包含：
 
-最近活动
-- Last Heartbeat: 2026-05-28 23:20:00
-- Dispatcher: Active
-- Recent Events: 3 (last hour)
+- `Running issues`
+- `Backfill candidates`
+- `Next issue`
+- `Why this one now`
+- `Label actions`
+- `Why`
 
-建议
-- Service 运行正常，无错误
-```
-
-**常见问题处理**：
-
-**FailedGate 存在**：
-```bash
-vibe3 serve resume --reason "clear FailedGate"
-```
-
-**Service stopped**：
-```bash
-vibe3 serve start
-```
-
-### Part 2: Issue Pool 治理（手动）
-
-#### Step 4: 查看 assignee pool 状态
-
-```bash
-vibe3 task status
-```
-
-解析输出：
-- Ready queue: 待执行 issues
-- Blocked queue: 阻塞 issues
-- Active flows: 活跃开发流程
-- Remote tasks: 远端仓库任务
-
-#### Step 5: 扫描候选 issues
-
-**查询候选**（无 assignee 的 open issues）：
-```bash
-gh issue list --state open --json number,title,assignee,labels --jq '.[] | select(.assignee == null) | select(.labels | any(.name == "orchestra-scanned") | not)'
-```
-
-**逐个审查**：
-```bash
-vibe3 task show <issue-number>
-```
-
-审查要点（参考 roadmap-intake 三级框架）：
-- Level 0: 是否涉及 `.claude/` 或 `.codex/`（权限问题）→ 跳过并打 `roadmap/rfc`（机械阻塞，需人类；与自动 intake 一致，见 Step 6）
-- Level 1: 问题是否明确？范围是否可控？
-- Level 2: 架构是否仍相关？引用的代码/文档是否存在？
-- Level 3: 是否过时/重复？是否有未完成工作？
-
-#### Step 6: 手动分配 assignee
-
-**接受 issue**：
-```bash
-# 分配给 manager bot
-gh issue edit <issue-number> --add-assignee "@vibe-manager-agent"
-
-# 写简短 intake 说明
-gh issue comment <issue-number> --body "[governance] Intake: assigned to @vibe-manager-agent (manager-pool); scope=<bugfix/feature/refactor>."
-```
-
-**跳过 issue**：
-```bash
-# 打 orchestra-scanned 标签
-gh issue edit <issue-number> --add-label "orchestra-scanned"
-
-# 写跳过原因
-gh issue comment <issue-number> --body "[governance suggest] Skipped: <原因>"
-```
-
-**跳过 Level 0（`.claude/`/`.codex/` 机械阻塞）**：除 `orchestra-scanned` 外**直接打 `roadmap/rfc`**（与 roadmap-intake 的机械例外一致）。Level 0 issue 无 assignee，pool 扫不到；只有 `roadmap/rfc` 能命中 task-status Rule 1 被 `/vibe-task` surface，否则永久隐藏。
-```bash
-gh issue edit <issue-number> --add-label "orchestra-scanned" --add-label "roadmap/rfc"
-gh issue comment <issue-number> --body "[governance suggest] Skipped: 涉及 .claude/.codex 权限配置，机械阻塞需人类决策（已打 roadmap/rfc 供 /vibe-task surface）"
-```
-
-**关闭过时 issue**：
-```bash
-gh issue close <issue-number> --comment "关闭理由：<具体理由>"
-```
-
-## 交互式决策流程
-
-**用户主导**：
-1. 用户询问："帮我看看有哪些 issue 可以分配"
-2. Agent 扫描候选 issues 并展示
-3. 用户选择："issue #123 看起来可以分配"
-4. Agent 执行三级审查并报告："issue #123 通过三级审查，建议分配给 vibe-manager-agent"
-5. 用户确认："好的，分配吧"
-6. Agent 执行分配并写 comment
-
-**不自动执行**：
-- ❌ 不主动触发 governance scan
-- ❌ 不批量处理所有 issues
-- ❌ 不绕过用户确认直接分配
-
-## 与其他 Skills 的区别
-
-| Skill | 职责 | 触发方式 | 自动化程度 |
-|-------|------|---------|-----------|
-| **vibe-orchestra** | Service 监控 + 手动 issue 治理 | 交互式 | 人机协作 |
-| **vibe scan governance -r roadmap-intake** | 自动化 issue triage | 定时/手动触发 | 全自动 |
-| **vibe-task** | Task/flow 状态查看 | 只读查询 | - |
-| **vibe-roadmap** | 版本规划和 backlog triage | 交互式 | 人机协作 |
-| **vibe-debug-serve** | 深度调试 service 问题 | 交互式 | 人机协作 |
-
-**与 roadmap-intake 的关键区别**：
-- `roadmap-intake`：自动化扫描 + 批量处理 + 最小动作
-- `vibe-orchestra`：手动扫描 + 单个处理 + 用户确认
-
-## 使用场景
-
-### 场景 1: 检查 serve 健康状态
-```
-用户: vibe-orchestra
-Agent: 
-  1. 运行 vibe3 serve status
-  2. 解析并展示运行状态、错误、活动
-  3. 如有 FailedGate，建议清除方法
-```
-
-### 场景 2: 手动分配 issue
-```
-用户: 帮我看看 issue pool 里有哪些可以分配的 issue
-Agent:
-  1. 运行 vibe3 task status 查看 pool 状态
-  2. 扫描无 assignee 的 open issues
-  3. 展示候选列表（标题、简要描述）
-  4. 等待用户选择
-
-用户: issue #123 看起来不错，帮我审查一下
-Agent:
-  1. 运行 vibe3 task show 123
-  2. 执行三级审查（Level 0-3）
-  3. 报告审查结果："通过三级审查，建议分配"
-
-用户: 好的，分配吧
-Agent:
-  1. 执行 gh issue edit 123 --add-assignee "@vibe-manager-agent"
-  2. 写 [governance] comment
-  3. 确认完成
-```
-
-### 场景 3: 跳过不适合的 issue
-```
-用户: issue #456 看起来有问题
-Agent:
-  1. 运行 vibe3 task show 456
-  2. 发现 Level 0 检查失败（涉及 .claude/ 目录）
-  3. 建议："跳过，涉及权限配置，打 orchestra-scanned + roadmap/rfc（机械阻塞，需人类）"
-
-用户: 确认跳过
-Agent:
-  1. 执行 gh issue edit 456 --add-label "orchestra-scanned" --add-label "roadmap/rfc"
-  2. 写 [governance suggest] comment 说明原因
-  3. 确认完成（roadmap/rfc 让 /vibe-task 后续可 surface 给人类）
-```
+如果当前没有合适的建议 issue，明确写无，并说明原因。
 
 ## Stop Point
 
-完成以下之一后停止：
-- Service 状态报告完成
-- Issue 分配或跳过完成
-- 用户明确结束对话
-
-**不进入**：
-- 自动化批量处理
-- Plan/run/review 执行链
-- Roadmap 版本规划
+完成治理建议后停止。
+不要进入执行分配、实现方案、代码修改或单 flow 管理。

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -1,33 +1,121 @@
 ---
 name: vibe-roadmap
-description: Use when the user wants project-level roadmap planning, version goals, backlog triage, or to review and correct assignee-pool's automated roadmap/priority/rfc decisions. Do not use for entry intake/assignment (use vibe-orchestra) or single-flow execution.
+description: Use when the user wants project-level roadmap planning, version goals, backlog triage, governance suggest review, or issue placement decisions. Triggered by "vibe roadmap", "/vibe-roadmap", "版本规划", "roadmap 审查", "消化 governance suggest", "下一个版本做什么", or "这个 issue 放哪一版". Do not use for assignee pool governance (use vibe-orchestra) or single-flow execution.
 ---
 
-# /vibe-roadmap - 版本规划与 Backlog Triage
+# /vibe-roadmap - 版本规划与治理审查
 
-管理版本路线图和 backlog 分类。
+维护版本路线图，同时作为三层治理架构的 Layer 3 审查者，消化 pool 层的 `[governance suggest]` 并形成最终 `[roadmap decision]`。
+
+三层架构、标签语义（orchestra-scanned / orchestra-governed / roadmap-reviewed）和三级审查框架（Level 1/2/3）见 [supervisor/roadmap-common.md](../../supervisor/roadmap-common.md)。
 
 ## 核心原则
 
-- **只管规划**：版本目标、milestone、backlog triage
+- **审查纠正 governance 决策**：消化 assignee-pool 的 `[governance suggest]`，写 `[roadmap decision]`，打 `roadmap-reviewed`
 - **GitHub-as-truth**：所有操作通过 GitHub labels
 - **不做执行**：不处理单个 flow 执行
+- **manager_bot 解析**：分配 assignee 时（Step 0 第 5 步、Step X 场景 A）使用 `config.orchestra.manager_usernames[0]`（默认 `vibe-manager-agent`），**禁止指派人类用户名**
 
 ## Scope
 
-**只做规划层决策**：
-- 版本目标定义
-- Issue 分类与 milestone 分配
-- Roadmap/priority labels 设置
-- Backlog triage（哪些 issue 进入规划）
-- **对标 assignee-pool**：审查并纠正其自动决策（`roadmap/*`、`priority/*`、rfc/split 的错漏），作为 pool 的人类纠偏层（可 override pool 的决策）
+**做**：
+- 消化 pool 层的 `[governance suggest]`（Step 0）
+- 治理漏网检查（Step 0.5）
+- 版本目标定义与 milestone 分配
+- Issue 分类与 roadmap/priority labels 设置
+- Intake gate 判断：纳入 / rfc / 建议关闭（Step X）
 
 **不做**：
-- 入口 intake 与 serve 监控（由 `vibe-orchestra` 负责，对标 `roadmap-intake`）
-- 单 flow 执行
-- RFC/blocked 的只读 surface 提醒（由 `vibe-task` 负责）——但 vibe-roadmap **可纠正** pool 对 rfc 的决策（见上）
+- Assignee issue pool 实时治理（由 `vibe-orchestra` 负责）
+- RFC issues 处理（由 `vibe-task` 负责）
+- 根据当前 runtime 现场做即时抢占排序（由 `vibe-orchestra` 负责）
 
 ## Workflow
+
+### Step 0: 消化未处理的 governance suggest
+
+每次 `/vibe-roadmap` 被触发，**必做的第一步**。
+
+1. **找到上次决策锚点**：
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   gh search issues "repo:$REPO [roadmap decision]" --match comments --limit 20 \
+     --json number,updatedAt --jq 'sort_by(.updatedAt) | reverse | .[0] | {number, updatedAt}'
+   ```
+   若无历史 `[roadmap decision]` 评论（首次运行），锚点设为 7 天前。
+
+2. **列出未消化的 `[governance suggest]`**（过滤已决策的 issue）：
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   gh search issues "repo:$REPO [governance suggest]" --match comments --limit 50 \
+     --json number,labels,title \
+     --jq '.[] | select(.labels | map(.name) | index("roadmap-reviewed") | not)
+               | select(.labels | map(.name) | index("roadmap/rfc") | not)
+               | {number, title}'
+   ```
+
+3. **按 suggest 类型排列决策优先级**：
+   - 先处理 `needs split`（产出最大）
+   - 再处理 `Recommend Close`（清积压）
+   - 再处理 `waiting on #X`（依赖校验）
+   - 最后处理 `Skipped (needs human)`（判断是 rfc 还是可继续）
+
+4. **闭环要求**：处理完每个 suggest 后：
+   - 写 `[roadmap decision]` 评论（marker 含义见 roadmap-common.md Comment Marker Contract）
+   - decision 不是 `rfc` → **打 `roadmap-reviewed`**：`gh issue edit <number> --add-label "roadmap-reviewed"`
+   - decision 是 `rfc` → **不打 `roadmap-reviewed`**，打 `roadmap/rfc`，等人类决策后再处理
+
+5. **推翻 intake skip 时的三步处理**：
+
+   当被审查的 `[governance suggest]` 来自 intake 层 skip 决策（issue 带 `orchestra-scanned` 且无 assignee），如果你决定纳入该 issue，**必须显式执行三步**（标签语义见 roadmap-common.md）：
+
+   ```bash
+   # 1. 移除 intake 跳过标记
+   gh issue edit <number> --remove-label "orchestra-scanned"
+
+   # 2. 分配 manager assignee，让 issue 进入 assignee-pool
+   gh issue edit <number> --add-assignee <manager_bot_name>
+
+   # 3. 写决策评论 + 打 roadmap-reviewed
+   gh issue comment <number> --body "[roadmap decision] override intake skip: <理由>"
+   gh issue edit <number> --add-label "roadmap-reviewed"
+   ```
+
+### Step 0.5: 治理漏网检查
+
+Step 0 处理完后，检查两类"漏网" issue：
+
+**类型 A：有 assignee 但缺 state 标签**（通过了 intake 但 pool 还没处理，卡在两层之间）
+
+```bash
+gh issue list --assignee vibe-manager-agent --limit 50 --json number,title,labels \
+  --jq '.[] | select(.state == "OPEN")
+            | select([.labels[].name] | map(select(startswith("state/"))) | length == 0)
+            | {number, title}'
+```
+
+对每个漏网 issue：
+- 应执行（范围明确、有 priority）→ 补 `state/ready`
+- 应关闭（过时/冲突/无价值）→ 写 `[roadmap decision] close` + 打 `roadmap-reviewed`
+
+**类型 B：state/done 但 issue 仍 OPEN**（系统未自动关闭）
+
+```bash
+gh issue list --label "state/done" --limit 30 --json number,title \
+  --jq '.[] | select(.state == "OPEN") | {number, title}'
+```
+
+对每个漏网 issue，**必须代码实际验证**（不能只看标签或 PR 状态）：
+```bash
+git log --oneline -10 --all --grep="<issue 关键词>"
+uv run python src/vibe3/cli.py inspect files <相关路径>
+```
+- 完成了（代码实际包含改动）→ 关闭 issue，comment 说明代码证据
+- 没完成（代码中无改动）→ 关闭当前 issue + 创建新 issue（范围更明确，引用原 issue）
+
+处理完后打 `roadmap-reviewed`，结果写入 `.agent/context/memory.md` 缓存。
+
+---
 
 ### Step 1: 检查版本目标
 
@@ -38,24 +126,42 @@ gh issue list -l "roadmap/p0"
 gh issue list -l "roadmap/p1"
 ```
 
-获取：
-- 当前版本目标是什么
-- 有哪些 issues 等待分类
-- 各版本窗口下的候选 issue
-
 ### Step 2: 版本规划决策
 
 **场景 A: 没有版本目标**
-- 提示用户定义版本目标
-- 展示 backlog 中的 issues 供选择
-- 要求人类讨论确定目标
+- 提示用户定义版本目标，展示 backlog issues 供选择
 
 **场景 B: 有版本目标但有新 issues**
-- 对新 issues 进行分类：
-  1. 分配 milestone
-  2. 添加 roadmap 状态标签（`roadmap/p0`, `roadmap/p1` 等）
-  3. 必要时补 `priority/[0-9]`
-- 对候选 issues 做 intake gate 判断：纳入 / 不纳入 / RFC
+- 对新 issues 分类：分配 milestone、添加 roadmap 状态标签、必要时补 `priority/[0-9]`
+- 对候选 issues 做 intake gate 判断（见 Step X）
+
+**场景 C: 版本结束**
+- 确认下一版本目标，重新评估待分类 Issue，更新 roadmap 状态标签
+
+### Step X: Intake 判断
+
+对新进入的 issue 运行三级审查（Level 1/2/3，见 roadmap-common.md）后，选择：
+
+**场景 A: 适合自动化推进**（通过全部三级审查）
+```bash
+gh issue edit <number> --add-assignee <manager_bot_name>
+gh issue comment <number> --body "[roadmap decision] assign to @{manager_bot} (manager-pool); scope=<bugfix|feature|refactor>."
+gh issue edit <number> --add-label "roadmap-reviewed"
+```
+
+**场景 B: 需要人类讨论**（目标不明确/架构方向未定/scope 过大无法判断拆分）
+```bash
+gh issue comment <number> --body "[roadmap decision] rfc: <具体原因>."
+gh issue edit <number> --add-label "roadmap/rfc"
+# 不打 roadmap-reviewed，不分配 assignee
+```
+
+**场景 C: 建议关闭**（Level 2/3 不通过：依赖已移除/API 废弃/重复）
+```bash
+gh issue comment <number> --body "[roadmap decision] close: <关闭原因>."
+gh issue edit <number> --add-label "roadmap-reviewed"
+# 建议人类关闭 issue（不自动关闭）
+```
 
 ### Step 3: 应用标签
 
@@ -68,7 +174,7 @@ gh issue edit <issue-number> --add-label "priority/5"
 ### Step 4: 输出状态
 
 ```text
-📋 版本规划状态
+版本规划状态
 
 当前版本: Phase 1: 基础设施
 
@@ -88,13 +194,15 @@ RFC (需讨论)
 
 ## 与其他 Skills 的区别
 
-- **vibe-roadmap**: 版本规划 + 纠正 assignee-pool 的自动决策（pool 的人类对标）
-- **vibe-orchestra**: 入口 intake（筛 broader repo 打 assignee）+ serve 监控（roadmap-intake 的人类对标）
-- **vibe-task**: surface RFC/blocked，提请人类关注（只读，不做决策）
+- **vibe-roadmap**: 版本规划、治理审查、governance suggest 消化（Layer 3 decider）
+- **vibe-orchestra**: assignee issue pool 治理（人机协作入口，Layer 2）
+- **vibe-task**: RFC 和 blocked issues 检查
+- **vibe-debug-serve**: vibe3 serve 运行状态与深度调试
 
 ## Restrictions
 
-- 不处理入口 intake / serve 监控（由 `vibe-orchestra` 负责）
-- 不做 RFC/blocked 的只读 surface（由 `vibe-task` 负责）；但可纠正 pool 的 rfc/决策
-- 不根据当前 runtime 现场做即时抢占排序（由 `vibe-orchestra` 负责）
+- 不处理执行层管理（转 `vibe-orchestra`）
+- 不看 RFC 或 blocked issues（转 `vibe-task`）
+- 不根据当前 runtime 现场做即时抢占排序（转 `vibe-orchestra`）
 - 所有操作通过 GitHub labels，不在本地存储
+- 所有决策必须写 `[roadmap decision]` marker，**禁止**写 `[governance suggest]`

--- a/skills/vibe-task/SKILL.md
+++ b/skills/vibe-task/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: vibe-task
-description: Use when the user wants to inspect RFC and blocked issues, or check overall task status. Do not use for roadmap prioritization or issue pool governance.
+description: Use when the user wants to inspect RFC, blocked, or epic issues, check dependency chains, or assess milestone readiness. Do not use for roadmap prioritization or issue pool governance.
 ---
 
-# /vibe-task - RFC & Blocked Issues 检查
+# /vibe-task - RFC / Blocked / Epic 检查与依赖图编排
 
-检查项目中的 RFC issues 和 blocked issues 状态。
+检查项目中的 RFC、blocked、epic issues 状态，并梳理三类 issue 间的依赖关系。
 
 ## 核心原则
 
-- **专注问题 issue**：RFC 和 blocked issues
+- **专注问题 issue**：RFC、blocked、epic
 - **基于真源**：只读 shell 输出，不补充字段
-- **简单总览**：给出状态，不做复杂建议
+- **依赖优先**：梳理依赖链，给出 milestone 可进性判断
 
 ## Scope
 
-**只看两类 issue**：
+**只看三类 issue**：
 
 1. **RFC issues** (`roadmap/rfc` label)
    - 需要人类讨论的 issue
@@ -24,6 +24,16 @@ description: Use when the user wants to inspect RFC and blocked issues, or check
 2. **Blocked issues** (`state/blocked` label)
    - 有依赖阻塞的 issue
    - 需要解除阻塞才能继续
+
+3. **Epic issues** (`roadmap/epic` label)
+   - scope 过大、需要先拆分的 issue
+   - 不可直接执行，需 split 成子 issues
+   - 依赖图节点：影响多个 downstream issues 的调度
+
+**依赖图编排**（三类 issue 间的依赖关系）：
+- epic → 子 issues（split 产出的依赖关系）
+- blocked_by 链（A depends on B depends on C）
+- milestone 可进性：某 milestone 是否所有 blocker 已解除
 
 **不看**：
 - 正常运行的 issue（由 `vibe-orchestra` 管理）
@@ -53,33 +63,57 @@ vibe3 task status
 - 阻塞原因（从 `blocked_reason` 或 `blocked_by_issue` 中解析）
 - 依赖的 issue（如有）
 
-### Step 4: 输出状态
+### Step 4: 解析 Epic issues
+
+从输出中找出带 `roadmap/epic` 的 issues：
+
+- issue 编号、标题
+- 已有的子 issues（从 body 或 comments 中解析 split 产出）
+- 是否已触发 split 流程
+
+### Step 5: 依赖图编排
+
+基于上述三类 issue，梳理依赖链：
+
+1. **构建依赖链**：找出 blocked_by 关系，找出 epic → 子 issues 关系
+2. **识别根节点阻塞**：依赖链最上游的阻塞点（RFC / epic 未 split）
+3. **milestone 可进性**：当前 milestone 的所有候选 issue 是否有未解除阻塞
+
+### Step 6: 输出状态
 
 ```text
-📋 RFC & Blocked Issues 检查
+RFC & Blocked & Epic Issues 检查
 
 RFC Issues (需要人类讨论)
 - #123: 架构方向未定
-  - 原因: 需要确认是否使用新框架
-  - 状态: open
+  原因: 需要确认是否使用新框架
+  状态: open
 
 Blocked Issues (有依赖阻塞)
 - #456: 依赖 #123 完成
-  - 阻塞原因: depends on #123
-  - 状态: blocked
+  阻塞原因: depends on #123
+  状态: blocked
+
+Epic Issues (需要拆分)
+- #789: 大功能重构
+  已有子 issues: #790, #791
+  状态: split in progress
+
+依赖图
+- #123 (RFC) -> #456 (blocked) [根节点阻塞：先解决 RFC]
+- #789 (epic) -> #790, #791 [split 未完成，milestone 暂不可进]
 
 建议
-- RFC issues: 安排讨论会议
-- Blocked issues: 先处理依赖 issue
+- RFC: 安排讨论，解除 #123 的 rfc 状态
+- Blocked: #123 解除后 #456 自动解锁
+- Epic: #789 需完成 split 才能进入调度
 ```
 
 ## 与其他 Skills 的区别
 
-- **vibe-task**: 只读 surface RFC/blocked（提请人类关注，不做决策）
-- **vibe-orchestra**: 入口 intake（筛选打 assignee）+ serve 监控
-- **vibe-roadmap**: 版本规划 + 纠正 assignee-pool 决策（含 rfc 的 override）
-
-**职责分工**：vibe-task 只**发现并提请**（rfc/blocked）；真正的**决策/纠正**去 vibe-roadmap（rfc/roadmap）或 vibe-orchestra（assign/入池）。Level 0 issue 由 intake/vibe-orchestra 打上 `roadmap/rfc` 后，vibe-task 通过 task-status Rule 1 自动 surface。
+- **vibe-task**: 看 RFC、blocked、epic issues（问题 issue）及依赖图
+- **vibe-orchestra**: 管理 assignee issue pool（运行中的 issues）
+- **vibe-roadmap**: 版本规划 + 治理审查（Layer 3：消化 governance suggest，纠正 pool 决策）
 
 ## Restrictions
 


### PR DESCRIPTION
## Summary

- **vibe-roadmap**: Add governance suggest digestion workflow (Step 0) with detailed procedures for processing governance suggestions from assignee-pool
- **vibe-roadmap**: Add manager_bot assignment requirement and intake skip override procedure
- **vibe-task**: Expand scope to include epic issues and dependency chains analysis
- **vibe-orchestra**: Add manual governance support with human-collaboration entrypoint
- **governance-roadmap-closed-loop**: Update reference to roadmap SKILL.md

## Key Changes

### vibe-roadmap SKILL.md
- Added Step 0: 消化未处理的 governance suggest workflow
- Added Step 0.5: 治理漏网检查
- Added manager_bot 解析规则 (manager_bot assignment requirement)
- Added intake skip override procedure (三步处理)
- Enhanced governance workflow with Level 3 review capabilities

### vibe-task SKILL.md
- Expanded scope to include epic issues (roadmap/epic label)
- Added dependency chain analysis
- Enhanced RFC/blocked issue inspection capabilities

### vibe-orchestra SKILL.md
- Added manual governance support
- Enhanced human-collaboration entrypoint for issue pool governance

## Test Plan

- [ ] Verify vibe-roadmap Step 0 workflow documentation clarity
- [ ] Confirm manager_bot assignment rules are correctly specified
- [ ] Review vibe-task epic issues scope expansion
- [ ] Validate vibe-orchestra manual governance entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)