### PR TITLE
test(orchestra): add mock_flow_blocker injection to test_health_check_detects_closed_issue

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -188,8 +188,8 @@ code_limits:
         limit: 540
         reason: "GitHub client PR 测试集，覆盖 auth check、PR create/update、review operations、CI 失败分类与检查步骤解析等多个场景，新增 failure category 测试后略微超标"
       - path: "tests/vibe3/orchestra/test_dispatch_health_checks.py"
-        limit: 470
-        reason: "Health check failure 测试集，7 个独立测试用例验证 coordinator 对 CheckService 结果的处理逻辑，每个测试需要完整 mock setup，拆分会降低可读性"
+        limit: 480
+        reason: "Health check failure 测试集，7 个独立测试用例验证 coordinator 对 CheckService 结果的处理逻辑，每个测试需要完整 mock setup，拆分会降低可读性；新增 mock_flow_blocker 注入对齐测试模式（#1723）"
       - path: "tests/vibe3/orchestra/test_dispatch_state_transitions.py"
         limit: 450
         reason: "Dispatch state transition 测试集，覆盖 promote、dispatch loop、recollection 等状态转换场景，每个测试需要完整 mock setup 和多步断言"

--- a/tests/vibe3/orchestra/test_dispatch_health_checks.py
+++ b/tests/vibe3/orchestra/test_dispatch_health_checks.py
@@ -86,6 +86,10 @@ class TestPreDispatchHealthChecks:
             branch="task/issue-42",
         )
         coordinator._check_service = mock_check_service
+
+        # Mock FlowService to verify block_flow call
+        mock_flow_blocker = MagicMock()
+        coordinator._flow_blocker = mock_flow_blocker
         _setup_health_check_service(coordinator, mock_check_service, store)
 
         result = coordinator._health_check_service.check_issue_health(issue)
@@ -94,6 +98,13 @@ class TestPreDispatchHealthChecks:
         assert (
             result is False
         ), "Health check should return False for consistency failures"
+
+        # Assert - block_flow should be called with correct parameters
+        mock_flow_blocker.block_flow.assert_called_once()
+        call_args = mock_flow_blocker.block_flow.call_args
+        assert call_args[1]["branch"] == "task/issue-42"
+        assert "Health check failed" in call_args[1]["reason"]
+        assert call_args[1]["actor"] == "orchestra:dispatcher"
 
     def test_health_check_passes_for_open_issue(self) -> None:
         """Health check should return True for healthy active flows."""


### PR DESCRIPTION
## Summary

- Add mock_flow_blocker injection to test_health_check_detects_closed_issue
- Ensures test properly mocks flow blocking behavior for closed issues
- Pattern aligned with test_health_check_blocks_on_genuine_failure

## Test plan

- [x] All 7 tests in test_health_check.py pass
- [x] Lint clean (ruff, black, mypy)
- [x] Pattern matches existing test patterns
- [x] Test-only change, low risk

Fixes #1723

---

## Contributors

claude/opus
