### PR TITLE
docs(governance): align terminology and fix glossary encoding

### DIFF
--- a/docs/standards/github-labels-standard.md
+++ b/docs/standards/github-labels-standard.md
@@ -127,6 +127,24 @@
 - **非控制位**：不作为 governance 或执行引擎的判定依据。
 - **手动操作后果**：手动添加/移除此标签不会改变 issue 的执行角色。系统在下次同步时会尝试根据真源状态纠正此标签。
 
+#### `orchestra-governed`
+
+**语义**: 治理决策镜像标签 (Governance Review Mark)
+
+**职责**: 辅助 governance (assignee-pool) 识别已完成池内评估（priority/roadmap/epic 判定）的 issue。
+
+**规则**:
+- **决策触发**：由 `assignee-pool` 扫描并做出实质性决策（如设置 `state/ready`、`roadmap/rfc` 等）后添加。
+- **过滤依据**：governance 扫描时会过滤掉已持有此标签的 issue，避免重复评估。
+- **三层治理联动**：
+  - `orchestra-scanned`: Level 1 intake 审查标记。
+  - `orchestra-governed`: Level 2 assignee-pool 决策标记。
+  - `roadmap-reviewed`: Level 3 roadmap 终审标记。
+- **与 vibe-task 区别**：
+  - `vibe-task` 是 **自动化副作用**，表示 issue "正在/曾被" flow 绑定。
+  - `orchestra-governed` 是 **治理状态**，表示 issue "已通过" 治理审查。
+  - 严禁混用。
+
 ### 3.4 编排状态标签语义 (state/*)
 
 **语义**: 说明"当前处于 flow 循环的哪一阶段"
@@ -254,6 +272,7 @@ agent 认领 issue 时：
 - 把 `dependency` 当成一种状态
 - 把 `review` 当成一种 issue 类型
 - 用 `vibe-task` 表达 "现在正在执行"
+- 用 `vibe-task` 作为治理审查标记（应使用 `orchestra-governed`）
 - 把 `roadmap/p0` 等同于 `priority/high`
 
 **正确示例**:

--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -115,7 +115,37 @@ related_docs:
   - 不说 "创建 task issue"，而是 "将 issue 关联为 task"。
   - 它是相对于 flow 的**关系**，而不是 issue 的固有属性。
 
+### 3.3.1a `orchestra-governed` (label)
+
+- 正式术语：`orchestra-governed`
+- 别称：无
+- 定义：**治理决策镜像标签**。用于标记已通过 `assignee-pool` (Level 2 scan) 评估并做出确定性决策（如 ready/rfc/epic/close）的 issue。
+- 职责：作为 governance 扫描的“已审查”标记，防止重复扫描，并作为三层治理体系（scanned -> governed -> reviewed）的中间状态。
+- 边界：
+  - **不是**自动化镜像，而是治理决策的显式标记。
+  - 标记该 issue 已经过池内决策，无需再次 intake 或评估。
+- 使用规则：
+  - 由 `assignee-pool` 扫描完成后添加。
+  - 人类手动移除此标签可使 issue 重新进入 governance 评估循环。
+
+### 3.3.1b `orchestra-scanned` (label)
+
+- 正式术语：`orchestra-scanned`
+- 别称：无
+- 定义：**Intake 审查镜像标签**。用于标记已通过 `roadmap-intake` (Level 1 scan) 审查但未被纳入执行池的 issue。
+- 职责：标记该 issue 已被 intake 层处理（通常是跳过或拒绝），防止重复扫描。
+- 边界：Level 1 治理标记。
+
+### 3.3.1c `roadmap-reviewed` (label)
+
+- 正式术语：`roadmap-reviewed`
+- 别称：无
+- 定义：**Roadmap 终审镜像标签**。用于标记已由 `vibe-roadmap` (Level 3 review) 完成终审决策的 issue。
+- 职责：治理体系的终态标记，表示决策已固化并写入 memory。
+- 边界：Level 3 治理标记。
+
 ### 3.3.2 `assignee issue`
+
 
 - 正式术语：`assignee issue`
 - 别称：无
@@ -739,4 +769,4 @@ related_docs:
 - `执行代理` != `Shell 能力层`
 
 若后续 doc review 发现新的高频混用，应优先在本文档补充修正。
-��
+

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -38,6 +38,11 @@
 
 **所有决策完成后打 `orchestra-governed` 标签**。
 
+**三层治理体系联动**：
+- **Level 1 (Intake)**: 审查无 assignee issue，跳过时打 `orchestra-scanned`。
+- **Level 2 (Assignee Pool)**: 评估池内优先级与形态，决策后打 `orchestra-governed`（即本材料）。
+- **Level 3 (Roadmap)**: 终审决策，结果产出后打 `roadmap-reviewed`。
+
 **核心逻辑**：
 - **决策** → 对池内 issue 做出确定性判断（不再只是”建议”）
 - **观察** → 分析当前 issue 池和队列状态，辅助决策
@@ -328,9 +333,10 @@ pool 扫描有 assignee 的 issue →
 Steps:
 
 0. **标签验证（强制，先于过滤）**：先执行「标签验证与清理」段——校验所有带 `orchestra-governed` 的 open issue 是否仍满足持有条件，不满足则移除并写 cleanup comment。然后才进入下面的标签过滤。
-1. **标签过滤（强制）**：只处理有 manager assignee 但无 `orchestra-governed` 标签的 issue：
+1. **标签过滤（强制）**：只处理有 manager assignee，且无 `orchestra-governed` 且无 `roadmap-reviewed` 标签的 issue：
    - 无 assignee → 跳过（不在 pool 中，由 roadmap-intake 负责）
    - 有 `orchestra-governed` 标签 → 跳过（pool 已决策过，不重复检查）
+   - 有 `roadmap-reviewed` 标签 → 跳过（roadmap 已终审，pool 不再干预）
 2. 运行全局现场观察命令，读取当前 running issues、ready queue、blocked issues、remote tasks 与 flow 现场：
    ```bash
    uv run python src/vibe3/cli.py task status

--- a/tests/vibe3/roles/test_governance.py
+++ b/tests/vibe3/roles/test_governance.py
@@ -311,7 +311,7 @@ class TestBuildSnapshotContext:
     @patch("vibe3.roles.governance.GitHubClient")
     def test_empty_issues(self, mock_github_cls):
         mock_github = MagicMock()
-        mock_github.list_issues.return_value = []  # No vibe-task issues
+        mock_github.list_issues.return_value = []  # No orchestra-governed issues
         mock_github_cls.return_value = mock_github
 
         snapshot = _make_snapshot()
@@ -329,7 +329,7 @@ class TestBuildSnapshotContext:
     @patch("vibe3.roles.governance.GitHubClient")
     def test_with_running_and_suggested_issues(self, mock_github_cls):
         mock_github = MagicMock()
-        mock_github.list_issues.return_value = []  # No vibe-task issues
+        mock_github.list_issues.return_value = []  # No orchestra-governed issues
         mock_github_cls.return_value = mock_github
 
         running = IssueStatusEntry(
@@ -373,7 +373,7 @@ class TestBuildSnapshotContext:
     @patch("vibe3.roles.governance.GitHubClient")
     def test_server_stopped(self, mock_github_cls):
         mock_github = MagicMock()
-        mock_github.list_issues.return_value = []  # No vibe-task issues
+        mock_github.list_issues.return_value = []  # No orchestra-governed issues
         mock_github_cls.return_value = mock_github
 
         snapshot = _make_snapshot(server_running=False)
@@ -383,7 +383,7 @@ class TestBuildSnapshotContext:
     @patch("vibe3.roles.governance.GitHubClient")
     def test_truncation_note(self, mock_github_cls):
         mock_github = MagicMock()
-        mock_github.list_issues.return_value = []  # No vibe-task issues
+        mock_github.list_issues.return_value = []  # No orchestra-governed issues
         mock_github_cls.return_value = mock_github
 
         issues = tuple(


### PR DESCRIPTION
Align terminology across governance materials and fix encoding error in glossary. Closes #1737