### PR TITLE
docs: V3 documentation semantic alignment (Batch 9)

### DIFF
--- a/docs/standards/agent-workflow-standard.md
+++ b/docs/standards/agent-workflow-standard.md
@@ -136,8 +136,8 @@ vibe3 run --plan  # 恢复 session 继续工作
 # Handoff 显示 session 信息
 vibe3 handoff show
 
-# 查看当前 flow 状态
-vibe3 flow status
+# 查看当前 flow 详情
+vibe3 flow show
 ```
 
 **清理 Session**：

--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -65,7 +65,7 @@ related_docs:
   - GitHub issue 不是 flow
 - 落点：
   - 命令语义见 [command-standard.md](v3/command-standard.md)
-  - task 关联字段见 [registry-json-standard.md](v3/registry-json-standard.md)
+  - task 关联字段见 [data-model-standard.md](v3/data-model-standard.md)
   - 标准规范见 [issue-standard.md](issue-standard.md)
 - 使用规则：
   - 所有 issue 都是 GitHub repository issue
@@ -151,17 +151,17 @@ related_docs:
 - 使用规则：
   - roadmap governance 可从此池中把适合自动化推进的 issue 纳入 assignee issue pool。
   - cron governance 可从与文档治理相关的 broader repo 范围中形成 supervisor issue。
-### 3.3.5 `task audit`
+### 3.3.5 `check`
 
-- 正式术语：`task audit`
-- 别称：无
-- 定义：`vibe task audit` 对 execution record、runtime 绑定证据和关联完整性进行审计/修复的动作。
+- 正式术语：`check`
+- 别称：`handoff check`
+- 定义：`vibe3 check` 对 execution record (handoff artifact)、runtime 绑定证据和关联完整性进行审计/修复的动作。
 - 边界：
-  - `task audit` 不是 roadmap mirror 同步
-  - `task audit` 不替 OpenSpec 或 plan 文档定义规划优先级
+  - `check` 不是 roadmap mirror 同步
+  - `check` 不替 OpenSpec 或 plan 文档定义规划优先级
 - 使用规则：
-  - 讨论 task registry、分支、OpenSpec、plans 的执行层核对时使用 `task audit`
-  - 不要把 `task audit` 表述成 GitHub Project 同步
+  - 讨论 task registry、handoff store、分支、OpenSpec、plans 的执行层核对时使用 `check`
+  - 不要把 `check` 表述成 GitHub Project 同步
 
 ### 3.3.6 `OpenSpec 注册`
 
@@ -251,7 +251,7 @@ related_docs:
   - `pr` 不是 task
   - `pr` 不是 flow
 - 落点：
-  - task 与 PR 的关系见 [registry-json-standard.md](registry-json-standard.md)
+  - task 与 PR 的关系见 [data-model-standard.md](v3/data-model-standard.md)
 - 使用规则：
   - 讨论代码评审与合并对象时使用 `pr`
   - 不要把 `pr` 当作需求或执行单元

--- a/docs/standards/v3/orchestra-runtime-standard.md
+++ b/docs/standards/v3/orchestra-runtime-standard.md
@@ -43,9 +43,11 @@
 
 - 启动 HTTP server（webhook / health / status）
 - 启动 heartbeat loop
-- 注册 runtime services
+- 注册并驱动各 runtime services
+- **Event Bus (事件总线)**：负责领域事件的发布与订阅路由
+- **Dispatcher (派发器)**：负责异步任务（ExecutionRequest）的并发控制与 session 管理
 - 在每轮 heartbeat 时调用 service `on_tick()`
-- 在 webhook 到达时调用 service `handle_event()`
+- 在 webhook 或事件到达时调用对应的 handler
 
 它不是：
 

--- a/docs/standards/v3/python-capability-design.md
+++ b/docs/standards/v3/python-capability-design.md
@@ -149,7 +149,7 @@ Skill Layer 负责：
 - [glossary.md](../glossary.md)
 - [command-standard.md](./command-standard.md)
 - [data-model-standard.md](./data-model-standard.md)
-- [registry-json-standard.md](./registry-json-standard.md)
+- [registry-json-standard.md](./registry-json-standard.md) (deprecated → [data-model-standard.md](./data-model-standard.md))
 - [roadmap-json-standard.md](./roadmap-json-standard.md) (deprecated → [github-labels-standard.md](../github-labels-standard.md))
 
 设计层只回答：

--- a/docs/standards/vibe3-user-guide.md
+++ b/docs/standards/vibe3-user-guide.md
@@ -1,38 +1,27 @@
-# Deprecated Directory: vibe3-user-guide
+# [DEPRECATED] Vibe 3.0 User Guide
 
-状态：Deprecated
+⚠️ **本文档已废弃。请立即前往 V3 官方命令标准：**
 
-本文件仅保留为旧路径目录页，不再承载现行用户指南正文。
+👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)** 👈
+
+---
 
 ## 📖 现行真源 (Current Truth)
 
-**所有 Vibe 3.0 操作指南与命令规范请以此文档为准：**
+所有 Vibe 3.0 操作指南与命令规范请以上述文档为准。本文件仅保留为历史兼容路径，不再承载正文。
 
-👉 **[docs/standards/v3/command-standard.md](v3/command-standard.md)**
-
-**项目全局导航与 Agent 协作入口请参考：**
+**项目全局导航与 Agent 协作入口：**
 
 👉 **[AGENTS.md](../../AGENTS.md)**
 
 ---
 
-原因：
+### V3 推荐操作模型 (Quick Reference)
 
-- 旧版指南混入了多组历史命令示例
-- 包含 `flow create/switch/done/aborted/list` 等已退场入口
-- 已不适合作为当前操作指引
-
-其他参考入口：
-
-1. [README.md](../README.md)
-2. [docs/standards/v3/handoff-store-standard.md](v3/handoff-store-standard.md)
-3. [docs/standards/issue-standard.md](issue-standard.md)
-4. [docs/standards/roadmap-label-management.md](roadmap-label-management.md)
-
-当前推荐操作模型：
-
-- branch 生命周期管理：直接使用 `git`
-- issue / PR / project 远端操作：直接使用 `gh`
-- 本地 flow 注册与绑定：使用 `vibe3 flow update`、`vibe3 flow bind`
-- 本地现场与任务状态读取：使用 `vibe3 task status`、`vibe3 flow show`
-- 本地协作与交接增强：使用 `vibe3 handoff`
+- **Branch 管理**：直接使用 `git` (如 `git checkout -b <name>`)
+- **Issue/PR 操作**：直接使用 `gh` (如 `gh issue view`, `gh pr create`)
+- **Flow 注册**：`vibe3 flow update` (幂等同步)
+- **Task 绑定**：`vibe3 flow bind <issue_number>`
+- **状态核查**：`vibe3 flow show` (当前现场) 或 `vibe3 flow status` (全局面板)
+- **执行任务**：`vibe3 task show`
+- **协作交接**：`vibe3 handoff show` / `vibe3 handoff append`


### PR DESCRIPTION
This PR completes the V3 documentation alignment as requested in #1694.

Key changes:
- Updated docs/standards/glossary.md: Aligned V2 command references and standard links.
- Updated docs/standards/agent-workflow-standard.md: Consistent vibe3 flow show usage.
- Updated docs/standards/vibe3-orchestra-runtime-standard.md: Refined Dispatcher and Event Bus descriptions.
- Updated docs/standards/vibe3-user-guide.md: Strengthened V3 redirect and removed legacy remnants.
- Updated docs/standards/v3/python-capability-design.md: Corrected deprecated standard links.

Closes #1694