### PR TITLE
refactor(config): unify public interface and eliminate internal imports

### DIFF
--- a/src/vibe3/agents/models.py
+++ b/src/vibe3/agents/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 
 ExecutionRole = Literal["planner", "executor", "reviewer", "manager"]
 

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -14,7 +14,7 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import VibeError
 from vibe3.models.plan import PlanRequest
 from vibe3.models.prompt_meta import PromptContextMode

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -18,7 +18,7 @@ from typing import Literal
 from loguru import logger
 
 from vibe3.analysis.snapshot_diff_section import build_snapshot_diff_section
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import VibeError
 from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.models.review import ReviewRequest

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
 from vibe3.prompts.manifest import PromptManifest, PromptProvider

--- a/src/vibe3/analysis/coverage_service.py
+++ b/src/vibe3/analysis/coverage_service.py
@@ -40,7 +40,7 @@ class CoverageService:
         Returns:
             Dict of layer name -> threshold percentage
         """
-        from vibe3.config.loader import get_config
+        from vibe3.config import get_config
 
         config = get_config()
         tc = config.quality.test_coverage

--- a/src/vibe3/analysis/inspect_query_service.py
+++ b/src/vibe3/analysis/inspect_query_service.py
@@ -20,7 +20,7 @@ from vibe3.analysis.change_scope_service import (
 )
 from vibe3.analysis.pr_scoring import PRDimensions, generate_score_report
 from vibe3.analysis.serena_service import SerenaService
-from vibe3.config.loader import get_config
+from vibe3.config import get_config
 from vibe3.models.change_source import (
     BranchSource,
     CommitSource,

--- a/src/vibe3/analysis/pr_scoring.py
+++ b/src/vibe3/analysis/pr_scoring.py
@@ -13,7 +13,7 @@ from enum import Enum
 from loguru import logger
 from pydantic import BaseModel
 
-from vibe3.config.loader import get_config
+from vibe3.config import get_config
 from vibe3.exceptions import VibeError
 
 

--- a/src/vibe3/clients/ai_client.py
+++ b/src/vibe3/clients/ai_client.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.config.settings import AIConfig
+from vibe3.config import AIConfig
 
 # Check if litellm is available without importing
 HAS_LITELLM = importlib.util.find_spec("litellm") is not None

--- a/src/vibe3/clients/ai_suggestion_client.py
+++ b/src/vibe3/clients/ai_suggestion_client.py
@@ -6,7 +6,7 @@ import yaml
 from loguru import logger
 
 from vibe3.clients.ai_client import AIClient
-from vibe3.config.settings import AIConfig
+from vibe3.config import AIConfig
 
 DEFAULT_PROMPTS = {
     "pr": {

--- a/src/vibe3/clients/github_labels.py
+++ b/src/vibe3/clients/github_labels.py
@@ -43,7 +43,7 @@ class GhIssueLabelPort:
     def __init__(self, repo: str | None = None) -> None:
         self.repo = repo
         if self.repo is None:
-            from vibe3.config.settings import VibeConfig
+            from vibe3.config import VibeConfig
 
             config = VibeConfig.get_defaults()
             self.repo = getattr(getattr(config, "orchestra", None), "repo", None)

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -172,7 +172,7 @@ def update(
         )
         output_format = "json"
     from vibe3.clients.git_client import GitClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.config import load_orchestra_config
     from vibe3.services.branch_arg import resolve_branch_arg
     from vibe3.services.convention_resolver import ConventionResolver
     from vibe3.utils.issue_ref import try_parse_issue_number

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -29,7 +29,7 @@ from vibe3.commands.flow_status_helpers import (
     _render_snapshot_format,
     _timeline_to_flow_events,
 )
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.exceptions import SystemError, UserError
 from vibe3.services.flow_projection_service import FlowProjectionService
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/commands/inspect_base.py
+++ b/src/vibe3/commands/inspect_base.py
@@ -58,7 +58,7 @@ def register(app: typer.Typer) -> None:
         """
         from vibe3.clients.git_client import GitClient
         from vibe3.clients.github_client import GitHubClient
-        from vibe3.config.loader import get_config
+        from vibe3.config import get_config
         from vibe3.models.change_source import BranchSource
         from vibe3.utils.git_helpers import get_current_branch
 

--- a/src/vibe3/commands/inspect_base_helpers.py
+++ b/src/vibe3/commands/inspect_base_helpers.py
@@ -11,7 +11,7 @@ from vibe3.analysis.change_scope_service import (
 )
 from vibe3.analysis.serena_service import SerenaService
 from vibe3.clients.git_client import GitClient
-from vibe3.config.loader import get_config
+from vibe3.config import get_config
 from vibe3.exceptions import GitError, UserError
 from vibe3.models.change_source import BranchSource
 from vibe3.services.pr_scoring_service import PRDimensions, generate_score_report

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import typer
 
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.services.issue_context_loader import load_issue_info
 
 app = typer.Typer(

--- a/src/vibe3/commands/mcp.py
+++ b/src/vibe3/commands/mcp.py
@@ -38,7 +38,7 @@ def run() -> None:
     from vibe3.clients.git_client import GitClient
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.config import load_orchestra_config
     from vibe3.domain import FlowManager
     from vibe3.services.orchestra_status_service import OrchestraStatusService
 

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -16,7 +16,7 @@ from vibe3.commands.command_options import (
     _TRACE_OPT,
 )
 from vibe3.commands.common import enable_method_trace
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.roles.run import (
     ensure_plan_file_exists,

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.commands.command_options import _ASYNC_OPT
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.observability import setup_logging
 
 app = typer.Typer(
@@ -116,7 +116,7 @@ def _run_supervisor_scan_dry_run() -> None:
     from rich.console import Console
 
     from vibe3.clients.github_client import GitHubClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.config import load_orchestra_config
     from vibe3.services.scan_service import fetch_supervisor_candidates
     from vibe3.ui.scan_display import display_supervisor_dry_run
 

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -18,7 +18,7 @@ from vibe3.commands.common import (
     run_full_check_shortcut,
     validate_trace_options,
 )
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState

--- a/src/vibe3/config/__init__.py
+++ b/src/vibe3/config/__init__.py
@@ -1,24 +1,77 @@
 """Config package."""
 
+from vibe3.config.branch_convention import BranchConvention
 from vibe3.config.loader import get_config, load_config, reload_config
+from vibe3.config.orchestra_config import (
+    AssigneeDispatchConfig,
+    CircuitBreakerConfig,
+    GovernanceConfig,
+    OrchestraConfig,
+    PeriodicCheckConfig,
+    PollingConfig,
+    PRReviewDispatchConfig,
+    StateLabelDispatchConfig,
+    SupervisorHandoffConfig,
+    _default_pid_file,
+)
+from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.profile_config import ProfileConfig
+from vibe3.config.profile_convention import LabelsConvention, ProfileConvention
+from vibe3.config.role_policy import get_role_required_ref_key, get_role_section
 from vibe3.config.settings import (
+    AgentPromptConfig,
+    AIConfig,
+    CheckCleanupSettings,
     CodeLimitsConfig,
     CodePathsConfig,
+    DocLimitsConfig,
+    FileChangeWeights,
+    FlowConfig,
+    LineChangeWeights,
     MergeGateConfig,
+    ModuleChangeWeights,
+    PlanConfig,
     PRScoringConfig,
+    PRScoringThresholds,
+    PRScoringWeights,
     QualityConfig,
+    ReviewConfig,
     ReviewScopeConfig,
+    RunConfig,
     SingleFileLocConfig,
+    SizeThreshold,
+    SizeThresholds,
     TestPathsConfig,
     TotalFileLocConfig,
     VibeConfig,
 )
+from vibe3.config.timeline_comment_policy import (
+    DEFAULT_COMMENT_POLICY,
+    TimelineCommentPolicy,
+)
 
 __all__ = [
+    # From loader.py
     "get_config",
     "load_config",
     "reload_config",
+    # From settings.py
     "VibeConfig",
+    "AIConfig",
+    "FlowConfig",
+    "AgentPromptConfig",
+    "PlanConfig",
+    "ReviewConfig",
+    "RunConfig",
+    "DocLimitsConfig",
+    "CheckCleanupSettings",
+    "PRScoringWeights",
+    "PRScoringThresholds",
+    "LineChangeWeights",
+    "FileChangeWeights",
+    "ModuleChangeWeights",
+    "SizeThreshold",
+    "SizeThresholds",
     "CodeLimitsConfig",
     "SingleFileLocConfig",
     "TotalFileLocConfig",
@@ -28,4 +81,30 @@ __all__ = [
     "QualityConfig",
     "PRScoringConfig",
     "MergeGateConfig",
+    # From orchestra_config.py
+    "OrchestraConfig",
+    "PeriodicCheckConfig",
+    "GovernanceConfig",
+    "PollingConfig",
+    "CircuitBreakerConfig",
+    "AssigneeDispatchConfig",
+    "PRReviewDispatchConfig",
+    "StateLabelDispatchConfig",
+    "SupervisorHandoffConfig",
+    "_default_pid_file",
+    # From orchestra_settings.py
+    "load_orchestra_config",
+    # From role_policy.py
+    "get_role_section",
+    "get_role_required_ref_key",
+    # From timeline_comment_policy.py
+    "TimelineCommentPolicy",
+    "DEFAULT_COMMENT_POLICY",
+    # From profile_config.py
+    "ProfileConfig",
+    # From profile_convention.py
+    "ProfileConvention",
+    "LabelsConvention",
+    # From branch_convention.py
+    "BranchConvention",
 ]

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -12,7 +12,7 @@ from typing import Callable
 from loguru import logger
 
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.domain.events import (
     ExecutorDispatchIntent,
     PlannerDispatchIntent,

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.domain.events.governance import GovernanceScanStarted
 from vibe3.domain.handler_registry import register_handler
 from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
@@ -23,7 +23,7 @@ from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.config.orchestra_config import OrchestraConfig
+    from vibe3.config import OrchestraConfig
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.services.orchestra_status_service import OrchestraStatusService
 

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.domain.events.flow_lifecycle import ManagerDispatchIntent
 from vibe3.domain.handler_registry import register_handler
 from vibe3.exceptions import CapacityDeferredError
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from vibe3.agents.backends.codeagent import CodeagentBackend
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.config.orchestra_settings import OrchestraConfig
+    from vibe3.config import OrchestraConfig
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.execution.coordinator import ExecutionCoordinator

--- a/src/vibe3/domain/handlers/supervisor_scan.py
+++ b/src/vibe3/domain/handlers/supervisor_scan.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.domain.handler_registry import register_handler
 from vibe3.models.orchestration import IssueInfo

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.domain import publish
 from vibe3.domain.events.governance import GovernanceScanStarted
 from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/environment/session_registry.py
+++ b/src/vibe3/environment/session_registry.py
@@ -317,7 +317,7 @@ class SessionRegistryService:
             from vibe3.environment.worktree_context import WorktreeContext
 
             repo_root = find_repo_root()
-            from vibe3.config.orchestra_settings import load_orchestra_config
+            from vibe3.config import load_orchestra_config
 
             config = load_orchestra_config()
             context = WorktreeContext(

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -20,8 +20,7 @@ if TYPE_CHECKING:
         CodeagentCommand,
         CodeagentResult,
     )
-from vibe3.config.role_policy import get_role_required_ref_key, get_role_section
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig, get_role_required_ref_key, get_role_section
 from vibe3.execution.codeagent_support import resolve_command_agent_options
 from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.execution_lifecycle import (
@@ -69,7 +68,7 @@ class CodeagentExecutionService:
         the next tick does not re-dispatch the same issue.
         """
         from vibe3.clients.github_labels import GhIssueLabelPort
-        from vibe3.config.orchestra_settings import load_orchestra_config
+        from vibe3.config import load_orchestra_config
         from vibe3.services.orchestra_helpers import get_handoff_state_label
 
         config = load_orchestra_config()

--- a/src/vibe3/execution/codeagent_support.py
+++ b/src/vibe3/execution/codeagent_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal, Sequence
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.review_runner import AgentOptions
 
 

--- a/src/vibe3/execution/execution_role_policy.py
+++ b/src/vibe3/execution/execution_role_policy.py
@@ -9,7 +9,7 @@ from vibe3.agents.backends.codeagent_config import (
     resolve_effective_agent_options as resolve_backend_effective_agent_options,
 )
 from vibe3.agents.backends.codeagent_config import sync_models_json
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.review_runner import AgentOptions
 

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -14,7 +14,7 @@ from typer import echo
 
 from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
 from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.role_interfaces import GovernanceEventLogger, GovernanceFunctions

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -7,7 +7,7 @@ import typer
 from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
 from vibe3.execution.session_service import load_session_id

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -11,7 +11,7 @@ from typing import Any
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.execution import ExecutionRequest
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -13,8 +13,7 @@ from vibe3.agents.plan_prompt import (
     make_plan_context_builder,
 )
 from vibe3.clients.github_client import GitHubClient
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig, load_orchestra_config
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
 from vibe3.execution.contracts import ExecutionRequest

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -16,8 +16,7 @@ from vibe3.agents.review_prompt import (
     make_review_context_builder,
 )
 from vibe3.analysis.inspect_output_adapter import changed_symbols
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig, load_orchestra_config
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
 from vibe3.execution.contracts import ExecutionRequest

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -14,8 +14,7 @@ from vibe3.agents.run_prompt import (
     make_skill_context_builder,
 )
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig, load_orchestra_config
 from vibe3.exceptions import SkillNotAvailableError
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.execution.issue_role_support import (
     build_task_flow_branch_resolver,

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -10,7 +10,7 @@ from vibe3.agents.run_prompt import (
     make_run_context_builder,
 )
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.issue_role_support import build_issue_sync_spec
 from vibe3.execution.prompt_meta import build_prompt_meta

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -2,7 +2,7 @@
 
 from loguru import logger
 
-from vibe3.config.orchestra_config import PeriodicCheckConfig
+from vibe3.config import PeriodicCheckConfig
 from vibe3.orchestra.logging import append_orchestra_event
 
 

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -9,7 +9,7 @@ Runs two phases on each interval tick:
 
 from loguru import logger
 
-from vibe3.config.orchestra_config import PeriodicCheckConfig
+from vibe3.config import PeriodicCheckConfig
 from vibe3.orchestra.logging import append_orchestra_event
 
 

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -14,7 +14,7 @@ import uvicorn
 
 from vibe3.agents.backends.codeagent_config import find_missing_backend_commands
 from vibe3.clients.git_client import GitClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.observability.logger import setup_logging
 from vibe3.orchestra.logging import orchestra_events_log_path, orchestra_log_dir

--- a/src/vibe3/services/check_cleanup_service.py
+++ b/src/vibe3/services/check_cleanup_service.py
@@ -53,7 +53,7 @@ class CheckCleanupService:
         Returns:
             Dict with summary and details of cleaned branches.
         """
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
         from vibe3.services.expired_resource_cleanup_service import (
             ExpiredResourceCleanupService,
         )

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -340,7 +340,7 @@ class CheckPRService:
             )
 
             # Rebuild flow after reset to avoid dangling state
-            from vibe3.config.orchestra_config import OrchestraConfig
+            from vibe3.config import OrchestraConfig
             from vibe3.services.flow_orchestrator_service import (
                 FlowOrchestratorService,
             )

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -12,7 +12,7 @@ from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.orchestration import IssueState
 from vibe3.models.pr import PRState
 from vibe3.services.check_lock import check_lock

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.config.profile_convention import ProfileConvention
+from vibe3.config import ProfileConvention
 
 if TYPE_CHECKING:
-    from vibe3.config.profile_config import ProfileConfig
+    from vibe3.config import ProfileConfig
 
 
 @dataclass
@@ -186,7 +186,7 @@ class ConventionResolver:
             ProfileConfig instance with detected or explicit profile.
         """
         from vibe3.adapters import get_adapter
-        from vibe3.config.profile_config import ProfileConfig
+        from vibe3.config import ProfileConfig
 
         detected_profile = self.profile or self._detect_profile()
         return ProfileConfig(profile=detected_profile, adapter_resolver=get_adapter)

--- a/src/vibe3/services/expired_resource_cleanup_service.py
+++ b/src/vibe3/services/expired_resource_cleanup_service.py
@@ -185,7 +185,7 @@ class ExpiredResourceCleanupService:
             )
 
         # Load protected branches from config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
 
         config = VibeConfig.get_defaults()
         protected = set(config.flow.protected_branches)
@@ -325,7 +325,7 @@ class ExpiredResourceCleanupService:
             )
 
         # Load protected branches from config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
 
         config = VibeConfig.get_defaults()
         protected = set(config.flow.protected_branches)

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -24,7 +24,7 @@ from vibe3.services.signature_service import SignatureService
 from vibe3.services.task_service import TaskService
 
 if TYPE_CHECKING:
-    from vibe3.config.orchestra_config import OrchestraConfig
+    from vibe3.config import OrchestraConfig
     from vibe3.models.orchestration import IssueInfo
     from vibe3.services.orchestra_status_service import OrchestraSnapshot
 

--- a/src/vibe3/services/flow_service.py
+++ b/src/vibe3/services/flow_service.py
@@ -2,7 +2,7 @@
 
 from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.services.flow_block_mixin import FlowLifecycleMixin
 from vibe3.services.flow_transition import FlowTransitionMixin
 from vibe3.services.git_path_client import GitPathProtocol

--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -7,7 +7,7 @@ from loguru import logger
 from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.orchestration import IssueState
 
 

--- a/src/vibe3/services/flow_timeline_service.py
+++ b/src/vibe3/services/flow_timeline_service.py
@@ -9,7 +9,7 @@ from loguru import logger
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient
     from vibe3.clients.github_client import GitHubClient
-    from vibe3.config.timeline_comment_policy import TimelineCommentPolicy
+    from vibe3.config import TimelineCommentPolicy
 
 
 # Event type to display text mapping
@@ -79,7 +79,7 @@ class FlowTimelineService:
 
         # Use default policy if not provided
         if policy is None:
-            from vibe3.config.timeline_comment_policy import DEFAULT_COMMENT_POLICY
+            from vibe3.config import DEFAULT_COMMENT_POLICY
 
             policy = DEFAULT_COMMENT_POLICY
 

--- a/src/vibe3/services/flow_transition.py
+++ b/src/vibe3/services/flow_transition.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from vibe3.clients import SQLiteClient
 from vibe3.clients.github_client import GitHubClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.models.flow import FlowStatusResponse, MainBranchProtectedError
 from vibe3.services.flow_write_mixin import FlowWriteMixin

--- a/src/vibe3/services/flow_write_mixin.py
+++ b/src/vibe3/services/flow_write_mixin.py
@@ -8,7 +8,7 @@ from typing import Any, Self
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.models.flow import FlowState, FlowStatusResponse, MainBranchProtectedError
 from vibe3.services.flow_read_mixin import FlowReadMixin

--- a/src/vibe3/services/loc_service.py
+++ b/src/vibe3/services/loc_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from loguru import logger
 
 from vibe3.clients.git_client import GitClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.change_source import BranchSource, ChangeSource, PRSource
 
 

--- a/src/vibe3/services/pr_analysis_service.py
+++ b/src/vibe3/services/pr_analysis_service.py
@@ -12,7 +12,7 @@ from loguru import logger
 from vibe3.analysis import dag_service
 from vibe3.analysis.pr_scoring import PRDimensions
 from vibe3.analysis.serena_service import SerenaService
-from vibe3.config.loader import get_config
+from vibe3.config import get_config
 from vibe3.models.change_source import PRSource
 from vibe3.models.pr_analysis import (
     CommitInfo,

--- a/src/vibe3/services/pr_create_usecase.py
+++ b/src/vibe3/services/pr_create_usecase.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from vibe3.clients.ai_suggestion_client import AISuggestionClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.prompts.template_loader import resolve_prompts_path
 from vibe3.services.base_resolution_usecase import BaseResolutionUsecase
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import FailedGate
 from vibe3.services.error_tracking_service import ErrorTrackingService

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -8,7 +8,7 @@ from vibe3.clients import SQLiteClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
 from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.flow import FlowStatusResponse, IssueLink
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState

--- a/src/vibe3/utils/codeagent_helpers.py
+++ b/src/vibe3/utils/codeagent_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Final
 
 from loguru import logger
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 
 # Known backend-internal error patterns with suggested fixes
 KNOWN_BACKEND_ERROR_PATTERNS: Final[tuple[tuple[str, str, str], ...]] = (

--- a/src/vibe3/utils/comment_utils.py
+++ b/src/vibe3/utils/comment_utils.py
@@ -3,7 +3,7 @@
 import re
 from typing import Any
 
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.services.orchestra_helpers import get_manager_usernames
 from vibe3.utils.constants import AUTOMATED_MARKERS, GENERIC_AGENT_MARKER_PATTERN
 

--- a/tests/vibe3/agents/test_codeagent_backend.py
+++ b/tests/vibe3/agents/test_codeagent_backend.py
@@ -11,7 +11,7 @@ from vibe3.agents.backends.async_launcher import (
 from vibe3.agents.backends.codeagent import (
     CodeagentBackend,
 )
-from vibe3.config.settings import AgentPromptConfig, VibeConfig
+from vibe3.config import AgentPromptConfig, VibeConfig
 from vibe3.exceptions import AgentExecutionError
 from vibe3.models.review_runner import (
     AgentOptions,

--- a/tests/vibe3/agents/test_resolve_agent_options.py
+++ b/tests/vibe3/agents/test_resolve_agent_options.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.execution.codeagent_support import resolve_command_agent_options
 
 

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -8,7 +8,7 @@ from vibe3.agents.run_prompt import (
     build_run_prompt_body,
     build_run_task_section,
 )
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.plan import PlanRequest, PlanScope
 
 FORBIDDEN_INTERNAL_TOKENS = (

--- a/tests/vibe3/clients/test_ai_client.py
+++ b/tests/vibe3/clients/test_ai_client.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from vibe3.clients.ai_client import AIClient
-from vibe3.config.settings import AIConfig
+from vibe3.config import AIConfig
 
 
 class TestAIClient:

--- a/tests/vibe3/clients/test_ai_suggestion_client.py
+++ b/tests/vibe3/clients/test_ai_suggestion_client.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from vibe3.clients.ai_client import AIClient
 from vibe3.clients.ai_suggestion_client import AISuggestionClient
-from vibe3.config.settings import AIConfig
+from vibe3.config import AIConfig
 
 
 class TestAISuggestionClient:

--- a/tests/vibe3/commands/test_inspect_base.py
+++ b/tests/vibe3/commands/test_inspect_base.py
@@ -22,7 +22,7 @@ def test_inspect_base_default_parent():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 with patch(
@@ -45,7 +45,7 @@ def test_inspect_base_custom_base_branch():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
 
@@ -72,7 +72,7 @@ def test_inspect_base_with_core_files():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 dag_mod = "vibe3.analysis.dag_service"
@@ -104,7 +104,7 @@ def test_inspect_base_json_output():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = []
                 dag_mod = "vibe3.analysis.dag_service"
@@ -150,7 +150,7 @@ def test_inspect_base_json_custom_branch():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = []
                 dag_mod = "vibe3.analysis.dag_service"
@@ -192,7 +192,7 @@ def test_inspect_base_uses_shared_base_resolver():
         with patch(
             "vibe3.utils.git_helpers.get_current_branch", return_value="feature/test"
         ):
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 with patch(

--- a/tests/vibe3/commands/test_pr_create_ai.py
+++ b/tests/vibe3/commands/test_pr_create_ai.py
@@ -9,7 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from vibe3.cli import app
-from vibe3.config.settings import AIConfig
+from vibe3.config import AIConfig
 from vibe3.models.pr import UpdatePRRequest
 from vibe3.utils.branch_compare import BranchBehindInfo
 

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -33,7 +33,7 @@ class TestReviewContextBuilderUsesAssembler:
     def test_make_review_context_builder_calls_body_builder(self) -> None:
         """make_review_context_builder should invoke build_review_prompt_body."""
         from vibe3.agents.review_prompt import make_review_context_builder
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
         from vibe3.models.review import ReviewRequest, ReviewScope
 
         config = VibeConfig.get_defaults()

--- a/tests/vibe3/config/test_loader.py
+++ b/tests/vibe3/config/test_loader.py
@@ -6,13 +6,12 @@ from pathlib import Path
 
 import pytest
 
+from vibe3.config import VibeConfig, load_config
 from vibe3.config.loader import (
     _deep_merge,
     _expand_variables,
-    load_config,
     load_yaml_config,
 )
-from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import ConfigError
 
 

--- a/tests/vibe3/config/test_migrated_config_paths.py
+++ b/tests/vibe3/config/test_migrated_config_paths.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.prompts.manifest import DEFAULT_PROMPT_RECIPES_PATH
 
 

--- a/tests/vibe3/config/test_policy_paths.py
+++ b/tests/vibe3/config/test_policy_paths.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from vibe3.config.settings import PlanConfig, ReviewConfig, RunConfig
+from vibe3.config import PlanConfig, ReviewConfig, RunConfig
 from vibe3.services.convention_resolver import ConventionResolver
 
 

--- a/tests/vibe3/config/test_profile_config.py
+++ b/tests/vibe3/config/test_profile_config.py
@@ -1,7 +1,7 @@
 """Tests for profile-based resource resolution."""
 
 from vibe3.adapters import get_adapter
-from vibe3.config.profile_config import ProfileConfig
+from vibe3.config import ProfileConfig
 from vibe3.services.convention_resolver import ConventionResolver
 
 

--- a/tests/vibe3/config/test_profile_convention.py
+++ b/tests/vibe3/config/test_profile_convention.py
@@ -1,8 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from vibe3.config.branch_convention import BranchConvention
-from vibe3.config.profile_convention import LabelsConvention, ProfileConvention
+from vibe3.config import BranchConvention, LabelsConvention, ProfileConvention
 
 
 def test_labels_convention_minimal_defaults():

--- a/tests/vibe3/config/test_settings.py
+++ b/tests/vibe3/config/test_settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 
 
 class TestExpandConfigVariables:

--- a/tests/vibe3/hooks/test_loc_settings.py
+++ b/tests/vibe3/hooks/test_loc_settings.py
@@ -6,7 +6,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 
 
 def _load_loc_settings_module():

--- a/tests/vibe3/integration/test_ci_parity.py
+++ b/tests/vibe3/integration/test_ci_parity.py
@@ -87,7 +87,7 @@ class TestGitStateIndependence:
             with patch(
                 "vibe3.utils.git_helpers.get_current_branch", return_value="test-branch"
             ):
-                with patch("vibe3.config.loader.get_config") as mock_config:
+                with patch("vibe3.config.get_config") as mock_config:
                     mock_config.return_value.review_scope.critical_paths = []
                     mock_config.return_value.review_scope.public_api_paths = []
                     with patch(

--- a/tests/vibe3/integration/test_ci_parity.py
+++ b/tests/vibe3/integration/test_ci_parity.py
@@ -44,7 +44,7 @@ class TestWorkingDirectoryIndependence:
         """Verify config loading works from any working directory."""
         import os
 
-        from vibe3.config.loader import get_config
+        from vibe3.config import get_config
         from vibe3.services.path_helpers import get_worktree_root
 
         # Save current working directory
@@ -113,7 +113,7 @@ class TestEnvironmentVariableIndependence:
             # If a test requires GITHUB_ACTIONS=true, it should mock it
 
             # Import and verify basic functionality works
-            from vibe3.config.loader import get_config
+            from vibe3.config import get_config
 
             config = get_config()
             assert config is not None

--- a/tests/vibe3/models/test_flow_migration.py
+++ b/tests/vibe3/models/test_flow_migration.py
@@ -83,8 +83,7 @@ class TestOrchestraConfigMapping:
     def test_from_settings_maps_supervisor_prompt_template(self) -> None:
         from unittest.mock import patch
 
-        from vibe3.config.orchestra_settings import load_orchestra_config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig, load_orchestra_config
 
         settings = VibeConfig.get_defaults()
         settings.orchestra.supervisor_handoff.prompt_template = (
@@ -102,8 +101,7 @@ class TestOrchestraConfigMapping:
         """Default retry budget should be 3 (not 20) to fail fast on stuck entries."""
         from unittest.mock import patch
 
-        from vibe3.config.orchestra_settings import load_orchestra_config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig, load_orchestra_config
 
         settings = VibeConfig.get_defaults()
 

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 import vibe3.server.app as serve_module
 from vibe3.cli import app
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import GateResult
 from vibe3.server.registry import _build_async_serve_command

--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -275,7 +275,7 @@ def test_no_shutdown_callback_cleanup_still_runs() -> None:
 @pytest.mark.asyncio
 async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
     """Cleanup should trigger on tick number that is a multiple of interval_ticks."""
-    from vibe3.config.orchestra_config import PeriodicCheckConfig
+    from vibe3.config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,
@@ -319,7 +319,7 @@ async def test_tick_loop_triggers_cleanup_on_interval_tick(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -> None:
     """Cleanup failure should not prevent service dispatch."""
-    from vibe3.config.orchestra_config import PeriodicCheckConfig
+    from vibe3.config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,
@@ -363,7 +363,7 @@ async def test_tick_loop_cleanup_failure_does_not_affect_services(monkeypatch) -
 @pytest.mark.asyncio
 async def test_tick_loop_skip_cleanup_when_disabled(monkeypatch) -> None:
     """Cleanup should not run when disabled in config."""
-    from vibe3.config.orchestra_config import PeriodicCheckConfig
+    from vibe3.config import PeriodicCheckConfig
 
     config = OrchestraConfig(
         polling_interval=1,

--- a/tests/vibe3/services/test_convention_resolver.py
+++ b/tests/vibe3/services/test_convention_resolver.py
@@ -128,7 +128,7 @@ def test_convention_used_for_branch_generation():
 
 def test_convention_no_prefix_state_label():
     """Test state_label with empty prefix."""
-    from vibe3.config.profile_convention import ProfileConvention
+    from vibe3.config import ProfileConvention
 
     convention = ProfileConvention(state_prefix="")
     assert convention.state_label("handoff") == "handoff"

--- a/tests/vibe3/services/test_flow_main_branch_guard.py
+++ b/tests/vibe3/services/test_flow_main_branch_guard.py
@@ -3,7 +3,7 @@
 import pytest
 
 from vibe3.clients import SQLiteClient
-from vibe3.config.settings import FlowConfig, VibeConfig
+from vibe3.config import FlowConfig, VibeConfig
 from vibe3.models.flow import MainBranchProtectedError
 from vibe3.services.flow_service import FlowService
 

--- a/tests/vibe3/services/test_flow_orchestrator_service.py
+++ b/tests/vibe3/services/test_flow_orchestrator_service.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.models.orchestration import IssueInfo
 from vibe3.models.pr import PRResponse, PRState
 from vibe3.services.flow_orchestrator_service import FlowOrchestratorService

--- a/tests/vibe3/services/test_issue_flow_service.py
+++ b/tests/vibe3/services/test_issue_flow_service.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
-from vibe3.config.profile_convention import ProfileConvention
+from vibe3.config import ProfileConvention
 from vibe3.models.branch_convention import BranchConvention
 from vibe3.services.issue_flow_service import IssueFlowService
 


### PR DESCRIPTION
Closes #1647

## Summary

This PR expands `config/__init__.py` to serve as a comprehensive public API entry point and refactors 79 external files to import through the public interface instead of directly from config submodules.

## Changes

### 1. config/__init__.py: Expanded public API exports
Added imports and `__all__` entries for all public symbols from config submodules:
- Settings and configs (VibeConfig, OrchestraConfig, etc.)
- Loaders and utilities (load_config, load_orchestra_config, etc.)
- Policy and convention classes (TimelineCommentPolicy, ProfileConvention, etc.)

### 2. Source files (57 files): Import consolidation
Replaced `from vibe3.config.<submodule> import X` with `from vibe3.config import X`

### 3. Test files (22 files): Import consolidation
Applied same refactoring pattern to test files, with special handling for test_loader.py to keep private symbol imports.

### 4. Mock path updates (7 occurrences in 2 files)
Fixed test isolation issues after refactoring:
- tests/vibe3/commands/test_inspect_base.py (6 occurrences)
- tests/vibe3/integration/test_ci_parity.py (1 occurrence)

## Test Results

- ✅ mypy: no issues in 366 source files
- ✅ ruff: all checks passed
- ✅ Tests: 765 passed
- ✅ Violations reduced from 85 to 6 (only config internals + test_loader.py)

## Related

- Issue: #1647
- Follow-up: #1685 (test mock path updates for other files)
- Audit: docs/reports/issue-1647-audit-report.md

---

## Contributors

claude/opus
