### PR TITLE
docs(policy): add test strategy guidance to prevent mock coverage of core logic

### DIFF
--- a/supervisor/policies/review.md
+++ b/supervisor/policies/review.md
@@ -56,7 +56,30 @@ gh issue view <ISSUE_NUMBER> --comments
 - 最新的 agent 状态通报
 - Manager 的具体审查要求
 
-### 3. 确认影响范围
+### 3. 测试质量检查
+
+在审查执行报告时，必须检查测试质量：
+
+#### 检查核心逻辑是否有真实测试
+
+- 参考 `supervisor/policies/test-strategy.md` 的分类矩阵
+- 核心业务逻辑（路径解析、Git 命令解析、业务规则计算等）必须有真实测试
+- 不能仅凭 mock 测试通过就认为验证充分
+
+#### 检查 executor 报告中的验证证据
+
+- "验证通过"的声明是否有真实测试证据？
+- 是否明确标注了哪些是真实测试、哪些使用了 mock？
+- 是否提供了真实测试的输出片段或关键断言？
+
+#### 验证证据不足的处理
+
+如果核心函数只有 mock 测试：
+- 视为验证证据不足
+- 至少给 MAJOR
+- 要求补充真实测试或说明为何无法真实测试
+
+### 4. 确认影响范围
 
 ```bash
 uv run python src/vibe3/cli.py inspect base --json
@@ -66,7 +89,7 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 - 不要只看 diff 表面，要理解符号级波及范围
 - 检查是否触及关键路径、公开入口、共享状态
 
-### 4. 确认真源
+### 5. 确认真源
 
 - GitHub 当前 `state/*` labels（状态真源）
 - Issue comments（人类指令真源）
@@ -74,7 +97,7 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 
 如果历史 refs 与当前 GitHub scene 冲突，以当前 scene 为准。
 
-### 5. 读取 Executor Report（如有）
+### 6. 读取 Executor Report（如有）
 
 如果 flow 中有 `report_ref`，读取 executor 的执行报告：
 
@@ -84,7 +107,7 @@ uv run python src/vibe3/cli.py handoff show <report_ref>
 
 使用 `handoff show` 而非直接读文件路径，以正确处理跨 worktree 路径解析。
 
-### 6. 跨层一致性检查（命名/文档/API 变更）
+### 7. 跨层一致性检查（命名/文档/API 变更）
 
 对于涉及命名一致性、文档同步、API 签名的变更：
 - 使用 `inspect symbols` 和 `rg` 确认所有层（service/UI/command）的引用均已更新
@@ -106,7 +129,8 @@ uv run python src/vibe3/cli.py handoff show <report_ref>
 - **是否验证了执行效果？**
   - 检查测试是否真的覆盖了变更点
   - 检查 type check/lint 是否通过
-  - 不要因为"测试全部通过"就认为实现正确（可能是 mock 没生效）
+  - **检查核心逻辑是否有真实测试（参考 `supervisor/policies/test-strategy.md`）**
+  - 不要因为"测试全部通过"就认为实现正确（核心逻辑可能只有 mock 测试）
 
 ### 2. 我的 verdict 是否有足够证据？
 

--- a/supervisor/policies/run.md
+++ b/supervisor/policies/run.md
@@ -126,6 +126,40 @@
 
 如果改动触及公开入口、关键路径或 prompt contract，验证强度必须随之提高。
 
+### Test Strategy Compliance
+
+执行验证时，必须遵循 `supervisor/policies/test-strategy.md` 中定义的 mock vs real-test 分类矩阵。
+
+#### Executor 验证清单
+
+在声称验证完成前，必须确认：
+
+1. **核心业务逻辑是否有真实测试（非 mock）？**
+   - 参考 test-strategy.md 的"禁止 mock"分类
+   - 至少有一个真实测试覆盖核心逻辑
+
+2. **是否从不同工作目录测试过？**
+   - Repo root
+   - Subdirectory
+   - 验证路径解析的目录无关性
+
+3. **边界情况是否覆盖？**
+   - 空输入
+   - 异常路径
+   - None/空字符串处理
+
+4. **"验证通过"的声明是否有真实测试证据？**
+   - 引用真实测试的文件路径和测试名称
+   - 不能仅凭 mock 测试通过
+
+#### 执行报告要求
+
+在执行报告中，必须明确标注：
+
+- 哪些测试是真实测试（未 mock 核心逻辑）
+- 哪些测试使用了 mock（明确 mock 范围）
+- 真实测试的证据（输出片段、关键断言）
+
 ## 验证原则
 
 验证不是固定模板，而是必须与改动类型匹配。
@@ -227,11 +261,11 @@ git diff --name-only HEAD~1 HEAD -- src/vibe3/ | \
 
 ### 环境依赖代码的验证要求
 
-如果实现依赖环境变量或外部 API，验证必须包含：
+如果实现依赖环境变量或外部 API，验证必须遵循 `supervisor/policies/test-strategy.md` 的分类矩阵：
 
 ### 1. 至少一个真实环境测试
 
-- 不能只依赖 mock tests
+- **不能只依赖 mock tests**（详见 test-strategy.md "禁止 mock" 部分）
 - 必须在实际环境执行相关命令/调用
 - 记录真实执行的命令和输出
 

--- a/supervisor/policies/test-strategy.md
+++ b/supervisor/policies/test-strategy.md
@@ -1,0 +1,233 @@
+# Test Strategy: Mock vs Real-Test Classification
+
+本文档定义核心业务逻辑的测试策略，明确区分"必须真实测试"与"允许 mock"的边界，避免核心逻辑被 mock 覆盖导致虚假验证通过。
+
+## 1. Mock vs Real-Test 分类矩阵
+
+### 禁止 mock（必须真实测试）
+
+以下逻辑必须使用真实测试，不允许 mock 核心逻辑：
+
+#### 文件/路径解析逻辑
+- `_get_git_root()` — Git 根目录查找
+- 路径拼接与转换（相对路径 → 绝对路径）
+- Worktree 路径解析
+- 配置文件路径查找
+
+#### Git 命令执行结果解析
+- Branch 名提取（从 `git branch` 输出）
+- Worktree 路径解析（从 `git worktree list` 输出）
+- Remote URL 解析
+- Commit SHA 提取
+
+#### 外部工具调用的核心逻辑（非网络部分）
+- 命令参数构建（如构建 `git worktree add` 命令参数）
+- 命令输出解析（如解析 JSON、解析表格输出）
+- 错误码映射（如 exit code → exception type）
+
+#### 业务规则计算
+- 风险评分计算（如 `calculate_risk_score()`）
+- 状态判断逻辑（如 `should_trigger_flow()`）
+- 优先级排序（如 `sort_by_priority()`）
+- 条件分支逻辑（如 `if-else` 决策树）
+
+#### 配置读取与默认值 fallback 链路
+- 配置文件读取 + 默认值应用
+- 环境变量读取 + fallback 链路
+- 多层配置合并逻辑
+
+### 允许 mock 的场景
+
+以下场景允许使用 mock，但应明确标注：
+
+#### 外部服务调用
+- GitHub API 调用（`gh` 命令、REST API）
+- 网络请求（HTTP/HTTPS）
+- 第三方服务 API
+
+#### 时间相关函数
+- `datetime.now()`
+- `time.time()`
+- 时间格式化函数（当测试需要固定时间戳时）
+
+#### 随机数生成
+- `random.random()`
+- UUID 生成（当需要确定性测试时）
+
+#### Subprocess 调用中的外部进程执行
+- 允许 mock 外部进程的执行结果
+- **但进程参数构建必须真实测试**（见"禁止 mock"部分）
+
+## 2. 测试覆盖要求
+
+### 核心函数测试要求
+
+每个核心函数至少满足以下测试覆盖：
+
+#### 至少一个真实测试
+- 从真实工作目录执行
+- 不 mock 核心逻辑（允许 mock 外部服务/时间/随机数）
+- 验证实际输出或行为
+
+#### 不同工作目录测试
+- 从 repo root 执行
+- 从 subdirectory 执行（如 `src/vibe3/commands/`）
+- 验证路径解析逻辑的目录无关性
+
+#### 边界情况覆盖
+- 空输入
+- 异常路径（如不存在的文件、无效的 branch 名）
+- None/空字符串处理
+- 极端值（如超长字符串、嵌套极深的路径）
+
+### 测试命名约定
+
+为区分真实测试与 mock 测试，建议在测试名称中标注：
+
+```python
+# 真实测试（不 mock 核心逻辑）
+def test_get_git_root_real():
+    """Real test: 从真实工作目录查找 git root"""
+    ...
+
+# Mock 测试（mock 了外部服务）
+def test_github_api_mocked(mocker):
+    """Mock test: GitHub API 调用（mock 外部服务）"""
+    ...
+```
+
+## 3. "验证通过"声明的证据要求
+
+### 声明要求
+
+当 executor 在执行报告中声称"验证通过"时：
+
+#### 必须提供真实测试证据
+- 引用真实测试的文件路径和测试名称
+- 提供测试执行的输出片段
+- 说明测试覆盖了哪些核心逻辑
+
+#### 不能仅凭 mock 测试通过
+- 如果核心逻辑只有 mock 测试，视为验证不充分
+- 必须补充真实测试或明确说明为何无法真实测试
+
+### 执行报告模板
+
+在执行报告的 "Verification" 部分，应明确标注：
+
+```markdown
+## Verification
+
+### Real Tests (核心逻辑真实测试)
+- `tests/vibe3/path/test_file.py::test_get_git_root_real`: ✅ PASS
+  - 验证：从 repo root 和 subdirectory 都能正确找到 git root
+  - 输出：...
+
+### Mock Tests (外部服务 mock 测试)
+- `tests/vibe3/path/test_api.py::test_github_api_mocked`: ✅ PASS
+  - Mock 范围：GitHub API 调用
+  - 验证：参数构建和结果解析逻辑
+```
+
+## 4. 检查清单
+
+### Executor 自检清单
+
+在声称验证完成前，确认：
+
+- [ ] 核心业务逻辑是否有真实测试（非 mock）？
+- [ ] 是否从不同工作目录测试过？
+- [ ] 边界情况是否覆盖？
+- [ ] "验证通过"的声明是否有真实测试证据？
+- [ ] 执行报告中是否明确标注了哪些是真实测试、哪些使用了 mock？
+
+### Reviewer 检查清单
+
+在审查执行报告时，确认：
+
+- [ ] 核心逻辑是否有真实测试（引用本文档的分类矩阵）？
+- [ ] Executor 报告中的 "验证通过" 是否有真实测试证据？
+- [ ] 如果核心函数只有 mock 测试，是否视为验证证据不足？
+
+## 5. 示例场景
+
+### 场景 1：路径解析函数
+
+```python
+# src/vibe3/path/utils.py
+def get_git_root(start_dir: Path) -> Path:
+    """从 start_dir 向上查找 git root"""
+    ...
+```
+
+**测试策略**：
+- ✅ 真实测试：从真实 repo 的不同目录调用，验证返回正确的 git root
+- ❌ Mock 测试：不应 mock `subprocess.run` 或文件系统操作
+- ✅ 边界测试：从非 git 目录调用，验证抛出正确异常
+
+### 场景 2：GitHub API 调用
+
+```python
+# src/vibe3/services/github.py
+def get_issue_comments(issue_number: int) -> list[Comment]:
+    """调用 GitHub API 获取 issue comments"""
+    ...
+```
+
+**测试策略**：
+- ✅ Mock 测试：mock `requests.get` 或 `gh` 命令，验证参数构建和结果解析
+- ✅ 真实测试（可选）：使用测试 token 发送真实请求（CI 环境或手动验证）
+- ❌ 不应 mock 结果解析逻辑本身
+
+### 场景 3：风险评分计算
+
+```python
+# src/vibe3/analysis/risk.py
+def calculate_risk_score(changes: list[Change]) -> int:
+    """基于变更集计算风险评分"""
+    ...
+```
+
+**测试策略**：
+- ✅ 真实测试：使用真实的变更集数据，验证评分计算逻辑
+- ❌ Mock 测试：不应 mock 计算逻辑本身
+- ✅ 边界测试：空变更集、单个变更、大量变更
+
+## 6. 反模式警示
+
+### 反模式 1：Mock 核心逻辑
+
+```python
+# ❌ 错误：mock 了路径解析逻辑
+def test_get_git_root_bad(mocker):
+    mocker.patch('subprocess.run', return_value=Mock(stdout='/fake/root'))
+    result = get_git_root(Path.cwd())
+    assert result == Path('/fake/root')  # 只验证了 mock 生效，没验证真实逻辑
+```
+
+### 反模式 2：声称验证通过但无真实测试
+
+```markdown
+# ❌ 错误的执行报告
+## Verification
+- All tests pass ✅
+  - tests/test_path.py: 10 passed
+
+# 问题：没有说明哪些是真实测试，没有提供真实测试证据
+```
+
+### 反模式 3：只从单一工作目录测试
+
+```python
+# ❌ 不充分：只从 repo root 测试
+def test_get_git_root_incomplete():
+    result = get_git_root(Path.cwd())  # 假设 cwd 是 repo root
+    assert result == Path.cwd()
+
+# 问题：没有验证从 subdirectory 调用的行为
+```
+
+## 7. 参考链接
+
+- 本文档被 `supervisor/policies/run.md` 引用：executor 验证原则
+- 本文档被 `supervisor/policies/review.md` 引用：审查检查清单


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-1796` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-1796
```


---

Closes #1796

## Summary

Add comprehensive test strategy documentation to prevent mock coverage of core logic:

- **New**: `supervisor/policies/test-strategy.md` (233 lines)
  - Mock vs real-test classification matrix
  - Prohibit mocking: path resolution, git parsing, business rules, config fallback
  - Allow mocking: external services, time, random, subprocess execution
  - Test coverage requirements and evidence standards

- **Updated**: `supervisor/policies/run.md` (+38/-4 lines)
  - Add "Test Strategy Compliance" section in verification principles
  - Add executor checklist for real-test requirements
  - Reference test-strategy.md in environment-dependent code section

- **Updated**: `supervisor/policies/review.md` (+34/-3 lines)
  - Add "Test Quality Check" as mandatory review step
  - Strengthen mock test checking in verification requirements
  - Update section numbering (3→4→5→6→7)

## Test Plan

- [x] Documentation-only change (no code impact)
- [x] Pre-commit checks passed (black, ruff, mypy, shellcheck)
- [x] Cross-references verified (6 instances in run.md and review.md)
- [x] Review audit passed (claude/opus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
