### PR TITLE
refactor(status): remove redundant get_manager_usernames calls

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -221,13 +221,16 @@ def status(
 
     stale_flows = service.list_flows(status="stale") if not all_flows else []
 
+    # Extract manager_usernames once to avoid redundant calls
+    manager_usernames = get_manager_usernames(config)
+
     queued_set = set(orch_snapshot.queued_issues)
     query_service = StatusQueryService(repo=config.repo)
     orchestrated_issues = query_service.fetch_orchestrated_issues(
         flows,
         queued_set,
         stale_flows=stale_flows,
-        manager_usernames=get_manager_usernames(config),
+        manager_usernames=manager_usernames,
         supervisor_label=config.supervisor_handoff.issue_label,
     )
 
@@ -263,7 +266,6 @@ def status(
     # Split missing state items into two categories:
     # 1. Waiting for assignee-pool (no orchestra-governed label) - normal waiting
     # 2. Governed but anomaly (has orchestra-governed label) - needs attention
-    manager_usernames = get_manager_usernames(config)
 
     waiting_for_pool_items = [
         item
@@ -329,7 +331,7 @@ def status(
         bucket = classify_task_status(
             state,
             cast(str | None, item.get("assignee")),
-            get_manager_usernames(config),
+            manager_usernames,
         )
         bucketed_items[bucket].append(item)
 

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -27,8 +27,12 @@ def reset_error_tracking() -> Iterator[None]:
         db_paths.append(ErrorTrackingService._default_instance.db_path)
     ErrorTrackingService.clear_instance()
     for db_path in set(db_paths):
-        # Only handle "no such table" errors - these occur when the DB file
-        # was deleted by concurrent test cleanup. Other errors should propagate.
+        # Only handle "no such table" and "unable to open database file" errors
+        # - These occur when the DB file was deleted by concurrent test cleanup
+        # - Or when the path doesn't exist in worktree environments
+        # Other errors should propagate.
+        if not Path(db_path).exists():
+            continue
         try:
             with sqlite3.connect(db_path) as conn:
                 conn.execute("DELETE FROM error_log")


### PR DESCRIPTION
## Summary

移除 `src/vibe3/commands/status.py` 中冗余的 `get_manager_usernames(config)` 调用。

**Changes**:
- 提取 `manager_usernames` 为局部变量（line 230）
- 复用于 line 266 和 line 332（循环优化）
- 修复测试 fixture 以支持 worktree 环境

**Impact**:
- 性能优化：消除冗余调用（3→1），特别是循环内的调用
- 无功能变更：纯局部变量提取

## Test plan

- [x] `uv run mypy src/vibe3` 通过
- [x] `uv run ruff check src/vibe3` 通过
- [x] `uv run pytest tests/vibe3/` 通过（851 tests）
- [x] 在 worktree 环境中验证测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Contributors**:
- Executor: claude/sonnet (refactoring)
- Reviewer: claude/opus (verdict: PASS)
- Fix: claude/sonnet (test fixture for worktree)