### PR TITLE
refactor(tests): remove decorative CodeagentBackend mocks

### DIFF
--- a/tests/vibe3/commands/test_flow_update.py
+++ b/tests/vibe3/commands/test_flow_update.py
@@ -127,9 +127,7 @@ def test_flow_bind_remains_atomic_command_surface() -> None:
 
 @patch("vibe3.commands.flow_manage.FlowService")
 @patch("vibe3.environment.session_registry.SessionRegistryService")
-@patch("vibe3.agents.backends.codeagent.CodeagentBackend")
 def test_flow_update_blocks_when_branch_has_live_runtime_session(
-    mock_backend,
     mock_registry_cls,
     mock_flow_service,
 ) -> None:

--- a/tests/vibe3/domain/handlers/test_governance_scan.py
+++ b/tests/vibe3/domain/handlers/test_governance_scan.py
@@ -11,7 +11,6 @@ class TestGovernanceScanHandler:
 
     @patch("vibe3.orchestra.logging.append_governance_event")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
-    @patch("vibe3.agents.backends.codeagent.CodeagentBackend")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
     @patch("vibe3.orchestra.flow_dispatch.FlowManager")
@@ -24,7 +23,6 @@ class TestGovernanceScanHandler:
         mock_flow_cls: MagicMock,
         mock_status_cls: MagicMock,
         mock_sqlite_cls: MagicMock,
-        mock_backend_cls: MagicMock,
         mock_registry_cls: MagicMock,
         mock_append_governance_event: MagicMock,
     ) -> None:

--- a/tests/vibe3/services/test_check_cleanup_service.py
+++ b/tests/vibe3/services/test_check_cleanup_service.py
@@ -103,10 +103,7 @@ def test_clean_residual_branches_logs_skipped_branches() -> None:
 
     service = CheckCleanupService(store=store, git_client=git_client)
 
-    with (
-        patch("vibe3.agents.CodeagentBackend"),
-        patch("vibe3.environment.session_registry.SessionRegistryService") as registry,
-    ):
+    with patch("vibe3.environment.session_registry.SessionRegistryService") as registry:
         registry.return_value._store.list_live_runtime_sessions.return_value = [
             {
                 "branch": "task/issue-123",
@@ -131,12 +128,9 @@ def test_get_branches_with_live_sessions_queries_once() -> None:
     git_client = MagicMock()
     service = CheckCleanupService(store=store, git_client=git_client)
 
-    with (
-        patch("vibe3.agents.CodeagentBackend"),
-        patch(
-            "vibe3.environment.session_registry.SessionRegistryService"
-        ) as registry_cls,
-    ):
+    with patch(
+        "vibe3.environment.session_registry.SessionRegistryService"
+    ) as registry_cls:
         registry = registry_cls.return_value
         # Mock the new method
         registry.get_all_branches_with_live_sessions.return_value = {


### PR DESCRIPTION
## Summary

Remove 3 confirmed-decorative CodeagentBackend mocks that are never asserted and never intercept any code path:

1. **test_flow_update.py**: Remove mock from `test_flow_update_blocks_when_branch_has_live_runtime_session`. The command exits with error before backend is used.

2. **test_governance_scan.py**: Remove mock from `test_skips_when_governance_already_running`. The early-return path never reaches backend instantiation.

3. **test_check_cleanup_service.py**: Remove mocks from `test_clean_residual_branches_logs_skipped_branches` and `test_get_branches_with_live_sessions_queries_once`. SessionRegistryService.__init__ has backend=None default, so no backend is instantiated when the service is mocked.

## Why These Mocks Were Decorative

- They intercept instantiation but are never asserted
- The code paths in these tests never reach backend usage
- Keeping unasserted mocks obscures real test dependencies

## Test Plan

- ✅ All 35 tests in the affected files pass after removal
- ✅ No production code changes
- ✅ Pre-push checks passed (lint, type check, tests)

Closes #1767

---

## Contributors

claude/opus
