### PR TITLE
docs: align core documentation with 3-tier architecture and v3 facts

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -57,27 +57,42 @@ Publisher.publish(event) → EventPublisher 查找订阅者 → 调用 handlers
 - ❌ Handler 没有类型注解 → mypy 报错
 
 **详细文档**: [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md)
+---
+
+## 3-Tier 架构模型
+
+Vibe 3.0 采用三层架构模型，明确了认知治理、编排管理与原子能力的分工：
+
+| 层级 | 名称 | 职责 | 核心命令 |
+|------|------|------|----------|
+| **Tier 3** | **Cognitive / Governance** | 认知与治理层：负责策略、规则执行、Supervisor 扫描与全局状态监控。 | `serve`, `scan`, `check`, `mcp` |
+| **Tier 2** | **Skill Layer** | 技能/编排层：负责 Flow 生命周期管理、任务调度与上下文组装。 | `flow`, `task`, `run`, `plan`, `review` |
+| **Tier 1** | **Shell Layer** | 壳层/原子能力：提供原子级能力访问、状态读取与项目信息检索。 | `handoff`, `inspect`, `pr`, `snapshot`, `ask` |
 
 ---
 
-### 2. 执行层级与 Worktree
+## 关键概念速查
 
-**五层架构**：
+### 1. 执行层级与 3-tier 对应关系
+
+**层级映射**：
 ```
-L0  Orchestra / Heartbeat          -- 调度主循环
-L1  Governance Service             -- 定期扫描（cron-supervisor, roadmap-intake），只操作 GitHub labels
-                                      真源：supervisor/governance/ (cron-supervisor.md, roadmap-intake.md)
-L2  Supervisor + Apply             -- 轻量治理执行（supervisor-apply），临时 worktree 隔离
-                                      真源：supervisor/apply.md
-L3  Manager / Plan / Run / Review  -- 代码开发核心，独立 worktree
-L4  Human collaboration            -- 人工协作流程
+Tier 3 (Cognitive/Governance)
+  L0  Orchestra / Heartbeat          -- 调度主循环
+  L1  Governance Service             -- 定期扫描（cron-supervisor, roadmap-intake）
+  L2  Supervisor + Apply             -- 轻量治理执行（supervisor-apply）
+
+Tier 2 (Skill Layer)
+  L3  Manager / Plan / Run / Review  -- 核心编排流程（CodeAgent 执行）
+
+Tier 1 (Shell Layer)
+  L3/L4 Atomic Commands              -- 原子工具（pr, handoff, inspect, ask）
 ```
 
 **Worktree 语义**：
-- **L0/L1**: 无 worktree（`cwd=None`）
-- **L2**: 临时 worktree（`--worktree` 标志）
-- **L3**: 持久 worktree（`cwd=wt_path`）
-
+- **Tier 3 (L0/L1)**: 无 worktree（`cwd=None`）
+- **Tier 3 (L2)**: 临时 worktree（`--worktree` 标志）
+- **Tier 2 (L3)**: 持久 worktree（`cwd=wt_path`）
 
 **详细文档**: [worktree-lifecycle-standard.md](standards/v3/worktree-lifecycle-standard.md)
 

--- a/docs/standards/agent-workflow-standard.md
+++ b/docs/standards/agent-workflow-standard.md
@@ -65,11 +65,10 @@ Plan → Run → Review → Commit
 vibe3 plan --branch <branch_or_issue_number>
 vibe3 plan                    # 使用当前 branch
 
-# 从 spec 文件创建 plan（替换当前 flow 的 spec_ref）
-vibe3 plan --spec --file spec.md
-
-# 从 spec message 创建 plan
-vibe3 plan --spec --msg "Add dark mode support"
+# 从 spec 文件/Issue/别名创建 plan（更新当前 flow 的 spec_ref 并创建计划）
+vibe3 plan --spec docs/specs/feature.md
+vibe3 plan --spec #123
+vibe3 plan --spec @spec
 ```
 
 **Step 2: 执行 Plan（使用 Agent）**
@@ -88,8 +87,12 @@ vibe3 run --agent planner-pro --plan
 **Step 3: 审查结果**
 
 ```bash
-# 查看 handoff 记录
-vibe3 handoff show
+# 查看当前 flow 的 handoff 链路
+vibe3 handoff show @current
+
+# 查看指定 artifact
+vibe3 handoff show @plan
+vibe3 handoff show docs/reports/run-1.md
 
 # 查看 agent 做了哪些修改
 git status

--- a/docs/standards/v3-module-architecture-standard.md
+++ b/docs/standards/v3-module-architecture-standard.md
@@ -11,9 +11,21 @@
 - 确保清晰的分层架构，降低认知负担。
 - 为后续的自动化治理提供结构化参考。
 
-## 2. 分层架构规则 (Layered Architecture Rules)
+## 2. 分层架构规则 (3-Tier & 6-Layer Mapping)
 
-Vibe 3.0 采用六层架构模型，依赖方向应始终向下（Top-Down）。禁止低层模块直接依赖高层模块，禁止跨层级非授权调用。
+Vibe 3.0 采用 3-tier 架构模型作为顶层战略划分，并辅以六层架构进行代码实现约束。依赖方向应始终向下（Top-Down）。
+
+### 3-Tier 战略划分
+
+| 层级 (Tier) | 名称 | 职责 (Responsibility) | 对应六层模型层级 |
+| :--- | :--- | :--- | :--- |
+| **Tier 3** | **Cognitive / Governance** | 认知与治理：负责全局策略、规则、Supervisor 治理。 | Layer 1, 2, 3 (part) |
+| **Tier 2** | **Skill Layer** | 技能/编排层：负责 Flow 状态机、任务编排、Agent 执行。 | Layer 2, 3, 4 |
+| **Tier 1** | **Shell Layer** | 壳层/原子能力：提供原子指令、环境原语、基础设施。 | Layer 5, 6 |
+
+---
+
+### 六层架构实现标准
 
 1. **CLI & UI 层** (`cli.py`, `ui/`)
    - **职责**：人类与 Agent 的交互入口。负责命令行参数解析、结果美化输出、交互式反馈。
@@ -37,10 +49,11 @@ Vibe 3.0 采用六层架构模型，依赖方向应始终向下（Top-Down）。
    - **职责**：物理环境原语。负责 Git Worktree 创建/回收、Tmux 会话管理、环境变量隔离。
    - **规则**：仅处理物理资源，不感知业务语义。
 
-6. **Infrastructure & Models 层** (`runtime/`, `config/`, `exceptions/`, `observability/`, `utils/`, `models/`, `adapters/`)
+6. **Infrastructure & Models 层** (`runtime/`, `config/`, `exceptions/`, `observability/`, `utils/`, `models/`, `adapters/`, `resources/`)
    - **Models**：全系统的类型真源（Entities/DTOs）。
-   - **Infrastructure**：底层系统服务。负责配置、心跳、日志、调用链追踪、异常定义。
+   - **Infrastructure**：底层系统服务。负责配置、心跳、日志、调用链追踪、异常定义、静态资源管理（resources）。
    - **规则**：作为全系统的基石，严禁依赖上述任何上层模块。
+
 
 ## 3. 模块职责边界 (22 Submodules)
 
@@ -52,7 +65,6 @@ Vibe 3.0 核心包 `src/vibe3` 由以下 22 个核心子模块构成：
 | `agents` | Execution | Agent 执行引擎。包含后端驱动（Claude/Codex 等）与执行流水线。 |
 | `analysis` | Service | 架构洞察工具。负责代码依赖扫描、风险审计与治理分析。 |
 | `cli.py` | CLI | 命令行主入口。负责顶级 Click 组装与全局上下文初始化。 |
-| `clients` | Infrastructure | 外部集成客户端。负责与 GitHub, Serena, Kiro 等外部系统通信。 |
 | `commands` | Command | CLI 命令具体实现。如 `flow`, `task`, `check`, `handoff` 等。 |
 | `config` | Infrastructure | 统一配置管理。负责 YAML 加载、校验、默认值注入与动态重载。 |
 | `domain` | Domain | 业务真相真源。持有事件定义（Events）与核心业务编排处理器。 |
@@ -63,13 +75,15 @@ Vibe 3.0 核心包 `src/vibe3` 由以下 22 个核心子模块构成：
 | `models` | Models | 数据契约。定义 DTO、ORM 映射、API Schema 与状态常量。 |
 | `observability` | Infrastructure | 观测系统。负责结构化日志记录、调用链追踪（Trace）与性能监控。 |
 | `orchestra` | Runtime | 顶层调度外壳。基于心跳驱动的多角色派发与自动治理逻辑。 |
-| `prompts` | Execution | 提示词工厂。负责模板管理、上下文裁剪与 Agent 指令生成。 |
+| `prompts` | Execution | 提示词工厂。负责模板管理、上下文裁剪与 Agent 指令生成. |
+| `resources` | Infrastructure | 静态资源管理。负责运行时所需的文件模板、资产与内置素材。 |
 | `roles` | Execution | 角色行为定义。包含 Plan, Run, Review, Supervisor 等角色的专属逻辑。 |
 | `runtime` | Runtime | 运行时内核。负责心跳循环、异步任务分发、事件总线与路由。 |
 | `server` | Server | 服务入口。负责 HTTP/Webhook Server 启停与 Driver 装配。 |
 | `services` | Service | 业务逻辑封装。如 `TaskService`, `FlowService`, `AuditService` 等。 |
 | `ui` | UI | 展示原语。负责控制台 UI 组件、时间轴视图、表格格式化与着色。 |
-| `utils` | Infrastructure | 系统工具集。提供文件操作、字符串处理、路径解析等通用辅助。 |
+| `utils` | Infrastructure | 系统工具集. 提供文件操作、字符串处理、路径解析等通用辅助。 |
+
 
 ## 4. 依赖规则 (Dependency Rules)
 

--- a/docs/standards/vibe3-role-checks-and-balances-standard.md
+++ b/docs/standards/vibe3-role-checks-and-balances-standard.md
@@ -43,12 +43,12 @@ Vibe3 的架构是**协作式制衡**:
 
 ### 2.2 这是"三权分立"的制衡架构
 
-| 分支 | 对应角色 | 权力 | 制衡机制 |
-|------|----------|------|----------|
-| 立法 / 观察 | Governance (L1) | 观察 assignee pool、建议、写 `[governance suggest]` | 无强制执行权，只能通过建议影响 Manager |
-| 治理执行 | Supervisor/Apply (L2) | 处理 supervisor issue、close/recreate 治理 issue | Manager 不干预 supervisor issue；人类可 override |
-| 行政 / 执行 | Manager + Plan / Run (L3) | 状态机推进、代码实现、PR 产出 | Review 可 BLOCK; Orchestra 系统可强制回退 |
-| 司法 / 审计 | Review (L3) | PASS / MAJOR / BLOCK 裁决 | Manager 可覆盖 UNKNOWN / 判定 review 不可信 |
+| 分层 | 架构 Tier | 对应角色 | 权力 | 制衡机制 |
+|------|-----------|----------|------|----------|
+| **L1** | **Tier 3 (Cognitive)** | Governance | 观察 assignee pool、建议、写 `[governance suggest]` | 无强制执行权，只能通过建议影响 Manager |
+| **L2** | **Tier 3 (Governance)**| Supervisor/Apply | 处理 supervisor issue、close/recreate 治理 issue | Manager 不干预 supervisor issue；人类可 override |
+| **L3** | **Tier 2 (Skill)** | Manager + Plan / Run | 状态机推进、代码实现、PR 产出 | Review 可 BLOCK; Orchestra 系统可强制回退 |
+| **L3** | **Tier 2 (Skill)** | Review | PASS / MAJOR / BLOCK 裁决 | Manager 可覆盖 UNKNOWN / 判定 review 不可信 |
 
 ## 3. 权力结构
 

--- a/docs/v3/orchestra/README.md
+++ b/docs/v3/orchestra/README.md
@@ -52,15 +52,14 @@ related_docs:
 
 - 触发条件：`issues/assigned` 且 assignee 在 `manager_usernames`。
 - 执行动作：创建/复用 flow，检查依赖后调度 manager 执行。
-- 默认策略：`assignee_dispatch.use_worktree=true`，通过 `vibe3 run --worktree ...` 触发独立临时 worktree 执行。
+- 默认策略：`assignee_dispatch.use_worktree=true`，通过 `vibe3 run ...` 触发。
 - 执行语义（当前真源）：
   - 不切换 `serve` 进程当前分支，避免污染守护进程工作树。
   - 优先在已存在的 issue 分支 worktree 执行；不存在则自动创建 `.worktrees/issue-<number>`。
-  - 对旧分支兼容：若目标分支暂不支持 `vibe3 run --worktree`，自动降级去掉该参数继续执行。
 - 心跳会对当前已分配 issue 做重检（依赖/flow 存在性），避免漏调度。
 
 代码参考：
-- `src/vibe3/orchestra/global_dispatch_coordinator.py` — frozen queue coordinator
+- `src/vibe3/orchestra/global_dispatch_coordinator.py` — 调度主入口（Heartbeat Tick Driver）
 - `src/vibe3/orchestra/flow_dispatch.py` — flow/manager dispatch
 - `src/vibe3/orchestra/issue_loader.py` — issue loading utilities
 - `src/vibe3/domain/handlers/issue_state_dispatch.py` — ManagerDispatchIntent handler
@@ -71,7 +70,7 @@ related_docs:
 - 触发条件：requested reviewer 命中 `manager_usernames`。
 - 执行动作：通过 `GlobalDispatchCoordinator` 冻结队列派发 reviewer 角色执行。
 - 默认策略：优先复用 PR 对应已有 worktree（按 `head_branch` 匹配），不新建 worktree。
-- 可选：配置中使用 worktree 参数时改为 `vibe3 review pr <pr_number> --worktree`。
+- 可选：配置中使用派发 reviewer 执行。
 - 可选异步：配置异步模式时，调度为 `vibe3 review pr <pr_number> --async`（tmux 后台执行，不阻塞当前进程）。
 
 代码参考：


### PR DESCRIPTION
This PR aligns core documentation with the V3 runtime facts and 3-tier architecture model as requested in issue #1773.

### Changes:
- ARCHITECTURE_GUIDE.md: Introduced 3-tier model and updated command list.
- docs/v3/orchestra/README.md: Corrected vibe3 serve start, removed --worktree from vibe3 run, and confirmed GlobalDispatchCoordinator as entry point.
- docs/standards/agent-workflow-standard.md: Updated vibe3 plan and vibe3 handoff show usage.
- docs/standards/v3-module-architecture-standard.md: Aligned 6-layer with 3-tier, removed clients, added resources.
- docs/standards/vibe3-role-checks-and-balances-standard.md: Aligned role hierarchy with 3-tier.

Fixes #1773