### PR TITLE
refactor(models): Add change_source types to public API

### DIFF
--- a/src/vibe3/analysis/change_scope_service.py
+++ b/src/vibe3/analysis/change_scope_service.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from vibe3.analysis.serena_service import SerenaService
-    from vibe3.models.change_source import ChangeSource
+    from vibe3.models import ChangeSource
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/analysis/inspect_query_service.py
+++ b/src/vibe3/analysis/inspect_query_service.py
@@ -21,7 +21,7 @@ from vibe3.analysis.change_scope_service import (
 from vibe3.analysis.pr_scoring import PRDimensions, generate_score_report
 from vibe3.analysis.serena_service import SerenaService
 from vibe3.config import get_config
-from vibe3.models.change_source import (
+from vibe3.models import (
     BranchSource,
     CommitSource,
     PRSource,

--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -12,7 +12,7 @@ from vibe3.analysis.serena_file_analyzer import analyze_files
 from vibe3.clients import SerenaClient
 from vibe3.clients.git_client import GitClient
 from vibe3.exceptions import SerenaError
-from vibe3.models.change_source import ChangeSource
+from vibe3.models import ChangeSource
 
 if TYPE_CHECKING:
     from vibe3.models import DeadCodeReport

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -1,5 +1,13 @@
 """Models package."""
 
+from vibe3.models.change_source import (
+    BranchSource,
+    ChangeSource,
+    ChangeSourceType,
+    CommitSource,
+    PRSource,
+    UncommittedSource,
+)
 from vibe3.models.coverage import CoverageReport, LayerCoverage
 from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
 from vibe3.models.inspection import CallNode, CommandInspection
@@ -21,8 +29,12 @@ from vibe3.models.snapshot import (
 from vibe3.models.trace import ExecutionStep, TraceOutput
 
 __all__: list[str] = [
+    "BranchSource",
     "CallNode",
+    "ChangeSource",
+    "ChangeSourceType",
     "CommandInspection",
+    "CommitSource",
     "CoverageReport",
     "DeadCodeFinding",
     "DeadCodeReport",
@@ -37,9 +49,11 @@ __all__: list[str] = [
     "LayerCoverage",
     "ModuleChange",
     "ModuleSnapshot",
+    "PRSource",
     "PromptContextMode",
     "StructureDiff",
     "StructureMetrics",
     "StructureSnapshot",
     "TraceOutput",
+    "UncommittedSource",
 ]


### PR DESCRIPTION
Closes #1703

## Summary
Add 6 change_source types to vibe3.models public API and update 3 analysis module imports to use package-level import path.

## Changes
- Export BranchSource, ChangeSource, ChangeSourceType, CommitSource, PRSource, UncommittedSource from vibe3.models
- Update 3 analysis modules to use package-level imports instead of direct submodule imports
- Purely additive change with no breaking changes

## Test plan
- ✅ Pre-commit checks pass (black, ruff, mypy, shellcheck)
- ✅ Existing tests pass (126 tests in tests/vibe3/analysis/)
- ✅ Type checking clean (mypy)

---

## Contributors

claude/opus
