### PR TITLE
feat(status): 增强 Roadmap Epic section 展示依赖完成状态

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -233,8 +233,8 @@ code_limits:
         limit: 500
         reason: "Check PR 状态测试集，覆盖 PR closed 检测、terminal 状态判断、duplicate handling 等紧密耦合场景，新增 before_issue_is_closed 测试后略微超标"
       - path: "src/vibe3/commands/status_render.py"
-        limit: 450
-        reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"
+        limit: 490
+        reason: "Status 渲染层，包含 render_epic_items（+42行 Epic 依赖状态可视化）、render_missing_state_items（+24行）等渲染函数，与其他渲染函数共享 console/config 依赖，拆分收益低"
 
 
   total_file_loc:

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -260,6 +260,9 @@ def status(
     ]
     roadmap_epic_numbers = {cast(int, item["number"]) for item in roadmap_epic_items}
 
+    # Enrich epic items with dependency completion status
+    roadmap_epic_items = query_service.enrich_epic_items(roadmap_epic_items)
+
     # Split missing state items into two categories:
     # 1. Waiting for assignee-pool (no orchestra-governed label) - normal waiting
     # 2. Governed but anomaly (has orchestra-governed label) - needs attention

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -332,10 +332,52 @@ def render_epic_items(epic_items: list[dict[str, object]]) -> None:
             title = cast(str, item["title"])
             state = cast(IssueState | None, item["state"])
             flow = cast(FlowStatusResponse | None, item["flow"])
+            dep_status = cast(dict[str, object] | None, item.get("dep_status"))
 
-            state_str = state.value.upper() if state else "NO STATE"
             display_title = title[:60] + ("..." if len(title) > 60 else "")
-            console.print(f"  #{number:4}  [magenta]{state_str:10}[/]  {display_title}")
+
+            # Determine state display with dependency awareness
+            if dep_status:
+                total = cast(int, dep_status["total"])
+                is_ready = cast(bool, dep_status["is_ready"])
+                summary_text = cast(str, dep_status["summary_text"])
+                items = cast(list[dict[str, object]], dep_status["items"])
+
+                if total == 0:
+                    # No dependencies - show as OPEN (not BLOCKED)
+                    state_str = state.value.upper() if state else "NO STATE"
+                    console.print(
+                        f"  #{number:4}  [magenta]{state_str:10}[/]  {display_title}"
+                    )
+                elif is_ready:
+                    # All dependencies complete - show as READY
+                    console.print(
+                        f"  #{number:4}  [green]✓ READY    [/]  {display_title}"
+                    )
+                    # Show dependency summary
+                    console.print(f"         [dim]{summary_text}[/]")
+                else:
+                    # Some incomplete - show as WAITING
+                    console.print(
+                        f"  #{number:4}  [yellow]⏳ WAITING  [/]  {display_title}"
+                    )
+                    # Show dependency summary with per-issue status
+                    console.print(f"         [dim]{summary_text}[/]")
+                    # Show individual dependency status
+                    for dep_item in items:
+                        dep_num = cast(int, dep_item["number"])
+                        dep_state = cast(str, dep_item["state"])
+                        dep_completed = cast(bool, dep_item["completed"])
+                        status_icon = "✓" if dep_completed else "○"
+                        status_color = "green" if dep_completed else "dim"
+                        dep_line = f"         [{status_color}]{status_icon} #{dep_num}"
+                        console.print(f"{dep_line} ({dep_state})[/]")
+            else:
+                # No dependency status - use original behavior
+                state_str = state.value.upper() if state else "NO STATE"
+                console.print(
+                    f"  #{number:4}  [magenta]{state_str:10}[/]  {display_title}"
+                )
 
             if flow:
                 console.print(f"         [dim]flow:[/] [cyan]{flow.branch}[/]")

--- a/src/vibe3/services/epic_dependency_service.py
+++ b/src/vibe3/services/epic_dependency_service.py
@@ -1,0 +1,167 @@
+"""Epic dependency status service for roadmap management."""
+
+import re
+from typing import cast
+
+from ..clients.github_client import GitHubClient
+
+
+def _parse_dependencies_from_body(body: str) -> list[int]:
+    """Extract dependency issue numbers from ## Dependencies section.
+
+    Parses the format:
+        ## Dependencies
+        - Blocked by #N (description)
+        - Blocked by #M (another description)
+
+    Args:
+        body: Issue body text
+
+    Returns:
+        List of dependency issue numbers (order preserved)
+    """
+    if not body:
+        return []
+
+    # Find the ## Dependencies section
+    lines = body.split("\n")
+    in_deps_section = False
+    dependencies: list[int] = []
+    seen: set[int] = set()
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Check for section header
+        if stripped.startswith("## Dependencies"):
+            in_deps_section = True
+            continue
+
+        # Check for next section (end of dependencies)
+        if in_deps_section and stripped.startswith("##"):
+            break
+
+        # Parse dependency lines
+        if in_deps_section and stripped.startswith("-"):
+            # Extract issue numbers from the line
+            # Format: "- Blocked by #N (description)" or "- Blocked by #N"
+            matches = re.findall(r"#(\d+)", stripped)
+            for match in matches:
+                num = int(match)
+                if num not in seen:
+                    seen.add(num)
+                    dependencies.append(num)
+
+    return dependencies
+
+
+class EpicDependencyService:
+    """Service for checking epic dependency completion status."""
+
+    def __init__(self, github: GitHubClient):
+        """Initialize epic dependency service.
+
+        Args:
+            github: GitHub client for issue queries
+        """
+        self.github = github
+
+    def check_epic_dependency_status(self, issue_number: int) -> dict[str, object]:
+        """Check dependency completion status for an epic issue.
+
+        Args:
+            issue_number: Epic issue number
+
+        Returns:
+            Dict with keys:
+                - total: total number of dependencies
+                - completed: number of completed dependencies
+                - items: list of dependency status dicts
+                - is_ready: whether all dependencies are complete
+                - summary_text: human-readable summary
+        """
+        body = self.github.get_issue_body(issue_number)
+        if not body:
+            return {
+                "total": 0,
+                "completed": 0,
+                "items": [],
+                "is_ready": False,
+                "summary_text": "No dependencies",
+            }
+
+        dep_numbers = _parse_dependencies_from_body(body)
+        if not dep_numbers:
+            return {
+                "total": 0,
+                "completed": 0,
+                "items": [],
+                "is_ready": False,
+                "summary_text": "No dependencies",
+            }
+
+        # Check each dependency's state
+        items: list[dict[str, object]] = []
+        completed = 0
+
+        for dep_num in dep_numbers:
+            dep_data = self.github.view_issue(dep_num)
+
+            if dep_data is None or dep_data == "network_error":
+                # Skip deleted/inaccessible dependencies
+                items.append(
+                    {
+                        "number": dep_num,
+                        "state": "DELETED",
+                        "completed": False,
+                    }
+                )
+                continue
+
+            if isinstance(dep_data, dict):
+                state = dep_data.get("state", "OPEN")
+                is_closed = state == "CLOSED"
+                items.append(
+                    {
+                        "number": dep_num,
+                        "state": state,
+                        "completed": is_closed,
+                    }
+                )
+                if is_closed:
+                    completed += 1
+
+        total = len(dep_numbers)
+        is_ready = completed == total and total > 0
+
+        # Build summary text
+        if is_ready:
+            summary_text = f"✓ {completed}/{total} 完成"
+        else:
+            summary_text = f"⏳ {completed}/{total} 完成"
+
+        return {
+            "total": total,
+            "completed": completed,
+            "items": items,
+            "is_ready": is_ready,
+            "summary_text": summary_text,
+        }
+
+    def enrich_epic_items(
+        self, epic_items: list[dict[str, object]]
+    ) -> list[dict[str, object]]:
+        """Enrich epic items with dependency completion status.
+
+        Args:
+            epic_items: List of epic item dicts from fetch_orchestrated_issues
+
+        Returns:
+            Same list with each item having a 'dep_status' key added
+        """
+        enriched: list[dict[str, object]] = []
+        for item in epic_items:
+            number = cast(int, item["number"])
+            dep_status = self.check_epic_dependency_status(number)
+            enriched.append({**item, "dep_status": dep_status})
+        return enriched

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -20,63 +20,13 @@ from vibe3.orchestra.queue_ordering import (
     resolve_roadmap_rank,
     sort_ready_issues,
 )
+from vibe3.services.epic_dependency_service import EpicDependencyService
 from vibe3.services.issue_collection_service import IssueCollectionService
 from vibe3.services.issue_dispatch_policy import IssueDispatchPolicy
 
 if TYPE_CHECKING:
     from vibe3.models.flow import FlowStatusResponse
     from vibe3.services.issue_title_cache_service import IssueTitleCacheService
-
-
-def _parse_dependencies_from_body(body: str) -> list[int]:
-    """Extract dependency issue numbers from ## Dependencies section.
-
-    Parses the format:
-        ## Dependencies
-        - Blocked by #N (description)
-        - Blocked by #M (another description)
-
-    Args:
-        body: Issue body text
-
-    Returns:
-        List of dependency issue numbers (order preserved)
-    """
-    if not body:
-        return []
-
-    # Find the ## Dependencies section
-    lines = body.split("\n")
-    in_deps_section = False
-    dependencies: list[int] = []
-    seen: set[int] = set()
-
-    for line in lines:
-        stripped = line.strip()
-
-        # Check for section header
-        if stripped.startswith("## Dependencies"):
-            in_deps_section = True
-            continue
-
-        # Check for next section (end of dependencies)
-        if in_deps_section and stripped.startswith("##"):
-            break
-
-        # Parse dependency lines
-        if in_deps_section and stripped.startswith("-"):
-            # Extract issue numbers from the line
-            # Format: "- Blocked by #N (description)" or "- Blocked by #N"
-            import re
-
-            matches = re.findall(r"#(\d+)", stripped)
-            for match in matches:
-                num = int(match)
-                if num not in seen:
-                    seen.add(num)
-                    dependencies.append(num)
-
-    return dependencies
 
 
 def _state_from_labels(raw_labels: object) -> IssueState | None:
@@ -255,6 +205,7 @@ class StatusQueryService:
         self.repo = repo
         self.store = store or SQLiteClient()
         self._title_cache = title_cache
+        self._epic_dependency = EpicDependencyService(self.github)
 
     @property
     def title_cache(self) -> IssueTitleCacheService:
@@ -510,99 +461,15 @@ class StatusQueryService:
     def check_epic_dependency_status(self, issue_number: int) -> dict[str, object]:
         """Check dependency completion status for an epic issue.
 
-        Args:
-            issue_number: Epic issue number
-
-        Returns:
-            Dict with keys:
-                - total: total number of dependencies
-                - completed: number of completed dependencies
-                - items: list of dependency status dicts
-                - is_ready: whether all dependencies are complete
-                - summary_text: human-readable summary
+        Delegates to EpicDependencyService.
         """
-        body = self.github.get_issue_body(issue_number)
-        if not body:
-            return {
-                "total": 0,
-                "completed": 0,
-                "items": [],
-                "is_ready": False,
-                "summary_text": "No dependencies",
-            }
-
-        dep_numbers = _parse_dependencies_from_body(body)
-        if not dep_numbers:
-            return {
-                "total": 0,
-                "completed": 0,
-                "items": [],
-                "is_ready": False,
-                "summary_text": "No dependencies",
-            }
-
-        # Check each dependency's state
-        items: list[dict[str, object]] = []
-        completed = 0
-
-        for dep_num in dep_numbers:
-            dep_data = self.github.view_issue(dep_num)
-
-            if dep_data is None or dep_data == "network_error":
-                # Skip deleted/inaccessible dependencies
-                items.append(
-                    {
-                        "number": dep_num,
-                        "state": "DELETED",
-                        "completed": False,
-                    }
-                )
-                continue
-
-            if isinstance(dep_data, dict):
-                state = dep_data.get("state", "OPEN")
-                is_closed = state == "CLOSED"
-                items.append(
-                    {
-                        "number": dep_num,
-                        "state": state,
-                        "completed": is_closed,
-                    }
-                )
-                if is_closed:
-                    completed += 1
-
-        total = len(dep_numbers)
-        is_ready = completed == total and total > 0
-
-        # Build summary text
-        if is_ready:
-            summary_text = f"✓ {completed}/{total} 完成"
-        else:
-            summary_text = f"⏳ {completed}/{total} 完成"
-
-        return {
-            "total": total,
-            "completed": completed,
-            "items": items,
-            "is_ready": is_ready,
-            "summary_text": summary_text,
-        }
+        return self._epic_dependency.check_epic_dependency_status(issue_number)
 
     def enrich_epic_items(
         self, epic_items: list[dict[str, object]]
     ) -> list[dict[str, object]]:
         """Enrich epic items with dependency completion status.
 
-        Args:
-            epic_items: List of epic item dicts from fetch_orchestrated_issues
-
-        Returns:
-            Same list with each item having a 'dep_status' key added
+        Delegates to EpicDependencyService.
         """
-        enriched: list[dict[str, object]] = []
-        for item in epic_items:
-            number = cast(int, item["number"])
-            dep_status = self.check_epic_dependency_status(number)
-            enriched.append({**item, "dep_status": dep_status})
-        return enriched
+        return self._epic_dependency.enrich_epic_items(epic_items)

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -28,6 +28,57 @@ if TYPE_CHECKING:
     from vibe3.services.issue_title_cache_service import IssueTitleCacheService
 
 
+def _parse_dependencies_from_body(body: str) -> list[int]:
+    """Extract dependency issue numbers from ## Dependencies section.
+
+    Parses the format:
+        ## Dependencies
+        - Blocked by #N (description)
+        - Blocked by #M (another description)
+
+    Args:
+        body: Issue body text
+
+    Returns:
+        List of dependency issue numbers (order preserved)
+    """
+    if not body:
+        return []
+
+    # Find the ## Dependencies section
+    lines = body.split("\n")
+    in_deps_section = False
+    dependencies: list[int] = []
+    seen: set[int] = set()
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Check for section header
+        if stripped.startswith("## Dependencies"):
+            in_deps_section = True
+            continue
+
+        # Check for next section (end of dependencies)
+        if in_deps_section and stripped.startswith("##"):
+            break
+
+        # Parse dependency lines
+        if in_deps_section and stripped.startswith("-"):
+            # Extract issue numbers from the line
+            # Format: "- Blocked by #N (description)" or "- Blocked by #N"
+            import re
+
+            matches = re.findall(r"#(\d+)", stripped)
+            for match in matches:
+                num = int(match)
+                if num not in seen:
+                    seen.add(num)
+                    dependencies.append(num)
+
+    return dependencies
+
+
 def _state_from_labels(raw_labels: object) -> IssueState | None:
     """Extract orchestration state from GitHub label payload."""
     if not isinstance(raw_labels, list):
@@ -455,3 +506,103 @@ class StatusQueryService:
                         resumable.append({**issue, "resume_kind": "aborted"})
 
         return resumable
+
+    def check_epic_dependency_status(self, issue_number: int) -> dict[str, object]:
+        """Check dependency completion status for an epic issue.
+
+        Args:
+            issue_number: Epic issue number
+
+        Returns:
+            Dict with keys:
+                - total: total number of dependencies
+                - completed: number of completed dependencies
+                - items: list of dependency status dicts
+                - is_ready: whether all dependencies are complete
+                - summary_text: human-readable summary
+        """
+        body = self.github.get_issue_body(issue_number)
+        if not body:
+            return {
+                "total": 0,
+                "completed": 0,
+                "items": [],
+                "is_ready": False,
+                "summary_text": "No dependencies",
+            }
+
+        dep_numbers = _parse_dependencies_from_body(body)
+        if not dep_numbers:
+            return {
+                "total": 0,
+                "completed": 0,
+                "items": [],
+                "is_ready": False,
+                "summary_text": "No dependencies",
+            }
+
+        # Check each dependency's state
+        items: list[dict[str, object]] = []
+        completed = 0
+
+        for dep_num in dep_numbers:
+            dep_data = self.github.view_issue(dep_num)
+
+            if dep_data is None or dep_data == "network_error":
+                # Skip deleted/inaccessible dependencies
+                items.append(
+                    {
+                        "number": dep_num,
+                        "state": "DELETED",
+                        "completed": False,
+                    }
+                )
+                continue
+
+            if isinstance(dep_data, dict):
+                state = dep_data.get("state", "OPEN")
+                is_closed = state == "CLOSED"
+                items.append(
+                    {
+                        "number": dep_num,
+                        "state": state,
+                        "completed": is_closed,
+                    }
+                )
+                if is_closed:
+                    completed += 1
+
+        total = len(dep_numbers)
+        is_ready = completed == total and total > 0
+
+        # Build summary text
+        if is_ready:
+            summary_text = f"✓ {completed}/{total} 完成"
+        else:
+            summary_text = f"⏳ {completed}/{total} 完成"
+
+        return {
+            "total": total,
+            "completed": completed,
+            "items": items,
+            "is_ready": is_ready,
+            "summary_text": summary_text,
+        }
+
+    def enrich_epic_items(
+        self, epic_items: list[dict[str, object]]
+    ) -> list[dict[str, object]]:
+        """Enrich epic items with dependency completion status.
+
+        Args:
+            epic_items: List of epic item dicts from fetch_orchestrated_issues
+
+        Returns:
+            Same list with each item having a 'dep_status' key added
+        """
+        enriched: list[dict[str, object]] = []
+        for item in epic_items:
+            number = cast(int, item["number"])
+            dep_status = self.check_epic_dependency_status(number)
+            enriched.append({**item, "dep_status": dep_status})
+        return enriched

--- a/tests/vibe3/commands/test_task_status_dashboard.py
+++ b/tests/vibe3/commands/test_task_status_dashboard.py
@@ -295,6 +295,24 @@ def test_task_status_shows_missing_state_label_section(
     ]
     mock_status_service_cls.return_value = status_service
 
+    # Mock enrich_epic_items to add dep_status
+    def mock_enrich_epic_items(epic_items):
+        return [
+            {
+                **item,
+                "dep_status": {
+                    "total": 0,
+                    "completed": 0,
+                    "items": [],
+                    "is_ready": False,
+                    "summary_text": "No dependencies",
+                },
+            }
+            for item in epic_items
+        ]
+
+    status_service.enrich_epic_items = mock_enrich_epic_items
+
     result = runner.invoke(app, ["task", "status"])
 
     assert result.exit_code == 0

--- a/tests/vibe3/commands/test_task_status_rfc_epic.py
+++ b/tests/vibe3/commands/test_task_status_rfc_epic.py
@@ -92,6 +92,24 @@ def test_task_status_shows_rfc_and_epic_in_separate_sections(
     ]
     mock_status_service_cls.return_value = status_service
 
+    # Mock enrich_epic_items to add dep_status
+    def mock_enrich_epic_items(epic_items):
+        return [
+            {
+                **item,
+                "dep_status": {
+                    "total": 0,
+                    "completed": 0,
+                    "items": [],
+                    "is_ready": False,
+                    "summary_text": "No dependencies",
+                },
+            }
+            for item in epic_items
+        ]
+
+    status_service.enrich_epic_items = mock_enrich_epic_items
+
     result = runner.invoke(app, ["task", "status"])
 
     assert result.exit_code == 0

--- a/tests/vibe3/services/test_status_query_utils.py
+++ b/tests/vibe3/services/test_status_query_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from vibe3.models.orchestration import IssueState
 from vibe3.services.status_query_service import (
     StatusQueryService,
+    _parse_dependencies_from_body,
     is_auto_task_branch,
     is_canonical_task_branch,
     issue_priority,
@@ -294,3 +295,207 @@ class TestRemoteField:
         assert len(result) == 1
         assert result[0]["remote"] is True
         assert result[0]["state"] == IssueState.MERGE_READY
+
+
+class TestParseDependenciesFromBody:
+    """Tests for _parse_dependencies_from_body function."""
+
+    def test_standard_dependencies_section(self) -> None:
+        """Should parse standard ## Dependencies section."""
+        body = """## Summary
+This is an epic.
+
+## Dependencies
+- Blocked by #123 (need API)
+- Blocked by #456 (need DB)
+
+## Notes
+Some notes.
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == [123, 456]
+
+    def test_mixed_format(self) -> None:
+        """Should handle various formats within dependencies section."""
+        body = """## Dependencies
+- Blocked by #100
+- #200 (another format)
+- Blocked by #300 (with description)
+"""
+        result = _parse_dependencies_from_body(body)
+        # Should find all issue numbers
+        assert 100 in result
+        assert 200 in result
+        assert 300 in result
+
+    def test_no_dependencies_section(self) -> None:
+        """Should return empty list if no ## Dependencies section."""
+        body = """## Summary
+This is an epic.
+
+## Notes
+Some notes.
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == []
+
+    def test_empty_dependencies_section(self) -> None:
+        """Should return empty list if dependencies section is empty."""
+        body = """## Dependencies
+
+## Notes
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == []
+
+    def test_ignores_references_outside_section(self) -> None:
+        """Should only parse issue numbers inside ## Dependencies section."""
+        body = """## Summary
+This references #999.
+
+## Dependencies
+- Blocked by #123
+
+## Notes
+Also references #888.
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == [123]
+        assert 999 not in result
+        assert 888 not in result
+
+    def test_empty_body(self) -> None:
+        """Should handle empty body."""
+        result = _parse_dependencies_from_body("")
+        assert result == []
+
+    def test_none_body(self) -> None:
+        """Should handle None body."""
+        result = _parse_dependencies_from_body(None)  # type: ignore
+        assert result == []
+
+    def test_deduplication(self) -> None:
+        """Should deduplicate issue numbers."""
+        body = """## Dependencies
+- Blocked by #123
+- Blocked by #123 (duplicate)
+- Blocked by #456
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == [123, 456]
+
+    def test_section_ended_by_next_header(self) -> None:
+        """Should stop parsing at next section header."""
+        body = """## Dependencies
+- Blocked by #100
+
+## Notes
+- Blocked by #200
+"""
+        result = _parse_dependencies_from_body(body)
+        assert result == [100]
+        assert 200 not in result
+
+
+class TestCheckEpicDependencyStatus:
+    """Tests for check_epic_dependency_status method."""
+
+    def _make_mock_service(self) -> StatusQueryService:
+        """Create a StatusQueryService with mocked dependencies."""
+        github_mock = MagicMock()
+        git_mock = MagicMock()
+        store_mock = MagicMock()
+        return StatusQueryService(
+            github_client=github_mock,
+            git_client=git_mock,
+            store=store_mock,
+        )
+
+    def test_all_dependencies_closed(self) -> None:
+        """All dependencies CLOSED -> completed == total, is_ready == True."""
+        service = self._make_mock_service()
+        service.github.get_issue_body.return_value = """## Dependencies
+- Blocked by #100
+- Blocked by #200
+"""
+        service.github.view_issue.side_effect = [
+            {"number": 100, "state": "CLOSED"},
+            {"number": 200, "state": "CLOSED"},
+        ]
+
+        result = service.check_epic_dependency_status(1)
+
+        assert result["total"] == 2
+        assert result["completed"] == 2
+        assert result["is_ready"] is True
+        assert "✓" in result["summary_text"]
+
+    def test_some_dependencies_open(self) -> None:
+        """Some OPEN dependencies -> completed < total, is_ready == False."""
+        service = self._make_mock_service()
+        service.github.get_issue_body.return_value = """## Dependencies
+- Blocked by #100
+- Blocked by #200
+"""
+        service.github.view_issue.side_effect = [
+            {"number": 100, "state": "CLOSED"},
+            {"number": 200, "state": "OPEN"},
+        ]
+
+        result = service.check_epic_dependency_status(1)
+
+        assert result["total"] == 2
+        assert result["completed"] == 1
+        assert result["is_ready"] is False
+        assert "⏳" in result["summary_text"]
+
+    def test_no_dependencies(self) -> None:
+        """No dependencies -> total == 0, is_ready == False."""
+        service = self._make_mock_service()
+        service.github.get_issue_body.return_value = """## Summary
+No dependencies here.
+"""
+
+        result = service.check_epic_dependency_status(1)
+
+        assert result["total"] == 0
+        assert result["completed"] == 0
+        assert result["is_ready"] is False
+        assert result["summary_text"] == "No dependencies"
+
+    def test_deleted_dependency(self) -> None:
+        """Deleted/inaccessible dependency should be skipped."""
+        service = self._make_mock_service()
+        service.github.get_issue_body.return_value = """## Dependencies
+- Blocked by #100
+- Blocked by #999 (deleted)
+"""
+        service.github.view_issue.side_effect = [
+            {"number": 100, "state": "CLOSED"},
+            None,  # Deleted issue
+        ]
+
+        result = service.check_epic_dependency_status(1)
+
+        assert result["total"] == 2
+        # Only #100 is completed, #999 is DELETED (not completed)
+        assert result["completed"] == 1
+        assert result["is_ready"] is False
+
+    def test_network_error_on_dependency(self) -> None:
+        """Network error should be treated as inaccessible."""
+        service = self._make_mock_service()
+        service.github.get_issue_body.return_value = """## Dependencies
+- Blocked by #100
+- Blocked by #200
+"""
+        service.github.view_issue.side_effect = [
+            {"number": 100, "state": "CLOSED"},
+            "network_error",
+        ]
+
+        result = service.check_epic_dependency_status(1)
+
+        assert result["total"] == 2
+        assert result["completed"] == 1
+        assert result["is_ready"] is False

--- a/tests/vibe3/services/test_status_query_utils.py
+++ b/tests/vibe3/services/test_status_query_utils.py
@@ -3,9 +3,9 @@
 from unittest.mock import MagicMock
 
 from vibe3.models.orchestration import IssueState
+from vibe3.services.epic_dependency_service import _parse_dependencies_from_body
 from vibe3.services.status_query_service import (
     StatusQueryService,
-    _parse_dependencies_from_body,
     is_auto_task_branch,
     is_canonical_task_branch,
     issue_priority,


### PR DESCRIPTION
## 功能描述

增强 Roadmap Epic section，展示 Epic 依赖的完成状态，帮助管理者快速识别哪些 Epic 可以开始工作。

## 主要改动

### 核心功能
- Epic 依赖完成状态可视化
  - ✓ READY: 所有依赖已完成
  - ⏳ WAITING: 存在未完成的依赖
  - OPEN: 无依赖的 Epic
- 依赖进度摘要展示
- 单个依赖项状态列表

### 实现细节
- `check_epic_dependency_status()`: 检查 Epic 依赖完成状态
- `enrich_epic_items()`: 为 Epic items 添加依赖状态信息
- 更新 `render_epic_items()` 渲染逻辑

### 测试覆盖
- 新增 14 个测试用例
- 覆盖场景：
  - 无依赖 Epic
  - 全部依赖已完成
  - 部分依赖未完成
  - 网络错误处理
  - 无 Dependencies section
  - 空 Dependencies section

## 验收标准

- [x] Epic 依赖状态可视化（✓ READY / ⏳ WAITING / OPEN）
- [x] 依赖进度摘要展示
- [x] 无依赖 epic 显示为 OPEN
- [x] 测试覆盖充分（28/28 通过，14 个新测试）
- [x] 类型检查和代码风格检查通过
- [x] 跨层一致性良好

## 已知限制

1. 仅使用 `## Dependencies` section 作为数据源
2. 完成判断仅基于 CLOSED 状态
3. 防御性编程缺口已在 #1680 跟踪

## 质量评估

**Verdict**: MINOR
- 实现正确、测试充分、跨层一致性良好
- 发现一个防御性编程缺口（未触发实际错误）
- 改进 issue 已创建: #1680

## Test Plan

- [x] 运行新增测试：`uv run pytest tests/vibe3/services/test_status_query_utils.py -v`
- [x] 运行相关测试：`uv run pytest tests/vibe3/commands/test_task_status_rfc_epic.py -v`
- [x] 运行完整测试套件：pre-push hook 自动执行
- [x] 类型检查：`uv run mypy src`
- [x] 代码风格检查：`uv run ruff check src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
