### PR TITLE
refactor(domain): move role resolution from orchestra to domain layer

### DIFF
--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -27,6 +27,7 @@ from vibe3.domain.protocols.dispatch_protocols import (
 )
 from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
 from vibe3.domain.qualify_gate import QualifyGateService
+from vibe3.domain.role_resolver import find_role_for_state
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.observability.degraded_mode import get_degraded_manager
@@ -35,7 +36,6 @@ from vibe3.observability.degraded_mode import get_degraded_manager
 # GlobalDispatchCoordinator depends on them via protocols
 from vibe3.orchestra.dispatch_health_check import DispatchHealthCheckService
 from vibe3.orchestra.issue_loader import (
-    find_role_for_state,
     get_flow_context,
     load_issue,
 )

--- a/src/vibe3/domain/role_resolver.py
+++ b/src/vibe3/domain/role_resolver.py
@@ -1,0 +1,32 @@
+"""Role resolution utilities for dispatch coordination.
+
+Migrated from orchestra/issue_loader.py to establish domain-first architecture.
+Role resolution is domain logic, not orchestra adapter concern.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vibe3.roles.registry import LABEL_DISPATCH_ROLES
+
+if TYPE_CHECKING:
+    from vibe3.models.orchestration import IssueState
+    from vibe3.roles.definitions import TriggerableRoleDefinition
+
+
+def find_role_for_state(
+    state: "IssueState",
+) -> "TriggerableRoleDefinition | None":
+    """Find the role definition for a state label.
+
+    Args:
+        state: Issue state label to find role for
+
+    Returns:
+        Role definition if found, None otherwise
+    """
+    for role in LABEL_DISPATCH_ROLES:
+        if role.trigger_state == state:
+            return role
+    return None

--- a/src/vibe3/domain/role_resolver.py
+++ b/src/vibe3/domain/role_resolver.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from vibe3.roles.registry import LABEL_DISPATCH_ROLES
-
 if TYPE_CHECKING:
     from vibe3.models.orchestration import IssueState
     from vibe3.roles.definitions import TriggerableRoleDefinition
@@ -20,12 +18,18 @@ def find_role_for_state(
 ) -> "TriggerableRoleDefinition | None":
     """Find the role definition for a state label.
 
+    Defers registry import to avoid circular dependencies and keep
+    domain layer imports lightweight.
+
     Args:
         state: Issue state label to find role for
 
     Returns:
         Role definition if found, None otherwise
     """
+    # Deferred import to avoid circular dependencies at module load time
+    from vibe3.roles.registry import LABEL_DISPATCH_ROLES
+
     for role in LABEL_DISPATCH_ROLES:
         if role.trigger_state == state:
             return role

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -7,25 +7,12 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
-from vibe3.roles.registry import LABEL_DISPATCH_ROLES
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.models.orchestration import IssueInfo
     from vibe3.orchestra.protocols import FlowManagerProtocol
-    from vibe3.roles.definitions import TriggerableRoleDefinition
-
-
-def find_role_for_state(
-    state: IssueState,
-) -> "TriggerableRoleDefinition | None":
-    """Find the role definition for a state label."""
-    for role in LABEL_DISPATCH_ROLES:
-        if role.trigger_state == state:
-            return role
-    return None
 
 
 def is_auto_task_branch(branch: str) -> bool:

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Callable
 
 from vibe3.config.orchestra_config import get_manager_usernames
 from vibe3.domain.qualify_gate import QualifyGateService
+from vibe3.domain.role_resolver import find_role_for_state
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.orchestra.issue_loader import (
-    find_role_for_state,
     get_flow_context,
     is_auto_task_branch,
     load_issue,

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -27,6 +27,8 @@ def reset_error_tracking() -> Iterator[None]:
         db_paths.append(ErrorTrackingService._default_instance.db_path)
     ErrorTrackingService.clear_instance()
     for db_path in set(db_paths):
+        # Only handle "no such table" errors - these occur when the DB file
+        # was deleted by concurrent test cleanup. Other errors should propagate.
         try:
             with sqlite3.connect(db_path) as conn:
                 conn.execute("DELETE FROM error_log")
@@ -34,9 +36,9 @@ def reset_error_tracking() -> Iterator[None]:
                     "UPDATE failed_gate_state SET is_active = 0, "
                     "reason = NULL, triggered_at = NULL, blocked_ticks = 0 WHERE id = 1"
                 )
-        except sqlite3.OperationalError:
-            # Database file may not exist in concurrent test scenarios
-            pass
+        except sqlite3.OperationalError as e:
+            if "no such table" not in str(e):
+                raise
 
 
 @pytest.fixture

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -27,12 +27,16 @@ def reset_error_tracking() -> Iterator[None]:
         db_paths.append(ErrorTrackingService._default_instance.db_path)
     ErrorTrackingService.clear_instance()
     for db_path in set(db_paths):
-        with sqlite3.connect(db_path) as conn:
-            conn.execute("DELETE FROM error_log")
-            conn.execute(
-                "UPDATE failed_gate_state SET is_active = 0, "
-                "reason = NULL, triggered_at = NULL, blocked_ticks = 0 WHERE id = 1"
-            )
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("DELETE FROM error_log")
+                conn.execute(
+                    "UPDATE failed_gate_state SET is_active = 0, "
+                    "reason = NULL, triggered_at = NULL, blocked_ticks = 0 WHERE id = 1"
+                )
+        except sqlite3.OperationalError:
+            # Database file may not exist in concurrent test scenarios
+            pass
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Migrate `find_role_for_state` from `orchestra/issue_loader.py` to `domain/role_resolver.py` to establish proper architectural boundaries and complete the domain layer independence requirement.

## Changes

- **New**: Created `domain/role_resolver.py` for role resolution logic
- **Updated**: `domain/dispatch_coordinator.py` to import from domain layer
- **Updated**: `orchestra/queue_operations.py` to import from domain layer
- **Removed**: Roles imports from `orchestra/issue_loader.py`
- **Fixed**: Test teardown race condition in `test_failed_gate.py`

## Architecture Impact

This PR completes the architectural boundary enforcement:

**Before**:
```
orchestra.issue_loader → roles.registry → roles.definitions
```

**After**:
```
domain.role_resolver → roles.registry → roles.definitions
orchestra.queue_operations → domain.role_resolver
domain.dispatch_coordinator → domain.role_resolver
```

## Acceptance Criteria

- [x] orchestra 层无 roles 导入（直接或懒加载）
- [x] orchestra 层只提供 adapter 功能（persistence、read models）
- [x] 角色触发由 domain handlers 调用
- [x] 所有测试通过（224 tests）
- [x] 类型检查通过（mypy strict）

## Test Results

```
224 passed, 3 warnings in 32.16s
```

All tests pass including:
- `test_no_orchestra_imports.py` - domain layer independence verification
- All dispatch and queue related tests
- All failed gate tests

## Related Issues

- Closes #1625
- Depends on: #1624 (PR #1664 - already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)