### PR TITLE
fix(config): add vibe3 config root fallback for cross-project invocation

### DIFF
--- a/docs/closeout/task-issue-1663.md
+++ b/docs/closeout/task-issue-1663.md
@@ -1,0 +1,54 @@
+# Executor Publish Directive
+
+## Task
+Create PR for issue #1663 - Cross-Project Config Loading Fix
+
+## Commit
+- SHA: 2361eb86
+- Message: fix(config): add vibe3 config root fallback for cross-project invocation
+- Branch: task/issue-1663
+- Base branch: main
+
+## PR Requirements
+
+### Title
+fix(config): add vibe3 config root fallback for cross-project invocation
+
+### Description Template
+```markdown
+## Summary
+- Fixes #1663: Cross-project vibe3 invocation now correctly loads agent_config
+- Root cause: Config loader used CWD-relative paths which failed from external projects
+- Solution: Added `_vibe3_config_root()` helper to find vibe3 installation directory as fallback
+
+## Changes
+- **settings.py**: Added `_vibe3_config_root()` helper to locate vibe3 installation directory
+- **settings.py**: Modified `get_defaults()` to check vibe3 config root after CWD checks fail
+- **settings.py**: Modified `_load_supplementary()` to accept config_path parameter for relative resolution
+- **loader.py**: Modified `find_config_file()` to include vibe3 config root in search path (step 4)
+- **loader.py**: Modified `load_config()` to fallback to vibe3 config root for repo_config_path
+
+## Testing
+- ✅ 75/75 config tests pass
+- ✅ Manual verification from /tmp successful
+- ✅ Type checking (mypy) pass
+- ✅ Linting (ruff) pass
+- ✅ All existing tests pass (backward compatibility preserved)
+
+## Notes
+- Backward compatible: CWD-local config still has priority
+- Created follow-up issue #1690 for pre-existing config naming inconsistency
+```
+
+## Review Reference
+- Audit report: docs/reports/issue-1663-audit-report.md
+- Verdict: PASS
+
+## After PR Creation
+- PR reference will be recorded as pr_ref
+- Issue will transition to state/done after manager reviews PR
+
+## Important
+- Ensure PR targets main branch
+- Verify CI passes before reporting completion
+- If CI fails, report failure in handoff and remain in merge-ready state

--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import yaml
 from loguru import logger
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config.settings import VibeConfig, _vibe3_config_root
 from vibe3.exceptions import ConfigError
 
 
@@ -129,7 +129,8 @@ def find_config_file() -> Path | None:
     1. .vibe/config.yaml (project-specific)
     2. config/v3/settings.yaml (new default config)
     3. config/settings.yaml (deprecated fallback)
-    4. ~/.vibe/config.yaml (global config)
+    4. config/v3/settings.yaml (vibe3 installation root fallback)
+    5. ~/.vibe/config.yaml (global config)
 
     Returns:
         Path to config file or None if not found
@@ -158,6 +159,15 @@ def find_config_file() -> Path | None:
             "Please migrate to config/v3/settings.yaml"
         )
         return old_config
+
+    # Check vibe3 installation root as fallback (for cross-project invocation)
+    import_root = _vibe3_config_root()
+    root_config = import_root / "config" / "v3" / "settings.yaml"
+    if root_config.exists() and root_config.resolve() != new_config.resolve():
+        logger.bind(domain="config", action="find", path=str(root_config)).debug(
+            "Found vibe3 installation config"
+        )
+        return root_config
 
     # Check global config
     global_config = Path.home() / ".vibe" / "config.yaml"
@@ -201,6 +211,8 @@ def load_config(config_path: Path | None = None) -> VibeConfig:
         # If explicit config_path is provided, treat it as highest priority
         # Otherwise, use repo fallback as base
         repo_config_path = Path("config/v3/settings.yaml")
+        if not repo_config_path.exists():
+            repo_config_path = _vibe3_config_root() / "config" / "v3" / "settings.yaml"
 
         # Check if config_path is auto-detected or explicit
         auto_detected = find_config_file()
@@ -233,7 +245,8 @@ def load_config(config_path: Path | None = None) -> VibeConfig:
 
         # Apply supplementary loading (loc_limits + prompts)
         # This ensures we don't bypass VibeConfig.from_yaml() semantics
-        config_data = VibeConfig._load_supplementary(config_data)
+        # Pass repo_config_path as base for resolving supplementary files
+        config_data = VibeConfig._load_supplementary(config_data, repo_config_path)
 
         try:
             config = VibeConfig(**config_data)

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -28,6 +28,47 @@ from vibe3.config.settings_pr import (
 )
 
 
+def _vibe3_config_root() -> Path:
+    """Find the vibe3 config root directory by walking up from this module.
+
+    Returns the directory containing config/v3/settings.yaml, which is the vibe3
+    installation root (repo root for source installs, ~/.vibe for pip installs).
+
+    Used as fallback when CWD-relative config paths fail (cross-project invocation).
+    """
+    # Start from this module's location
+    current = Path(__file__).resolve()
+
+    # Walk up to find the directory containing config/v3/settings.yaml
+    # Max 10 levels to prevent infinite loops
+    for _ in range(10):
+        parent = current.parent
+        if parent == current:
+            # Reached filesystem root, stop
+            break
+
+        # Check if this parent contains config/v3/settings.yaml
+        if (parent / "config" / "v3" / "settings.yaml").exists():
+            return parent
+
+        current = parent
+
+    # Fallback: return parent of src/ directory (repo root for source installs)
+    # This handles the case where config/v3/settings.yaml doesn't exist yet
+    # Walk up from __file__ to find the directory containing src/vibe3/
+    current = Path(__file__).resolve()
+    for _ in range(10):
+        parent = current.parent
+        if parent == current:
+            break
+        if (parent / "src" / "vibe3").exists():
+            return parent
+        current = parent
+
+    # Last resort: return current working directory
+    return Path.cwd()
+
+
 class AIConfig(BaseModel):
     """AI 辅助配置.
 
@@ -310,14 +351,25 @@ class VibeConfig(BaseModel):
     check_cleanup: CheckCleanupSettings = Field(default_factory=CheckCleanupSettings)
 
     @classmethod
-    def _load_supplementary(cls, data: dict) -> dict:
+    def _load_supplementary(cls, data: dict, config_path: Path | None = None) -> dict:
         """Merge LOC limits and prompt content from their migrated config files."""
         import yaml
         from loguru import logger
 
+        # Determine base directory for resolving supplementary files
+        if config_path is not None:
+            # Use the directory containing the config file
+            config_root = config_path.resolve().parent.parent  # config/v3/ -> config/
+        else:
+            config_root = None
+
         # Load loc_limits.yaml for code_limits and doc_limits
         # Try new path first, then fallback to old path
         new_loc_limits_path = Path("config/v3/loc_limits.yaml")
+        if not new_loc_limits_path.exists():
+            new_loc_limits_path = (
+                _vibe3_config_root() / "config" / "v3" / "loc_limits.yaml"
+            )
         old_loc_limits_path = Path("config/loc_limits.yaml")
         loc_limits_path = None
 
@@ -329,6 +381,11 @@ class VibeConfig(BaseModel):
                 "Please migrate to config/v3/loc_limits.yaml"
             )
             loc_limits_path = old_loc_limits_path
+        elif config_root is not None:
+            # Try relative to config file
+            root_loc_limits = config_root / "v3" / "loc_limits.yaml"
+            if root_loc_limits.exists():
+                loc_limits_path = root_loc_limits
 
         if loc_limits_path:
             with open(loc_limits_path) as f:
@@ -355,6 +412,11 @@ class VibeConfig(BaseModel):
                 prompts_path = new_prompts_path
             elif old_prompts_path.exists():
                 prompts_path = old_prompts_path
+            elif config_root is not None:
+                # Try relative to config file
+                root_prompts = config_root / "prompts" / "prompts.yaml"
+                if root_prompts.exists():
+                    prompts_path = root_prompts
 
         if prompts_path:
             with open(prompts_path) as f:
@@ -426,7 +488,7 @@ class VibeConfig(BaseModel):
         if data is None:
             data = {}
 
-        data = cls._load_supplementary(data)
+        data = cls._load_supplementary(data, config_path)
 
         # Expand variable references before instantiation
         data = cls._expand_config_variables(data)
@@ -439,7 +501,15 @@ class VibeConfig(BaseModel):
         new_default_path = Path("config/v3/settings.yaml")
         if new_default_path.exists():
             return cls.from_yaml(new_default_path)
+        # Fallback: vibe3 installation default config
+        root = _vibe3_config_root()
+        root_new_path = root / "config" / "v3" / "settings.yaml"
+        if root_new_path.exists():
+            return cls.from_yaml(root_new_path)
         legacy_default_path = Path("config/settings.yaml")
         if legacy_default_path.exists():
             return cls.from_yaml(legacy_default_path)
+        root_legacy_path = root / "config" / "settings.yaml"
+        if root_legacy_path.exists():
+            return cls.from_yaml(root_legacy_path)
         return cls()

--- a/tests/vibe3/config/test_loader.py
+++ b/tests/vibe3/config/test_loader.py
@@ -237,3 +237,14 @@ class TestLoadConfig:
 
         with pytest.raises(ConfigError, match="Invalid YAML"):
             load_config()
+
+    def test_load_config_from_external_cwd(self, tmp_path: Path, monkeypatch) -> None:
+        """Config loading works when CWD has no vibe3 config files."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        # tmp_path is empty — no .vibe/, no config/v3/ — simulating external project
+        config = load_config()
+        # Should have agent_config from vibe3 installation defaults
+        assert config.plan.agent_config.agent is not None
+        assert config.run.agent_config.agent is not None
+        assert config.review.agent_config.agent is not None

--- a/tests/vibe3/config/test_migrated_config_paths.py
+++ b/tests/vibe3/config/test_migrated_config_paths.py
@@ -112,6 +112,13 @@ def test_get_defaults_prefers_v3_settings_path(tmp_path: Path, monkeypatch) -> N
     assert config.flow.protected_branches == ["v3-main"]
 
 
+def test_get_defaults_from_external_cwd(tmp_path: Path, monkeypatch) -> None:
+    """get_defaults() works when CWD has no config/v3/settings.yaml."""
+    monkeypatch.chdir(tmp_path)
+    config = VibeConfig.get_defaults()
+    assert config.plan.agent_config.agent is not None
+
+
 def test_dependencies_loader_reads_v3_path(tmp_path: Path, monkeypatch) -> None:
     """The dependencies helper should not require root config/dependencies.toml."""
     config_dir = tmp_path / "config" / "v3"

--- a/tests/vibe3/config/test_vibe_config.py
+++ b/tests/vibe3/config/test_vibe_config.py
@@ -15,3 +15,15 @@ def test_vibe_center_repo_config():
 
     assert config["profile"] == "vibe-center"
     assert config["adapter"] == "vibe-center"
+
+
+def test_supplementary_loading_from_external_cwd(tmp_path: Path, monkeypatch) -> None:
+    """Verify that supplementary data is loaded when CWD is external."""
+    from vibe3.config.settings import VibeConfig
+
+    monkeypatch.chdir(tmp_path)
+    config = VibeConfig.get_defaults()
+    # Verify supplementary fields are populated
+    assert config.doc_limits, "doc_limits should be loaded from loc_limits.yaml"
+    assert config.review.review_task, "review_task should be loaded from prompts.yaml"
+    assert config.plan.plan_task, "plan_task should be loaded from prompts.yaml"


### PR DESCRIPTION
## Summary
- Fixes #1663: Cross-project vibe3 invocation now correctly loads agent_config
- Root cause: Config loader used CWD-relative paths which failed from external projects
- Solution: Added `_vibe3_config_root()` helper to find vibe3 installation directory as fallback

## Changes
- **settings.py**: Added `_vibe3_config_root()` helper to locate vibe3 installation directory
- **settings.py**: Modified `get_defaults()` to check vibe3 config root after CWD checks fail
- **settings.py**: Modified `_load_supplementary()` to accept config_path parameter for relative resolution
- **loader.py**: Modified `find_config_file()` to include vibe3 config root in search path (step 4)
- **loader.py**: Modified `load_config()` to fallback to vibe3 config root for repo_config_path

## Testing
- ✅ 75/75 config tests pass
- ✅ Manual verification from /tmp successful
- ✅ Type checking (mypy) pass
- ✅ Linting (ruff) pass
- ✅ All existing tests pass (backward compatibility preserved)

## Notes
- Backward compatible: CWD-local config still has priority
- Created follow-up issue #1690 for pre-existing config naming inconsistency

---

## Contributors

claude/opus
