### PR TITLE
feat(commands): add --branch/--pr options to task resume and flow rebuild

### DIFF
--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -7,11 +7,14 @@ from loguru import logger
 
 from vibe3.commands.common import enable_method_trace
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.exceptions import SystemError, UserError
 from vibe3.services.branch_arg import resolve_branch_arg
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services.issue_flow_service import IssueFlowService
+from vibe3.services.pr_branch_resolver import resolve_command_branch
 from vibe3.utils.issue_ref import try_parse_issue_number
 
 
@@ -130,7 +133,15 @@ def blocked(
 
 
 def rebuild(
-    issue_number: Annotated[int, typer.Argument(help="Issue number to rebuild")],
+    issue_number: Annotated[
+        int | None, typer.Argument(help="Issue number to rebuild")
+    ] = None,
+    branch_opt: Annotated[
+        str | None, typer.Option("--branch", help="Branch name or issue number")
+    ] = None,
+    pr_opt: Annotated[
+        int | None, typer.Option("--pr", help="PR number to resolve branch from")
+    ] = None,
     keep_remote: Annotated[
         bool,
         typer.Option("--keep-remote", help="Keep remote branch during rebuild"),
@@ -149,29 +160,94 @@ def rebuild(
     This deletes the old task flow/worktree/branch scene, recreates the flow,
     appends a rebuild handoff event, and clears blocked state through the
     label-auto resume path.
+
+    Examples:
+        vibe3 flow rebuild 123 --yes                     # Rebuild issue #123
+        vibe3 flow rebuild --branch task/issue-123 --yes # Rebuild via branch
+        vibe3 flow rebuild --pr 456 --yes                # Rebuild via PR number
     """
-    branch = (
-        ConventionResolver.from_repo().resolve().branch.canonical_branch(issue_number)
-    )
+    # Validate that exactly one target is provided
+    provided = [
+        name
+        for opt, name in [
+            (branch_opt, "--branch"),
+            (pr_opt, "--pr"),
+            (issue_number, "<issue-number>"),
+        ]
+        if opt is not None
+    ]
+
+    if len(provided) == 0:
+        typer.echo(
+            "Error: Must specify issue number, --branch, or --pr",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if len(provided) > 1:
+        typer.echo(
+            f"错误：不能同时使用 {', '.join(provided)}，请只指定一个目标。",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    service = FlowService()
+
+    # Resolve target branch
+    if branch_opt is not None or pr_opt is not None:
+        position_arg = str(issue_number) if issue_number is not None else None
+        try:
+            target_branch = resolve_command_branch(
+                branch_opt=branch_opt,
+                pr_opt=pr_opt,
+                position_arg=position_arg,
+                flow_service=service,
+                allow_no_flow=True,  # rebuild can work even without existing flow
+            )
+        except (UserError, SystemError) as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(1) from error
+
+        # Parse issue number from target_branch for output message
+        issue_svc = IssueFlowService(store=service.store)
+        resolved_issue = issue_svc.parse_issue_number_any(target_branch)
+        if resolved_issue is None:
+            typer.echo(
+                f"Error: 无法从分支 '{target_branch}' 解析 issue 编号",
+                err=True,
+            )
+            raise typer.Exit(1)
+        resolved_issue_number = resolved_issue
+    else:
+        # Use positional issue_number
+        assert issue_number is not None
+        resolved_issue_number = issue_number
+        target_branch = (
+            ConventionResolver.from_repo()
+            .resolve()
+            .branch.canonical_branch(issue_number)
+        )
+
     if not yes:
         typer.echo(
             "[dry-run mode] Would hard rebuild "
-            f"issue #{issue_number} at branch {branch}. Use --yes to execute."
+            f"issue #{resolved_issue_number} at branch {target_branch}. "
+            "Use --yes to execute."
         )
         return
 
     from vibe3.clients.github_client import GitHubClient
 
     config = load_orchestra_config()
-    issue = load_issue_info(issue_number, config=config, github=GitHubClient())
+    issue = load_issue_info(resolved_issue_number, config=config, github=GitHubClient())
     result = FlowRebuildUsecase().rebuild_issue_flow(
         issue=issue,
-        branch=branch,
+        branch=target_branch,
         reason="manual flow rebuild",
         include_remote=not keep_remote,
         ensure_worktree=not no_worktree,
     )
-    typer.echo(f"Rebuilt flow for issue #{issue_number}: {result}")
+    typer.echo(f"Rebuilt flow for issue #{resolved_issue_number}: {result}")
 
 
 def register_lifecycle_commands(app: typer.Typer) -> None:

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -3,9 +3,12 @@
 
 import json
 from contextlib import contextmanager
-from typing import Annotated, Iterator
+from typing import TYPE_CHECKING, Annotated, Iterator
 
 import typer
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
 
 from vibe3.commands.command_options import FormatOption
 from vibe3.commands.common import enable_method_trace
@@ -13,6 +16,8 @@ from vibe3.exceptions import SystemError, UserError
 from vibe3.models.orchestration import IssueState
 from vibe3.observability.logger import setup_logging
 from vibe3.services.flow_service import FlowService
+from vibe3.services.issue_flow_service import IssueFlowService
+from vibe3.services.pr_branch_resolver import resolve_command_branch
 from vibe3.services.task_resume_usecase import TaskResumeUsecase
 from vibe3.services.task_service import TaskService
 from vibe3.ui.task_ui import (
@@ -32,6 +37,8 @@ Examples:
   vibe3 task status              # Show global task dashboard
   vibe3 task resume --blocked    # Resume all blocked issues (dry-run)
   vibe3 task resume 456 --yes    # Resume issue #456 (execute)
+  vibe3 task resume --branch task/issue-123 --yes  # Resume via branch name
+  vibe3 task resume --pr 456 --yes                 # Resume via PR number
 
 For more details: vibe3 task <command> --help
 """,
@@ -48,6 +55,43 @@ def _noop() -> Iterator[None]:
 def _build_resume_usecase() -> TaskResumeUsecase:
     """Construct a unified resume usecase."""
     return TaskResumeUsecase()
+
+
+def _parse_issue_number_from_branch(
+    branch: str, store: "SQLiteClient", flow_service: FlowService
+) -> int:
+    """Extract task issue number from a resolved branch name.
+
+    Priority:
+    1. DB links (most reliable — handles non-canonical branches)
+    2. Pattern matching (task/issue-N, dev/issue-N)
+
+    Args:
+        branch: Resolved branch name
+        store: SQLiteClient for DB queries
+        flow_service: FlowService for issue resolution
+
+    Returns:
+        Issue number
+
+    Raises:
+        UserError: If cannot parse issue number from branch
+    """
+    # Try DB links first (most reliable — handles non-canonical branches)
+    links = store.get_issue_links(branch)
+    for link in links:
+        if link.get("issue_role") == "task":
+            issue_num = link["issue_number"]
+            if isinstance(issue_num, int):
+                return issue_num
+
+    # Fall back to pattern matching (task/issue-N, dev/issue-N)
+    issue_svc = IssueFlowService(store=store)
+    num = issue_svc.parse_issue_number_any(branch)
+    if num is not None:
+        return num
+
+    raise UserError(f"无法从分支 '{branch}' 解析 issue 编号")
 
 
 @app.command()
@@ -167,6 +211,14 @@ def resume(
     blocked: Annotated[
         bool, typer.Option("--blocked", help="Resume all blocked issues")
     ] = False,
+    branch_opt: Annotated[
+        str | None,
+        typer.Option("--branch", help="Branch name or issue number"),
+    ] = None,
+    pr_opt: Annotated[
+        int | None,
+        typer.Option("--pr", help="PR number to resolve branch from"),
+    ] = None,
     label: Annotated[
         str | None,
         typer.Option(
@@ -192,6 +244,12 @@ def resume(
     Destructive scene rebuild is handled by `vibe3 flow rebuild`.
 
     By default, runs in dry-run mode. Use --yes to execute the resume.
+
+    Examples:
+        vibe3 task resume --blocked          # Resume all blocked issues
+        vibe3 task resume 456 --yes          # Resume issue #456
+        vibe3 task resume --branch task/issue-123 --yes  # Resume via branch
+        vibe3 task resume --pr 456 --yes     # Resume via PR number
     """
     if trace:
         setup_logging(verbose=2)
@@ -202,9 +260,26 @@ def resume(
     register_event_handlers()
 
     # Validate arguments
-    if not blocked and not issue_numbers:
+    # Check for --blocked conflicts with --branch/--pr
+    if blocked and (branch_opt is not None or pr_opt is not None):
         typer.echo(
-            "Error: Must specify --blocked or provide issue numbers",
+            "Error: Cannot combine --blocked with --branch or --pr",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    # Check for conflicts between --branch/--pr and positional issue_numbers
+    if (branch_opt is not None or pr_opt is not None) and issue_numbers:
+        typer.echo(
+            "Error: Cannot combine --branch/--pr with positional issue numbers",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    # Check if at least one target is specified
+    if not blocked and not issue_numbers and not branch_opt and not pr_opt:
+        typer.echo(
+            "Error: Must specify --blocked, --branch, --pr, or provide issue numbers",
             err=True,
         )
         raise typer.Exit(1)
@@ -240,15 +315,45 @@ def resume(
             )
             raise typer.Exit(1)
 
+    # Resolve branch if --branch or --pr is provided
+    flow_service = FlowService()
+    resolved_issue_numbers: list[int] | None = None
+
+    if branch_opt is not None or pr_opt is not None:
+        # Build position_arg from issue_numbers if provided
+        position_arg = str(issue_numbers[0]) if issue_numbers else None
+
+        try:
+            target_branch = resolve_command_branch(
+                branch_opt=branch_opt,
+                pr_opt=pr_opt,
+                position_arg=position_arg,
+                flow_service=flow_service,
+            )
+        except (UserError, SystemError) as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(1) from error
+
+        # Parse issue number from resolved branch
+        try:
+            issue_num = _parse_issue_number_from_branch(
+                target_branch, flow_service.store, flow_service
+            )
+            resolved_issue_numbers = [issue_num]
+        except UserError as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(1) from error
+
     target_issues: list[int] | None
     if blocked:
         target_issues = None
+    elif resolved_issue_numbers is not None:
+        target_issues = resolved_issue_numbers
     else:
         assert issue_numbers is not None
         target_issues = list(issue_numbers)
 
     usecase = _build_resume_usecase()
-    flow_service = FlowService()
 
     # Fetch all flows for candidate building
     resume_flows = flow_service.list_flows(status="active")

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -60,22 +60,9 @@ def _build_resume_usecase() -> TaskResumeUsecase:
 def _parse_issue_number_from_branch(
     branch: str, store: "SQLiteClient", flow_service: FlowService
 ) -> int:
-    """Extract task issue number from a resolved branch name.
+    """Extract task issue number from branch.
 
-    Priority:
-    1. DB links (most reliable — handles non-canonical branches)
-    2. Pattern matching (task/issue-N, dev/issue-N)
-
-    Args:
-        branch: Resolved branch name
-        store: SQLiteClient for DB queries
-        flow_service: FlowService for issue resolution
-
-    Returns:
-        Issue number
-
-    Raises:
-        UserError: If cannot parse issue number from branch
+    Tries DB links first, then pattern matching.
     """
     # Try DB links first (most reliable — handles non-canonical branches)
     links = store.get_issue_links(branch)
@@ -260,15 +247,11 @@ def resume(
     register_event_handlers()
 
     # Validate arguments
-    # Check for --blocked conflicts with --branch/--pr
+    # Check for conflicts between --blocked, --branch/--pr, and positional issue_numbers
     if blocked and (branch_opt is not None or pr_opt is not None):
-        typer.echo(
-            "Error: Cannot combine --blocked with --branch or --pr",
-            err=True,
-        )
+        typer.echo("Error: Cannot combine --blocked with --branch or --pr", err=True)
         raise typer.Exit(1)
 
-    # Check for conflicts between --branch/--pr and positional issue_numbers
     if (branch_opt is not None or pr_opt is not None) and issue_numbers:
         typer.echo(
             "Error: Cannot combine --branch/--pr with positional issue numbers",
@@ -276,17 +259,13 @@ def resume(
         )
         raise typer.Exit(1)
 
-    # Check if at least one target is specified
+    if blocked and issue_numbers:
+        typer.echo("Error: Cannot combine issue numbers with --blocked", err=True)
+        raise typer.Exit(1)
+
     if not blocked and not issue_numbers and not branch_opt and not pr_opt:
         typer.echo(
             "Error: Must specify --blocked, --branch, --pr, or provide issue numbers",
-            err=True,
-        )
-        raise typer.Exit(1)
-
-    if blocked and issue_numbers:
-        typer.echo(
-            "Error: Cannot combine issue numbers with --blocked",
             err=True,
         )
         raise typer.Exit(1)

--- a/tests/vibe3/commands/test_flow_rebuild.py
+++ b/tests/vibe3/commands/test_flow_rebuild.py
@@ -1,0 +1,177 @@
+"""Tests for flow rebuild command."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from vibe3.cli import app
+
+runner = CliRunner()
+
+
+@patch("vibe3.commands.flow_lifecycle.FlowRebuildUsecase")
+@patch("vibe3.commands.flow_lifecycle.load_issue_info")
+@patch("vibe3.clients.github_client.GitHubClient")
+@patch("vibe3.commands.flow_lifecycle.load_orchestra_config")
+def test_flow_rebuild_position_arg(
+    load_config: MagicMock,
+    github_client: MagicMock,
+    load_issue: MagicMock,
+    rebuild_usecase_cls: MagicMock,
+) -> None:
+    """Existing behavior with positional issue number."""
+    # Mock config
+    load_config.return_value = MagicMock()
+
+    # Mock issue info
+    issue = MagicMock()
+    issue.number = 123
+    load_issue.return_value = issue
+
+    # Mock rebuild usecase
+    rebuild_usecase = MagicMock()
+    rebuild_usecase.rebuild_issue_flow.return_value = {"status": "success"}
+    rebuild_usecase_cls.return_value = rebuild_usecase
+
+    result = runner.invoke(app, ["flow", "rebuild", "123", "--yes"])
+
+    assert result.exit_code == 0
+    assert "Rebuilt flow for issue #123" in result.output
+    rebuild_usecase.rebuild_issue_flow.assert_called_once()
+
+
+@patch("vibe3.commands.flow_lifecycle.FlowService")
+@patch("vibe3.commands.flow_lifecycle.FlowRebuildUsecase")
+@patch("vibe3.commands.flow_lifecycle.load_issue_info")
+@patch("vibe3.clients.github_client.GitHubClient")
+@patch("vibe3.commands.flow_lifecycle.load_orchestra_config")
+@patch("vibe3.commands.flow_lifecycle.resolve_command_branch")
+def test_flow_rebuild_branch_option(
+    resolve_branch: MagicMock,
+    load_config: MagicMock,
+    github_client: MagicMock,
+    load_issue: MagicMock,
+    rebuild_usecase_cls: MagicMock,
+    flow_service_cls: MagicMock,
+) -> None:
+    """`--branch task/issue-123` resolves correctly."""
+    # Mock branch resolution
+    resolve_branch.return_value = "task/issue-123"
+
+    # Mock flow service and issue parsing
+    flow_service = MagicMock()
+    flow_service.store.get_issue_links.return_value = [
+        {"issue_role": "task", "issue_number": 123}
+    ]
+    flow_service_cls.return_value = flow_service
+
+    # Mock config
+    load_config.return_value = MagicMock()
+
+    # Mock issue info
+    issue = MagicMock()
+    issue.number = 123
+    load_issue.return_value = issue
+
+    # Mock rebuild usecase
+    rebuild_usecase = MagicMock()
+    rebuild_usecase.rebuild_issue_flow.return_value = {"status": "success"}
+    rebuild_usecase_cls.return_value = rebuild_usecase
+
+    result = runner.invoke(
+        app, ["flow", "rebuild", "--branch", "task/issue-123", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert "Rebuilt flow for issue #123" in result.output
+    rebuild_usecase.rebuild_issue_flow.assert_called_once()
+    # Verify the branch was passed correctly
+    call_kwargs = rebuild_usecase.rebuild_issue_flow.call_args.kwargs
+    assert call_kwargs["branch"] == "task/issue-123"
+
+
+@patch("vibe3.commands.flow_lifecycle.FlowService")
+@patch("vibe3.commands.flow_lifecycle.FlowRebuildUsecase")
+@patch("vibe3.commands.flow_lifecycle.load_issue_info")
+@patch("vibe3.clients.github_client.GitHubClient")
+@patch("vibe3.commands.flow_lifecycle.load_orchestra_config")
+@patch("vibe3.commands.flow_lifecycle.resolve_command_branch")
+def test_flow_rebuild_pr_option(
+    resolve_branch: MagicMock,
+    load_config: MagicMock,
+    github_client: MagicMock,
+    load_issue: MagicMock,
+    rebuild_usecase_cls: MagicMock,
+    flow_service_cls: MagicMock,
+) -> None:
+    """`--pr 456` resolves PR to branch."""
+    # Mock branch resolution from PR
+    resolve_branch.return_value = "task/issue-456"
+
+    # Mock flow service and issue parsing
+    flow_service = MagicMock()
+    flow_service.store.get_issue_links.return_value = [
+        {"issue_role": "task", "issue_number": 456}
+    ]
+    flow_service_cls.return_value = flow_service
+
+    # Mock config
+    load_config.return_value = MagicMock()
+
+    # Mock issue info
+    issue = MagicMock()
+    issue.number = 456
+    load_issue.return_value = issue
+
+    # Mock rebuild usecase
+    rebuild_usecase = MagicMock()
+    rebuild_usecase.rebuild_issue_flow.return_value = {"status": "success"}
+    rebuild_usecase_cls.return_value = rebuild_usecase
+
+    result = runner.invoke(app, ["flow", "rebuild", "--pr", "456", "--yes"])
+
+    assert result.exit_code == 0
+    assert "Rebuilt flow for issue #456" in result.output
+    rebuild_usecase.rebuild_issue_flow.assert_called_once()
+    # Verify the branch was passed correctly
+    call_kwargs = rebuild_usecase.rebuild_issue_flow.call_args.kwargs
+    assert call_kwargs["branch"] == "task/issue-456"
+
+
+def test_flow_rebuild_no_target() -> None:
+    """No args should error."""
+    result = runner.invoke(app, ["flow", "rebuild"])
+
+    assert result.exit_code != 0
+    assert "Must specify issue number, --branch, or --pr" in result.output
+
+
+def test_flow_rebuild_conflict_branch_and_position() -> None:
+    """`--branch 123 456` should error."""
+    result = runner.invoke(
+        app, ["flow", "rebuild", "--branch", "task/issue-123", "456"]
+    )
+
+    assert result.exit_code != 0
+    assert "不能同时使用" in result.output
+
+
+@patch("vibe3.commands.flow_lifecycle.FlowService")
+@patch("vibe3.commands.flow_lifecycle.resolve_command_branch")
+def test_flow_rebuild_non_issue_branch_error(
+    resolve_branch: MagicMock,
+    flow_service_cls: MagicMock,
+) -> None:
+    """Non-issue branch should error."""
+    # Mock branch resolution to non-issue branch
+    resolve_branch.return_value = "main"
+
+    # Mock flow service and issue parsing (no issue number found)
+    flow_service = MagicMock()
+    flow_service.store.get_issue_links.return_value = []
+    flow_service_cls.return_value = flow_service
+
+    result = runner.invoke(app, ["flow", "rebuild", "--branch", "main", "--yes"])
+
+    assert result.exit_code != 0
+    assert "无法从分支 'main' 解析 issue 编号" in result.output

--- a/tests/vibe3/commands/test_task_resume_command.py
+++ b/tests/vibe3/commands/test_task_resume_command.py
@@ -117,3 +117,95 @@ def test_task_resume_has_no_all_option() -> None:
 
     assert result.exit_code != 0
     assert "No such option" in result.output
+
+
+@patch("vibe3.commands.task.FlowService")
+@patch("vibe3.commands.task._build_resume_usecase")
+@patch("vibe3.commands.task.resolve_command_branch")
+def test_task_resume_branch_resolves_to_issue_number(
+    resolve_branch: MagicMock,
+    build_usecase: MagicMock,
+    flow_service_cls: MagicMock,
+) -> None:
+    """`--branch task/issue-123` resolves to issue #123."""
+    # Mock branch resolution
+    resolve_branch.return_value = "task/issue-123"
+
+    # Mock store.get_issue_links to return task issue
+    flow_service = MagicMock()
+    flow_service.store.get_issue_links.return_value = [
+        {"issue_role": "task", "issue_number": 123}
+    ]
+    flow_service.list_flows.side_effect = [[_flow(123)], []]
+    flow_service_cls.return_value = flow_service
+
+    # Mock usecase
+    usecase = MagicMock()
+    usecase.resume_issues.return_value = {
+        "requested": [123],
+        "resumed": [{"number": 123, "resume_kind": "blocked"}],
+        "skipped": [],
+    }
+    build_usecase.return_value = usecase
+
+    result = runner.invoke(
+        app, ["task", "resume", "--branch", "task/issue-123", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    call = usecase.resume_issues.call_args.kwargs
+    assert call["issue_numbers"] == [123]
+
+
+@patch("vibe3.commands.task.FlowService")
+@patch("vibe3.commands.task._build_resume_usecase")
+@patch("vibe3.commands.task.resolve_command_branch")
+def test_task_resume_pr_resolves_to_issue_number(
+    resolve_branch: MagicMock,
+    build_usecase: MagicMock,
+    flow_service_cls: MagicMock,
+) -> None:
+    """`--pr 456` resolves PR to branch, then to issue."""
+    # Mock branch resolution from PR
+    resolve_branch.return_value = "task/issue-456"
+
+    # Mock store.get_issue_links to return task issue
+    flow_service = MagicMock()
+    flow_service.store.get_issue_links.return_value = [
+        {"issue_role": "task", "issue_number": 456}
+    ]
+    flow_service.list_flows.side_effect = [[_flow(456)], []]
+    flow_service_cls.return_value = flow_service
+
+    # Mock usecase
+    usecase = MagicMock()
+    usecase.resume_issues.return_value = {
+        "requested": [456],
+        "resumed": [{"number": 456, "resume_kind": "blocked"}],
+        "skipped": [],
+    }
+    build_usecase.return_value = usecase
+
+    result = runner.invoke(app, ["task", "resume", "--pr", "456", "--yes"])
+
+    assert result.exit_code == 0
+    call = usecase.resume_issues.call_args.kwargs
+    assert call["issue_numbers"] == [456]
+
+
+def test_task_resume_branch_and_position_conflict() -> None:
+    """`--branch 123 456` should error (conflict)."""
+    result = runner.invoke(app, ["task", "resume", "--branch", "task/issue-123", "456"])
+
+    assert result.exit_code != 0
+    assert "Cannot combine --branch/--pr with positional issue numbers" in result.output
+
+
+def test_task_resume_blocked_and_branch_conflict() -> None:
+    """`--blocked --branch 123` should error."""
+    result = runner.invoke(
+        app, ["task", "resume", "--blocked", "--branch", "task/issue-123"]
+    )
+
+    assert result.exit_code != 0
+    assert "Cannot combine --blocked with --branch or --pr" in result.output


### PR DESCRIPTION
## Summary
Add \`--branch\` and \`--pr\` parameters to \`vibe3 task resume\` and \`vibe3 flow rebuild\` commands, allowing users to specify target issue by branch name or PR number instead of positional argument.

## Changes
- \`src/vibe3/commands/task.py\`:
  - Add \`--branch\` and \`--pr\` options to \`resume()\` command
  - Add conflict detection for \`--blocked\` + \`--branch\`/\`--pr\`
  - Add branch resolution logic using \`resolve_command_branch\`
  - Add \`_parse_issue_number_from_branch\` helper function

- \`src/vibe3/commands/flow_lifecycle.py\`:
  - Make \`issue_number\` argument optional in \`rebuild()\`
  - Add \`--branch\` and \`--pr\` options to \`rebuild()\` command
  - Add target validation (exactly one required)
  - Fix exception handling to use specific exceptions

- \`tests/vibe3/commands/test_task_resume_command.py\`:
  - Add tests for \`--branch\` resolution
  - Add tests for \`--pr\` resolution
  - Add tests for conflict detection

- \`tests/vibe3/commands/test_flow_rebuild.py\` (new):
  - Add tests for positional, \`--branch\`, and \`--pr\` options
  - Add tests for conflict detection
  - Add tests for non-issue branch error handling

## Verification
- ✅ 15 tests passed (task resume + flow rebuild)
- ✅ mypy 0 errors
- ✅ ruff all passed
- ✅ Backward compatibility maintained (positional arguments still work)
- ✅ Parameter conflict detection working
- ✅ Exception handling uses specific exceptions

## Usage Examples

### Using --branch
\`\`\`bash
vibe3 task resume --branch task/issue-1823
vibe3 flow rebuild --branch task/issue-1823
\`\`\`

### Using --pr
\`\`\`bash
vibe3 task resume --pr 1829
vibe3 flow rebuild --pr 1829
\`\`\`

### Positional (backward compatible)
\`\`\`bash
vibe3 task resume 1823
vibe3 flow rebuild 1823
\`\`\`

## Design Notes
- Reuses existing \`resolve_command_branch\` function from branch_arg module
- Maintains backward compatibility with positional argument syntax
- Clear error messages for invalid branches or PR numbers
- Conflict detection prevents ambiguous invocations

Closes #1823

---

## Contributors

claude/opus
