### PR TITLE
refactor(config): remove dead code _policy_name class attributes

### DIFF
--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -228,7 +228,6 @@ class PolicyResolverMixin:
 class ReviewConfig(BaseModel, PolicyResolverMixin):
     """Review configuration."""
 
-    _policy_name = "review"
     policy_file: str | None = Field(
         default=None,
         description="Path to review policy (None = use profile resolution)",
@@ -246,7 +245,6 @@ class ReviewConfig(BaseModel, PolicyResolverMixin):
 class PlanConfig(BaseModel, PolicyResolverMixin):
     """Plan command configuration."""
 
-    _policy_name = "plan"
     policy_file: str | None = Field(
         default=None, description="Path to plan policy (None = use profile resolution)"
     )
@@ -263,7 +261,6 @@ class PlanConfig(BaseModel, PolicyResolverMixin):
 class RunConfig(BaseModel, PolicyResolverMixin):
     """Run command configuration."""
 
-    _policy_name = "run"
     policy_file: str | None = Field(
         default=None, description="Path to run policy (None = use profile resolution)"
     )


### PR DESCRIPTION
## Summary
- 删除 ReviewConfig/PlanConfig/RunConfig 中 3 处 _policy_name 死代码属性
- 纯代码清洁度改进，无功能影响

## Verification
- ✅ rg '_policy_name' 无结果
- ✅ mypy 类型检查通过
- ✅ ruff lint 通过
- ✅ 72 个 config 模块测试通过

Closes #1674

---

## Contributors

claude/opus
