### PR TITLE
feat(models): export DeadCodeFinding and DeadCodeReport from public API

### DIFF
--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -15,7 +15,7 @@ from vibe3.exceptions import SerenaError
 from vibe3.models.change_source import ChangeSource
 
 if TYPE_CHECKING:
-    from vibe3.models.dead_code import DeadCodeReport
+    from vibe3.models import DeadCodeReport
 
 
 class SerenaService:
@@ -266,7 +266,7 @@ class SerenaService:
             SerenaError: If scan fails
         """
         from vibe3.analysis.dead_code_rules import classify_confidence, is_dead_code
-        from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
+        from vibe3.models import DeadCodeFinding, DeadCodeReport
 
         log = logger.bind(domain="serena", action="scan_dead_code", root=root)
         log.info("Scanning for dead code")

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -1,5 +1,6 @@
 """Models package."""
 
+from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
 from vibe3.models.inspection import CallNode, CommandInspection
 from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.models.snapshot import (
@@ -21,6 +22,8 @@ from vibe3.models.trace import ExecutionStep, TraceOutput
 __all__: list[str] = [
     "CallNode",
     "CommandInspection",
+    "DeadCodeFinding",
+    "DeadCodeReport",
     "DependencyChange",
     "DependencyEdge",
     "DiffSummary",


### PR DESCRIPTION
## Summary
- Add DeadCodeFinding and DeadCodeReport to vibe3/models public API exports
- Update serena_service.py imports to use public API instead of private submodules
- Closes the public API gap identified in #1708

## Changes
- `src/vibe3/models/__init__.py`: Add imports and __all__ entries for DeadCodeFinding and DeadCodeReport
- `src/vibe3/analysis/serena_service.py`: Update imports to use public API

## Verification
- All pre-push checks passed (black, ruff, mypy, tests)
- Import validation confirms public API is accessible
- No breaking changes to existing code

Closes #1708

---

## Contributors

claude/opus
