### PR TITLE
refactor(clients): Add GitClient and GitHubClient to public API

### DIFF
--- a/src/vibe3/analysis/coverage_service.py
+++ b/src/vibe3/analysis/coverage_service.py
@@ -111,7 +111,7 @@ class CoverageService:
         Raises:
             RuntimeError: If pytest or coverage run fails
         """
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         # Always use branch for paths (branch is always available)
         git = GitClient()

--- a/src/vibe3/analysis/pre_push_scope.py
+++ b/src/vibe3/analysis/pre_push_scope.py
@@ -72,7 +72,7 @@ def resolve_pre_push_scope(
     # - Git version doesn't provide stdin properly
     # - Multiple refs pushed but none matched above
     try:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         git_client = GitClient()
         current_branch = git_client.get_current_branch()

--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -9,8 +9,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.analysis.serena_file_analyzer import analyze_files
-from vibe3.clients import SerenaClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient, SerenaClient
 from vibe3.exceptions import SerenaError
 from vibe3.models.change_source import ChangeSource
 

--- a/src/vibe3/analysis/snapshot_service.py
+++ b/src/vibe3/analysis/snapshot_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from loguru import logger
 
 from vibe3.analysis import dag_service, structure_service
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.exceptions import VibeError
 from vibe3.models import (
     DependencyEdge,

--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -1,5 +1,7 @@
 """Vibe3 clients layer."""
 
+from vibe3.clients.git_client import GitClient
+from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.serena_client import (
     SerenaClient,
     count_references,
@@ -8,6 +10,8 @@ from vibe3.clients.serena_client import (
 from vibe3.clients.sqlite_client import SQLiteClient
 
 __all__ = [
+    "GitClient",
+    "GitHubClient",
     "SerenaClient",
     "SQLiteClient",
     "count_references",

--- a/tests/vibe3/analysis/test_coverage_service.py
+++ b/tests/vibe3/analysis/test_coverage_service.py
@@ -66,7 +66,7 @@ def test_run_pytest_cov_success(
         cov_file.write_text(json.dumps(sample_coverage_data))
         return mock_result
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git:
+    with patch("vibe3.clients.GitClient") as mock_git:
         mock_git.return_value.get_current_branch.return_value = "test-branch"
         with patch("subprocess.run", side_effect=fake_subprocess_run):
             data = coverage_service._run_pytest_cov()
@@ -82,7 +82,7 @@ def test_run_pytest_cov_failure(
     """Test _run_pytest_cov when pytest fails."""
     coverage_service.project_root = mock_project_root
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git:
+    with patch("vibe3.clients.GitClient") as mock_git:
         mock_git.return_value.get_current_branch.return_value = "test-branch"
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="", stderr="error", returncode=1)
@@ -112,7 +112,7 @@ def test_subprocess_command_construction(
         cov_file.write_text(json.dumps(sample_coverage_data))
         return MagicMock(stdout="", stderr="", returncode=0)
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git:
+    with patch("vibe3.clients.GitClient") as mock_git:
         mock_git.return_value.get_current_branch.return_value = "test-branch"
         with patch("subprocess.run", side_effect=fake_subprocess_run) as mock_run:
             coverage_service._run_pytest_cov()
@@ -208,7 +208,7 @@ class TestRunCoverageCheck:
             cov_file.write_text(json.dumps(sample_coverage_data))
             return mock_result
 
-        with patch("vibe3.clients.git_client.GitClient") as mock_git:
+        with patch("vibe3.clients.GitClient") as mock_git:
             mock_git.return_value.get_current_branch.return_value = "test-branch"
             with patch("subprocess.run", side_effect=fake_subprocess_run):
                 report = coverage_service.run_coverage_check()
@@ -269,7 +269,7 @@ class TestRunCoverageCheck:
             cov_file.write_text(json.dumps(low_coverage_data))
             return mock_result
 
-        with patch("vibe3.clients.git_client.GitClient") as mock_git:
+        with patch("vibe3.clients.GitClient") as mock_git:
             mock_git.return_value.get_current_branch.return_value = "test-branch"
             with patch("subprocess.run", side_effect=fake_subprocess_run):
                 report = coverage_service.run_coverage_check()
@@ -310,7 +310,7 @@ class TestRunCoverageCheck:
             cov_file.write_text(json.dumps(empty_data))
             return mock_result
 
-        with patch("vibe3.clients.git_client.GitClient") as mock_git:
+        with patch("vibe3.clients.GitClient") as mock_git:
             mock_git.return_value.get_current_branch.return_value = "test-branch"
             with patch("subprocess.run", side_effect=fake_subprocess_run):
                 report = coverage_service.run_coverage_check()

--- a/tests/vibe3/analysis/test_pre_push_scope.py
+++ b/tests/vibe3/analysis/test_pre_push_scope.py
@@ -55,7 +55,7 @@ class TestResolvePrePushScope:
         assert scope.base_ref == "2222222222222222222222222222222222222222"
         assert scope.head_ref == "1111111111111111111111111111111111111111"
 
-    @patch("vibe3.clients.git_client.GitClient")
+    @patch("vibe3.clients.GitClient")
     def test_infers_incremental_push_from_git_state(
         self, mock_git_client: MagicMock
     ) -> None:
@@ -72,7 +72,7 @@ class TestResolvePrePushScope:
         assert scope.is_incremental is True
         assert "inferred incremental push" in scope.summary
 
-    @patch("vibe3.clients.git_client.GitClient")
+    @patch("vibe3.clients.GitClient")
     def test_infers_new_branch_push_from_git_state(
         self, mock_git_client: MagicMock
     ) -> None:


### PR DESCRIPTION
Closes #1704

## Summary

- Add GitClient and GitHubClient to clients public API exports
- Update 4 analysis module imports to use public API path (vibe3.clients)
- Fix test mock paths to patch vibe3.clients.GitClient for lazy imports

## Changes

**Public API**:
- src/vibe3/clients/__init__.py: Add GitClient and GitHubClient to `__all__`

**Import Updates** (4 analysis modules):
- src/vibe3/analysis/snapshot_service.py: Use public import
- src/vibe3/analysis/serena_service.py: Merge GitClient import with SerenaClient
- src/vibe3/analysis/coverage_service.py: Use public import in lazy import
- src/vibe3/analysis/pre_push_scope.py: Use public import in lazy import

**Test Fixes**:
- tests/vibe3/analysis/test_coverage_service.py: Update mock path to vibe3.clients.GitClient
- tests/vibe3/analysis/test_pre_push_scope.py: Update mock path to vibe3.clients.GitClient

## Verification

- ✅ All tests pass (169 passed)
- ✅ Type check passes (mypy success)
- ✅ Pre-push checks pass
- ✅ No breaking changes (backward compatible)

Refs: #1704

---

## Contributors

claude/opus
