### PR TITLE
fix(execution): adjust noop_gate to warn instead of block when state changed but ref missing

### DIFF
--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -339,36 +339,67 @@ def apply_unified_noop_gate(
     elif required_ref_key is not None and flow_state is not None:
         ref_value = flow_state.get(required_ref_key)
         if not ref_value:
-            logger.bind(
-                domain="codeagent",
-                role=role,
-                issue_number=issue_number,
-                branch=branch,
-            ).warning(
-                f"No-op gate BLOCK: required ref {required_ref_key} "
-                f"missing after {role}"
-            )
-            store.add_event(
-                branch,
-                EVENT_REQUIRED_REF_MISSING,
-                actor,
-                detail=(
-                    f"Required ref {required_ref_key} missing after {role}: "
-                    f"state was {before_state_label}"
-                ),
-                refs={
-                    "before_state": str(before_state_label or ""),
-                    "issue": str(issue_number),
-                    "required_ref": required_ref_key,
-                },
-            )
-            _block_fn(
-                issue_number=issue_number,
-                repo=repo,
-                reason=f"required ref missing: {required_ref_key}",
-                actor=actor,
-            )
-            return
+            if before_state_label != after_state_label:
+                # State changed but missing ref → WARNING only, pass gate
+                logger.bind(
+                    domain="codeagent",
+                    role=role,
+                    issue_number=issue_number,
+                    branch=branch,
+                ).warning(
+                    f"No-op gate WARNING: required ref {required_ref_key} "
+                    f"missing after {role} but state changed, passing gate"
+                )
+                store.add_event(
+                    branch,
+                    EVENT_REQUIRED_REF_MISSING,
+                    actor,
+                    detail=(
+                        f"Required ref {required_ref_key} missing after {role} "
+                        f"but state changed: {before_state_label} -> "
+                        f"{after_state_label}"
+                    ),
+                    refs={
+                        "before_state": str(before_state_label or ""),
+                        "after_state": after_state_label,
+                        "issue": str(issue_number),
+                        "required_ref": required_ref_key,
+                        "severity": "warning",
+                    },
+                )
+                # Do NOT block — fall through to state transition check
+            else:
+                # State unchanged AND missing ref → BLOCK
+                logger.bind(
+                    domain="codeagent",
+                    role=role,
+                    issue_number=issue_number,
+                    branch=branch,
+                ).warning(
+                    f"No-op gate BLOCK: required ref {required_ref_key} "
+                    f"missing after {role} AND state unchanged"
+                )
+                store.add_event(
+                    branch,
+                    EVENT_REQUIRED_REF_MISSING,
+                    actor,
+                    detail=(
+                        f"Required ref {required_ref_key} missing after {role}: "
+                        f"state was {before_state_label}"
+                    ),
+                    refs={
+                        "before_state": str(before_state_label or ""),
+                        "issue": str(issue_number),
+                        "required_ref": required_ref_key,
+                    },
+                )
+                _block_fn(
+                    issue_number=issue_number,
+                    repo=repo,
+                    reason=f"required ref missing: {required_ref_key}",
+                    actor=actor,
+                )
+                return
 
     if before_state_label == after_state_label:
         state_desc = before_state_label or "(no state)"

--- a/tests/vibe3/execution/test_noop_gate_ref_check.py
+++ b/tests/vibe3/execution/test_noop_gate_ref_check.py
@@ -22,8 +22,8 @@ def _make_github_issue_payload(state_label: str = "state/plan") -> dict:
 class TestRefCheck:
     """Tests for required_ref_key logic in no-op gate."""
 
-    def test_blocks_when_required_ref_missing_even_if_state_changed(self) -> None:
-        """Gate blocks when required ref is missing, even if state changed."""
+    def test_passes_when_state_changed_but_ref_missing(self) -> None:
+        """Gate passes with warning when state changed but required ref is missing."""
         store = _make_mock_store()
 
         with (
@@ -34,6 +34,38 @@ class TestRefCheck:
         ):
             mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
                 "state/in-progress"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=42,
+                branch="task/issue-42",
+                actor="agent:plan",
+                role="planner",
+                before_state_label="state/plan",
+                required_ref_key="plan_ref",
+                flow_state={},  # plan_ref missing
+            )
+
+        mock_block.assert_not_called()
+        # Should have two events: ref_missing warning and state_transitioned
+        assert store.add_event.call_count == 2
+        event_calls = [call[0][1] for call in store.add_event.call_args_list]
+        assert "required_ref_missing" in event_calls
+        assert "state_transitioned" in event_calls
+
+    def test_blocks_when_ref_missing_and_state_unchanged(self) -> None:
+        """Gate blocks when required ref is missing AND state unchanged."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.role_policy_helpers.block_planner_noop_issue"
+            ) as mock_block,
+        ):
+            # State unchanged: before and after are the same
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/plan"
             )
             apply_unified_noop_gate(
                 store=store,


### PR DESCRIPTION
## Summary

Fixes #1743

**Problem**: Executor completes work and successfully changes state, but gets blocked by `noop_gate` due to missing `report_ref`, which is overly strict.

**Root Cause**: The required_ref check immediately blocks when `report_ref` is missing, without checking if state has changed. State change indicates the executor has done work and should not be blocked.

**Solution**: 
- Adjust check order: verify state change before blocking
- Distinguish severity: state changed → warning only (pass gate); state unchanged → block
- Backward compatible: state unchanged + ref missing still blocks (existing behavior)

**Changes**:
- Modified `src/vibe3/execution/noop_gate.py` (lines 339-371)
- Updated test: `test_passes_when_state_changed_but_ref_missing` (new behavior)
- Added test: `test_blocks_when_ref_missing_and_state_unchanged` (backward compatibility)

**Impact**:
- Single bugfix, minimal changes (+31 LOC)
- All 14 noop_gate tests pass
- Type checks pass (mypy/ruff)

## Test plan

- [x] All existing noop_gate tests pass (14 tests)
- [x] New test verifies: state changed + ref missing → warning, pass gate
- [x] New test verifies: state unchanged + ref missing → block (backward compatible)
- [x] Type checks pass (mypy)
- [x] Lint checks pass (ruff, black)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
