### PR TITLE
fix: cross-project dispatch always uses global vibe3

### DIFF
--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -30,13 +30,14 @@ def resolve_async_cli_project_root(repo_path: Path | None = None) -> Path:
     """Resolve the code/project root used by async child self-invocation.
 
     Rules:
-    - If `VIBE3_ASYNC_CLI_PROJECT_ROOT` is set, use it. This is the debug-mode
-      override from `vibe3 serve start --debug`, and points at the current
-      worktree code.
-    - Otherwise, derive the installed/source project root from this module's
-      own location. This keeps cross-project execution pinned to the real
-      vibe3 code instead of the caller repository.
-    - As a final fallback, use the provided repo_path / orchestra root.
+    - If `VIBE3_ASYNC_CLI_PROJECT_ROOT` is set (non-empty), use it.
+      Reserved for manual debugging scenarios only.
+      Note: Serve command no longer auto-sets this (as of PR #1662).
+    - Otherwise, derive from this module's location (installed/source vibe3).
+    - Falls back to repo_path / orchestra root if module location fails.
+
+    This ensures cross-project dispatch always uses the global vibe3 installation,
+    not the caller repository, preventing wrong cli.py resolution.
     """
     override_root = os.environ.get("VIBE3_ASYNC_CLI_PROJECT_ROOT", "").strip()
     if override_root:

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -49,13 +49,12 @@ def _resolve_async_cli_override_root(
 ) -> Path | None:
     """Resolve optional async child code-root override.
 
-    Only debug mode should override the async child code root. Normal mode must
-    keep using the installed/source vibe3 project root so cross-project scans
-    do not treat the caller repository as the vibe3 source tree.
+    DEPRECATED: Always returns None. Cross-project dispatch must always use
+    the installed/source vibe3 project root, never the caller repository.
+
+    Debug mode only affects logging verbosity and debug output, not code paths.
     """
-    if not config.debug:
-        return None
-    return (launch_cwd or Path.cwd()).resolve()
+    return None
 
 
 def _resolve_orchestra_log_dir(launch_cwd: Path | None = None) -> Path:

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -49,10 +49,20 @@ def _resolve_async_cli_override_root(
 ) -> Path | None:
     """Resolve optional async child code-root override.
 
-    DEPRECATED: Always returns None. Cross-project dispatch must always use
-    the installed/source vibe3 project root, never the caller repository.
+    DEPRECATED: Always returns None.
+
+    Cross-project dispatch must always use the installed/source vibe3 project
+    root, never the caller repository. This ensures correct cli.py resolution
+    when running `vibe3 scan` from external projects.
 
     Debug mode only affects logging verbosity and debug output, not code paths.
+    See VIBE3_REPO_MODELS_ROOT for project-specific models root override
+    (which IS debug-mode sensitive).
+
+    Historical context (PR #1662):
+    - Pre-fix: debug mode returned launch_cwd, breaking cross-project dispatch
+    - Post-fix: always returns None, forcing module-based resolution
+    - Rationale: cli.py must always point to vibe3 installation, not caller repo
     """
     return None
 

--- a/tests/vibe3/execution/test_issue_role_support.py
+++ b/tests/vibe3/execution/test_issue_role_support.py
@@ -78,7 +78,15 @@ def test_build_issue_async_cli_request_uses_main_repo_by_default() -> None:
 def test_build_issue_async_cli_request_uses_debug_code_root_override(
     monkeypatch,
 ) -> None:
-    """Debug serve mode should only override the code root, not orchestration repo."""
+    """Manual VIBE3_ASYNC_CLI_PROJECT_ROOT override for debugging purposes.
+
+    Note: Serve command no longer sets this env var automatically (even in debug mode),
+    as of PR #1662. This tests the manual override capability for advanced debugging
+    scenarios where developers need to point to a specific vibe3 installation.
+
+    The test verifies that when manually set, the override takes precedence over
+    the default module-based resolution.
+    """
     monkeypatch.setenv("VIBE3_ASYNC_CLI_PROJECT_ROOT", str(WORKTREE_REPO))
     issue = IssueInfo(number=431, title="Test issue", labels=[])
 

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -167,22 +167,30 @@ def test_build_async_serve_command_forces_sync_child_process() -> None:
     assert "--no-async" in cmd
 
 
-def test_build_async_serve_command_sets_code_root_override_only_in_debug() -> None:
-    debug_root = Path("/tmp/debug-wt").resolve()
-    cmd = _build_async_serve_command(
+def test_build_async_serve_command_never_sets_code_root_override() -> None:
+    """Cross-project dispatch must always use global vibe3, never caller repo.
+
+    Debug mode only affects logging verbosity, not code paths.
+    Both debug and normal mode set VIBE3_ASYNC_CLI_PROJECT_ROOT= (empty)
+    to ensure resolve_async_cli_project_root() uses module location.
+    """
+    # Debug mode: still must NOT set code root override
+    debug_cmd = _build_async_serve_command(
         OrchestraConfig(pid_file=Path(".git/vibe3/orchestra.pid"), debug=True),
         verbose=0,
         launch_cwd=Path("/tmp/debug-wt"),
     )
+    assert "VIBE3_ASYNC_CLI_PROJECT_ROOT=" in debug_cmd
+    # Should NOT contain the debug-wt path
+    debug_root = Path("/tmp/debug-wt").resolve()
+    assert f"VIBE3_ASYNC_CLI_PROJECT_ROOT={debug_root}" not in debug_cmd
 
-    assert f"VIBE3_ASYNC_CLI_PROJECT_ROOT={debug_root}" in cmd
-
+    # Normal mode: also sets empty string (not unset)
     normal_cmd = _build_async_serve_command(
         OrchestraConfig(pid_file=Path(".git/vibe3/orchestra.pid"), debug=False),
         verbose=0,
         launch_cwd=Path("/tmp/external-repo"),
     )
-
     # Normal mode must explicitly clear VIBE3_ASYNC_CLI_PROJECT_ROOT
     # to prevent parent environment hijacking
     assert "VIBE3_ASYNC_CLI_PROJECT_ROOT=" in normal_cmd


### PR DESCRIPTION
## Summary

修复 orchestra serve tick dispatch 在跨项目场景下查找错误 cli.py 的问题。

**问题**：在其他项目运行 `vibe3 scan` 能正确找到全局的 cli.py，但 orchestra serve 的 tick dispatch 报错，查找当前项目的 cli.py。

## Root Cause

**两套不同的 cli.py 查找策略**：

1. **serve 启动时**（正确）：
   - 通过模块 `__file__` 位置查找
   - 总能找到 vibe3 安装位置

2. **tick dispatch 时**（问题）：
   - 优先使用环境变量 `VIBE3_ASYNC_CLI_PROJECT_ROOT`
   - debug 模式下设置为启动项目路径
   - 导致所有 dispatch 都使用启动项目的 cli.py

**影响链**：
```
debug 模式启动 serve 
→ 设置 VIBE3_ASYNC_CLI_PROJECT_ROOT=<启动项目>
→ 所有 governance/supervisor dispatch 
→ 使用启动项目的 cli.py
→ 跨项目场景找错 cli.py ❌
```

## Fix

**核心修改**：`_resolve_async_cli_override_root` 总是返回 `None`

```python
def _resolve_async_cli_override_root(...) -> Path | None:
    """DEPRECATED: Always returns None. 
    Cross-project dispatch must always use the installed/source vibe3 project root.
    Debug mode only affects logging verbosity, not code paths.
    """
    return None
```

**修复效果**：
- ✅ debug 和非 debug 模式都使用模块位置查找 cli.py
- ✅ 跨项目 dispatch 总是使用全局 vibe3 安装位置
- ✅ debug 模式只影响日志，不改变代码路径

## Changes

- `src/vibe3/server/registry.py`: `_resolve_async_cli_override_root` 总是返回 None
- `tests/vibe3/orchestra/test_serve.py`: 更新测试以反映新行为

## Test Plan

- [x] 运行所有 serve 测试（15/15 通过）
- [x] 运行 governance runner 测试（5/5 通过）
- [x] 运行 governance handler 测试（7/7 通过）
- [x] 验证跨项目行为：总是使用模块位置查找 cli.py
- [x] 验证 debug 模式不影响 cli.py 查找路径

## Verification

**跨项目行为验证**：
```bash
# 无论在哪个目录启动 serve
# dispatch 总是找到正确的 vibe3 cli.py
✅ /Users/chenyi/src/vibe-coding-control-center/.worktrees/wt-codex
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)