### PR TITLE
refactor(models): eliminate cross-module import violation

### DIFF
--- a/src/vibe3/models/_actor_utils.py
+++ b/src/vibe3/models/_actor_utils.py
@@ -1,0 +1,48 @@
+"""Actor normalization utilities for models layer.
+
+This module provides pure functions for normalizing actor identifiers,
+extracted from vibe3.utils.actor_utils to maintain proper architecture layering.
+
+This is a private module (underscore prefix) not part of the public models API.
+"""
+
+# Placeholder actors for FLOW OPERATIONS (used in signature_service._is_placeholder).
+# These signal "no meaningful actor has claimed this operation."
+_PLACEHOLDER_ACTORS = {"", "unknown", "server", "system", "workflow"}
+
+# Placeholder actors for DISPLAY / PR BODY (normalize_actor).
+# Wider set: also includes generic AI labels that carry no specific identity.
+_DISPLAY_PLACEHOLDER_ACTORS = frozenset(
+    {*_PLACEHOLDER_ACTORS, "ai_assistant", "ai-assistant"}
+)
+
+# Actor alias → normalized identifier (for display layer).
+_ACTOR_ALIAS_MAP: dict[str, str] = {
+    "agent-claude": "claude",
+    "claude-ai": "claude",
+    "agent-codex": "codex",
+    "openai-code-agent[bot]": "openai",
+    "openai-code-agent": "openai",
+}
+
+
+def normalize_actor(actor: str | None) -> str | None:
+    """Normalize an actor identifier for display (PR body, UI).
+
+    Handles:
+    - ``None`` / empty / whitespace-only → ``None``
+    - Placeholder values (unknown, system, workflow, ai-assistant, …) → ``None``
+    - Actor aliases (``Agent-Claude``) → standard backend (``claude``)
+    - Already-standard format (``claude/sonnet-4.6``) → pass through, trimmed
+
+    This is the single source of truth for actor normalisation at the
+    display / PR-body layer.
+    """
+    if not actor or not actor.strip():
+        return None
+    key = actor.strip().lower()
+    if key in _DISPLAY_PLACEHOLDER_ACTORS:
+        return None
+    if key in _ACTOR_ALIAS_MAP:
+        return _ACTOR_ALIAS_MAP[key]
+    return actor.strip()

--- a/src/vibe3/models/_actor_utils.py
+++ b/src/vibe3/models/_actor_utils.py
@@ -1,7 +1,10 @@
 """Actor normalization utilities for models layer.
 
-This module provides pure functions for normalizing actor identifiers,
+This module provides the canonical implementation of normalize_actor,
 extracted from vibe3.utils.actor_utils to maintain proper architecture layering.
+
+This is the single source of truth for actor normalization. The utils module
+(vibe3.utils.actor_utils) re-exports from here for backward compatibility.
 
 This is a private module (underscore prefix) not part of the public models API.
 """

--- a/src/vibe3/models/pr.py
+++ b/src/vibe3/models/pr.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
-from vibe3.utils.actor_utils import normalize_actor
+from vibe3.models._actor_utils import normalize_actor
 
 
 class CICheck(BaseModel):

--- a/src/vibe3/utils/actor_utils.py
+++ b/src/vibe3/utils/actor_utils.py
@@ -1,46 +1,23 @@
 """Actor normalization utilities for display and PR body rendering.
 
-This module provides pure functions for normalizing actor identifiers,
-extracted from SignatureService to maintain proper architecture layering.
+This module re-exports normalize_actor from vibe3.models._actor_utils
+to maintain backward compatibility while ensuring a single source of truth.
+
+The canonical implementation lives in vibe3.models._actor_utils (models layer),
+and this module provides a convenient import path for other layers.
 """
 
-# Placeholder actors for FLOW OPERATIONS (used in signature_service._is_placeholder).
-# These signal "no meaningful actor has claimed this operation."
-_PLACEHOLDER_ACTORS = {"", "unknown", "server", "system", "workflow"}
-
-# Placeholder actors for DISPLAY / PR BODY (normalize_actor).
-# Wider set: also includes generic AI labels that carry no specific identity.
-_DISPLAY_PLACEHOLDER_ACTORS = frozenset(
-    {*_PLACEHOLDER_ACTORS, "ai_assistant", "ai-assistant"}
+# Re-export from canonical location in models layer
+from vibe3.models._actor_utils import (
+    _ACTOR_ALIAS_MAP,
+    _DISPLAY_PLACEHOLDER_ACTORS,
+    _PLACEHOLDER_ACTORS,
+    normalize_actor,
 )
 
-# Actor alias → normalized identifier (for display layer).
-_ACTOR_ALIAS_MAP: dict[str, str] = {
-    "agent-claude": "claude",
-    "claude-ai": "claude",
-    "agent-codex": "codex",
-    "openai-code-agent[bot]": "openai",
-    "openai-code-agent": "openai",
-}
-
-
-def normalize_actor(actor: str | None) -> str | None:
-    """Normalize an actor identifier for display (PR body, UI).
-
-    Handles:
-    - ``None`` / empty / whitespace-only → ``None``
-    - Placeholder values (unknown, system, workflow, ai-assistant, …) → ``None``
-    - Actor aliases (``Agent-Claude``) → standard backend (``claude``)
-    - Already-standard format (``claude/sonnet-4.6``) → pass through, trimmed
-
-    This is the single source of truth for actor normalisation at the
-    display / PR-body layer.
-    """
-    if not actor or not actor.strip():
-        return None
-    key = actor.strip().lower()
-    if key in _DISPLAY_PLACEHOLDER_ACTORS:
-        return None
-    if key in _ACTOR_ALIAS_MAP:
-        return _ACTOR_ALIAS_MAP[key]
-    return actor.strip()
+__all__ = [
+    "normalize_actor",
+    "_PLACEHOLDER_ACTORS",
+    "_DISPLAY_PLACEHOLDER_ACTORS",
+    "_ACTOR_ALIAS_MAP",
+]


### PR DESCRIPTION
Closes #1645

## Summary
- Eliminate cross-module import violation in models layer by moving `normalize_actor` from `vibe3.utils.actor_utils` to private submodule `vibe3.models._actor_utils`
- Ensures models layer (Layer 5) has no dependencies on other layers, maintaining architecture compliance
- No behavioral changes, pure import path substitution

## Changes
- Create `src/vibe3/models/_actor_utils.py` with `normalize_actor` function
- Update `src/vibe3/models/pr.py` import to use internal module
- Actual violations fixed: 1 (not 198 as issue title suggested)

## Test Plan
- [x] All existing tests pass (98/98 in models/)
- [x] Type checks clean (mypy: 367 source files)
- [x] Pre-commit hooks pass
- [x] No cross-module imports remain in models layer (verified by violation scan)

## Architecture Compliance
✅ Models layer now has zero dependencies on other layers
✅ Private submodule `_actor_utils.py` maintains encapsulation
✅ Public API unchanged - `vibe3.utils.actor_utils.normalize_actor` still available for other modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
