### PR TITLE
refactor(models): Add CoverageReport and LayerCoverage to public API

### DIFF
--- a/src/vibe3/analysis/coverage_service.py
+++ b/src/vibe3/analysis/coverage_service.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.models.coverage import CoverageReport, LayerCoverage
+from vibe3.models import CoverageReport, LayerCoverage
 
 
 class CoverageService:

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -1,5 +1,6 @@
 """Models package."""
 
+from vibe3.models.coverage import CoverageReport, LayerCoverage
 from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
 from vibe3.models.inspection import CallNode, CommandInspection
 from vibe3.models.prompt_meta import PromptContextMode
@@ -22,6 +23,7 @@ from vibe3.models.trace import ExecutionStep, TraceOutput
 __all__: list[str] = [
     "CallNode",
     "CommandInspection",
+    "CoverageReport",
     "DeadCodeFinding",
     "DeadCodeReport",
     "DependencyChange",
@@ -32,6 +34,7 @@ __all__: list[str] = [
     "FileChange",
     "FileSnapshot",
     "FunctionSnapshot",
+    "LayerCoverage",
     "ModuleChange",
     "ModuleSnapshot",
     "PromptContextMode",


### PR DESCRIPTION
Closes #1702

## Summary
- Add `CoverageReport` and `LayerCoverage` to `vibe3.models.__init__.py` public API
- Update import in `coverage_service.py` to use public API instead of internal submodule
- Part of Epic #1626 (模块公共接口统一)

## Changes
1. **src/vibe3/models/__init__.py**: Export `CoverageReport` and `LayerCoverage` from public API
2. **src/vibe3/analysis/coverage_service.py**: Update import to use public API

## Verification
- ✅ All pre-commit checks passed (ruff, black, mypy)
- ✅ All pre-push checks passed (type check, tests)
- ✅ Tests: 11 passed in incremental test suite

## Related
- Epic: #1626
- Blocked by: #1660 (resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
