### PR TITLE
feat(policy): add package-level import validation to planner policy

### DIFF
--- a/supervisor/policies/plan.md
+++ b/supervisor/policies/plan.md
@@ -104,6 +104,22 @@ tmux display-message -p '#{session_name}'
   - 检查现有代码使用的命名模式
   - 检查是否有已存在的相似解决方案
 
+- **验证包级导入（通过 `__init__.py` 重导出链）**
+  - 如果计划涉及以下任一改动，必须测试包级导入：
+    - 新增/修改 `__init__.py` 中的 re-export
+    - 新增/修改模块间的交叉导入
+    - 移动或重命名符号
+    - 重组模块结构
+  - 验证命令模板：
+    ```bash
+    # 直接子模块导入（验证子模块自身无循环依赖）
+    uv run python -c "from vibe3.<module>.<submodule> import <Symbol>"
+    
+    # 包级导入（验证 __init__.py 重导出链无循环依赖）
+    uv run python -c "from vibe3.<module> import <Symbol>"
+    ```
+  - 失败处理：直接导入通过而包级导入失败是循环依赖的典型信号，必须在 plan 阶段记录为 finding 并标记为阻塞条件
+
 - **如果发现冲突**：
   ```bash
   uv run python src/vibe3/cli.py handoff append "Plan 前提不成立：<具体冲突点>" --kind finding --actor "<actor>"


### PR DESCRIPTION
Closes #1611

## Summary

- Add package-level import validation requirements to planner policy
- Prevents circular import issues discovered at execution phase
- Adds verification command templates for testing imports through `__init__.py`

## Context

Issue #1592 revealed that plan-phase validation only tested direct submodule imports, missing package-level imports that can trigger circular dependencies:

```python
# Plan validation tested (passed):
from vibe3.execution.codeagent_runner import CodeagentExecutionService

# Actual usage triggered circular import:
from vibe3.execution import ExecutionCoordinator
```

This PR adds validation requirements to catch such issues during planning, not execution.

## Changes

- Modified `supervisor/policies/plan.md` (lines 104-119)
- Added package-level import validation in "独立判断强制验证点" section
- Includes concrete verification command templates
- No code or config changes - policy text only

## Test Plan

- [x] Prompt builder verified working after change
- [x] Modularity tests passed
- [x] Pre-push checks passed (type check, smoke tests)
- [x] Review audit completed with PASS verdict

## Risk Assessment

**Low Risk**: Only policy documentation changes (+16 lines)
- No code structure modifications
- No breaking changes to existing workflows
- Backward compatible enhancement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
