### PR TITLE
docs: archive stale plans (Issue #1789)

### DIFF
--- a/docs/archive/2026-04-01-fix-actor-semantic-pollution-plan.md
+++ b/docs/archive/2026-04-01-fix-actor-semantic-pollution-plan.md
@@ -1,0 +1,89 @@
+# Fix: actor 语义污染 — orchestra 抢占 actor 字段
+
+- **Issue**: #411
+- **优先级**: P1 (bug — 概念模型被破坏)
+- **分支**: 基于 main 新建 `fix/actor-semantic-pollution`
+- **预估改动**: ~8 文件，~80 行
+
+## 背景
+
+`actor` 的原始设计语义是 "哪个 AI agent 或 human 在操作"（格式 `backend/model`），但 orchestra 组件把自身标识（`"orchestra"`）写入了 `latest_actor` 字段，导致 `vibe3 flow show` 显示混乱的非 agent 身份。
+
+核心矛盾：actor 回答"谁在做事"，orchestra 回答"什么组件发起了 flow"。这是两个不同维度，不能共用同一字段。
+
+## 修复方案
+
+引入 `initiated_by` 字段标识 flow 发起源，同时让 `actor` 守住 agent/human 身份语义。
+
+## Task List
+
+### Phase 1: 模型层 (无破坏性)
+
+- [ ] **T1.1** `src/vibe3/models/flow.py`
+  - FlowState 新增 `initiated_by: str | None = None`
+  - 放在 `latest_actor` 之后
+
+- [ ] **T1.2** `src/vibe3/clients/sqlite_client.py`
+  - `VALID_FLOW_STATE_FIELDS` 增加 `"initiated_by"`
+
+### Phase 2: 服务层
+
+- [ ] **T2.1** `src/vibe3/services/flow_service.py`
+  - `create_flow()` 增加可选参数 `initiated_by: str | None = None`
+  - 传递到 `store.update_flow_state(branch, ..., initiated_by=initiated_by)`
+
+### Phase 3: Orchestra 修正 (核心改动)
+
+- [ ] **T3.1** `src/vibe3/orchestra/flow_orchestrator.py`
+  - `create_flow_for_issue()` 中：
+    - `actor="orchestra"` 改为 `actor=None`（此时无 agent 接手）
+    - 新增 `initiated_by="orchestra:dispatcher"`
+  - `task_service.link_issue()` 中：
+    - `actor="orchestra"` 改为 `actor=None`
+  - 方法签名保持不变（不向调用方暴露 `initiated_by` 参数，内部硬编码即可）
+
+### Phase 4: UI 展示
+
+- [ ] **T4.1** `src/vibe3/ui/flow_ui.py`
+  - `_render_flow_state()` 中：在 `actor` 行之前增加 `initiated_by` 展示
+  - `_render_flow_status()` 紧凑摘要行也展示 `initiated_by`（仅当非 None）
+
+### Phase 5: 文档
+
+- [ ] **T5.1** `docs/standards/glossary.md`
+  - §7 Identity Tracking Terms 新增：
+    - `7.3 actor` — 执行操作的 Agent 或 Human 身份标识
+    - `7.4 initiated_by` — flow 的发起源标识（orchestra:dispatcher / manual / skill:vibe-new）
+
+### Phase 6: 测试
+
+- [ ] **T6.1** `tests/vibe3/orchestra/test_flow_orchestrator.py`
+  - 更新 `create_flow_for_issue` 测试，断言 `actor` 不再是 `"orchestra"`
+  - 断言 `initiated_by` 被正确设置
+
+- [ ] **T6.2** 新增或更新 `tests/vibe3/services/test_flow_service.py`
+  - 测试 `create_flow(initiated_by=...)` 参数传递
+
+## 不改动的部分
+
+以下使用合理，**不需要修改**：
+
+- **LabelService** 中 `actor="orchestra:triage"` / `"orchestra:manager"` / `"orchestra:dispatcher"`
+  — 这些是 event/transition 级的 actor，标识"谁触发了这个 label 变更"，与 flow state 的 `latest_actor` 无关
+- **Event 系统** (`store.add_event()`) 中的 actor 参数
+  — 事件是审计日志，允许记录系统组件来源
+- **result_handler.py** 和 **master_handler.py** 中的 label actor
+  — 不影响 flow state
+
+## 迁移说明
+
+- `initiated_by` 是新增字段，默认 `None`，对已有 flow 零破坏
+- 旧 flow 的 `latest_actor` 如果是 `"orchestra"`，不做数据迁移（历史数据保留原样）
+- SQLite 是 schema-less 的 JSON 存储，无需 migration
+
+## 验证步骤
+
+1. `uv run pytest tests/vibe3/orchestra/test_flow_orchestrator.py -v`
+2. `uv run pytest tests/vibe3/services/ -v`
+3. `uv run mypy src/vibe3/`
+4. 手动验证 `vibe3 flow show` 输出格式

--- a/docs/archive/2026-04-01-fix-orchestra-review-bugs-plan.md
+++ b/docs/archive/2026-04-01-fix-orchestra-review-bugs-plan.md
@@ -1,0 +1,117 @@
+# Fix Plan: Orchestra & Review Bug Fixes (Issues #401/#402/#403/#404)
+
+**Date**: 2026-04-01  
+**Base**: origin/main (2a8cb4f2)  
+**Branch**: fix/orchestra-review-bugs  
+**Issues**: #401, #402, #403, #404
+
+---
+
+## Bug Summary
+
+### #401 / #402 (重复 issue): CommentReplyService 自触发循环
+
+**文件**: `src/vibe3/orchestra/services/comment_reply.py`
+
+**根因**: `handle_event` 收到 `issue_comment/created` 后，检测到 manager mention 就调 `_post_ack`。但 ack 内容包含 `` `@username` `` 格式的文字，GitHub 不会触发 mention 事件；然而 ack body 中若不小心含裸 `@username`（如 f-string 变更），GitHub 会再次 emit `issue_comment` 事件，导致无限循环。
+
+**加固措施（两层防御）**:
+
+1. **Sentinel 标记**: ack body 中加入固定标记 `<!-- vibe-ack -->`，在 `handle_event` 入口检测若 comment body 含此 sentinel 则直接 return。
+2. **作者过滤**: 从 event payload 的 `comment.user.login` 读取评论者，若等于 bot/viewer 配置的用户名（`config.bot_username`）则跳过。（若无 `bot_username` 配置则回退到只靠 sentinel）
+
+**改动范围**:
+- `src/vibe3/orchestra/services/comment_reply.py`
+  - `handle_event`: 加 sentinel 检测 + 作者检测（early return）
+  - `_post_ack`: body 中插入 `<!-- vibe-ack -->` sentinel
+- `src/vibe3/orchestra/config.py`（可选）: 若无 `bot_username` 字段可按需添加，默认 `None`
+
+---
+
+### #403: async PR review 写状态到错误分支
+
+**文件**: `src/vibe3/commands/review.py`、`src/vibe3/services/async_execution_service.py`
+
+**根因**: 在 `pr()` 命令中：
+```python
+branch = get_current_branch() if async_mode and not dry_run else None
+```
+这里用的是**调用者当前分支**，不是 PR 的 head branch。当用户从非 PR 对应 worktree 触发 `vibe3 review pr N --async` 时，async 生命周期事件会写到错误的 flow state 下。
+
+**修复思路**:
+1. 在 `build_pr_review` 之后，若 `async_mode=True`，通过 GitHub API（已有 `GitHubClient`）获取 PR 的 head branch。
+2. 将 PR head branch 传给 `execute_review` 作为 `branch` 参数。
+3. 若获取失败（API 错误），refuse async 并返回友好错误信息。
+
+**改动范围**:
+- `src/vibe3/commands/review.py`
+  - `pr()` 函数：async mode 时先解析 PR head branch，再传 `branch`
+- `src/vibe3/agents/review_agent.py`（可能）: 若 `build_pr_review` 已返回 head branch 信息则直接复用，无需再次 API 调用
+- `src/vibe3/services/async_execution_service.py`: 无需改动（branch 注入正确即可）
+
+---
+
+### #404: review parser 失败开放（缺 VERDICT 时默认 PASS）
+
+**文件**: `src/vibe3/agents/review_parser.py`
+
+**根因**:
+```python
+verdict = verdict_match.group(1).upper() if verdict_match else "PASS"
+```
+当 agent 输出截断、为空或格式错误时，`verdict_match` 为 None，直接 fallback 到 `"PASS"`，产生假绿结果。
+
+**修复思路**:
+- 无 verdict 时抛出 `ReviewParserError`，区分两种情况：
+  - `raw` 完全为空 → `"Empty or missing review output"`
+  - `raw` 有内容但无 VERDICT → `"No parseable VERDICT found in output"`
+- 调用方（`review_agent.py` 或上层）catch `ReviewParserError` 后映射成 `UNKNOWN` 或 `ERROR` verdict，不允许进入正常 PASS 路径。
+
+**改动范围**:
+- `src/vibe3/agents/review_parser.py`
+  - `parse_codex_review`: 移除 fallback to PASS，改为 raise `ReviewParserError`
+- `src/vibe3/agents/review_agent.py`（或 `review.py`）: catch `ReviewParserError`，verdict = `"ERROR"`，emit 明确失败信息
+
+---
+
+## 实现顺序
+
+```
+Phase 1 (独立，无依赖)
+  - Fix #401/#402: comment_reply.py sentinel + author filter
+  - Fix #404: review_parser.py fail closed
+
+Phase 2 (依赖 Phase 1 review_agent 接口稳定)
+  - Fix #403: review.py async branch resolution
+```
+
+---
+
+## 测试覆盖
+
+### #401/#402
+- `tests/vibe3/orchestra/test_comment_reply.py`
+  - `test_ignores_own_ack_by_sentinel`: 含 sentinel 的 comment → 不 post
+  - `test_ignores_bot_author`: comment.user.login == bot → 不 post
+  - `test_replies_to_valid_mention`: 正常 mention → post ack 且含 sentinel
+
+### #403
+- `tests/vibe3/commands/test_review.py`
+  - `test_async_pr_uses_pr_head_branch`: 确认 branch 参数来自 PR head，不是当前分支
+  - `test_async_pr_refuses_when_head_fetch_fails`: API 错误时 refuse 而不静默
+
+### #404
+- `tests/vibe3/agents/test_review_parser.py`
+  - `test_empty_output_raises`: 空 raw → ReviewParserError
+  - `test_no_verdict_raises`: 有内容但无 VERDICT → ReviewParserError
+  - `test_valid_verdict_pass/major/block`: 正常解析不受影响
+
+---
+
+## 验收标准
+
+- [ ] `uv run ruff check src` 通过
+- [ ] `uv run mypy src` 通过
+- [ ] 上述新增测试全部绿
+- [ ] `uv run pytest tests/vibe3 -q` 全量通过
+- [ ] PR closes #401 #402 #403 #404

--- a/docs/archive/2026-04-01-pr-ready-human-only-convergence-plan.md
+++ b/docs/archive/2026-04-01-pr-ready-human-only-convergence-plan.md
@@ -1,0 +1,244 @@
+# PR Ready Human-Only Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 pr ready 收敛为 human-only 命令，只负责 gh ready 与 PR reviewer briefing；移除本地门禁和 state/merge-ready 自动流转，并同步最小必要文档。
+
+**Architecture:** 本地质量门禁继续由 pre-push 和 CI 承担，pr ready 不再决定“能否进入 review”。pr ready 保留为一个人类操作入口，在执行 gh pr ready 前后生成可复用的 reviewer briefing 评论，为 @codex、@copilot、@auggie、@claude 提供统一上下文。
+
+**Tech Stack:** Python, Typer, GitHub CLI, pytest, existing inspect/review/snapshot services
+
+---
+
+## Decision Audit
+
+### What pre-push already covers
+
+- Compile check: `uv run python -m compileall -q src/vibe3`
+- Type check: `uv run mypy src`
+- Incremental or fallback pytest targets via `vibe3.analysis.pre_push_test_selector`
+- Inspect-based risk assessment via `vibe3 inspect base <REVIEW_BASE> --json`
+- High-risk async review trigger via `vibe3 review base <REVIEW_BASE> --async` when score reaches block threshold
+
+### What pre-push does not cover
+
+- Coverage gate from `CoverageService`
+- Blocking wait for review result before push
+- `inspect pr`-specific risk check for an already-created PR
+- `state/merge-ready` label sync
+
+### Decision
+
+- `pr ready` can safely stop doing local gates.
+- Do not move coverage gate into pre-push in this change.
+- Keep upstream conflict check inside `PRService.mark_ready()` because it is action validity, not policy gating.
+
+## Chunk 1: Remove PR Ready Gates
+
+### Task 1: Narrow command semantics
+
+**Files:**
+- Modify: `src/vibe3/commands/pr_lifecycle.py`
+- Modify: `src/vibe3/services/pr_ready_usecase.py`
+- Test: `tests/vibe3/commands/test_pr_ready.py`
+- Test: `tests/vibe3/services/test_pr_ready_usecase.py`
+
+- [ ] **Step 1: Write failing tests for gate removal**
+
+Add tests asserting:
+- `pr ready` no longer invokes coverage gate
+- `pr ready` no longer invokes risk gate
+- `--yes` only affects confirmation behavior, not quality gate bypass
+
+- [ ] **Step 2: Run targeted tests to verify failure**
+
+Run: `uv run pytest tests/vibe3/commands/test_pr_ready.py tests/vibe3/services/test_pr_ready_usecase.py -q`
+Expected: failures referencing legacy gate calls or old `--yes` semantics
+
+- [ ] **Step 3: Remove command-scoped gate orchestration**
+
+Update `src/vibe3/commands/pr_lifecycle.py` to:
+- delete `_run_ready_gates()`
+- stop wiring `pr_quality_gates` into `_build_pr_ready_usecase()`
+- update help text and docstring to reflect human-only behavior
+
+Update `src/vibe3/services/pr_ready_usecase.py` to:
+- remove `gate_runner` dependency
+- keep only confirmation + mark ready flow
+
+- [ ] **Step 4: Run targeted tests to verify pass**
+
+Run: `uv run pytest tests/vibe3/commands/test_pr_ready.py tests/vibe3/services/test_pr_ready_usecase.py -q`
+Expected: PASS
+
+### Task 2: Decide compatibility of `--yes`
+
+**Files:**
+- Modify: `src/vibe3/commands/pr_lifecycle.py`
+- Test: `tests/vibe3/commands/test_pr_ready.py`
+
+- [ ] **Step 1: Keep `--yes` as confirmation bypass only**
+
+Implement the narrowest behavior:
+- if `--yes`, skip interactive confirm
+- do not mention “绕过业务逻辑检查” in help text
+
+- [ ] **Step 2: Validate help output contract**
+
+Run: `uv run python src/vibe3/cli.py pr ready --help`
+Expected: no coverage/risk gate wording remains
+
+## Chunk 2: Add PR Reviewer Briefing Comment
+
+### Task 3: Build briefing payload from existing analysis primitives
+
+**Files:**
+- Create: `src/vibe3/services/pr_review_briefing_service.py`
+- Modify: `src/vibe3/services/pr_service.py`
+- Modify: `src/vibe3/clients/protocols.py`
+- Modify: `src/vibe3/clients/github_pr_ops.py`
+- Test: `tests/vibe3/services/test_pr_review_briefing_service.py`
+- Test: `tests/vibe3/services/test_pr_service.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Cover:
+- renders compact reviewer briefing body
+- includes PR metadata, linked issue, inspect summary, changed symbols, snapshot diff summary when available
+- degrades gracefully when snapshot diff is unavailable
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/vibe3/services/test_pr_review_briefing_service.py tests/vibe3/services/test_pr_service.py -q`
+Expected: missing service or missing client method failures
+
+- [ ] **Step 3: Implement briefing service**
+
+The service should reuse existing sources where practical:
+- `inspect pr` summary from `src/vibe3/commands/inspect_pr_helpers.py` or `inspect_output_adapter`
+- changed symbols from existing inspect JSON adapters
+- snapshot diff summary from `build_snapshot_diff()` when local branch matches PR head branch
+
+The comment body should stay short and stable:
+- PR number, title, base/head
+- linked issue
+- file and LOC delta summary
+- changed symbols grouped by file
+- dependency or structure hints when present
+- explicit “Please focus on” section
+
+- [ ] **Step 4: Add PR comment upsert support**
+
+Add minimal GitHub client capability to:
+- find existing bot-authored briefing comment by sentinel marker
+- create comment if missing
+- update comment if present
+
+Prefer one stable marker such as `<!-- vibe3:pr-review-briefing -->`.
+
+- [ ] **Step 5: Wire briefing publication into `PRService.mark_ready()`**
+
+Order:
+- resolve PR
+- mark ready if still draft
+- publish or update briefing comment on PR
+- record flow event
+
+- [ ] **Step 6: Run targeted tests**
+
+Run: `uv run pytest tests/vibe3/services/test_pr_review_briefing_service.py tests/vibe3/services/test_pr_service.py tests/vibe3/commands/test_pr_ready.py -q`
+Expected: PASS
+
+## Chunk 3: Remove Merge-Ready Auto Sync
+
+### Task 4: Stop mutating `state/merge-ready` from `pr ready`
+
+**Files:**
+- Modify: `src/vibe3/services/pr_ready_usecase.py`
+- Modify: `tests/vibe3/services/test_pr_ready_usecase.py`
+- Optional Modify: `docs/standards/github-labels-standard.md`
+
+- [ ] **Step 1: Write failing test for label sync removal**
+
+Assert `pr ready` does not call `LabelService.confirm_issue_state(..., IssueState.MERGE_READY, ...)`.
+
+- [ ] **Step 2: Run targeted test to verify failure**
+
+Run: `uv run pytest tests/vibe3/services/test_pr_ready_usecase.py -q`
+Expected: failure still expecting merge-ready sync
+
+- [ ] **Step 3: Remove `_sync_merge_ready_label()` path**
+
+Delete merge-ready sync logic from `PrReadyUsecase`.
+
+- [ ] **Step 4: Run targeted test to verify pass**
+
+Run: `uv run pytest tests/vibe3/services/test_pr_ready_usecase.py -q`
+Expected: PASS
+
+## Chunk 4: Retire `vibe-task` Mirror Semantics and Update Docs
+
+### Task 5: Update standards and direct command docs
+
+**Files:**
+- Modify: `docs/standards/quality-control-standard.md`
+- Modify: `docs/standards/github-labels-standard.md`
+- Modify: `skills/vibe-task/SKILL.md`
+- Optional Modify: `docs/standards/github-labels-reference.md`
+
+- [ ] **Step 1: Update quality-control standard**
+
+Document that:
+- pre-push owns local compile/type/test/risk checks
+- `pr ready` is human-only and no longer a gate
+- coverage remains CI or explicit manual verification, not part of `pr ready`
+
+- [ ] **Step 2: Remove `vibe-task` mirror label claims from active standards**
+
+Change active wording from “执行项镜像标签” to roadmap/flow-based semantics.
+
+- [ ] **Step 3: Update `skills/vibe-task/SKILL.md`**
+
+Avoid describing `vibe-task` as an active label or registration truth.
+
+- [ ] **Step 4: Validate key doc strings**
+
+Run: `rg -n "coverage gate|质量门禁|vibe-task|merge-ready" docs/standards skills/vibe-task src/vibe3/commands/pr_lifecycle.py src/vibe3/services/pr_ready_usecase.py`
+Expected: only intentional references remain
+
+## Chunk 5: Verification and Rollout Safety
+
+### Task 6: Run focused regression verification
+
+**Files:**
+- Test: `tests/vibe3/commands/test_pr_ready.py`
+- Test: `tests/vibe3/services/test_pr_ready_usecase.py`
+- Test: `tests/vibe3/services/test_pr_service.py`
+- Test: `tests/vibe3/services/test_pr_review_briefing_service.py`
+
+- [ ] **Step 1: Run focused suite**
+
+Run: `uv run pytest tests/vibe3/commands/test_pr_ready.py tests/vibe3/services/test_pr_ready_usecase.py tests/vibe3/services/test_pr_service.py tests/vibe3/services/test_pr_review_briefing_service.py -q`
+Expected: PASS
+
+- [ ] **Step 2: Run hook contract smoke check**
+
+Run: `bash scripts/hooks/pre-push.sh </dev/null`
+Expected: if fallback scope resolves locally, script completes or fails only for genuine environment reasons; no dependency on `pr ready`
+
+- [ ] **Step 3: Manual CLI smoke checks**
+
+Run:
+- `uv run python src/vibe3/cli.py pr ready --help`
+- `uv run python src/vibe3/cli.py review --help`
+
+Expected:
+- `pr ready` help shows human-only semantics
+- `review` remains the dedicated analysis path
+
+## Rollout Notes
+
+- Do not add coverage execution into pre-push in this change. It would turn every push into a second full pytest run.
+- Keep `check_upstream_conflicts()` inside `PRService.mark_ready()`.
+- Prefer PR comment publication over issue comment publication. If no PR exists, briefing should not silently fall back to issue comment in this change.
+- If comment upsert support is too large, phase the rollout: first create-only comment, then add update behavior in a follow-up.

--- a/docs/archive/2026-04-02-config-governance-design.md
+++ b/docs/archive/2026-04-02-config-governance-design.md
@@ -1,0 +1,335 @@
+# Config 治理与重构设计
+
+> 目标：将根目录 `config/` 从“杂糅入口”收敛为清晰的配置治理层，使配置文件按运行时和模块职责分布，并让配置说明同时承担开发指引、验证指引和清理依据。
+
+## 背景
+
+当前仓库的根目录 `config/` 同时承载了三类不同职责：
+
+- V2 shell 集成入口：`config/aliases.sh`、`config/loader.sh`、`config/keys.template.env`
+- V3 Python 运行时配置真源：`config/settings.yaml`
+- V3 prompt 模板：`config/prompts.yaml`
+
+这种布局会带来三个直接问题：
+
+1. 目录层级无法表达职责边界，开发者需要先读实现代码才能知道某个配置属于 shell 还是 V3。
+2. 文档与真相已经漂移。仓库内仍有多处文档引用 `config/aliases/*.sh`，但 alias 真正实现已经迁移到 `lib/alias/`。
+3. `config/settings.yaml` 中至少有 `github_project`、`doc_limits` 两个配置块没有进入当前 `VibeConfig` schema，存在“写在配置里，但不一定生效”的风险。
+
+## 现状审计结论
+
+### 当前实际文件
+
+根目录 `config/` 当前只有五个文件：
+
+- `config/aliases.sh`
+- `config/keys.template.env`
+- `config/loader.sh`
+- `config/prompts.yaml`
+- `config/settings.yaml`
+
+### 当前消费方
+
+已确认生效的配置域：
+
+- `flow`
+- `ai`
+- `code_limits`
+- `review_scope`
+- `quality`
+- `pr_scoring`
+- `review`
+- `plan`
+- `run`
+- `orchestra`
+- `prompts.yaml`
+
+疑似失效或未完整接线的配置域：
+
+- `github_project`
+- `doc_limits`
+
+### 现状判断
+
+当前问题的核心不是“文件太少”，而是“配置真源、配置说明、配置消费方、配置验证方式没有形成一套治理模型”。
+
+因此本次设计采用 **B 方案：按运行时和模块职责重组 + 配置注册表 + description 升级为治理说明**。
+
+## 设计目标
+
+### 一级目标
+
+1. 让 `config/` 目录结构一眼可见职责边界。
+2. 每个配置文件只承载一个稳定职责域。
+3. 每个重要配置项都能回答六个问题：
+   - 它为什么存在
+   - 谁在读取它
+   - 什么时候生效
+   - 调整它会影响什么
+   - 如何验证它真的在发挥作用
+   - 它当前是 active、partial、planned 还是 deprecated
+4. 让 manager runner 可以基于文档直接执行重构，而不是二次猜测。
+
+### 非目标
+
+1. 本次不改变功能语义，不顺手优化无关模块。
+2. 本次不把配置彻底下沉到各 Python 模块目录中。
+3. 本次不引入复杂的多文件动态 include 机制作为首要目标。
+
+## 推荐目标结构
+
+```text
+config/
+  README.md
+
+  shell/
+    aliases.sh
+    loader.sh
+    keys.template.env
+
+  prompts/
+    prompts.yaml
+
+  v3/
+    settings.yaml
+    registry.yaml
+    settings/
+      flow.yaml
+      ai.yaml
+      paths-and-limits.yaml
+      review-scope.yaml
+      quality.yaml
+      pr-scoring.yaml
+      review.yaml
+      plan.yaml
+      run.yaml
+      orchestra.yaml
+      task-bridge.yaml
+```
+
+## 结构说明
+
+### `config/shell/`
+
+职责：V2 shell 入口层配置与模板。
+
+包含：
+
+- `aliases.sh`：兼容入口，不再冒充 alias 真身
+- `loader.sh`：shell 初始化入口
+- `keys.template.env`：密钥模板
+
+说明原则：
+
+- 明确声明“实现位于 `lib/alias/` 和 `lib/config.sh`”
+- 配置文件本身负责入口和兼容，不负责业务实现说明
+
+### `config/prompts/`
+
+职责：V3 prompt 模板配置。
+
+包含：
+
+- `prompts.yaml`
+
+说明原则：
+
+- 明确哪些命令或服务会读取 prompt 模板
+- 对每个模板块标记其消费方和 fallback 行为
+
+### `config/v3/settings/`
+
+职责：V3 运行时配置域拆分。
+
+拆分规则不是平均拆分，而是按稳定职责域：
+
+- `flow.yaml`
+- `ai.yaml`
+- `paths-and-limits.yaml`
+- `review-scope.yaml`
+- `quality.yaml`
+- `pr-scoring.yaml`
+- `review.yaml`
+- `plan.yaml`
+- `run.yaml`
+- `orchestra.yaml`
+- `task-bridge.yaml`
+
+其中：
+
+- `task-bridge.yaml` 用于承接当前 `github_project` 这类“任务桥接/远端真源定位”配置
+- 如果确认 `github_project` 已废弃，则该文件可以不落地，但必须在注册表中标注 `deprecated` 或 `dead`
+
+### `config/v3/settings.yaml`
+
+职责：V3 唯一配置加载入口。
+
+要求：
+
+- 对 loader 来说仍然保持单入口
+- 可通过聚合方式装配各子配置文件
+- 对调用方透明，避免所有消费方一起改配置路径
+
+### `config/v3/registry.yaml`
+
+职责：配置治理注册表。
+
+这是本方案的关键产物，用来记录：
+
+- 每个配置域的真源文件
+- schema 对应模块
+- 运行时消费方
+- 当前状态
+- 测试覆盖
+- 迁移建议
+
+它不是运行时配置，而是开发治理真源。
+
+## 配置域映射
+
+| 当前配置块 | 建议目标文件 | 说明 |
+|---|---|---|
+| `flow` | `config/v3/settings/flow.yaml` | flow 生命周期规则 |
+| `ai` | `config/v3/settings/ai.yaml` | AI client 接入配置 |
+| `code_limits` | `config/v3/settings/paths-and-limits.yaml` | 统计口径与 LOC gate |
+| `review_scope` | `config/v3/settings/review-scope.yaml` | 风险识别重点路径 |
+| `quality` | `config/v3/settings/quality.yaml` | 覆盖率与质量门禁 |
+| `pr_scoring` | `config/v3/settings/pr-scoring.yaml` | 风险评分与 merge gate |
+| `review` | `config/v3/settings/review.yaml` | review agent 配置 |
+| `plan` | `config/v3/settings/plan.yaml` | plan agent 配置 |
+| `run` | `config/v3/settings/run.yaml` | runner/执行配置 |
+| `orchestra` | `config/v3/settings/orchestra.yaml` | 编排、webhook、governance |
+| `github_project` | `config/v3/settings/task-bridge.yaml` 或移除 | 先审计再决定保留/废弃 |
+| `doc_limits` | 移除或补接线 | 当前不应继续伪装为 active |
+
+## Description 升级规则
+
+本次设计要求 description 从“字段注释”升级为“治理说明”。
+
+对重要配置项，不再只写一句注释，而采用统一结构：
+
+```yaml
+block_on_score_at_or_above:
+  value: 10
+  description:
+    purpose: "定义什么时候从提示升级为阻断。"
+    consumer:
+      - "scripts/hooks/pre-push.sh"
+      - "src/vibe3/services/pr_scoring_service.py"
+    effect:
+      - "score >= 阈值时阻断推送或阻断合并"
+    guidance:
+      - "如果误报很多，先检查 weights 和 size thresholds"
+      - "不要把它当成兜底垃圾桶无限上调"
+    verification:
+      - "构造临界 score 样例运行 pre-push hook"
+      - "检查 inspect/review 输出中的 gate 判定"
+    status: "active"
+```
+
+### 统一字段规范
+
+- `purpose`：存在原因，不写实现细节
+- `consumer`：直接读取它的代码入口
+- `effect`：它如何影响系统行为
+- `guidance`：如何正确调整它
+- `verification`：如何证明它真的生效
+- `status`：当前治理状态
+
+### 状态枚举
+
+- `active`：已接线并有明确消费方
+- `partial`：部分接线，行为不完整
+- `planned`：设计存在，但尚未接线
+- `deprecated`：兼容保留，准备移除
+- `dead`：无消费方，应删除
+
+## 配置注册表规范
+
+`config/v3/registry.yaml` 建议采用如下结构：
+
+```yaml
+review:
+  source_file: "config/v3/settings/review.yaml"
+  schema: "src/vibe3/config/settings.py:ReviewConfig"
+  consumers:
+    - "src/vibe3/agents/review_prompt.py"
+    - "src/vibe3/agents/review_agent.py"
+  tests:
+    - "tests/vibe3/agents/test_review_prompt.py"
+  status: "active"
+  notes:
+    - "review_prompt 已接线"
+```
+
+### registry 的价值
+
+1. agent 修改配置前先查 registry，避免盲改。
+2. 审计时可以快速发现 dead config。
+3. 文档更新时有统一真源，不需要在多个文档里重复解释。
+
+## 判定规则
+
+### 什么叫“配置是有用的”
+
+必须同时满足以下至少两项：
+
+1. 进入 schema 或被显式解析
+2. 有运行时代码消费方
+3. 有测试覆盖或至少有可执行验证路径
+
+否则不能标记为 `active`。
+
+### 什么叫“description 在发挥作用”
+
+当开发者或 agent 面对一个配置项时，应该不读实现也能知道：
+
+1. 改它之前要看哪些文件
+2. 改它之后要跑哪些验证
+3. 改错了会影响什么范围
+
+如果 description 不能回答这三个问题，它就只是注释，不是开发指引。
+
+## 迁移原则
+
+1. **单入口兼容优先**
+   - 运行时仍通过 `config/v3/settings.yaml` 进入
+2. **先审计，后搬运**
+   - 先区分 active/partial/dead，再做移动
+3. **目录重组不等于语义变更**
+   - 第一阶段只迁移结构，不顺手改策略
+4. **文档跟着真源走**
+   - 所有仍引用 `config/aliases/*.sh` 的文档都要修正到真实结构
+
+## 风险与防护
+
+### 风险 1：拆文件后 loader 复杂度上升
+
+防护：
+
+- 保持单聚合入口
+- 在 schema 层做统一装配
+
+### 风险 2：把未接线配置当成 active 保留下来
+
+防护：
+
+- 先建立 registry
+- 所有配置块先做状态判定再迁移
+
+### 风险 3：description 继续写成大段注释，没人维护
+
+防护：
+
+- 只对关键配置采用结构化 description
+- 让 `verification` 字段直接对应测试或命令
+
+## 验收标准
+
+本设计落地后，应满足：
+
+1. 任意开发者看到 `config/` 目录即可分辨 shell、V3、prompts 三类职责。
+2. 任意一个重要配置项都能从 registry 找到消费方和验证方式。
+3. 当前无效配置项会被明确标记为 `planned`、`deprecated` 或 `dead`，而不是继续混在 active 配置里。
+4. 文档中不再把 `config/aliases.sh` 描述为 alias 真身，也不再引用不存在的 `config/aliases/*.sh`。
+5. manager runner 可以直接按实施计划推进，不需要重新做结构设计。

--- a/docs/archive/2026-04-02-config-governance-implementation-plan.md
+++ b/docs/archive/2026-04-02-config-governance-implementation-plan.md
@@ -1,0 +1,284 @@
+# Config Governance Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 将仓库根目录 `config/` 重构为清晰的配置治理层，按职责拆分 V2 shell、V3 settings、prompts，并补齐配置注册表与开发指引说明。
+
+**Architecture:** 保持 `config/v3/settings.yaml` 作为 V3 运行时单入口，在其背后重组子配置文件；新增 `config/v3/registry.yaml` 作为治理真源；shell 与 prompts 分别独立成域。先做审计和兼容迁移，再修正文档和测试。
+
+**Tech Stack:** YAML, Python 3.10+, Pydantic, shell loader, GitHub issue/PR workflow
+
+---
+
+### Task 1: 建立配置审计基线
+
+**Files:**
+- Modify: `docs/archive/2026-04-02-config-governance-design.md`
+- Create: `temp/config-audit-notes.md`
+
+**Step 1: 列出现有配置文件与配置块**
+
+Run:
+
+```bash
+find config -maxdepth 3 -type f | sort
+rg -n "^flow:|^ai:|^code_limits:|^review_scope:|^quality:|^pr_scoring:|^review:|^plan:|^run:|^orchestra:|^github_project:|^doc_limits:" config/settings.yaml
+```
+
+Expected: 能完整列出当前 `config/` 文件和 `settings.yaml` 顶层配置块。
+
+**Step 2: 审计每个配置块的消费方**
+
+Run:
+
+```bash
+rg -n "config\\.(flow|ai|code_limits|review_scope|quality|pr_scoring|review|plan|run|orchestra)|get_config\\(\\)\\." src scripts tests -S
+```
+
+Expected: 形成“配置块 -> 消费方”对照表。
+
+**Step 3: 记录 active/partial/dead 初判**
+
+Write `temp/config-audit-notes.md`，至少包含：
+
+- 配置块名称
+- schema 是否存在
+- 直接消费方
+- 测试覆盖
+- 初始状态判断
+
+**Step 4: 运行最小验证**
+
+Run:
+
+```bash
+uv run pytest tests/vibe3/services/test_pr_scoring_service.py tests/vibe3/agents/test_review_prompt.py tests/vibe3/orchestra/test_serve.py -q
+```
+
+Expected: 当前配置相关核心测试通过，作为迁移前基线。
+
+### Task 2: 重组目录结构并保持单入口
+
+**Files:**
+- Create: `config/README.md`
+- Create: `config/shell/aliases.sh`
+- Create: `config/shell/loader.sh`
+- Create: `config/shell/keys.template.env`
+- Create: `config/prompts/prompts.yaml`
+- Create: `config/v3/settings.yaml`
+- Create: `config/v3/settings/flow.yaml`
+- Create: `config/v3/settings/ai.yaml`
+- Create: `config/v3/settings/paths-and-limits.yaml`
+- Create: `config/v3/settings/review-scope.yaml`
+- Create: `config/v3/settings/quality.yaml`
+- Create: `config/v3/settings/pr-scoring.yaml`
+- Create: `config/v3/settings/review.yaml`
+- Create: `config/v3/settings/plan.yaml`
+- Create: `config/v3/settings/run.yaml`
+- Create: `config/v3/settings/orchestra.yaml`
+- Optional: `config/v3/settings/task-bridge.yaml`
+- Keep compatibility or remove old files after cutover
+
+**Step 1: 建立新目录骨架**
+
+Use `apply_patch` 创建目标目录中的说明和配置文件占位结构。
+
+Expected: 新结构存在，但旧入口暂不删除。
+
+**Step 2: 将现有配置按职责迁移到对应文件**
+
+规则：
+
+- shell 文件只迁移入口与模板
+- prompts 单独迁移
+- V3 settings 按职责域拆分
+
+Expected: 每个配置域只出现在一个目标文件中。
+
+**Step 3: 保持 `config/v3/settings.yaml` 为聚合入口**
+
+Implementation note:
+
+- 若当前 loader 不支持 include，则可先生成聚合文件
+- 允许第一阶段用代码装配子文件，不要求纯 YAML include
+
+Expected: 运行时仍然只需要一个入口文件。
+
+**Step 4: 保留迁移兼容层**
+
+Expected:
+
+- 旧路径在短期内仍可工作，或有明确失败提示
+- 不直接破坏现有调用方
+
+### Task 3: 建立配置注册表和 description 规范
+
+**Files:**
+- Create: `config/v3/registry.yaml`
+- Modify: `config/v3/settings/*.yaml`
+- Modify: `docs/standards/configuration-standard.md`
+
+**Step 1: 为每个配置域登记 registry**
+
+每个域至少包含：
+
+- `source_file`
+- `schema`
+- `consumers`
+- `tests`
+- `status`
+- `notes`
+
+**Step 2: 将关键配置项 description 升级为治理说明**
+
+至少覆盖：
+
+- `code_limits`
+- `review_scope`
+- `pr_scoring.merge_gate`
+- `review.agent_config`
+- `plan.agent_config`
+- `run.agent_config`
+- `orchestra.governance`
+
+**Step 3: 标记可疑配置域状态**
+
+对 `github_project`、`doc_limits` 给出明确状态：
+
+- `active`
+- `partial`
+- `planned`
+- `deprecated`
+- `dead`
+
+Expected: 不再存在“看起来像生效，其实没人读”的配置块。
+
+### Task 4: 更新 loader、schema 与消费方
+
+**Files:**
+- Modify: `src/vibe3/config/loader.py`
+- Modify: `src/vibe3/config/settings.py`
+- Modify: `src/vibe3/prompts/template_loader.py`
+- Modify: `src/vibe3/services/pr_create_usecase.py`
+- Modify any tests referencing `config/settings.yaml` or `config/prompts.yaml`
+
+**Step 1: 调整 V3 loader 到新入口**
+
+Run:
+
+```bash
+sed -n '1,220p' src/vibe3/config/loader.py
+```
+
+Implementation:
+
+- 将默认入口切到 `config/v3/settings.yaml`
+- 如需兼容旧入口，添加迁移期 fallback
+
+**Step 2: 调整 prompts 默认路径**
+
+Implementation:
+
+- 将默认路径切到 `config/prompts/prompts.yaml`
+- 保留旧路径 fallback，直到文档和测试一起切完
+
+**Step 3: 调整直接硬编码旧路径的调用方**
+
+重点检查：
+
+- `src/vibe3/services/pr_create_usecase.py`
+- `src/vibe3/prompts/template_loader.py`
+- tests 中硬编码路径的用例
+
+**Step 4: 运行定向测试**
+
+Run:
+
+```bash
+uv run pytest tests/vibe3/services/test_ai_service.py tests/vibe3/prompts/test_models.py tests/vibe3/orchestra/test_serve.py tests/vibe3/agents/test_review_prompt.py -q
+```
+
+Expected: 新路径不破坏现有行为。
+
+### Task 5: 清理文档漂移并补齐开发指引
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `STRUCTURE.md`
+- Modify: `CLAUDE.md`
+- Modify: `skills/vibe-instruction/SKILL.md`
+- Modify: `docs/standards/configuration-standard.md`
+- Modify any docs still referencing `config/aliases/*.sh`
+
+**Step 1: 搜索过时路径引用**
+
+Run:
+
+```bash
+rg -n "config/aliases/|config/settings.yaml|config/prompts.yaml" AGENTS.md STRUCTURE.md CLAUDE.md skills docs tests -S
+```
+
+**Step 2: 修正文档为新结构与新语义**
+
+要求：
+
+- 明确 alias 真身在 `lib/alias/`
+- 明确 V3 配置入口与 registry 的职责
+- 明确 description 是开发指引，不只是注释
+
+**Step 3: 运行文档相关最小验证**
+
+Run:
+
+```bash
+rg -n "config/aliases/" AGENTS.md STRUCTURE.md CLAUDE.md skills docs -S
+```
+
+Expected: 不再引用不存在的 `config/aliases/*.sh`。
+
+### Task 6: 验收与收口
+
+**Files:**
+- Modify: `docs/archive/2026-04-02-config-governance-design.md`
+- Modify: `config/v3/registry.yaml`
+
+**Step 1: 验收目录结构**
+
+Run:
+
+```bash
+find config -maxdepth 3 -type f | sort
+```
+
+Expected: shell、prompts、v3 三层结构清晰。
+
+**Step 2: 验收 registry 完整性**
+
+Run:
+
+```bash
+sed -n '1,260p' config/v3/registry.yaml
+```
+
+Expected: 所有重要配置域都有 consumer、status、tests。
+
+**Step 3: 验收配置行为**
+
+Run:
+
+```bash
+uv run pytest tests/vibe3/services/test_pr_scoring_service.py tests/vibe3/analysis/test_coverage_service.py tests/vibe3/orchestra/test_serve.py tests/vibe3/services/test_ai_service.py -q
+```
+
+Expected: 关键配置消费路径全部通过。
+
+**Step 4: 提交与 PR**
+
+Run:
+
+```bash
+git add config src/vibe3 docs AGENTS.md STRUCTURE.md CLAUDE.md skills
+git commit -m "refactor: reorganize config governance"
+```
+
+Expected: 提交只包含配置治理相关改动。


### PR DESCRIPTION
Archived 5 stale plan documents from `docs/plans/` to `docs/archive/` as requested in issue #1789.

Documents archived:
1. 2026-04-01-fix-actor-semantic-pollution-plan.md
2. 2026-04-01-fix-orchestra-review-bugs-plan.md
3. 2026-04-01-pr-ready-human-only-convergence-plan.md
4. 2026-04-02-config-governance-design.md
5. 2026-04-02-config-governance-implementation-plan.md

References within the documents have been updated to reflect the new location.

Closes #1789