### PR TITLE
refactor(services): 统一公共接口，消除外部模块直接导入子模块

### DIFF
--- a/scripts/refactor_services_imports.py
+++ b/scripts/refactor_services_imports.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Step 3: Simple regex-based refactoring of services imports.
+
+This approach is more reliable than AST-based transformation for this specific use case.
+"""
+
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+
+def refactor_file(file_path: Path) -> Tuple[bool, str]:
+    """
+    Refactor services imports in a single file using regex.
+
+    Returns (was_modified, error_message).
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        original_content = content
+
+        # Pattern to match: from vibe3.services.<submodule> import <symbols>
+        # This handles both single-line and multi-line imports
+        pattern = r'from\s+vibe3\.services\.\w+\s+import\s+'
+
+        # Replace with: from vibe3.services import <symbols>
+        content = re.sub(pattern, 'from vibe3.services import ', content)
+
+        if content == original_content:
+            return False, ""
+
+        # Verify syntax
+        import ast
+        try:
+            ast.parse(content)
+        except SyntaxError as e:
+            return False, f"Syntax error: {e}"
+
+        # Write back
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+        return True, ""
+
+    except Exception as e:
+        return False, str(e)
+
+
+def main():
+    print("=" * 80)
+    print("Step 3: Refactoring services imports")
+    print("=" * 80)
+
+    # Collect files to process
+    files_to_process = []
+
+    # Scan src/vibe3/ (excluding services/)
+    src_path = Path('src/vibe3')
+    for py_file in src_path.rglob('*.py'):
+        if 'services' not in py_file.parts and '__pycache__' not in py_file.parts:
+            files_to_process.append(py_file)
+
+    # Scan tests/vibe3/ (excluding services/)
+    test_path = Path('tests/vibe3')
+    for py_file in test_path.rglob('*.py'):
+        if 'services' not in py_file.parts and '__pycache__' not in py_file.parts:
+            files_to_process.append(py_file)
+
+    print(f"\nFound {len(files_to_process)} files to process")
+
+    # Process each file
+    modified_count = 0
+    error_count = 0
+    errors = []
+
+    for file_path in files_to_process:
+        was_modified, error = refactor_file(file_path)
+        if error:
+            error_count += 1
+            errors.append((file_path, error))
+            print(f"  ✗ {file_path}: {error}")
+        elif was_modified:
+            modified_count += 1
+            print(f"  ✓ {file_path}")
+
+    print(f"\n" + "=" * 80)
+    print(f"SUMMARY")
+    print("=" * 80)
+    print(f"Files processed: {len(files_to_process)}")
+    print(f"Files modified: {modified_count}")
+    print(f"Errors: {error_count}")
+
+    if errors:
+        print(f"\nERRORS:")
+        for file_path, error in errors:
+            print(f"  {file_path}: {error}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scan_services_imports.py
+++ b/scripts/scan_services_imports.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Step 1: AST scan to detect all external consumption of services symbols.
+
+Scans all non-services .py files in src/vibe3/ and tests/vibe3/ to find
+all `from vibe3.services.<submodule> import <symbol>` statements.
+"""
+
+import ast
+from pathlib import Path
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+
+def scan_file_for_services_imports(file_path: Path) -> List[Tuple[str, str, int, bool]]:
+    """
+    Scan a single file for services imports.
+
+    Returns list of (submodule, symbol, line_number, is_lazy) tuples.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        tree = ast.parse(content, filename=str(file_path))
+    except (SyntaxError, UnicodeDecodeError) as e:
+        print(f"Warning: Could not parse {file_path}: {e}")
+        return []
+
+    imports = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # Check if this is a services import
+            if node.module and node.module.startswith('vibe3.services.'):
+                # Extract submodule (e.g., 'flow_service' from 'vibe3.services.flow_service')
+                parts = node.module.split('.')
+                if len(parts) >= 3:
+                    submodule = parts[2]  # vibe3.services.<submodule>
+
+                    # Check if this is inside a function (lazy import)
+                    is_lazy = False
+                    for parent in ast.walk(tree):
+                        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            for child in ast.walk(parent):
+                                if child is node:
+                                    is_lazy = True
+                                    break
+
+                    # Extract imported symbols
+                    for alias in node.names:
+                        symbol = alias.name
+                        imports.append((submodule, symbol, node.lineno, is_lazy))
+
+    return imports
+
+
+def scan_directory(base_path: Path, exclude_dirs: Set[str]) -> Dict[str, Set[str]]:
+    """
+    Scan all .py files in directory (excluding certain dirs).
+
+    Returns {submodule: {symbols}} mapping.
+    """
+    symbols_map = defaultdict(set)
+    import_count = 0
+    lazy_count = 0
+
+    for py_file in base_path.rglob('*.py'):
+        # Skip excluded directories
+        if any(excluded in py_file.parts for excluded in exclude_dirs):
+            continue
+
+        # Skip __pycache__
+        if '__pycache__' in py_file.parts:
+            continue
+
+        imports = scan_file_for_services_imports(py_file)
+        for submodule, symbol, line_no, is_lazy in imports:
+            symbols_map[submodule].add(symbol)
+            import_count += 1
+            if is_lazy:
+                lazy_count += 1
+                print(f"  Lazy import: {py_file.relative_to(base_path)}:{line_no} - {submodule}.{symbol}")
+
+    return dict(symbols_map), import_count, lazy_count
+
+
+def main():
+    print("=" * 80)
+    print("Step 1: Scanning for external services imports")
+    print("=" * 80)
+
+    # Scan src/vibe3/ (excluding services/)
+    print("\nScanning src/vibe3/ (excluding services/)...")
+    src_path = Path('src/vibe3')
+    src_symbols, src_count, src_lazy = scan_directory(src_path, {'services'})
+
+    # Scan tests/vibe3/ (excluding services/)
+    print("\nScanning tests/vibe3/ (excluding services/)...")
+    test_path = Path('tests/vibe3')
+    test_symbols, test_count, test_lazy = scan_directory(test_path, {'services'})
+
+    # Merge results
+    all_symbols = defaultdict(set)
+    for submodule, symbols in src_symbols.items():
+        all_symbols[submodule].update(symbols)
+    for submodule, symbols in test_symbols.items():
+        all_symbols[submodule].update(symbols)
+
+    # Print summary
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"Total import statements: {src_count + test_count}")
+    print(f"  - src/vibe3/: {src_count} ({src_lazy} lazy)")
+    print(f"  - tests/vibe3/: {test_count} ({test_lazy} lazy)")
+    print(f"\nTotal submodules: {len(all_symbols)}")
+    print(f"Total unique symbols: {sum(len(s) for s in all_symbols.values())}")
+
+    # Print detailed mapping
+    print("\n" + "=" * 80)
+    print("SUBMODULE -> SYMBOLS MAPPING")
+    print("=" * 80)
+
+    for submodule in sorted(all_symbols.keys()):
+        symbols = sorted(all_symbols[submodule])
+        print(f"\n{submodule} ({len(symbols)} symbols):")
+        for i, symbol in enumerate(symbols):
+            if i % 5 == 0:
+                print("  ", end="")
+            print(f"{symbol}", end="")
+            if i % 5 == 4 or i == len(symbols) - 1:
+                print()
+            else:
+                print(", ", end="")
+
+    # Special checks as per plan
+    print("\n" + "=" * 80)
+    print("SPECIAL CHECKS")
+    print("=" * 80)
+
+    special_modules = ['flow_classifier', 'orchestra_status_service', 'scan_service', 'task_status_classifier']
+    for module in special_modules:
+        if module in all_symbols:
+            print(f"\n{module}: {sorted(all_symbols[module])}")
+        else:
+            print(f"\n{module}: NOT FOUND (may only be used via multiline imports)")
+
+    # Output Python code for Step 2
+    print("\n" + "=" * 80)
+    print("PYTHON CODE FOR STEP 2")
+    print("=" * 80)
+    print("\n# Copy this into services/__init__.py:\n")
+    for submodule in sorted(all_symbols.keys()):
+        symbols = sorted(all_symbols[submodule])
+        print(f"from vibe3.services.{submodule} import {', '.join(symbols)}")
+
+    print(f"\n# Total: {len(all_symbols)} submodules, {sum(len(s) for s in all_symbols.values())} symbols")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -21,7 +21,7 @@ from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.resources.runtime_assets import resolve_runtime_asset
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 PlanPromptMode = Literal["first", "retry"]
 

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -25,7 +25,7 @@ from vibe3.models.review import ReviewRequest
 from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.resources.runtime_assets import resolve_runtime_asset
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 ReviewPromptMode = Literal["first", "retry"]
 

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -18,7 +18,7 @@ from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.resources.runtime_assets import resolve_runtime_asset
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def build_run_task_section(task_text: str | None) -> str:

--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from vibe3.commands.check_support import execute_check_mode
 from vibe3.commands.common import enable_method_trace
 from vibe3.observability.logger import setup_logging
-from vibe3.services.check_service import CheckService
+from vibe3.services import CheckService
 
 app = typer.Typer(
     help="Verify handoff store consistency",

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -14,8 +14,7 @@ from rich.progress import (
     TextColumn,
 )
 
-from vibe3.services.check_remote import InitResult
-from vibe3.services.check_service import CheckResult, CheckService
+from vibe3.services import CheckResult, CheckService, InitResult
 
 
 @dataclass
@@ -103,7 +102,7 @@ def execute_check_mode(
 
     if mode == "clean_branch":
         # Use dedicated cleanup service for --clean-branch
-        from vibe3.services.check_cleanup_service import CheckCleanupService
+        from vibe3.services import CheckCleanupService
 
         cleanup_service = CheckCleanupService(
             store=service.store,

--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated, Literal, Optional
 import typer
 
 if TYPE_CHECKING:
-    from vibe3.services.flow_service import FlowService
+    from vibe3.services import FlowService
 
 _TRACE_OPT = Annotated[
     bool, typer.Option("--trace", help="Enable call tracing (set VIBE3_TRACE=1)")
@@ -89,7 +89,7 @@ def ensure_flow_for_current_branch() -> tuple["FlowService", str]:
         typer.Exit: If on main branch or flow creation fails
     """
     from vibe3.models.flow import MainBranchProtectedError
-    from vibe3.services.flow_service import FlowService
+    from vibe3.services import FlowService
 
     flow_service = FlowService()
     branch = flow_service.get_current_branch()

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -51,7 +51,7 @@ def run_full_check_shortcut() -> None:
     The status dashboard should still render even if the full check reports
     unfixable issues or raises unexpectedly, but users must see a warning.
     """
-    from vibe3.services.check_service import CheckService
+    from vibe3.services import CheckService
 
     try:
         result = execute_check_mode(CheckService(), "fix_all", show_progress=False)

--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -6,9 +6,7 @@ import typer
 from loguru import logger
 
 from vibe3.commands.common import enable_method_trace
-from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.flow_service import FlowService
+from vibe3.services import ConventionResolver, FlowService, resolve_branch_arg
 from vibe3.utils.issue_ref import try_parse_issue_number
 
 

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -13,8 +13,7 @@ from vibe3.commands.command_options import (
 )
 from vibe3.commands.common import enable_method_trace, validate_trace_options
 from vibe3.models.flow import IssueLink
-from vibe3.services.flow_service import FlowService
-from vibe3.services.task_service import TaskService
+from vibe3.services import FlowService, TaskService
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui import render_flow_created
 
@@ -173,8 +172,7 @@ def update(
         output_format = "json"
     from vibe3.clients.git_client import GitClient
     from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.services.branch_arg import resolve_branch_arg
-    from vibe3.services.convention_resolver import ConventionResolver
+    from vibe3.services import ConventionResolver, resolve_branch_arg
     from vibe3.utils.issue_ref import try_parse_issue_number
 
     # Early handling for issue number: resolve to canonical branch
@@ -220,7 +218,7 @@ def update(
         if name:
             updates["flow_slug"] = name
         if actor:
-            from vibe3.services.signature_service import SignatureService
+            from vibe3.services import SignatureService
 
             updates["latest_actor"] = SignatureService.resolve_actor(
                 explicit_actor=actor
@@ -454,7 +452,7 @@ def restore_flow(
         typer.echo("Error: Branch is required for flow restore", err=True)
         raise typer.Exit(1)
 
-    from vibe3.services.branch_arg import resolve_branch_arg
+    from vibe3.services import resolve_branch_arg
 
     target_branch = resolve_branch_arg(branch)
 

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -31,11 +31,13 @@ from vibe3.commands.flow_status_helpers import (
 )
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.exceptions import SystemError, UserError
-from vibe3.services.flow_projection_service import FlowProjectionService
-from vibe3.services.flow_service import FlowService
-from vibe3.services.pr_branch_resolver import resolve_command_branch
-from vibe3.services.pr_service import PRService
-from vibe3.services.task_binding_guard import build_bind_task_hint
+from vibe3.services import (
+    FlowProjectionService,
+    FlowService,
+    PRService,
+    build_bind_task_hint,
+    resolve_command_branch,
+)
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui import (
     render_error,
@@ -125,13 +127,13 @@ def show(
 
         # Fallback: parse issue number from branch name when local DB missing
         if task_issue_number is None:
-            from vibe3.services.issue_flow_service import IssueFlowService
+            from vibe3.services import IssueFlowService
 
             issue_flow_service = IssueFlowService(store=service.store)
             task_issue_number = issue_flow_service.parse_issue_number_any(target_branch)
 
     # Use resolver for source-aware read
-    from vibe3.services.flow_status_resolver import FlowStatusResolver
+    from vibe3.services import FlowStatusResolver
 
     resolver = FlowStatusResolver(store=service.store, flow_service=service)
     flow_status = resolver.resolve(
@@ -143,7 +145,7 @@ def show(
     # Handle non-registered flow or special branches
     if not flow_status or flow_status.flow_status == "aborted":
         if output_format == "table":
-            from vibe3.services.flow_service import FlowService as FlowService_
+            from vibe3.services import FlowService as FlowService_
 
             is_safe = target_branch.startswith(FlowService_.SAFE_BRANCH_PREFIX)
             is_aborted = flow_status and flow_status.flow_status == "aborted"
@@ -209,7 +211,7 @@ def show(
     if snapshot:
         # Use resolver's flow_status directly (already source-aware)
         # Do NOT re-read from local via FlowProjectionService.get_projection
-        from vibe3.services.flow_projection_service import FlowProjection
+        from vibe3.services import FlowProjection
 
         projection = FlowProjection.from_flow_status(flow_status)
 
@@ -361,7 +363,7 @@ def status(
         raise typer.Exit(0)
 
     # Try to fetch cached issue titles from orchestra server first
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     config = load_orchestra_config()
     orch_snapshot = OrchestraStatusService.fetch_live_snapshot(config)

--- a/src/vibe3/commands/flow_status_helpers.py
+++ b/src/vibe3/commands/flow_status_helpers.py
@@ -9,7 +9,7 @@ import typer
 from loguru import logger
 
 from vibe3.exceptions import UserError
-from vibe3.services.flow_projection_service import FlowProjectionService
+from vibe3.services import FlowProjectionService
 from vibe3.ui.flow_ui import render_error, render_flow_status
 from vibe3.utils.branch_utils import find_parent_branch
 
@@ -178,7 +178,7 @@ def _fetch_issue_titles_for_status(
         return titles, False
 
     # Server not running, use cache service with real branches
-    from vibe3.services.issue_title_cache_service import IssueTitleCacheService
+    from vibe3.services import IssueTitleCacheService
 
     branches = [flow.branch for flow in flows if flow.branch]
     title_cache = IssueTitleCacheService(

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -15,10 +15,12 @@ from vibe3.commands.handoff_render import (
     _render_handoff_events,
 )
 from vibe3.exceptions import SystemError, UserError
-from vibe3.services.flow_service import FlowService
-from vibe3.services.handoff_status_service import HandoffStatusService
-from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
-from vibe3.services.pr_branch_resolver import resolve_command_branch
+from vibe3.services import (
+    FlowService,
+    HandoffStatusService,
+    resolve_command_branch,
+    resolve_issue_branch_input,
+)
 from vibe3.ui.console import console
 from vibe3.ui.handoff_ui import render_handoff_detail
 
@@ -110,7 +112,7 @@ def show(
     if trace:
         enable_method_trace()
 
-    from vibe3.services.path_helpers import resolve_handoff_target
+    from vibe3.services import resolve_handoff_target
 
     if target is None:
         typer.echo(_HANDOFF_SHOW_HELP)

--- a/src/vibe3/commands/handoff_render.py
+++ b/src/vibe3/commands/handoff_render.py
@@ -5,7 +5,7 @@ Pure functions for rendering agent chains, handoff events, and updates log.
 
 import re
 
-from vibe3.services.path_helpers import ref_to_handoff_cmd, sanitize_event_detail_paths
+from vibe3.services import ref_to_handoff_cmd, sanitize_event_detail_paths
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import resolve_ref_path
 from vibe3.utils.constants import AUTOMATED_MARKERS

--- a/src/vibe3/commands/handoff_write.py
+++ b/src/vibe3/commands/handoff_write.py
@@ -7,9 +7,7 @@ from loguru import logger
 
 from vibe3.commands.common import enable_method_trace
 from vibe3.models.verdict_types import VerdictValue
-from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.handoff_service import HandoffService
-from vibe3.services.verdict_service import VerdictService
+from vibe3.services import HandoffService, VerdictService, resolve_branch_arg
 from vibe3.ui.console import console
 
 

--- a/src/vibe3/commands/inspect_base_helpers.py
+++ b/src/vibe3/commands/inspect_base_helpers.py
@@ -14,7 +14,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.config.loader import get_config
 from vibe3.exceptions import GitError, UserError
 from vibe3.models.change_source import BranchSource
-from vibe3.services.pr_scoring_service import PRDimensions, generate_score_report
+from vibe3.services import PRDimensions, generate_score_report
 
 
 def _code_paths() -> list[str]:

--- a/src/vibe3/commands/inspect_helpers.py
+++ b/src/vibe3/commands/inspect_helpers.py
@@ -18,7 +18,7 @@ from vibe3.models.pr_analysis import (  # noqa: F401
     CriticalFileInfo,
     PRCriticalAnalysis,
 )
-from vibe3.services.pr_analysis_service import (  # noqa: F401 - backward compat re-exports
+from vibe3.services import (  # noqa: F401 - backward compat re-exports
     _analyze_critical_files,
     _calculate_risk_score,
     _filter_critical_files,

--- a/src/vibe3/commands/inspect_pr_helpers.py
+++ b/src/vibe3/commands/inspect_pr_helpers.py
@@ -11,6 +11,6 @@ from vibe3.models.pr_analysis import (  # noqa: F401
     CriticalFileInfo,
     PRCriticalAnalysis,
 )
-from vibe3.services.pr_analysis_service import build_pr_analysis  # noqa: F401
+from vibe3.services import build_pr_analysis  # noqa: F401
 
 __all__ = ["build_pr_analysis", "CommitInfo", "CriticalFileInfo", "PRCriticalAnalysis"]

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services import load_issue_info
 
 app = typer.Typer(
     name="internal",
@@ -62,7 +62,7 @@ def internal_apply_dispatch(
     ] = False,
 ) -> None:
     """L2: Dispatch the Supervisor/Apply agent for a governance issue."""
-    from vibe3.services.scan_service import dispatch_supervisor_execution
+    from vibe3.services import dispatch_supervisor_execution
 
     dispatch_supervisor_execution(issue_number=issue, no_async=no_async)
 
@@ -89,7 +89,7 @@ def internal_governance_dispatch(
     Note: This command is only called via CLI self-invocation (internal governance)
     from the tmux wrapper launched by governance_scan handler. It always runs sync.
     """
-    from vibe3.services.scan_service import dispatch_governance_execution
+    from vibe3.services import dispatch_governance_execution
 
     dispatch_governance_execution(tick_count=tick, material_override=material)
 
@@ -132,7 +132,7 @@ def internal_bootstrap(
     from vibe3.clients.git_client import GitClient
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+    from vibe3.services import FlowOrchestratorService
 
     config = load_orchestra_config()
     store = SQLiteClient()
@@ -159,7 +159,7 @@ def backfill_worktree_paths() -> None:
     """Backfill worktree_path for existing active task/ flows."""
     from vibe3.clients.git_client import GitClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.services.status_query_service import is_auto_task_branch
+    from vibe3.services import is_auto_task_branch
 
     git = GitClient()
     store = SQLiteClient()

--- a/src/vibe3/commands/mcp.py
+++ b/src/vibe3/commands/mcp.py
@@ -40,7 +40,7 @@ def run() -> None:
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.domain import FlowManager
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     config = load_orchestra_config()
 

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -17,9 +17,7 @@ from vibe3.roles.plan import (
     execute_spec_plan_sync,
     resolve_spec_plan_input,
 )
-from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.flow_service import FlowService
-from vibe3.services.handoff_resolution import resolve_handoff_target
+from vibe3.services import FlowService, resolve_branch_arg, resolve_handoff_target
 
 app = typer.Typer(
     name="plan",

--- a/src/vibe3/commands/pr_create.py
+++ b/src/vibe3/commands/pr_create.py
@@ -14,10 +14,12 @@ from vibe3.commands.pr_helpers import build_base_resolution_usecase
 from vibe3.exceptions import UserError
 from vibe3.models.pr import PRResponse, UpdatePRRequest
 from vibe3.observability.logger import setup_logging
-from vibe3.services.flow_service import FlowService
-from vibe3.services.pr_create_usecase import PRCreateUsecase
-from vibe3.services.pr_service import PRService
-from vibe3.services.task_binding_guard import MissingTaskIssueError
+from vibe3.services import (
+    FlowService,
+    MissingTaskIssueError,
+    PRCreateUsecase,
+    PRService,
+)
 from vibe3.ui.pr_ui import render_pr_confirmed, render_pr_created
 from vibe3.utils.branch_compare import check_branch_behind, format_branch_behind_body
 

--- a/src/vibe3/commands/pr_helpers.py
+++ b/src/vibe3/commands/pr_helpers.py
@@ -3,7 +3,7 @@
 from contextlib import contextmanager
 from typing import Iterator
 
-from vibe3.services.base_resolution_usecase import BaseResolutionUsecase
+from vibe3.services import BaseResolutionUsecase
 
 
 @contextmanager

--- a/src/vibe3/commands/pr_lifecycle.py
+++ b/src/vibe3/commands/pr_lifecycle.py
@@ -14,9 +14,7 @@ from loguru import logger
 from vibe3.commands.common import enable_method_trace
 from vibe3.exceptions import UserError
 from vibe3.observability.logger import setup_logging
-from vibe3.services.flow_service import FlowService
-from vibe3.services.pr_ready_usecase import PrReadyAbortedError, PrReadyUsecase
-from vibe3.services.pr_service import PRService
+from vibe3.services import FlowService, PrReadyAbortedError, PrReadyUsecase, PRService
 from vibe3.ui.pr_ui import render_pr_ready
 
 

--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -34,11 +34,13 @@ from vibe3.commands.output_format import (
 )
 from vibe3.models.pr import PRResponse, PRState
 from vibe3.models.trace import TraceOutput
-from vibe3.services.branch_resolver import resolve_branch_from_pr
-from vibe3.services.flow_service import FlowService
-from vibe3.services.handoff_service import HandoffService
-from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
-from vibe3.services.pr_service import PRService
+from vibe3.services import (
+    FlowService,
+    HandoffService,
+    PRService,
+    resolve_branch_from_pr,
+    resolve_issue_branch_input,
+)
 from vibe3.ui.pr_ui import render_local_review_summary, render_pr_details
 from vibe3.utils.branch_compare import check_branch_behind, format_branch_behind_console
 

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -26,8 +26,7 @@ from vibe3.roles.review import (
     execute_manual_review_sync,
     validate_review_prerequisites,
 )
-from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.flow_service import FlowService
+from vibe3.services import FlowService, resolve_branch_arg
 
 app = typer.Typer(
     name="review",

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -25,9 +25,7 @@ from vibe3.roles.run import (
     validate_run_prerequisites,
 )
 from vibe3.roles.run_command import resolve_skill_path
-from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.flow_service import FlowService
-from vibe3.services.handoff_resolution import resolve_handoff_target
+from vibe3.services import FlowService, resolve_branch_arg, resolve_handoff_target
 
 app = typer.Typer(
     name="run",

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -27,7 +27,7 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.services.scan_service import dispatch_governance_execution
+    from vibe3.services import dispatch_governance_execution
 
     dispatch_governance_execution(material_override=material_override)
 
@@ -88,7 +88,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
-    from vibe3.services.scan_service import (
+    from vibe3.services import (
         dispatch_supervisor_execution,
         fetch_supervisor_candidates,
     )
@@ -117,7 +117,7 @@ def _run_supervisor_scan_dry_run() -> None:
 
     from vibe3.clients.github_client import GitHubClient
     from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.services.scan_service import fetch_supervisor_candidates
+    from vibe3.services import fetch_supervisor_candidates
     from vibe3.ui.scan_display import display_supervisor_dry_run
 
     console = Console()
@@ -170,7 +170,7 @@ def governance(
     """
     from rich.console import Console
 
-    from vibe3.services.scan_service import (
+    from vibe3.services import (
         get_available_governance_materials,
         governance_material_exists,
         list_governance_materials,

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -22,14 +22,15 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState
-from vibe3.server import _validate_pid_file
-from vibe3.services.flow_service import FlowService
-from vibe3.services.orchestra_helpers import get_manager_usernames
-from vibe3.services.orchestra_status_service import OrchestraStatusService
-from vibe3.services.status_query_service import StatusQueryService, is_auto_task_branch
-from vibe3.services.task_status_classifier import (
+from vibe3.server.registry import _validate_pid_file
+from vibe3.services import (
+    FlowService,
+    OrchestraStatusService,
+    StatusQueryService,
     TaskStatusBucket,
     classify_task_status,
+    get_manager_usernames,
+    is_auto_task_branch,
 )
 from vibe3.ui.console import console
 from vibe3.utils.time_format import format_age_aware_time
@@ -144,7 +145,7 @@ def status(
     if not orch_snapshot:
         from dataclasses import replace
 
-        from vibe3.services.flow_orchestrator_service import (
+        from vibe3.services import (
             FlowOrchestratorService,
         )
 

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -8,7 +8,7 @@ from typing import cast
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueState
-from vibe3.services.task_status_classifier import TaskStatusBucket
+from vibe3.services import TaskStatusBucket
 from vibe3.ui.console import console
 from vibe3.utils.error_message_cleaner import (
     CODEAGENT_WRAPPER_ANYWHERE_RE,

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -12,9 +12,7 @@ from vibe3.commands.common import enable_method_trace
 from vibe3.exceptions import SystemError, UserError
 from vibe3.models.orchestration import IssueState
 from vibe3.observability.logger import setup_logging
-from vibe3.services.flow_service import FlowService
-from vibe3.services.task_resume_usecase import TaskResumeUsecase
-from vibe3.services.task_service import TaskService
+from vibe3.services import FlowService, TaskResumeUsecase, TaskService
 from vibe3.ui.task_ui import (
     render_task_comments,
     render_task_show,

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -49,14 +49,14 @@ from vibe3.orchestra.queue_entry import QueueEntry
 from vibe3.orchestra.queue_operations import select_ready_issues_from_collected_issues
 from vibe3.orchestra.queue_persistence_service import QueuePersistenceService
 from vibe3.roles.registry import build_label_dispatch_event
-from vibe3.services.check_service import CheckService
-from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_collection_service import IssueCollectionService
-from vibe3.services.label_utils import (
+from vibe3.services import (
+    CheckService,
+    FlowService,
+    IssueCollectionService,
     clean_old_state_labels,
+    get_manager_usernames,
     should_skip_from_queue,
 )
-from vibe3.services.orchestra_helpers import get_manager_usernames
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient

--- a/src/vibe3/domain/failed_gate.py
+++ b/src/vibe3/domain/failed_gate.py
@@ -147,7 +147,7 @@ class FailedGate:
         Returns:
             GateResult with blocked=True if threshold reached
         """
-        from vibe3.services.error_tracking_service import ErrorTrackingService
+        from vibe3.services import ErrorTrackingService
 
         log = logger.bind(domain="orchestra", action="error_threshold_check")
         log.debug("Checking error threshold")
@@ -266,7 +266,7 @@ class FailedGate:
             )
 
         # Also clear error log (use store-specific instance for consistency)
-        from vibe3.services.error_tracking_service import ErrorTrackingService
+        from vibe3.services import ErrorTrackingService
 
         ErrorTrackingService.get_instance(store=self.store).clear(cleared_by, reason)
 

--- a/src/vibe3/domain/flow_manager.py
+++ b/src/vibe3/domain/flow_manager.py
@@ -16,12 +16,14 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
-from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_flow_service import IssueFlowService
-from vibe3.services.label_service import LabelService
-from vibe3.services.pr_service import PRService
-from vibe3.services.task_service import TaskService
+from vibe3.services import (
+    FlowOrchestratorService,
+    FlowService,
+    IssueFlowService,
+    LabelService,
+    PRService,
+    TaskService,
+)
 
 
 class FlowManager:

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -24,7 +24,7 @@ from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.roles.plan import build_plan_request
 from vibe3.roles.review import build_review_request
 from vibe3.roles.run import build_run_request
-from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services import load_issue_info
 
 _RequestBuilder = Callable[..., ExecutionRequest]
 
@@ -106,7 +106,7 @@ def _dispatch_role_intent(
         else:
             # Unexpected failure - record to error_log and log warning
             # FailedGate will control dispatch based on threshold
-            from vibe3.services.error_helpers import record_error
+            from vibe3.services import record_error
 
             error_message = f"{role} dispatch failed: {result.reason}"
             try:

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -19,13 +19,13 @@ from vibe3.domain.events.governance import GovernanceScanStarted
 from vibe3.domain.handler_registry import register_handler
 from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
 from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
+from vibe3.services import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
     from vibe3.config.orchestra_config import OrchestraConfig
     from vibe3.environment.session_registry import SessionRegistryService
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
 
 @dataclass(frozen=True)
@@ -51,7 +51,7 @@ class GovernanceScanDependencies:
         from vibe3.agents.backends.codeagent import CodeagentBackend
         from vibe3.domain import FlowManager
         from vibe3.environment.session_registry import SessionRegistryService
-        from vibe3.services.orchestra_status_service import OrchestraStatusService
+        from vibe3.services import OrchestraStatusService
 
         backend = CodeagentBackend()
         registry = SessionRegistryService(store, backend)

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -15,8 +15,10 @@ from vibe3.domain.handler_registry import register_handler
 from vibe3.exceptions import CapacityDeferredError
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.roles.manager import build_manager_request
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
-from vibe3.services.issue_failure_service import block_manager_noop_issue
+from vibe3.services import (
+    block_manager_noop_issue,
+    record_dispatch_failure_if_unexpected,
+)
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.codeagent import CodeagentBackend

--- a/src/vibe3/domain/handlers/supervisor_scan.py
+++ b/src/vibe3/domain/handlers/supervisor_scan.py
@@ -16,7 +16,7 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.domain.handler_registry import register_handler
 from vibe3.models.orchestration import IssueInfo
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
+from vibe3.services import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:
     from vibe3.execution.coordinator import ExecutionCoordinator

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -93,8 +93,7 @@ class OrchestrationFacade(ServiceBase):
         if self._capacity is not None:
             from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
             from vibe3.environment.session_registry import SessionRegistryService
-            from vibe3.services.check_service import CheckService
-            from vibe3.services.flow_service import FlowService
+            from vibe3.services import CheckService, FlowService
 
             actual_store = store or SQLiteClient()
             self._registry = registry or SessionRegistryService(

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -15,9 +15,7 @@ from vibe3.clients.github_client import GitHubClient
 from vibe3.models.coordination_truth import CoordinationTruth
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.coordination_resolver import CoordinationResolver
-from vibe3.services.flow_resume_resolver import infer_resume_label
+from vibe3.services import ConventionResolver, CoordinationResolver, infer_resume_label
 
 if TYPE_CHECKING:
     from vibe3.clients.sqlite_client import SQLiteClient
@@ -191,7 +189,7 @@ class QualifyGateService:
         match the remote truth. Adds state/blocked label if missing.
         """
         from vibe3.orchestra.logging import append_orchestra_event
-        from vibe3.services.blocked_state_service import BlockedStateService
+        from vibe3.services import BlockedStateService
 
         blocked_label = self._convention.state_label(self._convention.blocked_label)
         label_blocked = blocked_label in labels
@@ -215,7 +213,7 @@ class QualifyGateService:
 
         if blocked_label not in labels:
             try:
-                from vibe3.services.label_service import LabelService
+                from vibe3.services import LabelService
 
                 label_service = LabelService(repo=self.config.repo)
                 label_service.confirm_issue_state(
@@ -306,8 +304,7 @@ class QualifyGateService:
         """
         from vibe3.models.flow import FlowState
         from vibe3.orchestra.logging import append_orchestra_event
-        from vibe3.services.blocked_state_service import BlockedStateService
-        from vibe3.services.label_service import LabelService
+        from vibe3.services import BlockedStateService, LabelService
 
         if flow_state:
             fs_obj = FlowState.model_validate(flow_state)
@@ -355,8 +352,7 @@ class QualifyGateService:
         wt_path = Path(worktree_path)
         if not wt_path.exists():
             reason = f"Worktree path does not exist: {worktree_path}"
-            from vibe3.services.blocked_state_service import BlockedStateService
-            from vibe3.services.label_service import LabelService
+            from vibe3.services import BlockedStateService, LabelService
 
             service = BlockedStateService(
                 store=self._store,
@@ -393,8 +389,7 @@ class QualifyGateService:
                     f"Worktree branch mismatch: expected {branch}, "
                     f"got {actual_branch}"
                 )
-                from vibe3.services.blocked_state_service import BlockedStateService
-                from vibe3.services.label_service import LabelService
+                from vibe3.services import BlockedStateService, LabelService
 
                 service = BlockedStateService(
                     store=self._store,
@@ -440,8 +435,7 @@ class QualifyGateService:
             return True
 
         # Use BlockedStateService for consistent three-source blocking
-        from vibe3.services.blocked_state_service import BlockedStateService
-        from vibe3.services.label_service import LabelService
+        from vibe3.services import BlockedStateService, LabelService
 
         service = BlockedStateService(
             store=self._store,

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -231,7 +231,7 @@ class InvalidTransitionError(UserError):
 #   )
 #
 # Error tracking service (in services layer):
-#   from vibe3.services.error_tracking_service import ErrorTrackingService
+#   from vibe3.services import ErrorTrackingService
 #
 # Error recording helper (convenience function in services layer):
-#   from vibe3.services.error_helpers import record_error
+#   from vibe3.services import record_error

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -105,10 +105,10 @@ class AutoSceneRecoveryService:
         error_msg: str,
     ) -> ExecutionLaunchResult | None:
         from vibe3.exceptions.error_codes import E_EXEC_AUTO_SCENE_RESET
-        from vibe3.services.error_helpers import record_error
-        from vibe3.services.flow_cleanup_service import (
+        from vibe3.services import (
             FlowCleanupService,
             LiveSessionsDetectedError,
+            record_error,
         )
 
         detail = "; ".join(damage_signals)
@@ -218,7 +218,7 @@ class AutoSceneRecoveryService:
 
         # Use BlockedStateService to unblock and restore to READY
         # This ensures all three sources (body, DB, labels) are cleared
-        from vibe3.services.blocked_state_service import BlockedStateService
+        from vibe3.services import BlockedStateService
 
         service = BlockedStateService(store=self.store)
         service.unblock(

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -31,8 +31,7 @@ from vibe3.execution.execution_lifecycle import (
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
 from vibe3.models.review_runner import AgentOptions
-from vibe3.services.actor_support import format_agent_actor
-from vibe3.services.handoff_service import HandoffService
+from vibe3.services import HandoffService, format_agent_actor
 
 
 @dataclass
@@ -70,7 +69,7 @@ class CodeagentExecutionService:
         """
         from vibe3.clients.github_labels import GhIssueLabelPort
         from vibe3.config.orchestra_settings import load_orchestra_config
-        from vibe3.services.orchestra_helpers import get_handoff_state_label
+        from vibe3.services import get_handoff_state_label
 
         config = load_orchestra_config()
         handoff_label = get_handoff_state_label(config.supervisor_handoff)
@@ -430,7 +429,7 @@ class CodeagentExecutionService:
                 classify_error_hybrid,
                 get_error_handling_contract,
             )
-            from vibe3.services.error_helpers import record_error
+            from vibe3.services import record_error
 
             # Classify error and record to SQLite for threshold tracking.
             # FailedGate.check() reads SQLite error_log on next heartbeat tick.

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -18,7 +18,7 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
 from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.role_interfaces import GovernanceEventLogger, GovernanceFunctions
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
+from vibe3.services import record_dispatch_failure_if_unexpected
 
 
 def run_governance_sync(
@@ -59,7 +59,7 @@ def run_governance_sync(
 
     config = load_orchestra_config()
     from vibe3.domain import FlowManager
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     flow_manager = FlowManager(config)
     status_service = OrchestraStatusService(config, orchestrator=flow_manager)
@@ -122,7 +122,7 @@ def run_governance_sync(
     except Exception as exc:
         # Error tracking: classify and record for FailedGate threshold
         from vibe3.exceptions.error_classification import classify_error_hybrid
-        from vibe3.services.error_helpers import record_error
+        from vibe3.services import record_error
 
         error_code = classify_error_hybrid(exc)
 
@@ -176,7 +176,7 @@ def run_governance_async(
 
     from vibe3.domain import FlowManager
     from vibe3.orchestra.logging import append_governance_event
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     config = load_orchestra_config()
 

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -11,9 +11,11 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
 from vibe3.execution.session_service import load_session_id
-from vibe3.services.actor_support import format_agent_actor
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
-from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services import (
+    format_agent_actor,
+    load_issue_info,
+    record_dispatch_failure_if_unexpected,
+)
 
 
 def run_issue_role_async(

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -9,8 +9,7 @@ from vibe3.agents.models import ExecutionRole
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.models.verdict import VerdictRecord
 from vibe3.models.verdict_types import VerdictValue
-from vibe3.services.role_policy_helpers import get_role_block_function
-from vibe3.services.verdict_policy import requires_audit_ref
+from vibe3.services import get_role_block_function, requires_audit_ref
 
 # Loop prevention constants
 SINGLE_STEP_LIMIT = 3  # Max occurrences of same transition pair

--- a/src/vibe3/execution/role_request_factory.py
+++ b/src/vibe3/execution/role_request_factory.py
@@ -12,7 +12,7 @@ from vibe3.execution.issue_role_support import (
 )
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def build_role_async_request(

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -194,7 +194,7 @@ class StateVerificationService:
             return
 
         try:
-            from vibe3.services.error_helpers import record_error
+            from vibe3.services import record_error
 
             record_error(
                 error_code="E_API_UNAVAILABLE",

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -12,7 +12,7 @@ from typing import Protocol
 
 from vibe3.clients.git_client import GitClient
 from vibe3.models.orchestration import IssueInfo
-from vibe3.services.check_service import CheckResult
+from vibe3.services import CheckResult
 
 
 class CapacityServiceProtocol(Protocol):

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -16,8 +16,7 @@ from vibe3.orchestra.issue_loader import (
 from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.orchestra.queue_entry import QueueEntry
 from vibe3.orchestra.queue_ordering import sort_ready_issues
-from vibe3.services.label_utils import should_skip_from_queue
-from vibe3.services.orchestra_helpers import get_manager_usernames
+from vibe3.services import get_manager_usernames, should_skip_from_queue
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient

--- a/src/vibe3/orchestra/queue_persistence_service.py
+++ b/src/vibe3/orchestra/queue_persistence_service.py
@@ -13,8 +13,7 @@ from loguru import logger
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.orchestra.queue_entry import QueueEntry
 from vibe3.orchestra.queue_operations import promote_progressed_entries
-from vibe3.services.label_utils import should_skip_from_queue
-from vibe3.services.orchestra_helpers import get_manager_usernames
+from vibe3.services import get_manager_usernames, should_skip_from_queue
 
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -39,7 +39,7 @@ from vibe3.roles.governance_utils import (
     find_material_in_catalog,
     get_governed_issue_numbers,
 )
-from vibe3.services.orchestra_helpers import get_manager_usernames
+from vibe3.services import get_manager_usernames
 
 GOVERNANCE_ROLE = RoleDefinition(
     name="governance",

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -7,13 +7,14 @@ from typing import Any
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.services.label_utils import normalize_assignees, normalize_labels
-from vibe3.services.orchestra_helpers import get_manager_usernames
-from vibe3.services.orchestra_status_service import (
+from vibe3.services import (
     IssueStatusEntry,
     format_issue_runtime_line,
     format_issue_summary_line,
+    get_manager_usernames,
     is_running_issue,
+    normalize_assignees,
+    normalize_labels,
 )
 
 

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -27,8 +27,7 @@ from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.prompts.template_loader import resolve_prompts_path
 from vibe3.roles.definitions import IssueRoleSyncSpec, TriggerableRoleDefinition
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.issue_failure_service import fail_manager_issue
+from vibe3.services import ConventionResolver, fail_manager_issue
 
 MANAGER_ROLE = TriggerableRoleDefinition(
     name="manager",

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -34,9 +34,11 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
 from vibe3.roles.definitions import TriggerableRoleDefinition
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
-from vibe3.services.issue_failure_service import fail_planner_issue
+from vibe3.services import (
+    ConventionResolver,
+    fail_planner_issue,
+    record_dispatch_failure_if_unexpected,
+)
 
 PLANNER_ROLE = TriggerableRoleDefinition(
     name="planner",
@@ -83,8 +85,7 @@ def _build_plan_task_guidance(
     branch: str,
 ) -> str | None:
     """Build plan task guidance from flow and issue context."""
-    from vibe3.services.flow_service import FlowService
-    from vibe3.services.spec_ref_service import SpecRefService
+    from vibe3.services import FlowService, SpecRefService
 
     flow_service = FlowService()
     flow = flow_service.get_flow_status(branch)
@@ -268,8 +269,7 @@ def resolve_spec_plan_input(
     2. Flow's existing spec_ref (if available)
     3. Error if none available
     """
-    from vibe3.services.flow_service import FlowService
-    from vibe3.services.spec_ref_service import SpecRefService
+    from vibe3.services import FlowService, SpecRefService
 
     # Case 1: Explicit file provided
     if file:

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -40,10 +40,12 @@ from vibe3.roles.review_helpers import (
     ReviewRunResult,
     finalize_review_output,
 )
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
-from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_failure_service import fail_reviewer_issue
+from vibe3.services import (
+    ConventionResolver,
+    FlowService,
+    fail_reviewer_issue,
+    record_dispatch_failure_if_unexpected,
+)
 
 
 def validate_review_prerequisites(

--- a/src/vibe3/roles/review_helpers.py
+++ b/src/vibe3/roles/review_helpers.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from vibe3.services.flow_service import FlowService
+from vibe3.services import FlowService
 from vibe3.utils.constants import VERDICT_UNKNOWN
 
 

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -29,8 +29,7 @@ from vibe3.roles.run_helpers import (
     publish_run_command_failure,
     publish_run_command_success,
 )
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
+from vibe3.services import ConventionResolver, record_dispatch_failure_if_unexpected
 
 
 def resolve_skill_path(

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -15,7 +15,7 @@ from vibe3.execution.issue_role_support import (
 from vibe3.execution.role_contracts import EXECUTOR_GATE_CONFIG
 from vibe3.models.orchestration import IssueState
 from vibe3.roles.definitions import TriggerableRoleDefinition
-from vibe3.services.flow_service import FlowService
+from vibe3.services import FlowService
 
 if TYPE_CHECKING:
     from vibe3.models.flow import FlowStatusResponse
@@ -189,7 +189,7 @@ def ensure_plan_file_exists(
         return
     if Path(plan_file).is_absolute() and Path(plan_file).exists():
         return
-    from vibe3.services.path_helpers import resolve_handoff_target
+    from vibe3.services import resolve_handoff_target
 
     try:
         resolve_handoff_target(plan_file, branch=branch)

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -25,8 +25,7 @@ from vibe3.roles.run_helpers import (
     RUN_BRANCH_RESOLVER,
     resolve_run_options,
 )
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.issue_failure_service import fail_executor_issue
+from vibe3.services import ConventionResolver, fail_executor_issue
 
 
 def build_run_request(

--- a/src/vibe3/roles/supervisor.py
+++ b/src/vibe3/roles/supervisor.py
@@ -17,9 +17,7 @@ from vibe3.execution.role_contracts import (
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.definitions import IssueRoleSyncSpec, RoleDefinition
-from vibe3.services.convention_resolver import ConventionResolver
-from vibe3.services.issue_flow_service import IssueFlowService
-from vibe3.services.orchestra_helpers import get_handoff_state_label
+from vibe3.services import ConventionResolver, IssueFlowService, get_handoff_state_label
 
 SUPERVISOR_IDENTIFY_ROLE = RoleDefinition(
     name="supervisor-identify",

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -23,7 +23,7 @@ async def execute_expired_resource_cleanup(
     from vibe3.clients.git_client import GitClient
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.services.expired_resource_cleanup_service import (
+    from vibe3.services import (
         ExpiredResourceCleanupService,
     )
 

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -16,7 +16,7 @@ from vibe3.orchestra.logging import (
 )
 from vibe3.runtime.periodic_check_executor import execute_periodic_check
 from vibe3.runtime.service_protocol import ServiceBase
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services import ErrorTrackingService
 
 if TYPE_CHECKING:
     from vibe3.domain.failed_gate import FailedGate

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -30,7 +30,7 @@ async def execute_periodic_check(
     """
     # Delay imports to avoid circular dependencies
     from vibe3.clients import SQLiteClient
-    from vibe3.services.check_service import CheckService
+    from vibe3.services import CheckService
 
     # Initialize services
     store = SQLiteClient()

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -346,8 +346,7 @@ def status() -> None:
     """Show Orchestra server status, FailedGate state, and recent activity."""
     from rich.console import Console
 
-    from vibe3.services.orchestra_helpers import get_manager_usernames
-    from vibe3.services.serve_status_service import ServeStatusService
+    from vibe3.services import ServeStatusService, get_manager_usernames
 
     console = Console()
 

--- a/src/vibe3/server/mcp.py
+++ b/src/vibe3/server/mcp.py
@@ -8,7 +8,7 @@ from loguru import logger
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
-    from vibe3.services.orchestra_status_service import (
+    from vibe3.services import (
         OrchestraSnapshot,
         OrchestraStatusService,
     )

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -23,15 +23,14 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.logging import orchestra_events_log_path, orchestra_log_dir
 from vibe3.runtime.circuit_breaker import CircuitBreaker
 from vibe3.runtime.heartbeat import HeartbeatServer
-from vibe3.services.orchestra_status_service import (
-    OrchestraSnapshot,
-    OrchestraStatusService,
-)
-
-from .orchestra_instance import (
+from vibe3.server.orchestra_instance import (
     OrchestraInstanceInfo,
     read_instance_info,
     validate_instance,
+)
+from vibe3.services import (
+    OrchestraSnapshot,
+    OrchestraStatusService,
 )
 
 ORCHESTRA_TMUX_SESSION = "vibe3-orchestra-serve"

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -1,15 +1,264 @@
 """Vibe3 services layer."""
 
+# Bootstrap services
+# External consumption symbols (from AST scan)
+# Note: Some imports are deferred to avoid circular dependency
+from vibe3.services.base_resolution_usecase import BaseResolutionUsecase
+from vibe3.services.blocked_state_service import BlockedStateService
 from vibe3.services.bootstrap_context_service import (
     BootstrapAction,
     BootstrapActionKind,
     BootstrapContextService,
     BootstrapPlan,
 )
+from vibe3.services.branch_arg import resolve_branch_arg
+from vibe3.services.branch_resolver import resolve_branch_from_pr
+from vibe3.services.check_cleanup_service import CheckCleanupService
+from vibe3.services.check_remote import InitResult
+from vibe3.services.check_service import CheckResult, CheckService
+from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services.coordination_resolver import CoordinationResolver
+from vibe3.services.error_helpers import (
+    record_dispatch_failure_if_unexpected,
+    record_error,
+)
+from vibe3.services.error_tracking_queries import get_all_errors_status
+from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services.expired_resource_cleanup_service import (
+    ExpiredResourceCleanupService,
+)
+from vibe3.services.flow_classifier import (
+    FlowCategory,
+    FlowState,
+    classify_flow,
+    get_flow_state,
+)
+from vibe3.services.flow_cleanup_service import (
+    FlowCleanupService,
+    LiveSessionsDetectedError,
+)
+from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+from vibe3.services.flow_projection_service import FlowProjection, FlowProjectionService
+from vibe3.services.flow_resume_resolver import infer_resume_label
+from vibe3.services.flow_service import FlowService
+from vibe3.services.flow_status_resolver import FlowStatusResolver
+from vibe3.services.git_path_client import get_worktree_root
+from vibe3.services.handoff_resolution import resolve_handoff_target
+from vibe3.services.handoff_service import HandoffService
+from vibe3.services.handoff_status_service import (
+    HandoffStatusResult,
+    HandoffStatusService,
+)
+from vibe3.services.issue_branch_resolver import (
+    _format_flow_details,
+    resolve_issue_branch_input,
+)
+from vibe3.services.issue_collection_service import IssueCollectionService
+from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services.issue_failure_service import (
+    block_manager_noop_issue,
+    fail_executor_issue,
+    fail_issue,
+    fail_manager_issue,
+    fail_planner_issue,
+    fail_reviewer_issue,
+)
+from vibe3.services.issue_flow_service import IssueFlowService
+from vibe3.services.issue_title_cache_service import IssueTitleCacheService
+from vibe3.services.label_service import LabelService
+from vibe3.services.label_utils import (
+    clean_old_state_labels,
+    has_manager_assignee,
+    normalize_assignees,
+    normalize_labels,
+    should_skip_from_queue,
+)
+
+# orchestra_helpers imports deferred (causes circular import with utils.comment_utils)
+from vibe3.services.orchestra_status_service import (
+    IssueStatusEntry,
+    OrchestraSnapshot,
+    OrchestraStatusService,
+    format_issue_runtime_line,
+    format_issue_summary_line,
+    is_running_issue,
+)
+from vibe3.services.path_helpers import (
+    check_ref_exists,
+    ref_to_handoff_cmd,
+    resolve_ref_path,
+    sanitize_event_detail_paths,
+)
+from vibe3.services.pr_analysis_service import (
+    _analyze_critical_files,
+    _calculate_risk_score,
+    _filter_critical_files,
+    _get_pr_changed_files,
+    _get_pr_commit_count,
+    _get_recent_commits,
+    build_pr_analysis,
+)
+from vibe3.services.pr_branch_resolver import resolve_command_branch
+from vibe3.services.pr_create_usecase import PRCreateUsecase
+from vibe3.services.pr_ready_usecase import PrReadyAbortedError, PrReadyUsecase
+from vibe3.services.pr_scoring_service import PRDimensions, generate_score_report
+from vibe3.services.pr_service import PRService
+from vibe3.services.role_policy_helpers import get_role_block_function  # noqa: F401
+from vibe3.services.scan_service import (
+    dispatch_governance_execution,
+    dispatch_supervisor_execution,
+    fetch_supervisor_candidates,
+    get_available_governance_materials,
+    governance_material_exists,
+    list_governance_materials,
+)
+from vibe3.services.serve_status_service import ServeStatusService
+from vibe3.services.signature_service import SignatureService
+from vibe3.services.spec_ref_service import SpecRefService
+from vibe3.services.status_query_service import StatusQueryService, is_auto_task_branch
+from vibe3.services.task_binding_guard import (
+    MissingTaskIssueError,
+    build_bind_task_hint,
+)
+from vibe3.services.task_resume_usecase import TaskResumeUsecase
+from vibe3.services.task_service import (
+    TaskCommentSummary,
+    TaskPRSummary,
+    TaskRefSummary,
+    TaskService,
+    TaskShowResult,
+)
+from vibe3.services.task_status_classifier import (
+    TaskStatusBucket,
+    classify_task_status,
+)
+from vibe3.services.verdict_policy import requires_audit_ref  # noqa: F401
+from vibe3.services.verdict_service import VerdictService
+
+
+def __getattr__(name: str):  # type: ignore[no-untyped-def]
+    """Lazy import for symbols that cause circular dependencies."""
+    if name == "format_agent_actor":
+        from vibe3.services.actor_support import format_agent_actor as _symbol
+
+        return _symbol
+    if name == "get_handoff_state_label":
+        from vibe3.services.orchestra_helpers import (  # type: ignore[assignment]
+            get_handoff_state_label as _symbol,
+        )
+
+        return _symbol
+    if name == "get_manager_usernames":
+        from vibe3.services.orchestra_helpers import (  # type: ignore[assignment]
+            get_manager_usernames as _symbol,
+        )
+
+        return _symbol
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
+    "BaseResolutionUsecase",
     "BootstrapAction",
     "BootstrapActionKind",
     "BootstrapContextService",
     "BootstrapPlan",
+    "BlockedStateService",
+    "CheckCleanupService",
+    "CheckResult",
+    "CheckService",
+    "ConventionResolver",
+    "CoordinationResolver",
+    "ErrorTrackingService",
+    "ExpiredResourceCleanupService",
+    "FlowCategory",
+    "FlowCleanupService",
+    "FlowOrchestratorService",
+    "FlowProjection",
+    "FlowProjectionService",
+    "FlowService",
+    "FlowState",
+    "FlowStatusResolver",
+    "HandoffService",
+    "HandoffStatusResult",
+    "HandoffStatusService",
+    "InitResult",
+    "IssueCollectionService",
+    "IssueFlowService",
+    "IssueStatusEntry",
+    "IssueTitleCacheService",
+    "LabelService",
+    "LiveSessionsDetectedError",
+    "MissingTaskIssueError",
+    "OrchestraSnapshot",
+    "OrchestraStatusService",
+    "PRCreateUsecase",
+    "PRDimensions",
+    "PRService",
+    "PrReadyAbortedError",
+    "PrReadyUsecase",
+    "ServeStatusService",
+    "SignatureService",
+    "SpecRefService",
+    "StatusQueryService",
+    "TaskCommentSummary",
+    "TaskPRSummary",
+    "TaskRefSummary",
+    "TaskResumeUsecase",
+    "TaskService",
+    "TaskShowResult",
+    "TaskStatusBucket",
+    "VerdictService",
+    "_analyze_critical_files",
+    "_calculate_risk_score",
+    "_filter_critical_files",
+    "_format_flow_details",
+    "_get_pr_changed_files",
+    "_get_pr_commit_count",
+    "_get_recent_commits",
+    "block_manager_noop_issue",
+    "build_bind_task_hint",
+    "build_pr_analysis",
+    "check_ref_exists",
+    "classify_flow",
+    "classify_task_status",
+    "clean_old_state_labels",
+    "dispatch_governance_execution",
+    "dispatch_supervisor_execution",
+    "fail_executor_issue",
+    "fail_issue",
+    "fail_manager_issue",
+    "fail_planner_issue",
+    "fail_reviewer_issue",
+    "fetch_supervisor_candidates",
+    "format_agent_actor",
+    "format_issue_runtime_line",
+    "format_issue_summary_line",
+    "generate_score_report",
+    "get_all_errors_status",
+    "get_available_governance_materials",
+    "get_flow_state",
+    "get_handoff_state_label",
+    "get_manager_usernames",
+    "get_worktree_root",
+    "governance_material_exists",
+    "has_manager_assignee",
+    "infer_resume_label",
+    "is_auto_task_branch",
+    "is_running_issue",
+    "list_governance_materials",
+    "load_issue_info",
+    "normalize_assignees",
+    "normalize_labels",
+    "record_dispatch_failure_if_unexpected",
+    "record_error",
+    "ref_to_handoff_cmd",
+    "resolve_branch_arg",
+    "resolve_branch_from_pr",
+    "resolve_command_branch",
+    "resolve_handoff_target",
+    "resolve_issue_branch_input",
+    "resolve_ref_path",
+    "sanitize_event_detail_paths",
+    "should_skip_from_queue",
 ]

--- a/src/vibe3/ui/flow_ui.py
+++ b/src/vibe3/ui/flow_ui.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from vibe3.models.flow import FlowStatusResponse
-from vibe3.services.path_helpers import ref_to_handoff_cmd
+from vibe3.services import ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import display_actor, kv, resolve_ref_path, status_text
 from vibe3.ui.flow_ui_timeline import render_flow_timeline  # noqa: F401
@@ -150,7 +150,7 @@ def render_flow_status(
             f"  [dim]verdict:[/] [{verdict_color}]{v.verdict}[/]" f"  [dim]{v.actor}[/]"
         )
 
-    from vibe3.services.spec_ref_service import SpecRefService
+    from vibe3.services import SpecRefService
 
     spec_service = SpecRefService()
     spec_display = spec_service.get_spec_display(
@@ -233,7 +233,7 @@ def render_flows_status_dashboard(
     - Blocked: Flows with blocked_by
     - Done/Aborted/Stale: Completed flows
     """
-    from vibe3.services.flow_classifier import (
+    from vibe3.services import (
         FlowCategory,
         FlowState,
         classify_flow,

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -64,6 +64,6 @@ def resolve_ref_path(
 
     Redirects to vibe3.services.path_helpers.resolve_ref_path.
     """
-    from vibe3.services.path_helpers import resolve_ref_path as _resolve
+    from vibe3.services import resolve_ref_path as _resolve
 
     return _resolve(ref_value, worktree_root, absolute=absolute)

--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -1,7 +1,7 @@
 """Flow UI timeline rendering components."""
 
 from vibe3.models.flow import FlowEvent, FlowStatusResponse
-from vibe3.services.path_helpers import check_ref_exists, ref_to_handoff_cmd
+from vibe3.services import check_ref_exists, ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import display_actor, kv, status_text
 

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -6,13 +6,13 @@ from dataclasses import asdict
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from vibe3.services.path_helpers import ref_to_handoff_cmd
+from vibe3.services import ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import resolve_ref_path
 from vibe3.utils.constants import AUTOMATED_MARKERS
 
 if TYPE_CHECKING:
-    from vibe3.services.task_service import TaskShowResult
+    from vibe3.services import TaskShowResult
 
 # Display limits for task show output
 MAX_SUMMARY_LINES = 3  # Maximum summary lines shown in non-full mode

--- a/src/vibe3/utils/comment_utils.py
+++ b/src/vibe3/utils/comment_utils.py
@@ -4,7 +4,6 @@ import re
 from typing import Any
 
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.services.orchestra_helpers import get_manager_usernames
 from vibe3.utils.constants import AUTOMATED_MARKERS, GENERIC_AGENT_MARKER_PATTERN
 
 
@@ -72,6 +71,8 @@ def is_human_comment(comment: dict[str, Any]) -> bool:
             return False
 
         # Check manager_usernames list
+        from vibe3.services import get_manager_usernames
+
         manager_usernames = get_manager_usernames(config)
         if manager_usernames:
             manager_logins = [u.lower() for u in manager_usernames]

--- a/tests/vibe3/architecture/test_error_block_boundary.py
+++ b/tests/vibe3/architecture/test_error_block_boundary.py
@@ -148,7 +148,7 @@ class TestBlockModulesDoNotImportErrorModules:
         """BLOCK modules should not import record_error helper."""
         for file_path in block_files:
             content = get_file_content(file_path)
-            if "from vibe3.services.error_helpers import record_error" in content:
+            if "from vibe3.services import record_error" in content:
                 pytest.fail(
                     f"{file_path.name} imports record_error "
                     f"from services.error_helpers (ERROR module)"

--- a/tests/vibe3/commands/conftest.py
+++ b/tests/vibe3/commands/conftest.py
@@ -11,7 +11,7 @@ from vibe3.commands.inspect import app as inspect_app
 from vibe3.models.coverage import CoverageReport, LayerCoverage
 from vibe3.models.flow import FlowState, FlowStatusResponse
 from vibe3.models.pr import PRResponse, PRState
-from vibe3.services.handoff_status_service import HandoffStatusResult
+from vibe3.services import HandoffStatusResult
 
 
 @pytest.fixture(autouse=True)

--- a/tests/vibe3/commands/test_flow_show_cache.py
+++ b/tests/vibe3/commands/test_flow_show_cache.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from vibe3.clients import SQLiteClient
-from vibe3.services.flow_projection_service import FlowProjectionService
+from vibe3.services import FlowProjectionService
 
 
 def test_flow_projection_uses_cached_issue_title() -> None:

--- a/tests/vibe3/commands/test_flow_status_remote_projection.py
+++ b/tests/vibe3/commands/test_flow_status_remote_projection.py
@@ -38,7 +38,7 @@ def test_projection_pr_resolves_by_branch() -> None:
         flow_status="active",
     )
 
-    from vibe3.services.flow_projection_service import FlowProjectionService
+    from vibe3.services import FlowProjectionService
 
     svc = FlowProjectionService(
         flow_service=mock_flow_service, pr_service=mock_pr_service

--- a/tests/vibe3/commands/test_handoff_basic_commands.py
+++ b/tests/vibe3/commands/test_handoff_basic_commands.py
@@ -240,7 +240,7 @@ class TestHandoffBasicCommands:
         self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --format json outputs JSON."""
-        from vibe3.services.handoff_status_service import HandoffStatusResult
+        from vibe3.services import HandoffStatusResult
 
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
@@ -279,7 +279,7 @@ class TestHandoffBasicCommands:
         self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --format yaml outputs YAML."""
-        from vibe3.services.handoff_status_service import HandoffStatusResult
+        from vibe3.services import HandoffStatusResult
 
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"
@@ -315,7 +315,7 @@ class TestHandoffBasicCommands:
         self, mock_flow_service_class, mock_handoff_status_service_class
     ):
         """Test handoff status --json shows deprecation warning."""
-        from vibe3.services.handoff_status_service import HandoffStatusResult
+        from vibe3.services import HandoffStatusResult
 
         mock_flow_service = MagicMock()
         mock_flow_service.get_current_branch.return_value = "feature/test"

--- a/tests/vibe3/commands/test_pr_ready.py
+++ b/tests/vibe3/commands/test_pr_ready.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from vibe3.commands.pr import app
-from vibe3.services.pr_ready_usecase import PrReadyAbortedError
+from vibe3.services import PrReadyAbortedError
 
 runner = CliRunner()
 

--- a/tests/vibe3/commands/test_task_show.py
+++ b/tests/vibe3/commands/test_task_show.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from vibe3.cli import app
 from vibe3.models.flow import FlowStatusResponse
-from vibe3.services.task_service import (
+from vibe3.services import (
     TaskCommentSummary,
     TaskPRSummary,
     TaskRefSummary,

--- a/tests/vibe3/commands/test_task_status_dashboard.py
+++ b/tests/vibe3/commands/test_task_status_dashboard.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from vibe3.cli import app
 from vibe3.models.orchestration import IssueState
-from vibe3.services.orchestra_status_service import OrchestraSnapshot
+from vibe3.services import OrchestraSnapshot
 
 runner = CliRunner(env={"NO_COLOR": "1"})
 

--- a/tests/vibe3/commands/test_task_status_rfc_epic.py
+++ b/tests/vibe3/commands/test_task_status_rfc_epic.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from vibe3.cli import app
 from vibe3.models.orchestration import IssueState
-from vibe3.services.orchestra_status_service import OrchestraSnapshot
+from vibe3.services import OrchestraSnapshot
 
 runner = CliRunner(env={"NO_COLOR": "1"})
 

--- a/tests/vibe3/config/test_policy_paths.py
+++ b/tests/vibe3/config/test_policy_paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from vibe3.config.settings import PlanConfig, ReviewConfig, RunConfig
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def test_convention_resolver_vibe_center_policy_path() -> None:

--- a/tests/vibe3/config/test_profile_config.py
+++ b/tests/vibe3/config/test_profile_config.py
@@ -2,7 +2,7 @@
 
 from vibe3.adapters import get_adapter
 from vibe3.config.profile_config import ProfileConfig
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def test_profile_config_vibe_center_loads_adapter() -> None:

--- a/tests/vibe3/exceptions/conftest.py
+++ b/tests/vibe3/exceptions/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from vibe3.clients import SQLiteClient
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services import ErrorTrackingService
 
 
 @pytest.fixture(autouse=True)

--- a/tests/vibe3/exceptions/test_error_tracking.py
+++ b/tests/vibe3/exceptions/test_error_tracking.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from vibe3.clients import SQLiteClient
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services import ErrorTrackingService
 
 
 def test_cleanup_deletes_old_records(temp_store: SQLiteClient) -> None:
@@ -524,7 +524,7 @@ def test_get_all_errors_status_total_includes_unknown_severity(
         conn.commit()
 
     # Call get_all_errors_status via the query function
-    from vibe3.services.error_tracking_queries import get_all_errors_status
+    from vibe3.services import get_all_errors_status
 
     status = get_all_errors_status(temp_store.db_path)
 
@@ -550,7 +550,7 @@ def test_get_all_errors_status_null_severity_defaults_to_error(
         """)
         conn.commit()
 
-    from vibe3.services.error_tracking_queries import get_all_errors_status
+    from vibe3.services import get_all_errors_status
 
     status = get_all_errors_status(temp_store.db_path)
 
@@ -579,7 +579,7 @@ def test_get_all_errors_status_no_unknown_severity_returns_empty_dict(
         "E_EXEC_NO_OUTPUT", "Warning", severity=ErrorSeverity.WARNING
     )
 
-    from vibe3.services.error_tracking_queries import get_all_errors_status
+    from vibe3.services import get_all_errors_status
 
     status = get_all_errors_status(temp_store.db_path)
 

--- a/tests/vibe3/exceptions/test_error_tracking_edge_cases.py
+++ b/tests/vibe3/exceptions/test_error_tracking_edge_cases.py
@@ -3,7 +3,7 @@
 import sqlite3
 
 from vibe3.clients import SQLiteClient
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services import ErrorTrackingService
 
 
 def test_get_all_errors_status_empty_db(temp_store: SQLiteClient) -> None:

--- a/tests/vibe3/execution/test_auto_scene_recovery.py
+++ b/tests/vibe3/execution/test_auto_scene_recovery.py
@@ -9,7 +9,7 @@ from vibe3.execution.auto_scene_recovery import AutoSceneRecoveryService
 from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.role_contracts import WorktreeRequirement
 from vibe3.models.orchestration import IssueState
-from vibe3.services.flow_cleanup_service import LiveSessionsDetectedError
+from vibe3.services import LiveSessionsDetectedError
 
 
 @pytest.fixture

--- a/tests/vibe3/execution/test_error_block_decoupling.py
+++ b/tests/vibe3/execution/test_error_block_decoupling.py
@@ -16,7 +16,7 @@ import pytest
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.exceptions.runtime_errors import GitHubAPIError
 from vibe3.execution.noop_gate import apply_unified_noop_gate
-from vibe3.services.issue_failure_service import (
+from vibe3.services import (
     fail_issue,
 )
 
@@ -197,7 +197,7 @@ class TestDependencyNotSatisfiedTriggersBlock:
 
     def test_flow_service_block_flow_writes_blocked_reason(self, temp_db):
         """FlowService.block_flow() should write blocked_reason."""
-        from vibe3.services.flow_service import FlowService
+        from vibe3.services import FlowService
 
         branch = "test-branch"
 
@@ -222,7 +222,7 @@ class TestErrorBlockOrthogonality:
 
     def test_error_log_stores_runtime_errors(self, temp_db):
         """Runtime errors should be stored in error_log, not block flow."""
-        from vibe3.services.error_tracking_service import ErrorTrackingService
+        from vibe3.services import ErrorTrackingService
 
         branch = "test-branch"
 
@@ -241,7 +241,7 @@ class TestErrorBlockOrthogonality:
 
     def test_block_flow_writes_blocked_reason(self, temp_db):
         """block_flow() should write blocked_reason."""
-        from vibe3.services.flow_service import FlowService
+        from vibe3.services import FlowService
 
         branch = "test-branch"
 

--- a/tests/vibe3/integration/test_ci_parity.py
+++ b/tests/vibe3/integration/test_ci_parity.py
@@ -17,7 +17,7 @@ class TestWorkingDirectoryIndependence:
         """Verify repo root detection works from any subdirectory."""
         import os
 
-        from vibe3.services.path_helpers import get_worktree_root
+        from vibe3.services import get_worktree_root
 
         # Save current working directory
         original_cwd = os.getcwd()
@@ -45,7 +45,7 @@ class TestWorkingDirectoryIndependence:
         import os
 
         from vibe3.config.loader import get_config
-        from vibe3.services.path_helpers import get_worktree_root
+        from vibe3.services import get_worktree_root
 
         # Save current working directory
         original_cwd = os.getcwd()

--- a/tests/vibe3/integration/test_error_severity_refactor.py
+++ b/tests/vibe3/integration/test_error_severity_refactor.py
@@ -8,7 +8,7 @@ import pytest
 
 from vibe3.clients import SQLiteClient
 from vibe3.orchestra.failed_gate import FailedGate
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.services import ErrorTrackingService
 
 
 @pytest.fixture(autouse=True)

--- a/tests/vibe3/integration/test_health_check_e2e.py
+++ b/tests/vibe3/integration/test_health_check_e2e.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
-from vibe3.services.check_service import CheckService
+from vibe3.services import CheckService
 
 
 def test_closed_issue_flow_gets_aborted_e2e(temp_store: SQLiteClient) -> None:

--- a/tests/vibe3/integration/test_vibe_center_profile.py
+++ b/tests/vibe3/integration/test_vibe_center_profile.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def test_vibe_center_profile_has_policies():

--- a/tests/vibe3/orchestra/test_dispatch_health_checks.py
+++ b/tests/vibe3/orchestra/test_dispatch_health_checks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.services.check_service import CheckResult
+from vibe3.services import CheckResult
 
 if TYPE_CHECKING:
     from vibe3.orchestra.global_dispatch_coordinator import GlobalDispatchCoordinator

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -12,8 +12,8 @@ from vibe3.clients import SQLiteClient
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import FailedGate, GateResult
 from vibe3.runtime.heartbeat import HeartbeatServer
-from vibe3.server import app
-from vibe3.services.error_tracking_service import ErrorTrackingService
+from vibe3.server.app import app
+from vibe3.services import ErrorTrackingService
 
 
 @pytest.fixture(autouse=True)

--- a/tests/vibe3/roles/test_governance.py
+++ b/tests/vibe3/roles/test_governance.py
@@ -15,7 +15,7 @@ from vibe3.roles.governance import (
     build_governance_snapshot_context,
     render_governance_prompt,
 )
-from vibe3.services.orchestra_status_service import (
+from vibe3.services import (
     IssueStatusEntry,
     OrchestraSnapshot,
 )

--- a/tests/vibe3/roles/test_manager.py
+++ b/tests/vibe3/roles/test_manager.py
@@ -265,7 +265,7 @@ class TestManagerBlockedReasonWriting:
             with patch("vibe3.services.flow_service.FlowService") as mock_flow_service:
                 mock_flow_instance = mock_flow_service.return_value
 
-                from vibe3.services.issue_failure_service import (
+                from vibe3.services import (
                     block_manager_noop_issue,
                 )
 

--- a/tests/vibe3/roles/test_run_command.py
+++ b/tests/vibe3/roles/test_run_command.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from vibe3.roles.run_command import resolve_skill_path
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def test_skill_path_uses_profile():

--- a/tests/vibe3/roles/test_supervisor.py
+++ b/tests/vibe3/roles/test_supervisor.py
@@ -16,7 +16,7 @@ from vibe3.roles.supervisor import (
     get_supervisor_prompt_path,
     iter_supervisor_identified_events,
 )
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.services import ConventionResolver
 
 
 def _make_config(**overrides) -> OrchestraConfig:

--- a/tests/vibe3/skills/test_vibe_closeout.py
+++ b/tests/vibe3/skills/test_vibe_closeout.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from vibe3.services.flow_cleanup_service import FlowCleanupService
+from vibe3.services import FlowCleanupService
 
 
 class TestVibeCloseout:

--- a/tests/vibe3/utils/test_issue_branch_resolver.py
+++ b/tests/vibe3/utils/test_issue_branch_resolver.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 from vibe3.exceptions import UserError
-from vibe3.services.issue_branch_resolver import (
+from vibe3.services import (
     _format_flow_details,
     resolve_issue_branch_input,
 )

--- a/tests/vibe3/utils/test_label_utils.py
+++ b/tests/vibe3/utils/test_label_utils.py
@@ -1,6 +1,6 @@
 """Tests for label utility functions."""
 
-from vibe3.services.label_utils import (
+from vibe3.services import (
     has_manager_assignee,
     normalize_assignees,
     normalize_labels,


### PR DESCRIPTION
Closes #1646

## Summary

成功完成 services 模块公共接口统一重构，将 `services/__init__.py` 从仅导出 4 个 bootstrap 符号扩展为完整的公共 API（103 个符号），并批量改写 100 个外部文件中的导入语句。

## Changes

### services/__init__.py 增强
- 扩展公共 API 从 4 个符号到 103 个符号
- 重导出所有被外部模块消费的符号（53 个子模块）
- 使用 `__getattr__` 实现懒加载，避免循环导入

### 外部模块导入重构 (100 个文件)
- 统一所有导入从 `from vibe3.services.<submodule> import <Sym>` 改为 `from vibe3.services import <Sym>`
- 包括 src/vibe3/ 和 tests/vibe3/ 中的所有非 services 目录文件
- 保留 services 子模块间的内部导入不变

### 循环依赖修复
- `src/vibe3/utils/comment_utils.py`: 将 `get_manager_usernames` 导入改为懒加载

## Verification

- ✅ 违规计数归零（grep 检查无外部直接导入子模块）
- ✅ 所有公共符号可通过包级导入访问
- ✅ 无循环导入错误
- ✅ 类型检查通过（mypy）
- ✅ Lint 检查通过（ruff）
- ⚠️ services 测试套件有 1 个预存在的测试失败（与本次重构无关）

## Audit Findings

**Verdict**: MINOR (audit 通过，有 2 个次要问题)

### MINOR 发现
1. **`__all__` 缺少 2 个重导出符号** (Finding 1)
   - `get_role_block_function` 和 `requires_audit_ref` 未列入 `__all__`
   - 不影响功能，显式导入正常工作
   - 已创建 follow-up issue #1687

2. **Scope creep - 死代码删除** (Finding 2)
   - 删除了 `PolicyResolverMixin` 中的 2 个未使用方法
   - 功能安全但超出原始 scope
   - 已在 follow-up issue #1687 中记录

## Test Plan

- [x] 违规计数归零验证
- [x] 包级导入验证
- [x] 循环导入检查
- [x] 类型检查（mypy）
- [x] Lint 检查（ruff）
- [x] services 测试套件（133 passed, 1 pre-existing failure）

## Related Issues

- Epic #1626：模块公共接口统一
- Follow-up #1687：处理 MINOR findings

---

## Contributors

claude/opus
