### PR TITLE
Unify resume/rebuild recovery architecture to eliminate blocked-issue loops

### DIFF
--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -18,7 +18,11 @@ from loguru import logger
 from vibe3.clients.github_client import GitHubClient
 from vibe3.models.orchestration import IssueState
 from vibe3.services.blocked_state_io import BlockedStateIO
-from vibe3.services.blocked_state_types import BlockedState, ConsistencyReport
+from vibe3.services.blocked_state_types import (
+    BlockedState,
+    ConsistencyReport,
+    UnblockResult,
+)
 from vibe3.services.flow_timeline_service import FlowTimelineService
 from vibe3.services.label_service import LabelService
 
@@ -160,7 +164,7 @@ class BlockedStateService:
         actor: str = "human:resume",
         issue_number: int | None = None,
         detail: str | None = None,
-    ) -> None:
+    ) -> UnblockResult:
         """Atomically clear blocked state in all three sources.
 
         Args:
@@ -170,8 +174,14 @@ class BlockedStateService:
             actor: Actor name for events
             issue_number: GitHub issue number
             detail: Custom timeline detail message (optional)
+
+        Returns:
+            UnblockResult indicating success/failure of each source.
         """
         has_branch = bool(branch)  # Skip DB ops for empty branch
+        body_ok = True
+        db_ok = True
+        label_ok = True
 
         if issue_number:
             try:
@@ -182,6 +192,7 @@ class BlockedStateService:
                     action="unblock",
                     branch=branch,
                 ).error(f"Failed to clear issue body projection: {exc}")
+                body_ok = False
                 raise
 
         if has_branch and self.store:
@@ -193,6 +204,7 @@ class BlockedStateService:
                     action="unblock",
                     branch=branch,
                 ).warning(f"Failed to clear database cache: {exc}")
+                db_ok = False
 
         if issue_number:
             try:
@@ -208,16 +220,15 @@ class BlockedStateService:
                         action="unblock",
                         branch=branch,
                         issue_number=issue_number,
-                    ).warning(
-                        "Label state machine blocked transition from BLOCKED; "
-                        "label may be out of sync with body/DB"
-                    )
+                    ).warning("Label state machine blocked transition from BLOCKED")
+                    label_ok = False
             except Exception as exc:
                 logger.bind(
                     domain="blocked_state",
                     action="unblock",
                     branch=branch,
                 ).warning(f"Failed to write label state: {exc}")
+                label_ok = False
 
         if has_branch and self.store and issue_number:
             try:
@@ -235,6 +246,12 @@ class BlockedStateService:
                     action="unblock",
                     branch=branch,
                 ).warning(f"Failed to write timeline event: {exc}")
+
+        return UnblockResult(
+            body_cleared=body_ok,
+            db_cleared=db_ok,
+            label_cleared=label_ok,
+        )
 
     # ========================================================================
     # Public API: Query Operations

--- a/src/vibe3/services/blocked_state_types.py
+++ b/src/vibe3/services/blocked_state_types.py
@@ -54,3 +54,12 @@ class ConsistencyReport:
     def authoritative_state(self) -> BlockedState:
         """Returns the truth-source state (issue body)."""
         return self.body_state
+
+
+@dataclass(frozen=True)
+class UnblockResult:
+    """Outcome of an unblock operation."""
+
+    body_cleared: bool = True
+    db_cleared: bool = True
+    label_cleared: bool = True

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -312,7 +312,7 @@ class CheckPRService:
                 branch=branch,
                 reason=f"PR #{pr_number} closed without merge",
                 include_remote=True,
-                ensure_worktree=False,
+                ensure_worktree=True,  # FIX: was False, caused worktree_path NULL
             )
 
             logger.bind(

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -449,7 +449,6 @@ class CheckService(CheckRemote):
 
             # Flow consistency check and auto-recovery
             if flow_status not in self.INACTIVE_FLOW_STATUSES:
-                from vibe3.services.flow_consistency_check import check_flow_consistency
                 from vibe3.services.flow_recovery_service import (
                     FlowRecoveryService,
                     RecoveryAction,
@@ -460,14 +459,13 @@ class CheckService(CheckRemote):
                     git_client=self.git_client,
                     github_client=self.github_client,
                 )
-                action = recovery_svc.classify(branch)
+                action, consistency = recovery_svc.classify(branch)
 
                 if action != RecoveryAction.RESUME_ONLY:
-                    # Capture consistency error before recovery attempt
-                    consistency = check_flow_consistency(
-                        branch, flow_data, git_client=self.git_client
+                    # Use precomputed consistency result for error message
+                    consistency_error = (
+                        consistency.reason if consistency else "No flow record"
                     )
-                    consistency_error = consistency.reason
 
                     try:
                         result = recovery_svc.recover(

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -447,60 +447,45 @@ class CheckService(CheckRemote):
                 )
                 return CheckResult(is_valid=True, branch=branch, issues=[])
 
-            # ref files exist
+            # Flow consistency check and auto-recovery
             if flow_status not in self.INACTIVE_FLOW_STATUSES:
-                from vibe3.services.flow_consistency_check import (
-                    check_flow_consistency,
+                from vibe3.services.flow_recovery_service import (
+                    FlowRecoveryService,
+                    RecoveryAction,
                 )
-                from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 
-                consistency = check_flow_consistency(
-                    branch,
-                    flow_data,
+                recovery_svc = FlowRecoveryService(
+                    store=self.store,
                     git_client=self.git_client,
+                    github_client=self.github_client,
                 )
-                if consistency.needs_rebuild:
-                    # Health check is automatic operation - must auto-rebuild
-                    # to fix inconsistent state without human intervention
-                    try:
-                        from vibe3.models.orchestration import IssueInfo
+                action = recovery_svc.classify(branch)
 
-                        rebuild_usecase = FlowRebuildUsecase(
-                            store=self.store,
-                            git_client=self.git_client,
-                            github_client=self.github_client,
-                        )
-                        issue_info = IssueInfo(
-                            number=task_issue or 0,
-                            title=f"Issue {task_issue}",
-                            labels=[IssueState.READY.to_label()],
-                            state=IssueState.READY,
-                        )
-                        rebuild_usecase.rebuild_issue_flow(
-                            issue=issue_info,
+                if action != RecoveryAction.RESUME_ONLY:
+                    try:
+                        result = recovery_svc.recover(
                             branch=branch,
-                            reason=f"Health check auto-rebuild: {consistency.reason}",
-                            include_remote=False,
+                            issue_number=task_issue or 0,
+                            reason="Health check auto-recover",
+                            auto=True,
                             ensure_worktree=True,
                         )
                         logger.info(
-                            "Auto-rebuilt inconsistent flow",
+                            "Auto-recovered inconsistent flow",
                             branch=branch,
-                            code=consistency.code.value,
-                            reason=consistency.reason,
+                            action=result.action.value,
+                            detail=result.detail,
                         )
-                        # Rebuild succeeded, mark as valid
                         return CheckResult(is_valid=True, branch=branch, issues=[])
                     except Exception as e:
-                        # Rebuild failed - report as error
                         logger.error(
-                            "Auto-rebuild failed",
+                            "Auto-recovery failed",
                             branch=branch,
                             error=str(e),
                         )
                         issues.append(
-                            f"Flow consistency issue: {consistency.reason}. "
-                            f"Auto-rebuild failed: {e}. "
+                            f"Flow consistency issue. "
+                            f"Auto-recovery failed: {e}. "
                             f"Manual fix: vibe3 flow rebuild {task_issue} --yes"
                         )
 

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -449,6 +449,7 @@ class CheckService(CheckRemote):
 
             # Flow consistency check and auto-recovery
             if flow_status not in self.INACTIVE_FLOW_STATUSES:
+                from vibe3.services.flow_consistency_check import check_flow_consistency
                 from vibe3.services.flow_recovery_service import (
                     FlowRecoveryService,
                     RecoveryAction,
@@ -462,6 +463,12 @@ class CheckService(CheckRemote):
                 action = recovery_svc.classify(branch)
 
                 if action != RecoveryAction.RESUME_ONLY:
+                    # Capture consistency error before recovery attempt
+                    consistency = check_flow_consistency(
+                        branch, flow_data, git_client=self.git_client
+                    )
+                    consistency_error = consistency.reason
+
                     try:
                         result = recovery_svc.recover(
                             branch=branch,
@@ -483,8 +490,9 @@ class CheckService(CheckRemote):
                             branch=branch,
                             error=str(e),
                         )
+                        # Preserve original consistency error in message
                         issues.append(
-                            f"Flow consistency issue. "
+                            f"{consistency_error}. "
                             f"Auto-recovery failed: {e}. "
                             f"Manual fix: vibe3 flow rebuild {task_issue} --yes"
                         )

--- a/src/vibe3/services/flow_consistency_check.py
+++ b/src/vibe3/services/flow_consistency_check.py
@@ -20,7 +20,13 @@ class FlowConsistencyCode(StrEnum):
 
 @dataclass(frozen=True)
 class FlowConsistencyResult:
-    """Result of shared structural consistency detection."""
+    """Result of shared structural consistency detection.
+
+    Classification:
+    - needs_rebuild: physical scene must be destroyed and recreated
+    - fix_action: cheap local fix (e.g. backfill DB field), no rebuild needed
+    - both False: scene is consistent
+    """
 
     needs_rebuild: bool
     code: FlowConsistencyCode = FlowConsistencyCode.OK
@@ -28,6 +34,8 @@ class FlowConsistencyResult:
     severity: str = ""
     ref_field: str | None = None
     ref_value: str | None = None
+    fix_action: str | None = None
+    worktree_path: str | None = None
 
 
 def check_flow_consistency(
@@ -36,11 +44,13 @@ def check_flow_consistency(
     *,
     git_client: Any,
 ) -> FlowConsistencyResult:
-    """Check whether a flow scene is structurally rebuild-worthy.
+    """Check whether a flow scene is structurally consistent.
 
-    This is intentionally limited to local scene consistency: physical worktree,
-    recorded worktree path, and artifact refs. Remote issue/PR semantics remain
-    in CheckService and QualifyGate.
+    Classification:
+    - MISSING_WORKTREE: physical worktree gone -> needs full rebuild
+    - MISSING_RECORDED_WORKTREE: worktree exists but DB out of sync -> cheap fix
+    - MISSING_REF: artifact ref points to non-existent file -> needs rebuild
+    - OK: scene is consistent
     """
     worktree_path = git_client.find_worktree_path_for_branch(branch)
     if worktree_path is None:
@@ -52,11 +62,15 @@ def check_flow_consistency(
         )
 
     if branch.startswith("task/issue-") and not flow_state.get("worktree_path"):
+        # Worktree physically exists but DB doesn't know about it.
+        # This is a cheap fix: just backfill the DB field.
         return FlowConsistencyResult(
-            needs_rebuild=True,
+            needs_rebuild=False,
             code=FlowConsistencyCode.MISSING_RECORDED_WORKTREE,
             reason="Worktree exists but is not recorded in flow_state",
-            severity="critical",
+            severity="low",
+            fix_action="backfill_worktree_path",
+            worktree_path=str(worktree_path),
         )
 
     for ref_field in ("plan_ref", "report_ref", "audit_ref"):
@@ -79,3 +93,19 @@ def check_flow_consistency(
             )
 
     return FlowConsistencyResult(needs_rebuild=False)
+
+
+def apply_consistency_fix(
+    result: FlowConsistencyResult,
+    branch: str,
+    *,
+    store: Any,
+) -> bool:
+    """Apply a cheap fix identified by check_flow_consistency.
+
+    Returns True if fix was applied, False if no fix applicable.
+    """
+    if result.fix_action == "backfill_worktree_path" and result.worktree_path:
+        store.update_flow_state(branch, worktree_path=result.worktree_path)
+        return True
+    return False

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -192,6 +192,12 @@ class FlowOrchestratorService:
                     use_worktree=True,
                 )
                 result["worktree_path"] = str(worktree_ctx.path)
+                # Persist worktree_path to store -- the in-memory result
+                # is only returned to the caller, so DB must be updated
+                # explicitly for consistency checks to pass later.
+                self.store.update_flow_state(
+                    branch, worktree_path=str(worktree_ctx.path)
+                )
             return result
         except Exception as exc:
             # CRITICAL: Complete cleanup on bootstrap failure

--- a/src/vibe3/services/flow_rebuild_usecase.py
+++ b/src/vibe3/services/flow_rebuild_usecase.py
@@ -119,31 +119,41 @@ class FlowRebuildUsecase:
         branch: str,
         reason: str,
     ) -> None:
-        from vibe3.models.flow import FlowStatusResponse
-        from vibe3.services.flow_service import FlowService
-        from vibe3.services.issue_flow_service import IssueFlowService
-        from vibe3.services.label_service import LabelService
-        from vibe3.services.task_resume_operations import TaskResumeOperations
+        """Clear blocked markers after rebuild.
 
-        flow = FlowStatusResponse(
-            branch=branch,
-            flow_slug=branch,
-            flow_status="active",
-            latest_actor="vibe3:flow_rebuild",
-            task_issue_number=issue_number,
-        )
-        operations = TaskResumeOperations(
-            git_client=self.git_client,
+        Post-rebuild: consistency is guaranteed (we just rebuilt), so we
+        skip the classify step and go straight to clearing blocked state.
+        """
+        from vibe3.models.flow import FlowState
+        from vibe3.models.orchestration import IssueState
+        from vibe3.services.blocked_state_service import BlockedStateService
+        from vibe3.services.flow_resume_resolver import infer_resume_label
+
+        # Determine target state from rebuilt flow
+        fs_dict = self.store.get_flow_state(branch)
+        if fs_dict:
+            target_state = infer_resume_label(FlowState.model_validate(fs_dict))
+        else:
+            target_state = IssueState.READY
+
+        result = BlockedStateService(
             github_client=self.github_client,
-            flow_service=FlowService(store=self.store),
-            label_service=LabelService(),
-            issue_flow_service=IssueFlowService(store=self.store),
-        )
-        operations.reset_issue_to_ready(
+            store=self.store,
+        ).unblock(
+            branch=branch,
+            target_state=target_state,
             issue_number=issue_number,
-            resume_kind="rebuild",
-            flow=flow,
-            repo=None,
-            reason=reason,
-            label_state="",
+            detail=f"Rebuilt and resumed: {reason}",
         )
+
+        if not result.label_cleared:
+            from loguru import logger
+
+            logger.bind(
+                domain="recovery",
+                branch=branch,
+                issue_number=issue_number,
+            ).error(
+                f"Label not cleared after rebuild for #{issue_number}. "
+                f"Manual fix: gh issue edit {issue_number} --remove-label state/blocked"
+            )

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -21,6 +21,7 @@ from loguru import logger
 from vibe3.exceptions import UserError
 from vibe3.services.flow_consistency_check import (
     FlowConsistencyCode,
+    FlowConsistencyResult,
     apply_consistency_fix,
     check_flow_consistency,
 )
@@ -66,29 +67,33 @@ class FlowRecoveryService:
         self.git_client = git_client
         self.github_client = github_client
 
-    def classify(self, branch: str) -> RecoveryAction:
+    def classify(
+        self, branch: str
+    ) -> tuple[RecoveryAction, FlowConsistencyResult | None]:
         """Classify what recovery action a branch needs.
 
         Returns:
-            RESUME_ONLY: scene consistent, just clear blocked markers
-            FIX_AND_RESUME: cheap DB fix + clear blocked markers
-            REBUILD: full scene rebuild + clear blocked markers
+            Tuple of (action, consistency_result):
+            - RESUME_ONLY: scene consistent, just clear blocked markers
+            - FIX_AND_RESUME: cheap DB fix + clear blocked markers
+            - REBUILD: full scene rebuild + clear blocked markers
+            - consistency_result: reusable check result (None if no flow_state)
         """
         flow_state = self.store.get_flow_state(branch)
         if flow_state is None:
-            return RecoveryAction.REBUILD
+            return (RecoveryAction.REBUILD, None)
 
         consistency = check_flow_consistency(
             branch, flow_state, git_client=self.git_client
         )
 
         if consistency.code == FlowConsistencyCode.OK:
-            return RecoveryAction.RESUME_ONLY
+            return (RecoveryAction.RESUME_ONLY, consistency)
         if consistency.fix_action:
-            return RecoveryAction.FIX_AND_RESUME
+            return (RecoveryAction.FIX_AND_RESUME, consistency)
         if consistency.needs_rebuild:
-            return RecoveryAction.REBUILD
-        return RecoveryAction.RESUME_ONLY
+            return (RecoveryAction.REBUILD, consistency)
+        return (RecoveryAction.RESUME_ONLY, consistency)
 
     def recover(
         self,
@@ -103,7 +108,7 @@ class FlowRecoveryService:
         """Execute the full recovery: classify -> act -> resume.
 
         Args:
-            branch: Flow branch name
+            branch: Flow branch name (empty string if no flow)
             issue_number: GitHub issue number
             reason: Human-readable reason for recovery
             auto: True for orchestra/health-check paths (auto-rebuild);
@@ -111,7 +116,37 @@ class FlowRecoveryService:
             ensure_worktree: Whether rebuild should create worktree
             include_remote: Whether rebuild should delete remote branch
         """
-        flow_state = self.store.get_flow_state(branch) or {}
+        # Special case: no branch (issue with no flow) -> just clear label
+        if not branch:
+            self._do_resume(branch, issue_number, reason)
+            return RecoveryResult(
+                action=RecoveryAction.RESUME_ONLY,
+                success=True,
+                detail="No flow branch; cleared blocked markers",
+            )
+
+        flow_state = self.store.get_flow_state(branch)
+
+        # Short-circuit: no flow record -> rebuild (consistent with classify())
+        if flow_state is None:
+            if not auto:
+                raise UserError(
+                    f"No flow record found for branch '{branch}'. "
+                    f"Run: vibe3 flow rebuild {issue_number} --yes"
+                )
+            self._do_rebuild(
+                branch,
+                issue_number,
+                reason,
+                ensure_worktree=ensure_worktree,
+                include_remote=include_remote,
+            )
+            self._do_resume(branch, issue_number, reason)
+            return RecoveryResult(
+                action=RecoveryAction.REBUILD,
+                success=True,
+                detail="No flow record; rebuilt scene and cleared blocked markers",
+            )
 
         consistency = check_flow_consistency(
             branch, flow_state, git_client=self.git_client
@@ -174,7 +209,11 @@ class FlowRecoveryService:
         )
 
     def _do_resume(self, branch: str, issue_number: int, reason: str) -> None:
-        """Clear blocked markers from all three sources (DB, body, label)."""
+        """Clear blocked markers from all three sources (DB, body, label).
+
+        Raises:
+            RuntimeError: If label write fails (RC2: prevents silent failure)
+        """
         from vibe3.models.flow import FlowState
         from vibe3.models.orchestration import IssueState
         from vibe3.services.blocked_state_service import BlockedStateService
@@ -196,14 +235,20 @@ class FlowRecoveryService:
             label_service=None,  # uses default
             store=self.store,
         )
-        service.unblock(
+        result = service.unblock(
             branch=branch,
             target_state=target_state,
             issue_number=issue_number,
             detail=f"Recovery resume: {reason}",
         )
-        # TODO(Task 4): After unblock() returns UnblockResult, check result
-        # and log if label_cleared is False
+
+        # RC2 fix: Fail-fast if label not cleared to prevent blocked loop
+        if not result.label_cleared:
+            raise RuntimeError(
+                f"Failed to clear state/blocked label on issue #{issue_number}. "
+                f"Manual fix: gh issue edit {issue_number} "
+                "--remove-label state/blocked"
+            )
 
     def _do_rebuild(
         self,

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -182,8 +182,12 @@ class FlowRecoveryService:
 
         # Determine target state from flow progress
         fs_dict = self.store.get_flow_state(branch)
-        if fs_dict:
-            target_state = infer_resume_label(FlowState.model_validate(fs_dict))
+        if fs_dict and isinstance(fs_dict, dict):
+            try:
+                target_state = infer_resume_label(FlowState.model_validate(fs_dict))
+            except Exception:
+                # Fallback to READY if validation fails
+                target_state = IssueState.READY
         else:
             target_state = IssueState.READY
 

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -1,0 +1,280 @@
+"""Unified flow recovery service.
+
+Single entry point for all recovery paths: health check auto-recover,
+PR-closed reset, manual task resume, and manual flow rebuild.
+
+Decision tree:
+  consistency OK           --> resume only (clear label + body + DB)
+  MISSING_RECORDED_WORKTREE --> fix (backfill DB) + resume
+  MISSING_WORKTREE          --> rebuild (delete + bootstrap) + resume
+  MISSING_REF               --> manual: guide user; auto: rebuild + resume
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from vibe3.exceptions import UserError
+from vibe3.services.flow_consistency_check import (
+    FlowConsistencyCode,
+    apply_consistency_fix,
+    check_flow_consistency,
+)
+
+if TYPE_CHECKING:
+    from vibe3.clients.git_client import GitClient
+    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients.sqlite_client import SQLiteClient
+
+
+class RecoveryAction(StrEnum):
+    """What kind of recovery is needed."""
+
+    RESUME_ONLY = "resume_only"
+    FIX_AND_RESUME = "fix_and_resume"
+    REBUILD = "rebuild"
+
+
+@dataclass
+class RecoveryResult:
+    """Outcome of a recovery attempt."""
+
+    action: RecoveryAction
+    success: bool
+    detail: str = ""
+
+
+class FlowRecoveryService:
+    """Unified recovery: classify inconsistency, act, resume.
+
+    All recovery paths (health check, PR closed, manual resume, manual
+    rebuild) call into this service so the logic is never duplicated.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: SQLiteClient,
+        git_client: GitClient,
+        github_client: GitHubClient,
+    ) -> None:
+        self.store = store
+        self.git_client = git_client
+        self.github_client = github_client
+
+    def classify(self, branch: str) -> RecoveryAction:
+        """Classify what recovery action a branch needs.
+
+        Returns:
+            RESUME_ONLY: scene consistent, just clear blocked markers
+            FIX_AND_RESUME: cheap DB fix + clear blocked markers
+            REBUILD: full scene rebuild + clear blocked markers
+        """
+        flow_state = self.store.get_flow_state(branch)
+        if flow_state is None:
+            return RecoveryAction.REBUILD
+
+        consistency = check_flow_consistency(
+            branch, flow_state, git_client=self.git_client
+        )
+
+        if consistency.code == FlowConsistencyCode.OK:
+            return RecoveryAction.RESUME_ONLY
+        if consistency.fix_action:
+            return RecoveryAction.FIX_AND_RESUME
+        if consistency.needs_rebuild:
+            return RecoveryAction.REBUILD
+        return RecoveryAction.RESUME_ONLY
+
+    def recover(
+        self,
+        *,
+        branch: str,
+        issue_number: int,
+        reason: str,
+        auto: bool,
+        ensure_worktree: bool = True,
+        include_remote: bool = False,
+    ) -> RecoveryResult:
+        """Execute the full recovery: classify -> act -> resume.
+
+        Args:
+            branch: Flow branch name
+            issue_number: GitHub issue number
+            reason: Human-readable reason for recovery
+            auto: True for orchestra/health-check paths (auto-rebuild);
+                  False for manual paths (guide user instead of rebuilding)
+            ensure_worktree: Whether rebuild should create worktree
+            include_remote: Whether rebuild should delete remote branch
+        """
+        flow_state = self.store.get_flow_state(branch) or {}
+
+        consistency = check_flow_consistency(
+            branch, flow_state, git_client=self.git_client
+        )
+
+        # --- Classify ---
+        if consistency.code == FlowConsistencyCode.OK:
+            self._do_resume(branch, issue_number, reason)
+            return RecoveryResult(
+                action=RecoveryAction.RESUME_ONLY,
+                success=True,
+                detail="Scene consistent; cleared blocked markers",
+            )
+
+        if consistency.fix_action:
+            applied = apply_consistency_fix(consistency, branch, store=self.store)
+            if applied:
+                logger.bind(
+                    domain="recovery", branch=branch, fix=consistency.fix_action
+                ).info("Applied cheap consistency fix")
+            self._do_resume(branch, issue_number, reason)
+            return RecoveryResult(
+                action=RecoveryAction.FIX_AND_RESUME,
+                success=True,
+                detail=(
+                    f"Applied fix ({consistency.fix_action}); "
+                    "cleared blocked markers"
+                ),
+            )
+
+        if consistency.needs_rebuild:
+            if not auto:
+                raise UserError(
+                    f"{consistency.reason}. "
+                    f"Run: vibe3 flow rebuild {issue_number} --yes"
+                )
+            self._do_rebuild(
+                branch,
+                issue_number,
+                reason,
+                ensure_worktree=ensure_worktree,
+                include_remote=include_remote,
+            )
+            self._do_resume(branch, issue_number, reason)
+            return RecoveryResult(
+                action=RecoveryAction.REBUILD,
+                success=True,
+                detail=(
+                    f"Rebuilt scene and cleared blocked markers: "
+                    f"{consistency.reason}"
+                ),
+            )
+
+        # Should not reach here
+        self._do_resume(branch, issue_number, reason)
+        return RecoveryResult(
+            action=RecoveryAction.RESUME_ONLY,
+            success=True,
+            detail="Fallback: cleared blocked markers",
+        )
+
+    def _do_resume(self, branch: str, issue_number: int, reason: str) -> None:
+        """Clear blocked markers from all three sources (DB, body, label)."""
+        from vibe3.models.flow import FlowState
+        from vibe3.models.orchestration import IssueState
+        from vibe3.services.blocked_state_service import BlockedStateService
+        from vibe3.services.flow_resume_resolver import infer_resume_label
+
+        # Determine target state from flow progress
+        fs_dict = self.store.get_flow_state(branch)
+        if fs_dict:
+            target_state = infer_resume_label(FlowState.model_validate(fs_dict))
+        else:
+            target_state = IssueState.READY
+
+        service = BlockedStateService(
+            github_client=self.github_client,
+            label_service=None,  # uses default
+            store=self.store,
+        )
+        service.unblock(
+            branch=branch,
+            target_state=target_state,
+            issue_number=issue_number,
+            detail=f"Recovery resume: {reason}",
+        )
+        # TODO(Task 4): After unblock() returns UnblockResult, check result
+        # and log if label_cleared is False
+
+    def _do_rebuild(
+        self,
+        branch: str,
+        issue_number: int,
+        reason: str,
+        *,
+        ensure_worktree: bool = True,
+        include_remote: bool = False,
+    ) -> None:
+        """Hard rebuild: cleanup + bootstrap (NO resume -- caller does that)."""
+        from vibe3.config.orchestra_settings import load_orchestra_config
+        from vibe3.models.orchestration import IssueInfo, IssueState
+        from vibe3.services.flow_cleanup_service import FlowCleanupService
+        from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+        from vibe3.services.handoff_service import HandoffService
+        from vibe3.services.issue_context_loader import load_issue_info
+
+        # Load issue info from GitHub
+        config = load_orchestra_config()
+        try:
+            issue_info = load_issue_info(
+                issue_number, config=config, github=self.github_client
+            )
+        except Exception:
+            issue_info = IssueInfo(
+                number=issue_number,
+                title=f"Issue {issue_number}",
+                labels=[IssueState.READY.to_label()],
+                state=IssueState.READY,
+            )
+
+        # Step 1: Cleanup old scene
+        cleanup_results = FlowCleanupService(
+            git_client=self.git_client,
+            store=self.store,
+        ).cleanup_flow_scene(
+            branch,
+            include_remote=include_remote,
+            terminate_sessions=True,
+            keep_flow_record=False,
+            force_delete=True,
+        )
+        failed_steps = [s for s, ok in cleanup_results.items() if not ok]
+        if failed_steps:
+            raise RuntimeError(
+                f"Cleanup failed for: {', '.join(failed_steps)}. "
+                "Cannot rebuild in dirty state."
+            )
+
+        # Step 2: Bootstrap new flow + worktree
+        orchestrator = FlowOrchestratorService(
+            config,
+            store=self.store,
+            git=self.git_client,
+            github=self.github_client,
+        )
+        orchestrator.bootstrap_issue_flow(
+            issue_info,
+            branch=branch,
+            slug=f"issue-{issue_number}",
+            source="flow:rebuild",
+            initiated_by="flow:rebuild",
+            ensure_worktree=ensure_worktree,
+            reactivate_existing=False,
+        )
+
+        # Step 3: Handoff record
+        HandoffService(
+            store=self.store,
+            git_client=self.git_client,
+            github_client=self.github_client,
+        ).append_current_handoff(
+            message=f"Flow rebuilt: {reason}",
+            actor="vibe3:flow_rebuild",
+            kind="milestone",
+            branch=branch,
+        )

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -10,10 +10,6 @@ from typing import TYPE_CHECKING, Callable
 
 from vibe3.exceptions import UserError
 from vibe3.models.orchestration import IssueState
-from vibe3.services.flow_consistency_check import (
-    FlowConsistencyResult,
-    check_flow_consistency,
-)
 
 if TYPE_CHECKING:
     from vibe3.clients.git_client import GitClient
@@ -43,21 +39,6 @@ class TaskResumeOperations:
         self.flow_service = flow_service
         self.label_service = label_service
         self.issue_flow_service = issue_flow_service
-
-    def _check_flow_consistency(
-        self, branch: str | None
-    ) -> FlowConsistencyResult | None:
-        """Return shared consistency result for an existing branch flow."""
-        if not isinstance(branch, str) or not branch:
-            return None
-        flow_state = self.flow_service.store.get_flow_state(branch)
-        if not flow_state:
-            return None
-        return check_flow_consistency(
-            branch,
-            flow_state,
-            git_client=self.git_client,
-        )
 
     def reset_issue_to_ready(
         self,
@@ -92,35 +73,23 @@ class TaskResumeOperations:
             if progress_callback:
                 progress_callback(issue_number, branch, step, status)
 
-        consistency = self._check_flow_consistency(branch)
-        if consistency and consistency.needs_rebuild:
-            # Task resume is manual operation - give user clear guidance
-            raise UserError(
-                f"{consistency.reason}. "
-                f"Suggestion: vibe3 flow rebuild {issue_number} --yes"
-            )
+        emit_progress("checking consistency and recovering")
 
-        target_state = self._resolve_target_state(branch, label_state)
+        # Delegate to unified recovery service (manual path: auto=False)
+        from vibe3.services.flow_recovery_service import FlowRecoveryService
 
-        emit_progress(
-            f"clearing reasons for branch {branch}"
-            if isinstance(branch, str)
-            else "clearing reasons (no branch)"
-        )
-
-        from vibe3.services.blocked_state_service import BlockedStateService
-
-        BlockedStateService(
-            github_client=self.github_client,
-            label_service=self.label_service,
+        recovery = FlowRecoveryService(
             store=self.flow_service.store,
-        ).unblock(
-            branch=branch or "",
-            target_state=target_state,
-            issue_number=issue_number,
-            detail=f"Resumed from {resume_kind} to {target_state.value}: {reason}",
+            git_client=self.git_client,
+            github_client=self.github_client,
         )
-        emit_progress("label resume done", status="done")
+        recovery.recover(
+            branch=branch or "",
+            issue_number=issue_number,
+            reason=f"Resumed from {resume_kind}: {reason}",
+            auto=False,
+        )
+        emit_progress("recovery complete", status="done")
 
     def _guard_no_live_sessions(self, branch: str) -> None:
         from vibe3.agents import CodeagentBackend

--- a/tests/vibe3/services/test_blocked_state_service.py
+++ b/tests/vibe3/services/test_blocked_state_service.py
@@ -312,4 +312,61 @@ def test_block_respects_state_machine_on_double_block(tmp_path: Path) -> None:
     flow_state = store.get_flow_state("test-branch")
     assert flow_state.get("flow_status") == "blocked"
     assert flow_state.get("blocked_reason") == "Second failure"
+
+
+def test_unblock_returns_result_with_label_status(tmp_path: Path) -> None:
+    """unblock() should return UnblockResult with label_cleared status."""
+    store = SQLiteClient(db_path=str(tmp_path / "test.db"))
+    store.update_flow_state(
+        "test-branch",
+        flow_slug="test",
+        flow_status="blocked",
+        blocked_reason="Previous error",
+    )
+
+    github = StubGitHubClient()
+    label_service = StubLabelService()
+    label_service.current_state = IssueState.BLOCKED
+
+    svc = BlockedStateService(
+        store=store, github_client=github, label_service=label_service
+    )
+    result = svc.unblock(
+        branch="test-branch",
+        target_state=IssueState.READY,
+        issue_number=123,
+        detail="test",
+    )
+    assert hasattr(result, "label_cleared")
+    assert result.label_cleared is True
+
+
+def test_unblock_reports_label_failure(tmp_path: Path) -> None:
+    """unblock() should report when label write fails."""
+    from unittest.mock import MagicMock
+
+    store = SQLiteClient(db_path=str(tmp_path / "test.db"))
+    store.update_flow_state(
+        "test-branch",
+        flow_slug="test",
+        flow_status="blocked",
+        blocked_reason="Previous error",
+    )
+
+    github = StubGitHubClient()
+    label_service = StubLabelService()
+    label_service.current_state = IssueState.BLOCKED
+
+    svc = BlockedStateService(
+        store=store, github_client=github, label_service=label_service
+    )
+    # Make label write fail
+    svc._io.write_label_state = MagicMock(side_effect=Exception("API error"))
+
+    result = svc.unblock(
+        branch="test-branch",
+        target_state=IssueState.READY,
+        issue_number=123,
+    )
+    assert result.label_cleared is False
     assert label_service.current_state == IssueState.BLOCKED

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -72,7 +72,9 @@ def test_handle_closed_pr_resets_issue_to_ready() -> None:
         assert call["issue"] == mock_issue_info
         assert call["branch"] == "task/issue-456"
         assert call["include_remote"] is True
-        assert call["ensure_worktree"] is False
+        assert (
+            call["ensure_worktree"] is True
+        )  # FIX: was False, caused worktree_path NULL
 
         assert handled is True
         assert len(issues) == 0

--- a/tests/vibe3/services/test_flow_consistency_check.py
+++ b/tests/vibe3/services/test_flow_consistency_check.py
@@ -1,4 +1,4 @@
-"""Tests for shared flow consistency detection."""
+"""Tests for flow consistency check and recovery classification."""
 
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -9,54 +9,57 @@ from vibe3.services.flow_consistency_check import (
 )
 
 
-def test_missing_worktree_requires_rebuild() -> None:
-    """A recorded flow with no physical worktree must be rebuilt."""
-    git_client = MagicMock()
-    git_client.find_worktree_path_for_branch.return_value = None
+def _make_git_client(worktree_path=None):
+    git = MagicMock()
+    git.find_worktree_path_for_branch.return_value = worktree_path
+    return git
 
-    result = check_flow_consistency(
-        "task/issue-303",
-        {"branch": "task/issue-303", "worktree_path": "/tmp/missing"},
-        git_client=git_client,
-    )
 
-    assert result.needs_rebuild is True
+def test_ok_when_worktree_and_recorded_path_match():
+    git = _make_git_client(Path("/wt/task/issue-1"))
+    state = {"worktree_path": "/wt/task/issue-1"}
+    result = check_flow_consistency("task/issue-1", state, git_client=git)
+    assert result.code == FlowConsistencyCode.OK
+    assert not result.needs_rebuild
+
+
+def test_missing_worktree_needs_rebuild():
+    git = _make_git_client(None)
+    state = {"worktree_path": "/wt/task/issue-1"}
+    result = check_flow_consistency("task/issue-1", state, git_client=git)
     assert result.code == FlowConsistencyCode.MISSING_WORKTREE
+    assert result.needs_rebuild
 
 
-def test_missing_recorded_worktree_path_requires_rebuild(
-    tmp_path: Path,
-) -> None:
-    """A task worktree that exists but is not recorded is an inconsistent scene."""
-    git_client = MagicMock()
-    git_client.find_worktree_path_for_branch.return_value = tmp_path
-
-    result = check_flow_consistency(
-        "task/issue-303",
-        {"branch": "task/issue-303", "worktree_path": None},
-        git_client=git_client,
-    )
-
-    assert result.needs_rebuild is True
+def test_missing_recorded_worktree_is_fixable():
+    """Worktree exists physically but not recorded -- cheap fix, not rebuild."""
+    git = _make_git_client(Path("/wt/task/issue-1"))
+    state = {}  # no worktree_path in state
+    result = check_flow_consistency("task/issue-1", state, git_client=git)
     assert result.code == FlowConsistencyCode.MISSING_RECORDED_WORKTREE
+    assert not result.needs_rebuild  # NEW: fixable, not rebuild-worthy
+    assert result.fix_action == "backfill_worktree_path"
 
 
-def test_missing_ref_requires_rebuild(tmp_path: Path) -> None:
-    """Missing refs should produce a rebuild recommendation, not label resume."""
-    git_client = MagicMock()
-    git_client.find_worktree_path_for_branch.return_value = tmp_path
-    (tmp_path / "docs" / "plans").mkdir(parents=True)
+def test_missing_ref_needs_rebuild():
+    git = _make_git_client(Path("/wt/task/issue-1"))
+    state = {"worktree_path": "/wt/task/issue-1", "plan_ref": "docs/plans/missing.md"}
+    # Mock check_ref_exists to return False
+    import vibe3.services.flow_consistency_check as mod
 
-    result = check_flow_consistency(
-        "task/issue-303",
-        {
-            "branch": "task/issue-303",
-            "worktree_path": str(tmp_path),
-            "plan_ref": "docs/plans/missing.md",
-        },
-        git_client=git_client,
-    )
+    orig = mod.check_ref_exists
+    mod.check_ref_exists = lambda ref, branch, **kw: (ref, False)
+    try:
+        result = check_flow_consistency("task/issue-1", state, git_client=git)
+        assert result.code == FlowConsistencyCode.MISSING_REF
+        assert result.needs_rebuild
+    finally:
+        mod.check_ref_exists = orig
 
-    assert result.needs_rebuild is True
-    assert result.code == FlowConsistencyCode.MISSING_REF
-    assert result.ref_field == "plan_ref"
+
+def test_non_task_branch_skips_recorded_check():
+    """dev/ branches don't require recorded worktree_path."""
+    git = _make_git_client(Path("/wt/dev/issue-1"))
+    state = {}  # no worktree_path
+    result = check_flow_consistency("dev/issue-1", state, git_client=git)
+    assert result.code == FlowConsistencyCode.OK

--- a/tests/vibe3/services/test_flow_orchestrator_service.py
+++ b/tests/vibe3/services/test_flow_orchestrator_service.py
@@ -219,6 +219,42 @@ def test_create_flow_for_issue_uses_shared_bootstrap_interface() -> None:
     assert result == {"branch": "task/issue-777"}
 
 
+def test_bootstrap_persists_worktree_path() -> None:
+    """bootstrap_issue_flow with ensure_worktree=True must persist worktree_path."""
+    from vibe3.models.orchestration import IssueState
+
+    config = load_orchestra_config()
+    store = MagicMock()
+    git = MagicMock()
+    github = MagicMock()
+    git.branch_exists.return_value = False
+    git.get_git_common_dir.return_value = "/tmp/repo/.git"
+    store.get_flow_state.return_value = {
+        "branch": "task/issue-999",
+        "flow_slug": "issue-999",
+    }
+    service = FlowOrchestratorService(config, store=store, git=git, github=github)
+    service.flow_service.create_flow = MagicMock(
+        return_value=MagicMock(model_dump=lambda: {"branch": "task/issue-999"})
+    )
+
+    # Mock worktree resolution
+    with patch("vibe3.services.flow_orchestrator_service.WorktreeManager") as mock_wm:
+        mock_ctx = MagicMock()
+        mock_ctx.path = Path("/tmp/worktrees/task/issue-999")
+        mock_wm.return_value.resolve_bootstrap_worktree_context.return_value = mock_ctx
+
+        issue = IssueInfo(number=999, title="Test", labels=[], state=IssueState.READY)
+        service.bootstrap_issue_flow(
+            issue, branch="task/issue-999", ensure_worktree=True
+        )
+
+    # Verify worktree_path was persisted to store
+    store.update_flow_state.assert_any_call(
+        "task/issue-999", worktree_path=str(mock_ctx.path)
+    )
+
+
 def test_rebuild_stale_issue_flow_delegates_to_flow_rebuild_usecase() -> None:
     config = load_orchestra_config()
     github = MagicMock()

--- a/tests/vibe3/services/test_flow_recovery_service.py
+++ b/tests/vibe3/services/test_flow_recovery_service.py
@@ -31,12 +31,12 @@ class TestClassifyRecovery:
             worktree_path=Path("/wt/task/issue-1"),
             flow_state={"worktree_path": "/wt/task/issue-1"},
         )
-        action = svc.classify("task/issue-1")
+        action, _ = svc.classify("task/issue-1")
         assert action == RecoveryAction.RESUME_ONLY
 
     def test_missing_worktree_returns_rebuild(self):
         svc = _make_service(worktree_path=None, flow_state={})
-        action = svc.classify("task/issue-1")
+        action, _ = svc.classify("task/issue-1")
         assert action == RecoveryAction.REBUILD
 
     def test_missing_recorded_worktree_returns_fix_and_resume(self):
@@ -44,7 +44,7 @@ class TestClassifyRecovery:
             worktree_path=Path("/wt/task/issue-1"),
             flow_state={},  # no worktree_path recorded
         )
-        action = svc.classify("task/issue-1")
+        action, _ = svc.classify("task/issue-1")
         assert action == RecoveryAction.FIX_AND_RESUME
 
     def test_missing_ref_returns_rebuild(self):
@@ -59,7 +59,7 @@ class TestClassifyRecovery:
             "vibe3.services.flow_consistency_check.check_ref_exists",
             return_value=("docs/plans/missing.md", False),
         ):
-            action = svc.classify("task/issue-1")
+            action, _ = svc.classify("task/issue-1")
         assert action == RecoveryAction.REBUILD
 
 

--- a/tests/vibe3/services/test_flow_recovery_service.py
+++ b/tests/vibe3/services/test_flow_recovery_service.py
@@ -1,0 +1,130 @@
+"""Tests for unified flow recovery service."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vibe3.services.flow_recovery_service import (
+    FlowRecoveryService,
+    RecoveryAction,
+)
+
+
+def _make_service(
+    *,
+    worktree_path=None,
+    flow_state=None,
+    ref_exists=True,
+):
+    store = MagicMock()
+    store.get_flow_state.return_value = flow_state or {}
+    git = MagicMock()
+    git.find_worktree_path_for_branch.return_value = worktree_path
+    github = MagicMock()
+    return FlowRecoveryService(store=store, git_client=git, github_client=github)
+
+
+class TestClassifyRecovery:
+    def test_healthy_flow_returns_resume_only(self):
+        svc = _make_service(
+            worktree_path=Path("/wt/task/issue-1"),
+            flow_state={"worktree_path": "/wt/task/issue-1"},
+        )
+        action = svc.classify("task/issue-1")
+        assert action == RecoveryAction.RESUME_ONLY
+
+    def test_missing_worktree_returns_rebuild(self):
+        svc = _make_service(worktree_path=None, flow_state={})
+        action = svc.classify("task/issue-1")
+        assert action == RecoveryAction.REBUILD
+
+    def test_missing_recorded_worktree_returns_fix_and_resume(self):
+        svc = _make_service(
+            worktree_path=Path("/wt/task/issue-1"),
+            flow_state={},  # no worktree_path recorded
+        )
+        action = svc.classify("task/issue-1")
+        assert action == RecoveryAction.FIX_AND_RESUME
+
+    def test_missing_ref_returns_rebuild(self):
+        svc = _make_service(
+            worktree_path=Path("/wt/task/issue-1"),
+            flow_state={
+                "worktree_path": "/wt/task/issue-1",
+                "plan_ref": "docs/plans/missing.md",
+            },
+        )
+        with patch(
+            "vibe3.services.flow_consistency_check.check_ref_exists",
+            return_value=("docs/plans/missing.md", False),
+        ):
+            action = svc.classify("task/issue-1")
+        assert action == RecoveryAction.REBUILD
+
+
+class TestRecover:
+    def test_resume_only_clears_blocked_state(self):
+        """When scene is healthy, recover() just clears blocked markers."""
+        svc = _make_service(
+            worktree_path=Path("/wt/task/issue-1"),
+            flow_state={"worktree_path": "/wt/task/issue-1"},
+        )
+        with patch.object(svc, "_do_resume") as mock_resume:
+            result = svc.recover(
+                branch="task/issue-1",
+                issue_number=1,
+                reason="manual resume",
+                auto=False,
+            )
+        assert result.action == RecoveryAction.RESUME_ONLY
+        assert result.success
+        mock_resume.assert_called_once()
+
+    def test_fix_and_resume_backfills_then_clears(self):
+        svc = _make_service(
+            worktree_path=Path("/wt/task/issue-1"),
+            flow_state={},
+        )
+        with patch.object(svc, "_do_resume") as mock_resume:
+            result = svc.recover(
+                branch="task/issue-1",
+                issue_number=1,
+                reason="auto recover",
+                auto=True,
+            )
+        assert result.action == RecoveryAction.FIX_AND_RESUME
+        assert result.success
+        # Verify backfill happened
+        svc.store.update_flow_state.assert_any_call(
+            "task/issue-1", worktree_path=str(Path("/wt/task/issue-1"))
+        )
+        mock_resume.assert_called_once()
+
+    def test_rebuild_auto_does_full_rebuild_then_resume(self):
+        svc = _make_service(worktree_path=None, flow_state={})
+        with (
+            patch.object(svc, "_do_rebuild") as mock_rebuild,
+            patch.object(svc, "_do_resume") as mock_resume,
+        ):
+            result = svc.recover(
+                branch="task/issue-1",
+                issue_number=1,
+                reason="health check",
+                auto=True,
+            )
+        assert result.action == RecoveryAction.REBUILD
+        assert result.success
+        mock_rebuild.assert_called_once()
+        mock_resume.assert_called_once()
+
+    def test_rebuild_manual_raises_for_user_guidance(self):
+        """Manual path (task resume) should NOT auto-rebuild; guide user."""
+        svc = _make_service(worktree_path=None, flow_state={})
+        with pytest.raises(Exception, match="flow rebuild"):
+            svc.recover(
+                branch="task/issue-1",
+                issue_number=1,
+                reason="manual",
+                auto=False,
+            )

--- a/tests/vibe3/services/test_task_resume_label_state.py
+++ b/tests/vibe3/services/test_task_resume_label_state.py
@@ -328,9 +328,10 @@ def test_label_auto_with_missing_physical_worktree_requires_rebuild() -> None:
     assert "vibe3 flow rebuild 303 --yes" in str(exc_info.value)
 
 
-def test_label_auto_with_unrecorded_existing_worktree_requires_rebuild() -> None:
-    """A physical task worktree without flow_state.worktree_path is inconsistent."""
+def test_label_auto_with_unrecorded_existing_worktree_fixes_and_resumes() -> None:
+    """A physical task worktree without flow_state.worktree_path gets backfilled."""
     operations = _make_operations()
+    operations.github_client.get_issue_body.return_value = "User content"
     operations.flow_service.store.get_flow_state.return_value = {
         "branch": "task/issue-303",
         "flow_slug": "issue-303",
@@ -346,8 +347,12 @@ def test_label_auto_with_unrecorded_existing_worktree_requires_rebuild() -> None
     mock_flow = MagicMock()
     mock_flow.branch = "task/issue-303"
 
-    # Task resume is manual operation - should raise UserError with rebuild suggestion
-    with pytest.raises(UserError) as exc_info:
+    with patch(
+        "vibe3.services.blocked_state_service.BlockedStateService"
+    ) as mock_service_cls:
+        mock_service = MagicMock()
+        mock_service_cls.return_value = mock_service
+
         operations.reset_issue_to_ready(
             issue_number=303,
             resume_kind="blocked",
@@ -357,5 +362,11 @@ def test_label_auto_with_unrecorded_existing_worktree_requires_rebuild() -> None
             label_state="",
         )
 
-    assert "not recorded in flow_state" in str(exc_info.value)
-    assert "vibe3 flow rebuild 303 --yes" in str(exc_info.value)
+        # Verify: worktree NOT deleted
+        operations.git_client.remove_worktree.assert_not_called()
+
+        # Verify: BlockedStateService.unblock was called (resume succeeded)
+        mock_service.unblock.assert_called_once()
+
+        # Verify: DB was backfilled with worktree_path
+        operations.flow_service.store.update_flow_state.assert_called()


### PR DESCRIPTION
## Summary

Eliminates three closed-loop defects where issues remain permanently blocked after resume by unifying the recovery decision tree across health check, task resume, and flow rebuild:

- **RC1 Fix**: Persists `worktree_path` to SQLite in `bootstrap_issue_flow` (prevents NULL worktree_path causing infinite rebuild loops)
- **RC2 Fix**: `BlockedStateService.unblock()` now returns `UnblockResult` to detect label write failures
- **Architecture**: Single `FlowRecoveryService` owns the decision tree: consistency check → classify → act (fix or rebuild) → resume
- **Classification**: `MISSING_RECORDED_WORKTREE` is now a cheap DB fix, not a full rebuild

## Changes

### Core Architecture (Task 3)
- Created `FlowRecoveryService` as single recovery entry point
- Three recovery actions: `RESUME_ONLY`, `FIX_AND_RESUME`, `REBUILD`
- Auto vs manual paths differentiated by `auto` boolean parameter

### Bug Fixes (Tasks 1, 4)
- Fixed worktree_path persistence bug in `flow_orchestrator_service.py`
- Changed `BlockedStateService.unblock()` to return `UnblockResult` dataclass

### Classification Enhancement (Task 2)
- Added `fix_action` and `worktree_path` fields to `FlowConsistencyResult`
- Added `apply_consistency_fix()` function for cheap fixes
- `MISSING_RECORDED_WORKTREE` now classified as fixable (backfill DB) vs rebuild-worthy

### Wiring (Task 5)
- `task_resume_operations`: delegates to `FlowRecoveryService(auto=False)`
- `flow_rebuild_usecase`: post-rebuild resume skips re-check
- `check_service`: replaces inline auto-rebuild with `FlowRecoveryService(auto=True)`
- `check_pr_service`: `ensure_worktree=True` for PR closed rebuild

## Test Plan

✅ All tests pass (27 recovery tests + full suite)
✅ Type checks pass (mpy --strict)
✅ Linting passes (ruff + black)

Manual verification steps:
- [ ] Run `vibe3 check` on existing blocked issues (#1629, #1692, #1717, #1792)
- [ ] Verify auto-recovery works for MISSING_RECORDED_WORKTREE
- [ ] Verify manual resume guides user to rebuild when worktree missing

## Root Causes Addressed

| Issue | Root Cause | Fix |
|-------|-----------|-----|
| #1629, #1647, #1648 | worktree_path NULL after rebuild | Persist to store after worktree creation |
| #1692, #1717, #1792 | Label not cleared but DB active | UnblockResult tracks label write failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)