### PR TITLE
docs: align core documentation files (#1752)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ authority:
   - essential-reading-order
 author: Claude Sonnet 4.5
 created: 2024-01-15
-last_updated: 2026-05-22
+last_updated: 2026-06-01
 related_docs:
   - SOUL.md
   - STRUCTURE.md
@@ -46,6 +46,18 @@ Follow this reading order. Each document is the authority for its domain:
 7. **[.agent/README.md](.agent/README.md)** — AI workflows and rules
 8. **[docs/README.md](docs/README.md)** — Documentation structure
 
+## 🔄 Key Workflows (工作流)
+
+| Workflow | Description | Usage |
+| :--- | :--- | :--- |
+| **[/vibe-new](.agent/workflows/vibe:new.md)** | 规划入口 | intake 新目标、handoff 或缺 spec 的 task，产出 plan 和 task 绑定。 |
+| **[/vibe-continue](.agent/workflows/vibe:continue.md)** | 执行入口 | 执行当前 flow 已绑定且带 plan 的 task，按图纸推进实现。 |
+| **[/vibe-commit](.agent/workflows/vibe:commit.md)** | 提交入口 | 读取工作区事实，处理提交分组与 PR 切片。 |
+| **[/vibe-task](.agent/workflows/vibe:task.md)** | 任务总览 | 处理跨 worktree 总览与 roadmap-task 状态修复。 |
+| **[/vibe-check](.agent/workflows/vibe:check.md)** | 运行时检查 | 处理 `task <-> flow` / runtime 状态不一致。 |
+| **[/vibe-issue](.agent/workflows/vibe:issue.md)** | Issue 管理 | 处理 GitHub issue 创建、查重与补全。 |
+| **[/vibe-save](.agent/workflows/vibe:save.md)** | 会话保存 | 将当前会话上下文持久化到本地 handoff。 |
+
 ## 📍 Project Identity
 
 V3 是默认执行链：flow、handoff、orchestra 和 role dispatch 的语义真源都在 V3 Python + `docs/standards/v3/`。V2 仍然存在，但只作为兼容入口和环境工具。
@@ -61,7 +73,7 @@ This project has **two parallel implementations**:
 
 - **V2 (Shell)**: `bin/`, `lib/`, `config/shell/`
 - **V3 (Python)**: `src/vibe3/` (Support global `vibe3` command via `uv tool install -e .`)
-- **V3 Hub**: `lib3/` (Shell wrappers for repo redirection and keys)
+- **V3 Hub**: `lib3/` (V3 Python 核心包装器与仓库重定向)
 - **Skills**: `skills/`（各技能的 SKILL.md 文件）
 - **Workflows, rules, context**: `.agent/`
 - **Shared state truth**: `.git/vibe3/handoff.db`（位于主仓库 git common dir，即最顶层 `.git`）

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -7,7 +7,7 @@ audience: both
 review_frequency: on-change
 author: Claude Sonnet 4.5
 created: 2024-01-15
-last_updated: 2026-04-24
+last_updated: 2026-06-01
 related_docs:
   - SOUL.md
   - CLAUDE.md
@@ -61,6 +61,7 @@ vibe-center/
 │   ├── observability/           # 可观测性
 │   ├── orchestra/               # 编排中枢
 │   ├── prompts/                 # Prompt 组装与变量解析
+│   ├── resources/               # 运行时资产与静态资源
 │   ├── roles/                   # 角色定义与执行模块
 │   ├── runtime/                 # 事件驱动运行时
 │   ├── server/                  # HTTP / MCP / health 服务
@@ -72,7 +73,7 @@ vibe-center/
 │   ├── *.sh                     # 各功能模块
 │   └── ...
 │
-├── lib3/                        # V3 Python 核心 Shell 包装器 (hub)
+├── lib3/                        # V3 Python 核心包装器与仓库重定向 (hub)
 │   └── vibe.sh                  # 负责仓库重定向和加载密钥
 │
 ├── config/                      # V2 配置文件
@@ -190,22 +191,23 @@ AI Agent → AGENTS.md → SOUL.md (宪法和原则)
 - `agents/` - AI Agent 调用层（plan/review/run pipeline + backends）
 - `analysis/` - 代码智能（symbol 分析、结构快照、变更范围）
 - `clients/` - 外部系统客户端（Git, GitHub, AI, Serena, SQLite）
-- `commands/` - CLI 子命令实现
-- `config/` - 配置加载与 Pydantic schema 验证
+- `commands/` - CLI 子命令实现（flow, handoff, pr, task, status, inspect 等）
+- `config/` - 配置加载、Profile 管理与 Pydantic schema 验证
 - `environment/` - 环境资源管理（Session 和 Worktree 统一抽象层）
 - `execution/` - 执行控制平面（统一协调层：coordinator, capacity, lifecycle, gates）
 - `exceptions/` - 统一异常层级
 - `domain/` - 领域事件与 handlers（events, handlers, orchestration_facade）
-- `models/` - Pydantic 领域数据模型
+- `models/` - 领域数据模型（Flow, Handoff, Task, PR, Verdict 等 Pydantic 模型）
 - `observability/` - 日志、链路追踪、审计
 - `orchestra/` - 编排中枢（issue 分诊、事件调度）
 - `prompts/` - Prompt 模板组装与变量解析
+- `resources/` - 运行时资产与静态资源
 - `roles/` - 角色定义和执行模块（manager, plan, run, review, supervisor, governance）
 - `runtime/` - 事件驱动运行时（EventBus, Heartbeat）
 - `server/` - HTTP 服务层（webhook, MCP, health check）
 - `services/` - 核心业务逻辑（flow/PR/task/handoff/check）
 - `ui/` - CLI 输出格式化（Rich 渲染）
-- `utils/` - 通用工具函数
+- `utils/` - 通用工具函数（Git 辅助、分支工具、评论处理等）
 
 **常用命令**：
 ```bash
@@ -237,9 +239,9 @@ vibe3 inspect commit <sha>                # 改动影响范围
 - `keys.sh` - API 密钥管理
 - `utils.sh` - 通用工具函数
 
-### `lib3/` - V3 Python 核心 Shell 包装器 (hub)
+### `lib3/` - V3 Python 核心包装器 (hub)
 
-**职责**：V3 Python 核心的 Shell 包装器，负责仓库重定向和加载密钥。
+**职责**：V3 Python 核心的运行时包装器，负责仓库重定向和加载密钥。
 
 **规则**：
 - 是 V3 Python 运行时的辅助入口。
@@ -577,3 +579,4 @@ uv run pytest tests/vibe3/ -k flow
 ---
 
 **注意**：本文档的元数据（作者、创建日期、最后更新日期）已在文档开头的 frontmatter 中定义。详见 [docs/standards/doc-quality-standards.md](docs/standards/doc-quality-standards.md)。
+tandards.md)。

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -14,7 +14,7 @@
 |------|------|---------|--------|
 | **Human-Mirror 架构** | [docs/standards/vibe3-human-mirror-architecture.md](standards/vibe3-human-mirror-architecture.md) | 核心设计哲学：系统操作 = 人类操作 | ⭐⭐⭐ 权威 |
 | **事件驱动架构** | [docs/standards/vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md) | 事件发布/订阅机制、处理器注册、向后兼容 | ⭐⭐⭐ 权威 |
-| **Worktree Runtime** | [docs/standards/vibe3-worktree-ownership-standard.md](standards/vibe3-worktree-ownership-standard.md) | 执行层级（L0-L4）、worktree 分配、runtime session | ⭐⭐⭐ 权威 (DEPRECATED) |
+| **Worktree Runtime** | [docs/standards/v3/worktree-lifecycle-standard.md](standards/v3/worktree-lifecycle-standard.md) | 执行层级（L0-L4）、worktree 生命周期管理、runtime session | ⭐⭐⭐ 权威 |
 | **Orchestra Runtime** | [docs/standards/v3/orchestra-runtime-standard.md](standards/v3/orchestra-runtime-standard.md) | Driver/Tick/Async Child 架构、调度主循环 | ⭐⭐⭐ 权威 |
 | **State Sync** | [docs/standards/v3/command-standard.md](standards/v3/command-standard.md) | Flow 状态机、状态转换规则 | ⭐⭐⭐ 权威 |
 
@@ -79,7 +79,7 @@ L4  Human collaboration            -- 人工协作流程
 - **L3**: 持久 worktree（`cwd=wt_path`）
 
 
-**详细文档**: [vibe3-worktree-ownership-standard.md (DEPRECATED)](standards/vibe3-worktree-ownership-standard.md)
+**详细文档**: [worktree-lifecycle-standard.md](standards/v3/worktree-lifecycle-standard.md)
 
 ---
 
@@ -218,4 +218,4 @@ def register_dispatch_handlers() -> None:
 ---
 
 **维护者**: Vibe Team
-**最后更新**: 2026-04-21
+**最后更新**: 2026-06-01

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 ## 📁 目录结构
 
 ```
-lib3/                                # V3 Python 核心 Shell 包装器 (hub)
+lib3/                                # V3 Python 核心包装器与仓库重定向 (hub)
 docs/
 ├── README.md                        # 本文件：文档总览
 ├── standards/                       # 标准和规范文档
@@ -20,11 +20,17 @@ docs/
 ├── prds/                           # 产品需求文档 (全局 PRD)
 ├── plans/                          # 执行计划 (草稿于 .agent/plans/)
 ├── reports/                        # 报告与总结 (草稿于 .agent/reports/)
+├── design/                          # 设计文档与架构演进
+├── closeout/                        # 任务结项报告与回顾
+├── directives/                      # 任务指令与执行引导
 ├── analysis/                        # 架构与逻辑分析报告
-├── governance/                      # 治理流程与审计记录
-├── handoff/                         # Handoff 链路存档
+├── governance/                      # 治理流程、审计记录与立项决策
+├── handoff/                         # Handoff 链路存档与交接记录
 ├── migration/                       # 迁移设计与执行记录
-├── references/                     # 外部参考资料
+├── project/                         # 项目级文档与 Meta-layer
+├── publish/                         # 发布记录与发布指令
+├── references/                      # 外部参考资料
+├── superpowers/                     # Superpowers 技能文档
 ├── validation/                      # 验证报告与测试证据
 └── ...                             # 其他现行文档
 ```


### PR DESCRIPTION
Align documentation across STRUCTURE.md, AGENTS.md, ARCHITECTURE_GUIDE.md, and docs/README.md as requested in #1752.