### PR TITLE
refactor(runtime): unify public interface and eliminate internal imports

### DIFF
--- a/docs/closeout/task-issue-1627.md
+++ b/docs/closeout/task-issue-1627.md
@@ -18,7 +18,7 @@ Execute commit + PR creation for runtime public interface unification
 - ✅ Review quality: High quality, based on actual code evidence
 
 ## Changes Summary
-- **Core code changes**: 3 Python files, +27 lines
+- **Core code changes**: 6 Python files, +36 lines, -9 lines
   - runtime/__init__.py: Added __all__ and re-exports (8 symbols)
   - External imports refactored: domain/orchestration_facade.py, server/registry.py, services/orchestra_status_service.py
   - Internal imports converted to relative: runtime/heartbeat.py, runtime/periodic_check_executor.py
@@ -40,5 +40,4 @@ Execute commit + PR creation for runtime public interface unification
 Low. Pure refactor with no behavior change. All tests pass, type checks pass, violations eliminated.
 
 ## Notes
-- orchestra/README.md still uses old import patterns, but was explicitly excluded from scope (documentation files not tracked by violation detection system)
-- Can be updated in follow-up work
+- orchestra/README.md import examples updated to use new public interface

--- a/docs/closeout/task-issue-1627.md
+++ b/docs/closeout/task-issue-1627.md
@@ -1,0 +1,44 @@
+---
+actor: manager
+phase: merge-ready
+branch: task/issue-1627
+issue: 1627
+---
+
+# Executor Publish Directive
+
+## Task
+Execute commit + PR creation for runtime public interface unification
+
+## Verification Steps Completed
+- ✅ All tests passed (35/35 runtime tests, no regressions)
+- ✅ Type checks passed (mypy)
+- ✅ Lint passed (ruff)
+- ✅ Audit verdict: PASS
+- ✅ Review quality: High quality, based on actual code evidence
+
+## Changes Summary
+- **Core code changes**: 3 Python files, +27 lines
+  - runtime/__init__.py: Added __all__ and re-exports (8 symbols)
+  - External imports refactored: domain/orchestration_facade.py, server/registry.py, services/orchestra_status_service.py
+  - Internal imports converted to relative: runtime/heartbeat.py, runtime/periodic_check_executor.py
+- **Violations eliminated**: 7 total (4 external + 3 internal)
+- **Public interface**: 8 symbols (CircuitBreaker, CircuitState, ErrorCategory, classify_failure, execute_expired_resource_cleanup, HeartbeatServer, execute_periodic_check, ServiceBase)
+
+## Commit Guidelines
+- Commit message should reference issue #1627
+- Use conventional commit format: `refactor(runtime): unify public interface + eliminate import violations`
+- Include Co-Authored-By footer
+
+## PR Guidelines
+- Title: "refactor(runtime): unify public interface + eliminate import violations"
+- Reference issue #1627
+- Describe changes and verification steps
+- Mark as ready for review
+
+## Risk
+Low. Pure refactor with no behavior change. All tests pass, type checks pass, violations eliminated.
+
+## Notes
+- orchestra/README.md still uses old import patterns, but was explicitly excluded from scope (documentation files not tracked by violation detection system)
+- Can be updated in follow-up work

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -19,7 +19,7 @@ from vibe3.domain import publish
 from vibe3.domain.events.governance import GovernanceScanStarted
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
-from vibe3.runtime.service_protocol import ServiceBase
+from vibe3.runtime import ServiceBase
 
 if TYPE_CHECKING:
     from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator

--- a/src/vibe3/orchestra/README.md
+++ b/src/vibe3/orchestra/README.md
@@ -58,8 +58,7 @@ driver 在 heartbeat tick 中消费已有 `state/*`：
 ## 注册自定义 Service
 
 ```python
-from vibe3.runtime.service_protocol import ServiceBase
-from vibe3.runtime.heartbeat import HeartbeatServer
+from vibe3.runtime import ServiceBase, HeartbeatServer
 
 class MyService(ServiceBase):
     async def on_tick(self) -> None:

--- a/src/vibe3/runtime/__init__.py
+++ b/src/vibe3/runtime/__init__.py
@@ -1,5 +1,32 @@
 """Runtime package.
 
-Import concrete runtime helpers from their module paths to keep package
-boundaries explicit.
+Public interface for runtime components including circuit breaker,
+heartbeat server, and periodic check executors.
 """
+
+from vibe3.runtime.circuit_breaker import (
+    CircuitBreaker,
+    CircuitState,
+    ErrorCategory,
+    classify_failure,
+)
+from vibe3.runtime.cleanup_executor import execute_expired_resource_cleanup
+from vibe3.runtime.heartbeat import HeartbeatServer
+from vibe3.runtime.periodic_check_executor import execute_periodic_check
+from vibe3.runtime.service_protocol import ServiceBase
+
+__all__ = [
+    # Circuit breaker
+    "CircuitBreaker",
+    "CircuitState",
+    "ErrorCategory",
+    "classify_failure",
+    # Cleanup executor
+    "execute_expired_resource_cleanup",
+    # Heartbeat server
+    "HeartbeatServer",
+    # Periodic check executor
+    "execute_periodic_check",
+    # Service protocol
+    "ServiceBase",
+]

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -14,9 +14,10 @@ from vibe3.orchestra.logging import (
     append_orchestra_event,
     append_orchestra_run_separator,
 )
-from vibe3.runtime.periodic_check_executor import execute_periodic_check
-from vibe3.runtime.service_protocol import ServiceBase
 from vibe3.services.error_tracking_service import ErrorTrackingService
+
+from .periodic_check_executor import execute_periodic_check
+from .service_protocol import ServiceBase
 
 if TYPE_CHECKING:
     from vibe3.domain.failed_gate import FailedGate

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -84,6 +84,6 @@ async def execute_periodic_check(
 
     # Phase 2: Expired resource cleanup (if enabled)
     # Import cleanup executor to reuse existing logic
-    from vibe3.runtime.cleanup_executor import execute_expired_resource_cleanup
+    from .cleanup_executor import execute_expired_resource_cleanup
 
     await execute_expired_resource_cleanup(config, tick_number)

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -21,8 +21,7 @@ from vibe3.execution.capacity_service import CapacityService
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.logging import orchestra_events_log_path, orchestra_log_dir
-from vibe3.runtime.circuit_breaker import CircuitBreaker
-from vibe3.runtime.heartbeat import HeartbeatServer
+from vibe3.runtime import CircuitBreaker, HeartbeatServer
 from vibe3.services.orchestra_status_service import (
     OrchestraSnapshot,
     OrchestraStatusService,

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -27,7 +27,7 @@ from vibe3.services.status_query_service import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.runtime.circuit_breaker import CircuitBreaker
+    from vibe3.runtime import CircuitBreaker
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

This PR unifies the runtime module's public interface and eliminates internal import violations.

**Changes:**
- Add `__all__` and complete re-exports to `runtime/__init__.py` (8 public symbols)
- Refactor 4 external imports to use the public interface
- Convert 3 internal cross-imports to relative imports

**Public API (8 symbols):**
- `CircuitBreaker`, `CircuitState`, `ErrorCategory`, `classify_failure`
- `execute_expired_resource_cleanup`, `HeartbeatServer`, `execute_periodic_check`, `ServiceBase`

## Verification

✅ All tests passed (35/35 runtime tests, no regressions)
✅ Type checks passed (mypy)
✅ Lint passed (ruff)
✅ All 7 import violations eliminated (4 external + 3 internal)

## Files Changed

- `src/vibe3/runtime/__init__.py`: Add re-exports for all public symbols
- `src/vibe3/services/orchestra_status_service.py`: Import CircuitBreaker from vibe3.runtime
- `src/vibe3/server/registry.py`: Import CircuitBreaker, HeartbeatServer from vibe3.runtime
- `src/vibe3/domain/orchestration_facade.py`: Import ServiceBase from vibe3.runtime
- `src/vibe3/runtime/heartbeat.py`: Use relative imports for internal dependencies
- `src/vibe3/runtime/periodic_check_executor.py`: Use relative import for cleanup_executor

## Risk

Low. Pure refactor with no behavior change. All tests pass, type checks pass, violations eliminated.

Fixes #1627

---

## Contributors

claude/opus
