### PR TITLE
docs: align documentation references to V3 truth sources (#1799)

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -163,7 +163,7 @@ def register_dispatch_handlers() -> None:
 ### 修改 Worktree 相关代码时
 
 1. **阅读架构文档**：
-   - [vibe3-worktree-ownership-standard.md (DEPRECATED)](standards/vibe3-worktree-ownership-standard.md)
+   - [worktree-lifecycle-standard.md](standards/v3/worktree-lifecycle-standard.md)
 
 2. **关键检查点**：
    - ✅ 确认执行层级（L0-L4）

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,9 @@ docs/
 - **[vibe3-role-checks-and-balances-standard.md](standards/vibe3-role-checks-and-balances-standard.md)** - Vibe3 角色制衡架构标准
 - **[agent-debugging-standard.md](standards/agent-debugging-standard.md)** - Agent 调试标准
 - **[doc-organization.md](standards/doc-organization.md)** - 文档组织标准
-- **[vibe3-worktree-ownership-standard.md](standards/vibe3-worktree-ownership-standard.md)** (DEPRECATED) - Worktree 所有权标准 (已废弃，见 v3/worktree-lifecycle-standard.md)
+
+**已废弃文档 (Archives)**：
+- **[vibe3-worktree-ownership-standard.md](standards/vibe3-worktree-ownership-standard.md)** (DEPRECATED) - Worktree 所有权标准 (已废弃，见 standards/v3/worktree-lifecycle-standard.md)
 
 **V3 规范目录**：
 - **[standards/v3/](standards/v3/)** - V3 核心标准（handoff, git, models, registry migration）

--- a/docs/standards/authorship-standard.md
+++ b/docs/standards/authorship-standard.md
@@ -11,7 +11,7 @@ created: 2026-03-08
 last_updated: 2026-04-01
 related_docs:
   - docs/standards/glossary.md
-  - docs/standards/v3/registry-json-standard.md
+  - docs/standards/v3/data-model-standard.md
   - skills/vibe-commit/SKILL.md
 ---
 

--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -215,7 +215,7 @@ related_docs:
   - `milestone` 不是 flow
 - 落点：
   - 规划语义见 [command-standard.md](v3/command-standard.md)
-  - 文件边界见 [roadmap-json-standard.md](v3/roadmap-json-standard.md)
+  - 文件边界见 [github-labels-standard.md](github-labels-standard.md)
 - 使用规则：
   - 讨论版本、阶段、交付窗口时优先使用 `milestone`
   - 历史上的 `version_goal` 应视为兼容字段，而不是长期上位概念

--- a/docs/standards/issue-dependency-standard.md
+++ b/docs/standards/issue-dependency-standard.md
@@ -21,7 +21,7 @@
 **本文档不回答的问题**:
 - 有哪些标签？→ 见 [github-labels-reference.md](github-labels-reference.md)
 - 标签如何管理？→ 见 [roadmap-label-management.md](roadmap-label-management.md)
-- 具体命令怎么用？→ 见 [vibe3-command-standard.md](vibe3-command-standard.md)
+- 具体命令怎么用？→ 见 [v3/command-standard.md](v3/command-standard.md)
 
 ---
 


### PR DESCRIPTION
Aligns documentation references in 5 documents to V3 truth sources as specified in issue #1799.

### Changes
- Updated docs/ARCHITECTURE_GUIDE.md: Replaced deprecated worktree ownership standard reference with v3/worktree-lifecycle-standard.md.
- Updated docs/README.md: Removed deprecated worktree ownership standard from must-read list and moved it to a new Archives section.
- Updated docs/standards/authorship-standard.md: Updated registry-json-standard.md reference to v3/data-model-standard.md.
- Updated docs/standards/glossary.md: Updated roadmap-json-standard.md reference to github-labels-standard.md.
- Updated docs/standards/issue-dependency-standard.md: Updated vibe3-command-standard.md reference to v3/command-standard.md.

Closes #1799