### PR TITLE
refactor(agents,roles): unify public interface exports

### DIFF
--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -31,11 +31,20 @@ Types:
 
 from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.agents.base import AgentBackend
-from vibe3.agents.models import CodeagentCommand, CodeagentResult, ExecutionRole
+from vibe3.agents.models import (
+    CodeagentCommand,
+    CodeagentResult,
+    ExecutionRole,
+    create_codeagent_command,
+)
 from vibe3.agents.plan_prompt import (
     build_plan_prompt_body,
     describe_plan_sections,
     make_plan_context_builder,
+)
+from vibe3.agents.review_pipeline_helpers import (
+    build_snapshot_diff,
+    run_inspect_json,
 )
 from vibe3.agents.review_prompt import (
     build_review_prompt_body,
@@ -44,6 +53,7 @@ from vibe3.agents.review_prompt import (
     make_review_context_builder,
 )
 from vibe3.agents.run_prompt import (
+    RunPromptMode,
     build_run_prompt_body,
     describe_run_plan_sections,
     make_run_context_builder,
@@ -56,6 +66,7 @@ __all__ = [
     "AgentBackend",
     "CodeagentCommand",
     "CodeagentResult",
+    "create_codeagent_command",
     "ExecutionRole",
     # Backend
     "CodeagentBackend",
@@ -71,6 +82,10 @@ __all__ = [
     "describe_plan_sections",
     "describe_run_plan_sections",
     "describe_review_sections",
+    # Pipeline Helpers
+    "build_snapshot_diff",
+    "run_inspect_json",
     # Types
     "PromptContextMode",
+    "RunPromptMode",
 ]

--- a/src/vibe3/roles/__init__.py
+++ b/src/vibe3/roles/__init__.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
         render_governance_prompt,
         resolve_governance_options,
     )
+    from vibe3.roles.governance_factory import build_default_governance_fns
+    from vibe3.roles.governance_utils import (
+        find_material_in_catalog,
+        normalize_material_name,
+    )
     from vibe3.roles.manager import (
         HANDOFF_MANAGER_ROLE,
         MANAGER_BRANCH_RESOLVER,
@@ -179,6 +184,10 @@ _LAZY_IMPORTS: dict[str, str] = {
     "load_governance_material_catalog": "vibe3.roles.governance",
     "render_governance_prompt": "vibe3.roles.governance",
     "resolve_governance_options": "vibe3.roles.governance",
+    # governance factory & utils
+    "build_default_governance_fns": "vibe3.roles.governance_factory",
+    "find_material_in_catalog": "vibe3.roles.governance_utils",
+    "normalize_material_name": "vibe3.roles.governance_utils",
 }
 
 
@@ -271,6 +280,10 @@ __all__ = [
     "load_governance_material_catalog",
     "render_governance_prompt",
     "resolve_governance_options",
+    # governance factory & utils (lazy)
+    "build_default_governance_fns",
+    "find_material_in_catalog",
+    "normalize_material_name",
 ]
 
 # Consistency check: ensure __all__ matches eager + lazy symbols

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -6,9 +6,10 @@ import os
 from pathlib import Path
 from typing import Any
 
-from vibe3.agents.models import CodeagentResult, create_codeagent_command
-from vibe3.agents.plan_prompt import (
+from vibe3.agents import (
+    CodeagentResult,
     build_plan_prompt_body,
+    create_codeagent_command,
     describe_plan_sections,
     make_plan_context_builder,
 )

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -8,12 +8,13 @@ from typing import Any, Callable, cast
 import typer
 from loguru import logger
 
-from vibe3.agents.models import create_codeagent_command
-from vibe3.agents.review_pipeline_helpers import build_snapshot_diff, run_inspect_json
-from vibe3.agents.review_prompt import (
+from vibe3.agents import (
     build_review_prompt_body,
+    build_snapshot_diff,
+    create_codeagent_command,
     describe_review_sections,
     make_review_context_builder,
+    run_inspect_json,
 )
 from vibe3.analysis.inspect_output_adapter import changed_symbols
 from vibe3.config.orchestra_settings import load_orchestra_config

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -6,9 +6,10 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 
-from vibe3.agents.models import CodeagentResult, create_codeagent_command
-from vibe3.agents.run_prompt import (
+from vibe3.agents import (
+    CodeagentResult,
     RunPromptMode,
+    create_codeagent_command,
     describe_run_plan_sections,
     make_run_context_builder,
     make_skill_context_builder,

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from vibe3.agents.run_prompt import (
+from vibe3.agents import (
     describe_run_plan_sections,
     make_run_context_builder,
 )


### PR DESCRIPTION
Closes #1715

## Summary

统一 `vibe3.agents` 和 `vibe3.roles` 的公共接口导出，确保外部模块只需从顶层包导入，无需直接访问子模块。

**改动内容**：
- **agents/__init__.py**: 新增导出 `create_codeagent_command`, `build_snapshot_diff`, `run_inspect_json`, `RunPromptMode`
- **roles/__init__.py**: 新增导出 `build_default_governance_fns`, `find_material_in_catalog`, `normalize_material_name`
- **roles 内部模块**: 替换直接子模块导入为顶层包导入（plan.py, review.py, run_command.py, run_request.py）

**影响范围**：
- 5 个文件修改，+31 LOC
- 无新增模块，仅重构现有导出结构
- 向后兼容，所有现有导入路径继续有效

## Test plan

✅ **类型检查**: mypy success, no issues found in 366 source files
✅ **单元测试**: 104 passed, 1 skipped (roles + agents 相关测试)
✅ **代码规范**: ruff all checks passed
✅ **导入验证**: 6 步验证全部通过
  - agents/__init__.py 导出所有公共接口
  - roles/__init__.py 导出所有公共接口
  - 无循环导入
  - 外部模块可正确导入

**关联 Issue**: #1715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
