### PR TITLE
fix(status): restore merge-ready issues in task status dashboard

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -54,6 +54,7 @@ def _include_issue_in_task_progress(item: dict[str, object]) -> bool:
             IssueState.CLAIMED,
             IssueState.IN_PROGRESS,
             IssueState.REVIEW,
+            IssueState.MERGE_READY,
         }
     return is_auto_task_branch(flow.branch)
 

--- a/src/vibe3/services/task_status_classifier.py
+++ b/src/vibe3/services/task_status_classifier.py
@@ -58,6 +58,7 @@ def classify_task_status(
         IssueState.HANDOFF,
         IssueState.IN_PROGRESS,
         IssueState.REVIEW,
+        IssueState.MERGE_READY,
     }:
         # Active state without assignee is an anomaly (rule 2)
         if not assignee or not assignee.strip():


### PR DESCRIPTION
## 问题

merge-ready issues 在以下条件下消失于 task status 仪表板：
1. Issue 没有本地 flow（flow 被清理或不存在）
2. Issue 不被标记为 remote（assignee 不是 manager 或为空）

**根本原因**：`_include_issue_in_task_progress` 中的无 flow 状态白名单缺少 `IssueState.MERGE_READY`（status.py 第 49-57 行）。

另外，`classify_task_status` 没有处理 MERGE_READY，导致它被分类为 OTHER bucket 而不是加入活跃状态组。

## 修复方案

1. 在 `_include_issue_in_task_progress` 的无 flow 状态白名单中添加 `IssueState.MERGE_READY`（status.py:49-57）
2. 在 `classify_task_status` 的活跃状态组中包含 `IssueState.MERGE_READY`（task_status_classifier.py:56-61）

这确保了无论 flow 状态如何，merge-ready issues 都会显示在 task 仪表板中。

## 验证

✅ mypy strict 检查通过  
✅ 所有 task_status 和 classify 测试通过（54 个测试）

## 相关

- PR #1815：诊断错误（误以为是 IndentationError，实际是状态过滤遗漏）
- Issue #1791：merge-ready 状态未派发的根本原因现已找到并修复