### PR TITLE
refactor(resume): unify delete strategy — task resume always hard deletes

### DIFF
--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -52,27 +52,27 @@ class TaskResumeOperations:
         flow: FlowStatusResponse | None,
         repo: str | None,
         reason: str,
-        worktree_path: str | None = None,
         label_state: str | None = None,
         remote: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> None:
         """Reset an issue to ready after clearing stale task scene state.
 
+        Two modes:
+        - --label provided: only restore labels, no flow involvement
+        - No --label: hard delete flow + worktree, complete rebuild
+
         Args:
             issue_number: GitHub issue number
-            resume_kind: Resume kind (failed, blocked, all)
+            resume_kind: Resume kind (blocked, all, aborted, pr_closed)
             flow: Flow status response
             repo: Repository (owner/repo format, optional)
             reason: Resume reason to include in comments
-            worktree_path: Optional worktree path (for optimization)
-            label_state: Optional state to restore (None=delete worktree,
+            label_state: Optional state to restore (None=full rebuild,
                 empty/"handoff"=restore to handoff, "ready"=restore to ready)
             remote: If True, keep remote branch (use with --remote flag).
                 If False, delete remote branch (default).
             progress_callback: Optional callback for progress updates.
-                Signature: (issue_number: int, branch: str | None, step: str,
-                    status: str) -> None
 
         Raises:
             UserError: If flow has status "done" (completed flows cannot be reset
@@ -170,26 +170,9 @@ class TaskResumeOperations:
 
             # DO NOT call reset_task_scene (keep worktree)
         else:
-            # Original logic: delete worktree/branch for full rebuild
+            # Full rebuild: hard delete flow + worktree, then orchestra rebuilds
             emit_progress("full rebuild mode")
 
-            # Determine deletion strategy based on resume_kind
-            # PR closed / resume all → hard delete (rebuild, clear events)
-            # Failed / blocked → soft delete (audit, keep events)
-            should_hard_delete = resume_kind in ("pr_closed", "all")
-
-            logger.bind(
-                domain="resume",
-                action="reset_issue_to_ready",
-                resume_kind=resume_kind,
-                force_delete=should_hard_delete,
-            ).info(
-                f"Resume strategy: "
-                f"{'hard delete' if should_hard_delete else 'soft delete'}"
-            )
-
-            # Always use BlockedStateService.unblock() for consistent state clearing
-            # Both blocked and non-blocked resume need to clear any stale metadata
             from vibe3.services.blocked_state_service import BlockedStateService
 
             service = BlockedStateService(
@@ -198,7 +181,7 @@ class TaskResumeOperations:
                 store=self.flow_service.store,
             )
             service.unblock(
-                branch=branch or "",  # Empty string if no branch (DB ops skipped)
+                branch=branch or "",
                 target_state=IssueState.READY,
                 issue_number=issue_number,
                 detail=f"Resumed from {resume_kind}: {reason}",
@@ -211,7 +194,6 @@ class TaskResumeOperations:
                     self.reset_task_scene(
                         branch,
                         include_remote=not remote,
-                        force_delete=should_hard_delete,  # Pass deletion strategy
                     )
                     emit_progress("task scene reset done", status="done")
                 except Exception as exc:
@@ -230,27 +212,17 @@ class TaskResumeOperations:
         self,
         branch: str,
         include_remote: bool = True,
-        force_delete: bool = False,
     ) -> None:
-        """Delete the stale task scene so the next run starts from scratch.
+        """Hard delete flow + worktree so the next run starts from scratch.
 
-        Flow record deletion is guaranteed even if worktree/branch/handoff
-        cleanup fails partially — a stale flow record is the root cause of
-        phantom downstream dispatches (issue #301).
-
-        This method uses FlowCleanupService for consistent cleanup behavior
-        across `task resume` and `check --clean-branch`.
+        Always uses hard delete (force_delete=True) because task resume
+        means complete rebuild — old events have no audit value.
+        Soft delete is only for vibe3 check (issue closed / flow aborted).
 
         Args:
             branch: Branch name
             include_remote: If True, delete remote branch (default).
                 If False, keep remote branch (for --remote mode).
-            force_delete: If True, hard delete flow (remove events).
-                Use True for rebuild scenarios (PR closed, resume all).
-                Use False for aborted scenarios (keep audit trail).
-
-        Note: Always deletes flow record (keep_flow_record=False) because
-            the purpose of `task resume` is to restart the flow from scratch.
         """
         from vibe3.services.flow_cleanup_service import FlowCleanupService
 
@@ -258,7 +230,6 @@ class TaskResumeOperations:
             domain="resume",
             action="reset_task_scene",
             branch=branch,
-            force_delete=force_delete,
         ).info("Resetting task scene")
 
         cleanup_service = FlowCleanupService(
@@ -270,10 +241,10 @@ class TaskResumeOperations:
 
         results = cleanup_service.cleanup_flow_scene(
             branch,
-            include_remote=include_remote,  # Use parameter (False for --remote mode)
+            include_remote=include_remote,
             terminate_sessions=True,
-            keep_flow_record=False,  # Delete flow record to allow fresh start
-            force_delete=force_delete,  # Hard delete for rebuild, soft for audit
+            keep_flow_record=False,
+            force_delete=True,
         )
 
         # Log if any step failed
@@ -359,26 +330,3 @@ class TaskResumeOperations:
                 issue_number=issue_number,
                 previous_state=previous_state.value,
             ).warning("Failed to rollback issue state after resume error: " f"{exc}")
-
-    def reactivate_aborted_flow(self, branch: str) -> None:
-        """Reactivate an aborted flow.
-
-        Args:
-            branch: Branch name for the aborted flow
-        """
-        try:
-            logger.bind(
-                domain="resume",
-                action="reactivate_aborted",
-                branch=branch,
-            ).info("Reactivating aborted flow")
-
-            # Reactivate the aborted flow (change status from "aborted" to "active")
-            self.flow_service.reactivate_flow(branch)
-        except Exception as exc:
-            logger.bind(
-                domain="resume",
-                action="reactivate_aborted",
-                branch=branch,
-            ).warning(f"Failed to reactivate aborted flow: {exc}")
-            raise

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -173,6 +173,21 @@ class TaskResumeOperations:
             # Original logic: delete worktree/branch for full rebuild
             emit_progress("full rebuild mode")
 
+            # Determine deletion strategy based on resume_kind
+            # PR closed / resume all → hard delete (rebuild, clear events)
+            # Failed / blocked → soft delete (audit, keep events)
+            should_hard_delete = resume_kind in ("pr_closed", "all")
+
+            logger.bind(
+                domain="resume",
+                action="reset_issue_to_ready",
+                resume_kind=resume_kind,
+                force_delete=should_hard_delete,
+            ).info(
+                f"Resume strategy: "
+                f"{'hard delete' if should_hard_delete else 'soft delete'}"
+            )
+
             # Always use BlockedStateService.unblock() for consistent state clearing
             # Both blocked and non-blocked resume need to clear any stale metadata
             from vibe3.services.blocked_state_service import BlockedStateService
@@ -196,6 +211,7 @@ class TaskResumeOperations:
                     self.reset_task_scene(
                         branch,
                         include_remote=not remote,
+                        force_delete=should_hard_delete,  # Pass deletion strategy
                     )
                     emit_progress("task scene reset done", status="done")
                 except Exception as exc:
@@ -214,6 +230,7 @@ class TaskResumeOperations:
         self,
         branch: str,
         include_remote: bool = True,
+        force_delete: bool = False,
     ) -> None:
         """Delete the stale task scene so the next run starts from scratch.
 
@@ -228,6 +245,9 @@ class TaskResumeOperations:
             branch: Branch name
             include_remote: If True, delete remote branch (default).
                 If False, keep remote branch (for --remote mode).
+            force_delete: If True, hard delete flow (remove events).
+                Use True for rebuild scenarios (PR closed, resume all).
+                Use False for aborted scenarios (keep audit trail).
 
         Note: Always deletes flow record (keep_flow_record=False) because
             the purpose of `task resume` is to restart the flow from scratch.
@@ -238,6 +258,7 @@ class TaskResumeOperations:
             domain="resume",
             action="reset_task_scene",
             branch=branch,
+            force_delete=force_delete,
         ).info("Resetting task scene")
 
         cleanup_service = FlowCleanupService(
@@ -252,6 +273,7 @@ class TaskResumeOperations:
             include_remote=include_remote,  # Use parameter (False for --remote mode)
             terminate_sessions=True,
             keep_flow_record=False,  # Delete flow record to allow fresh start
+            force_delete=force_delete,  # Hard delete for rebuild, soft for audit
         )
 
         # Log if any step failed

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -163,7 +163,6 @@ class TaskResumeUsecase:
             resume_kind = candidate.get("resume_kind")
             flow = cast("FlowStatusResponse | None", candidate.get("flow"))
             branch = getattr(flow, "branch", None) if flow else None
-            worktree_path: str | None = None
 
             if not isinstance(issue_number, int) or not isinstance(resume_kind, str):
                 continue
@@ -177,6 +176,8 @@ class TaskResumeUsecase:
             ).info("Processing resume candidate")
 
             if resume_kind == "all":
+                worktree_path: str | None = None
+                has_live_sessions: bool | None = None
                 if isinstance(branch, str):
                     resolved_path = self.git_client.find_worktree_path_for_branch(
                         branch
@@ -184,15 +185,13 @@ class TaskResumeUsecase:
                     worktree_path = (
                         str(resolved_path) if resolved_path is not None else None
                     )
-                    # Query registry for truly live sessions (with tmux liveness check)
                     backend = CodeagentBackend()
                     registry = SessionRegistryService(
                         store=self.flow_service.store, backend=backend
                     )
                     live_sessions = registry.get_truly_live_sessions_for_branch(branch)
                     has_live_sessions = len(live_sessions) > 0
-                else:
-                    has_live_sessions = None
+
                 skip_reason = self.candidates.maybe_skip_all_task_candidate(
                     issue_number=issue_number,
                     flow=flow,
@@ -207,53 +206,34 @@ class TaskResumeUsecase:
                     )
                     continue
 
-            # Defensive check: verify current state matches resume_kind
             if not self.candidates.verify_issue_state_for_resume(
                 issue_number, resume_kind, repo
             ):
-                # Generate state-specific skip reason
-                if resume_kind == "all":
-                    skip_reason = "issue 已完成（DONE），跳过恢复"
-                elif resume_kind == "blocked":
-                    skip_reason = "不再处于 blocked 状态，跳过恢复"
-                elif resume_kind == "aborted":
-                    skip_reason = "不再处于可恢复状态（ready/handoff），跳过恢复"
-                else:
-                    skip_reason = "状态验证失败，跳过恢复"
-
                 result["skipped"].append(
                     {
                         "number": issue_number,
-                        "reason": skip_reason,
+                        "reason": "状态验证失败，跳过恢复",
                     }
                 )
                 continue
 
             try:
-                if resume_kind in {"blocked", "all"}:
-                    self.operations.reset_issue_to_ready(
-                        issue_number=issue_number,
-                        resume_kind=resume_kind,
-                        flow=flow,
-                        repo=repo,
-                        reason=reason,
-                        worktree_path=worktree_path,
-                        label_state=label_state,
-                        remote=remote,
-                        progress_callback=progress_callback,
-                    )
+                self.operations.reset_issue_to_ready(
+                    issue_number=issue_number,
+                    resume_kind=resume_kind,
+                    flow=flow,
+                    repo=repo,
+                    reason=reason,
+                    label_state=label_state,
+                    remote=remote,
+                    progress_callback=progress_callback,
+                )
 
-                    if resume_kind == "all":
-                        self._comment_all_resume_success(
-                            issue_number=issue_number,
-                            repo=repo,
-                            reason=reason,
-                        )
-
-                elif resume_kind == "aborted":
-                    flow = cast("FlowStatusResponse | None", candidate.get("flow"))
-                    if flow and isinstance(flow.branch, str):
-                        self.operations.reactivate_aborted_flow(flow.branch)
+                self._comment_resume_success(
+                    issue_number=issue_number,
+                    repo=repo,
+                    reason=reason,
+                )
 
                 result["resumed"].append(
                     {"number": issue_number, "resume_kind": resume_kind}
@@ -277,14 +257,14 @@ class TaskResumeUsecase:
 
         return result
 
-    def _comment_all_resume_success(
+    def _comment_resume_success(
         self,
         *,
         issue_number: int,
         repo: str | None,
         reason: str,
     ) -> None:
-        """Record all-mode reset success without affecting command outcome."""
+        """Record resume success without affecting command outcome."""
         try:
             comment_body = (
                 "[resume] 已重置 task scene，回到 state/ready。\n\n"

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -229,11 +229,12 @@ class TaskResumeUsecase:
                     progress_callback=progress_callback,
                 )
 
-                self._comment_resume_success(
-                    issue_number=issue_number,
-                    repo=repo,
-                    reason=reason,
-                )
+                if label_state is None:
+                    self._comment_resume_success(
+                        issue_number=issue_number,
+                        repo=repo,
+                        reason=reason,
+                    )
 
                 result["resumed"].append(
                     {"number": issue_number, "resume_kind": resume_kind}

--- a/tests/vibe3/services/test_aborted_flow_resume.py
+++ b/tests/vibe3/services/test_aborted_flow_resume.py
@@ -1,6 +1,10 @@
-"""Tests for resuming aborted flows."""
+"""Tests for resuming aborted flows.
 
-from unittest.mock import MagicMock
+After simplification: aborted flows go through the same reset_issue_to_ready
+path as all other resume kinds. No special reactivation logic.
+"""
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,25 +16,21 @@ from vibe3.services.task_resume_usecase import TaskResumeUsecase
 
 @pytest.fixture
 def mock_status_service():
-    """Mock StatusQueryService."""
     return MagicMock(spec=StatusQueryService)
 
 
 @pytest.fixture
 def mock_label_service():
-    """Mock LabelService."""
     return MagicMock()
 
 
 @pytest.fixture
 def mock_flow_service():
-    """Mock FlowService."""
     return MagicMock()
 
 
 @pytest.fixture
 def resume_usecase(mock_status_service, mock_label_service, mock_flow_service):
-    """Create TaskResumeUsecase with mocked dependencies."""
     return TaskResumeUsecase(
         status_service=mock_status_service,
         label_service=mock_label_service,
@@ -39,13 +39,11 @@ def resume_usecase(mock_status_service, mock_label_service, mock_flow_service):
 
 
 class TestAbortedFlowRecovery:
-    """Tests for recovering aborted flows."""
 
-    def test_resume_can_reactivate_aborted_flow(
-        self, resume_usecase, mock_status_service, mock_label_service, mock_flow_service
+    def test_resume_aborted_flow_uses_unified_path(
+        self, resume_usecase, mock_status_service
     ):
-        """Aborted flow can be reactivated via resume."""
-        # Mock an aborted flow candidate (issue reopened after abandon)
+        """Aborted flow goes through reset_issue_to_ready like all other kinds."""
         aborted_flow = FlowStatusResponse(
             branch="task/issue-123",
             flow_slug="issue-123",
@@ -64,50 +62,19 @@ class TestAbortedFlowRecovery:
         ]
 
         mock_status_service.fetch_resume_candidates.return_value = candidates
-        # Mock label service to verify issue is in READY state
-        mock_label_service.get_state.return_value = IssueState.READY
-
-        # Resume should reactivate the flow
-        result = resume_usecase.resume_issues(issue_numbers=[123])
-
-        assert len(result["resumed"]) == 1
-        assert result["resumed"][0]["number"] == 123
-        assert result["resumed"][0]["resume_kind"] == "aborted"
-
-        # Verify flow was reactivated
-        mock_flow_service.reactivate_flow.assert_called_once_with("task/issue-123")
-
-    def test_resume_aborted_flow_preserves_artifacts(
-        self, resume_usecase, mock_status_service, mock_label_service, mock_flow_service
-    ):
-        """Resuming aborted flow preserves historical refs."""
-        # Mock an aborted flow with historical refs
-        aborted_flow = FlowStatusResponse(
-            branch="task/issue-456",
-            flow_slug="issue-456",
-            flow_status="aborted",
-            spec_ref="docs/specs/old-spec.md",  # Should be preserved
-            plan_ref="docs/plans/old-plan.md",  # Historical ref
+        resume_usecase.candidates.verify_issue_state_for_resume = MagicMock(
+            return_value=True
         )
 
-        candidates = [
-            {
-                "number": 456,
-                "title": "Test issue with history",
-                "state": IssueState.HANDOFF,
-                "flow": aborted_flow,
-                "resume_kind": "aborted",
-            }
-        ]
+        with patch.object(
+            resume_usecase.operations, "reset_issue_to_ready"
+        ) as mock_reset:
+            result = resume_usecase.resume_issues(issue_numbers=[123])
 
-        mock_status_service.fetch_resume_candidates.return_value = candidates
-        # Mock label service to verify issue is in HANDOFF state
-        mock_label_service.get_state.return_value = IssueState.HANDOFF
+            assert len(result["resumed"]) == 1
+            assert result["resumed"][0]["resume_kind"] == "aborted"
 
-        # Resume the aborted flow
-        result = resume_usecase.resume_issues(issue_numbers=[456])
-
-        assert len(result["resumed"]) == 1
-
-        # Verify reactivate was called (which preserves refs via events)
-        mock_flow_service.reactivate_flow.assert_called_once()
+            mock_reset.assert_called_once()
+            call_kwargs = mock_reset.call_args.kwargs
+            assert call_kwargs["resume_kind"] == "aborted"
+            assert call_kwargs["issue_number"] == 123

--- a/tests/vibe3/services/test_task_resume_core.py
+++ b/tests/vibe3/services/test_task_resume_core.py
@@ -95,4 +95,5 @@ def test_reset_issue_to_ready_with_remote_flag() -> None:
                 include_remote=False,  # Key assertion
                 terminate_sessions=True,
                 keep_flow_record=False,
+                force_delete=False,  # Soft delete for audit trail
             )

--- a/tests/vibe3/services/test_task_resume_core.py
+++ b/tests/vibe3/services/test_task_resume_core.py
@@ -40,7 +40,6 @@ def test_reset_issue_to_ready_without_label_deletes_worktree() -> None:
                 flow=mock_flow,
                 repo=None,
                 reason="test resume",
-                worktree_path="/tmp/issue-303",
                 label_state=None,  # No --label
             )
 
@@ -95,5 +94,5 @@ def test_reset_issue_to_ready_with_remote_flag() -> None:
                 include_remote=False,  # Key assertion
                 terminate_sessions=True,
                 keep_flow_record=False,
-                force_delete=False,  # Soft delete for audit trail
+                force_delete=True,
             )

--- a/tests/vibe3/services/test_task_resume_force_delete.py
+++ b/tests/vibe3/services/test_task_resume_force_delete.py
@@ -1,0 +1,177 @@
+"""Tests for force_delete strategy based on resume_kind."""
+
+from unittest.mock import MagicMock, patch
+
+from tests.vibe3.services.conftest import _make_operations
+
+
+def test_reset_issue_to_ready_uses_hard_delete_for_pr_closed() -> None:
+    """Test that PR closed scenario uses hard delete (force_delete=True)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Mock BlockedStateService
+        with patch(
+            "vibe3.services.blocked_state_service.BlockedStateService"
+        ) as mock_block_cls:
+            mock_block_instance = MagicMock()
+            mock_block_cls.return_value = mock_block_instance
+
+            # Call with resume_kind="pr_closed"
+            operations.reset_issue_to_ready(
+                issue_number=1719,
+                resume_kind="pr_closed",
+                flow=MagicMock(branch="task/issue-1719"),
+                repo=None,
+                reason="PR #1686 closed without merge",
+            )
+
+            # Verify hard delete was used
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+                "task/issue-1719",
+                include_remote=True,
+                terminate_sessions=True,
+                keep_flow_record=False,
+                force_delete=True,  # Key assertion: hard delete for PR closed
+            )
+
+
+def test_reset_issue_to_ready_uses_hard_delete_for_resume_all() -> None:
+    """Test that resume all scenario uses hard delete (force_delete=True)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Mock BlockedStateService
+        with patch(
+            "vibe3.services.blocked_state_service.BlockedStateService"
+        ) as mock_block_cls:
+            mock_block_instance = MagicMock()
+            mock_block_cls.return_value = mock_block_instance
+
+            # Call with resume_kind="all"
+            operations.reset_issue_to_ready(
+                issue_number=123,
+                resume_kind="all",
+                flow=MagicMock(branch="task/issue-123"),
+                repo=None,
+                reason="Resume all issues",
+            )
+
+            # Verify hard delete was used
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+                "task/issue-123",
+                include_remote=True,
+                terminate_sessions=True,
+                keep_flow_record=False,
+                force_delete=True,  # Key assertion: hard delete for resume all
+            )
+
+
+def test_reset_issue_to_ready_uses_soft_delete_for_failed() -> None:
+    """Test that failed flow scenario uses soft delete (force_delete=False)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Mock BlockedStateService
+        with patch(
+            "vibe3.services.blocked_state_service.BlockedStateService"
+        ) as mock_block_cls:
+            mock_block_instance = MagicMock()
+            mock_block_cls.return_value = mock_block_instance
+
+            # Call with resume_kind="failed"
+            operations.reset_issue_to_ready(
+                issue_number=456,
+                resume_kind="failed",
+                flow=MagicMock(branch="task/issue-456"),
+                repo=None,
+                reason="Resume failed flow",
+            )
+
+            # Verify soft delete was used
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+                "task/issue-456",
+                include_remote=True,
+                terminate_sessions=True,
+                keep_flow_record=False,
+                force_delete=False,  # Key assertion: soft delete for audit trail
+            )
+
+
+def test_reset_issue_to_ready_uses_soft_delete_for_blocked() -> None:
+    """Test that blocked flow scenario uses soft delete (force_delete=False)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Mock BlockedStateService
+        with patch(
+            "vibe3.services.blocked_state_service.BlockedStateService"
+        ) as mock_block_cls:
+            mock_block_instance = MagicMock()
+            mock_block_cls.return_value = mock_block_instance
+
+            # Call with resume_kind="blocked"
+            operations.reset_issue_to_ready(
+                issue_number=789,
+                resume_kind="blocked",
+                flow=MagicMock(branch="task/issue-789"),
+                repo=None,
+                reason="Resume blocked flow",
+            )
+
+            # Verify soft delete was used
+            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+                "task/issue-789",
+                include_remote=True,
+                terminate_sessions=True,
+                keep_flow_record=False,
+                force_delete=False,  # Key assertion: soft delete for audit trail
+            )

--- a/tests/vibe3/services/test_task_resume_force_delete.py
+++ b/tests/vibe3/services/test_task_resume_force_delete.py
@@ -1,12 +1,22 @@
-"""Tests for force_delete strategy based on resume_kind."""
+"""Tests that task resume always uses hard delete regardless of resume_kind."""
 
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tests.vibe3.services.conftest import _make_operations
 
 
-def test_reset_issue_to_ready_uses_hard_delete_for_pr_closed() -> None:
-    """Test that PR closed scenario uses hard delete (force_delete=True)."""
+@pytest.mark.parametrize(
+    "resume_kind",
+    ["pr_closed", "all", "blocked", "failed", "aborted"],
+)
+def test_reset_issue_to_ready_always_hard_deletes(resume_kind: str) -> None:
+    """All resume kinds use hard delete (force_delete=True).
+
+    Soft delete is only for vibe3 check (issue closed / flow aborted).
+    Task resume means complete rebuild — old events have no value.
+    """
     operations = _make_operations()
 
     with patch(
@@ -22,156 +32,24 @@ def test_reset_issue_to_ready_uses_hard_delete_for_pr_closed() -> None:
         }
         mock_cleanup_cls.return_value = mock_cleanup_instance
 
-        # Mock BlockedStateService
         with patch(
             "vibe3.services.blocked_state_service.BlockedStateService"
         ) as mock_block_cls:
             mock_block_instance = MagicMock()
             mock_block_cls.return_value = mock_block_instance
 
-            # Call with resume_kind="pr_closed"
-            operations.reset_issue_to_ready(
-                issue_number=1719,
-                resume_kind="pr_closed",
-                flow=MagicMock(branch="task/issue-1719"),
-                repo=None,
-                reason="PR #1686 closed without merge",
-            )
-
-            # Verify hard delete was used
-            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-                "task/issue-1719",
-                include_remote=True,
-                terminate_sessions=True,
-                keep_flow_record=False,
-                force_delete=True,  # Key assertion: hard delete for PR closed
-            )
-
-
-def test_reset_issue_to_ready_uses_hard_delete_for_resume_all() -> None:
-    """Test that resume all scenario uses hard delete (force_delete=True)."""
-    operations = _make_operations()
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Mock BlockedStateService
-        with patch(
-            "vibe3.services.blocked_state_service.BlockedStateService"
-        ) as mock_block_cls:
-            mock_block_instance = MagicMock()
-            mock_block_cls.return_value = mock_block_instance
-
-            # Call with resume_kind="all"
             operations.reset_issue_to_ready(
                 issue_number=123,
-                resume_kind="all",
+                resume_kind=resume_kind,
                 flow=MagicMock(branch="task/issue-123"),
                 repo=None,
-                reason="Resume all issues",
+                reason=f"Resume from {resume_kind}",
             )
 
-            # Verify hard delete was used
             mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
                 "task/issue-123",
                 include_remote=True,
                 terminate_sessions=True,
                 keep_flow_record=False,
-                force_delete=True,  # Key assertion: hard delete for resume all
-            )
-
-
-def test_reset_issue_to_ready_uses_soft_delete_for_failed() -> None:
-    """Test that failed flow scenario uses soft delete (force_delete=False)."""
-    operations = _make_operations()
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Mock BlockedStateService
-        with patch(
-            "vibe3.services.blocked_state_service.BlockedStateService"
-        ) as mock_block_cls:
-            mock_block_instance = MagicMock()
-            mock_block_cls.return_value = mock_block_instance
-
-            # Call with resume_kind="failed"
-            operations.reset_issue_to_ready(
-                issue_number=456,
-                resume_kind="failed",
-                flow=MagicMock(branch="task/issue-456"),
-                repo=None,
-                reason="Resume failed flow",
-            )
-
-            # Verify soft delete was used
-            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-                "task/issue-456",
-                include_remote=True,
-                terminate_sessions=True,
-                keep_flow_record=False,
-                force_delete=False,  # Key assertion: soft delete for audit trail
-            )
-
-
-def test_reset_issue_to_ready_uses_soft_delete_for_blocked() -> None:
-    """Test that blocked flow scenario uses soft delete (force_delete=False)."""
-    operations = _make_operations()
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Mock BlockedStateService
-        with patch(
-            "vibe3.services.blocked_state_service.BlockedStateService"
-        ) as mock_block_cls:
-            mock_block_instance = MagicMock()
-            mock_block_cls.return_value = mock_block_instance
-
-            # Call with resume_kind="blocked"
-            operations.reset_issue_to_ready(
-                issue_number=789,
-                resume_kind="blocked",
-                flow=MagicMock(branch="task/issue-789"),
-                repo=None,
-                reason="Resume blocked flow",
-            )
-
-            # Verify soft delete was used
-            mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-                "task/issue-789",
-                include_remote=True,
-                terminate_sessions=True,
-                keep_flow_record=False,
-                force_delete=False,  # Key assertion: soft delete for audit trail
+                force_delete=True,
             )

--- a/tests/vibe3/services/test_task_resume_label_state.py
+++ b/tests/vibe3/services/test_task_resume_label_state.py
@@ -41,7 +41,6 @@ def test_reset_issue_to_ready_with_label_keeps_worktree() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="",  # --label auto (converted to empty string internally)
         )
 
@@ -77,7 +76,6 @@ def test_reset_issue_to_ready_with_label_ready_restores_to_ready() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="ready",  # --label ready
         )
 
@@ -112,7 +110,6 @@ def test_reset_issue_to_ready_with_label_handoff_explicit() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="handoff",  # --label handoff (explicit)
         )
 
@@ -147,7 +144,6 @@ def test_reset_issue_to_ready_with_label_claimed() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="claimed",  # --label claimed
         )
 
@@ -180,7 +176,6 @@ def test_reset_issue_to_ready_with_label_in_progress() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="in-progress",  # --label in-progress
         )
 
@@ -213,7 +208,6 @@ def test_reset_issue_to_ready_with_label_review() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="review",  # --label review
         )
 
@@ -246,7 +240,6 @@ def test_reset_issue_to_ready_with_label_merge_ready() -> None:
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path="/tmp/issue-303",
             label_state="merge-ready",  # --label merge-ready
         )
 
@@ -283,7 +276,6 @@ def test_reset_issue_to_ready_with_label_auto_no_flow_restores_to_ready() -> Non
             flow=mock_flow,
             repo=None,
             reason="test resume",
-            worktree_path=None,
             label_state="",  # --label auto (no flow exists)
         )
 

--- a/tests/vibe3/services/test_task_resume_reset_scene.py
+++ b/tests/vibe3/services/test_task_resume_reset_scene.py
@@ -1,12 +1,16 @@
-"""Tests for reset_task_scene operation."""
+"""Tests for reset_task_scene operation.
+
+Task resume always hard deletes (force_delete=True).
+Soft delete is only for vibe3 check (issue closed / flow aborted).
+"""
 
 from unittest.mock import MagicMock, patch
 
 from tests.vibe3.services.conftest import _make_operations
 
 
-def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
-    """Test that reset_task_scene uses FlowCleanupService for complete cleanup."""
+def test_reset_task_scene_hard_deletes_by_default() -> None:
+    """reset_task_scene always uses hard delete (force_delete=True)."""
     operations = _make_operations()
 
     with patch(
@@ -24,60 +28,18 @@ def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
 
         operations.reset_task_scene("task/issue-329")
 
-        # Verify FlowCleanupService was instantiated
         mock_cleanup_cls.assert_called_once()
-
-        # Verify cleanup_flow_scene was called with correct parameters
         mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
             "task/issue-329",
             include_remote=True,
             terminate_sessions=True,
-            keep_flow_record=False,  # Resume always deletes flow record
-            force_delete=False,  # Default: soft delete for audit trail
-        )
-
-
-def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
-    """Test that reset_task_scene calls cleanup service for tombstone creation."""
-    operations = _make_operations()
-
-    branch = "task/issue-999"
-
-    # Mock FlowCleanupService to make test hermetic
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_class:
-        mock_cleanup_service = MagicMock()
-        mock_cleanup_class.return_value = mock_cleanup_service
-
-        # Setup cleanup result
-        mock_cleanup_service.cleanup_flow_scene.return_value = {
-            "tmux_sessions": {"success": True, "sessions": []},
-            "worktree": {"success": True, "path": None},
-            "local_branch": {"success": True, "deleted": True},
-            "remote_branch": {"success": True, "deleted": True},
-            "handoff_files": {"success": True, "files": []},
-            "flow_record": {"success": True, "deleted": True},
-        }
-
-        # Execute reset
-        operations.reset_task_scene(branch)
-
-        # Verify cleanup_flow_scene called with correct parameters
-        mock_cleanup_service.cleanup_flow_scene.assert_called_once_with(
-            branch,
-            include_remote=True,
-            terminate_sessions=True,
             keep_flow_record=False,
-            force_delete=False,  # Default: soft delete for audit trail
+            force_delete=True,
         )
-
-        # Note: Tombstone normalization is validated in repository tests
-        # This test verifies the call path through FlowCleanupService
 
 
 def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
-    """Test reset_task_scene with include_remote=False (--remote mode)."""
+    """reset_task_scene with include_remote=False keeps remote branch."""
     operations = _make_operations()
 
     with patch(
@@ -87,152 +49,18 @@ def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
         mock_cleanup_instance.cleanup_flow_scene.return_value = {
             "worktree": True,
             "local_branch": True,
-            "remote_branch": True,  # Though we're keeping it
+            "remote_branch": True,
             "handoff": True,
             "flow_record": True,
         }
         mock_cleanup_cls.return_value = mock_cleanup_instance
 
-        # Call with include_remote=False (--remote mode)
         operations.reset_task_scene("task/issue-123", include_remote=False)
 
-        # Verify FlowCleanupService was instantiated
-        mock_cleanup_cls.assert_called_once()
-
-        # Verify cleanup_flow_scene was called with include_remote=False
         mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
             "task/issue-123",
-            include_remote=False,  # Key assertion: keep remote branch
+            include_remote=False,
             terminate_sessions=True,
             keep_flow_record=False,
-            force_delete=False,  # Default: soft delete for audit trail
+            force_delete=True,
         )
-
-
-def test_reset_task_scene_with_force_delete_true() -> None:
-    """Test reset_task_scene with force_delete=True (hard delete for rebuild)."""
-    operations = _make_operations()
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Call with force_delete=True (PR closed / resume all scenario)
-        operations.reset_task_scene("task/issue-1719", force_delete=True)
-
-        # Verify cleanup_flow_scene was called with force_delete=True
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-            "task/issue-1719",
-            include_remote=True,
-            terminate_sessions=True,
-            keep_flow_record=False,
-            force_delete=True,  # Key assertion: hard delete for rebuild
-        )
-
-
-def test_reset_task_scene_with_force_delete_false_default() -> None:
-    """Test reset_task_scene defaults to force_delete=False (soft delete for audit)."""
-    operations = _make_operations()
-
-    with patch(
-        "vibe3.services.flow_cleanup_service.FlowCleanupService"
-    ) as mock_cleanup_cls:
-        mock_cleanup_instance = MagicMock()
-        mock_cleanup_instance.cleanup_flow_scene.return_value = {
-            "worktree": True,
-            "local_branch": True,
-            "remote_branch": True,
-            "handoff": True,
-            "flow_record": True,
-        }
-        mock_cleanup_cls.return_value = mock_cleanup_instance
-
-        # Call without force_delete (default behavior)
-        operations.reset_task_scene("task/issue-123")
-
-        # Verify cleanup_flow_scene was called with force_delete=False
-        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
-            "task/issue-123",
-            include_remote=True,
-            terminate_sessions=True,
-            keep_flow_record=False,
-            force_delete=False,  # Key assertion: soft delete for audit trail
-        )
-
-
-def test_soft_delete_then_create_flow_produces_clean_state() -> None:
-    """Full cycle: soft_delete -> create_flow must produce a clean active flow.
-
-    Simulates the orchestra dispatch after PR-closed reset:
-    1. Soft-delete the flow (as cleanup does)
-    2. Create a new flow (as orchestra dispatch does)
-    3. Verify: deleted_at is NULL, flow_status is 'active', no zombie links
-    """
-    import tempfile
-    from pathlib import Path
-
-    from vibe3.clients.sqlite_client import SQLiteClient
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "test.db"
-        store = SQLiteClient(db_path=str(db_path))
-
-        # Setup: create flow with links and session
-        store.update_flow_state(
-            "task/issue-100",
-            flow_slug="issue-100",
-            flow_status="active",
-        )
-        store.add_issue_link("task/issue-100", 100, "task")
-
-        conn = store._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(
-            "INSERT INTO runtime_session "
-            "(role, target_type, target_id, branch, session_name, status, "
-            "created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
-            ("planner", "issue", "100", "task/issue-100", "sess-1", "running"),
-        )
-        conn.commit()
-
-        # Step 1: Soft delete (as cleanup does)
-        store.soft_delete_flow("task/issue-100")
-
-        # Verify tombstone
-        tombstone = store.get_flow_state_include_deleted("task/issue-100")
-        assert tombstone is not None
-        assert tombstone["deleted_at"] is not None
-        assert tombstone["flow_status"] == "aborted"
-
-        # Verify cascade: runtime_session and flow_issue_links are gone
-        cursor.execute(
-            "SELECT COUNT(*) FROM runtime_session WHERE branch = ?",
-            ("task/issue-100",),
-        )
-        assert cursor.fetchone()[0] == 0
-
-        cursor.execute(
-            "SELECT COUNT(*) FROM flow_issue_links WHERE branch = ?",
-            ("task/issue-100",),
-        )
-        assert cursor.fetchone()[0] == 0
-
-        # Step 2: Simulate what create_flow does with tombstone
-        store.restore_flow("task/issue-100")
-        store.update_flow_state("task/issue-100", flow_status="active")
-
-        # Step 3: Verify clean state
-        active = store.get_flow_state("task/issue-100")
-        assert active is not None, "get_flow_state must find the restored flow"
-        assert active["deleted_at"] is None
-        assert active["flow_status"] == "active"

--- a/tests/vibe3/services/test_task_resume_reset_scene.py
+++ b/tests/vibe3/services/test_task_resume_reset_scene.py
@@ -33,6 +33,7 @@ def test_reset_task_scene_deletes_branch_handoff_and_flow_truth() -> None:
             include_remote=True,
             terminate_sessions=True,
             keep_flow_record=False,  # Resume always deletes flow record
+            force_delete=False,  # Default: soft delete for audit trail
         )
 
 
@@ -68,6 +69,7 @@ def test_reset_task_scene_creates_tombstone_after_full_rebuild() -> None:
             include_remote=True,
             terminate_sessions=True,
             keep_flow_record=False,
+            force_delete=False,  # Default: soft delete for audit trail
         )
 
         # Note: Tombstone normalization is validated in repository tests
@@ -103,6 +105,67 @@ def test_reset_task_scene_with_remote_keeps_remote_branch() -> None:
             include_remote=False,  # Key assertion: keep remote branch
             terminate_sessions=True,
             keep_flow_record=False,
+            force_delete=False,  # Default: soft delete for audit trail
+        )
+
+
+def test_reset_task_scene_with_force_delete_true() -> None:
+    """Test reset_task_scene with force_delete=True (hard delete for rebuild)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Call with force_delete=True (PR closed / resume all scenario)
+        operations.reset_task_scene("task/issue-1719", force_delete=True)
+
+        # Verify cleanup_flow_scene was called with force_delete=True
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-1719",
+            include_remote=True,
+            terminate_sessions=True,
+            keep_flow_record=False,
+            force_delete=True,  # Key assertion: hard delete for rebuild
+        )
+
+
+def test_reset_task_scene_with_force_delete_false_default() -> None:
+    """Test reset_task_scene defaults to force_delete=False (soft delete for audit)."""
+    operations = _make_operations()
+
+    with patch(
+        "vibe3.services.flow_cleanup_service.FlowCleanupService"
+    ) as mock_cleanup_cls:
+        mock_cleanup_instance = MagicMock()
+        mock_cleanup_instance.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+        mock_cleanup_cls.return_value = mock_cleanup_instance
+
+        # Call without force_delete (default behavior)
+        operations.reset_task_scene("task/issue-123")
+
+        # Verify cleanup_flow_scene was called with force_delete=False
+        mock_cleanup_instance.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-123",
+            include_remote=True,
+            terminate_sessions=True,
+            keep_flow_record=False,
+            force_delete=False,  # Key assertion: soft delete for audit trail
         )
 
 


### PR DESCRIPTION
## 问题描述

task resume 的删除逻辑过度复杂：

1. 软删除原本是为 `vibe3 check` 设计的（防止误删活跃 flow），但被错误地用在了 resume 重建场景
2. resume 重建后旧 flow_events 未清除，导致 timeline 混乱
3. 不同 resume_kind 走不同删除策略（soft vs hard），增加了无意义的复杂度

## 解决方案

**统一规则：task resume 永远硬删除**

| 场景 | 删除方式 | 原因 |
|------|---------|------|
| `vibe3 check`（issue closed / flow aborted） | 软删除 | 保留审计记录，非重建场景 |
| `task resume`（任何 resume_kind） | **硬删除** | 完全重建，旧 events 无保留价值 |

**两种 resume 模式**：
- `task resume`：硬删除 flow + worktree，完全重建
- `task resume --label`：只恢复标签，不涉及 flow 删除

## 修改内容

**简化 task_resume_operations.py**（-66 行）：
- `reset_task_scene()` 始终 `force_delete=True`，移除参数
- `reset_issue_to_ready()` 移除 `should_hard_delete` 条件判断
- 删除 `reactivate_aborted_flow()`（aborted 走统一路径）

**简化 task_resume_usecase.py**（-41 行）：
- 所有 resume_kind 统一调用 `reset_issue_to_ready`
- 删除 `if resume_kind in {"blocked", "all"}: ... elif resume_kind == "aborted":` 分叉
- `_comment_resume_success` 只在 full rebuild 模式发送

**测试简化**（-385 行）：
- 1 个参数化测试覆盖所有 resume_kind 的硬删除行为
- 删除 soft/hard 对比测试和 reactivate 测试

**总计**：+91 -499（净删 408 行）

## 验证

- 23 个 resume 相关测试通过
- mypy / ruff / black 通过

## 关联 Issue

Closes #1719
Closes #1720

## Contributors

- Design & Review: Yi Chen
- Implementation: Claude Opus 4.6