### PR TITLE
fix(error-helpers): fix f-string bug in has_recent_specific_error SQL query

### DIFF
--- a/src/vibe3/services/error_helpers.py
+++ b/src/vibe3/services/error_helpers.py
@@ -39,12 +39,12 @@ def has_recent_specific_error(
     if store is None:
         store = SQLiteClient()
 
-    query = """
+    query = f"""
         SELECT COUNT(*) FROM error_log
         WHERE error_code != 'E_DISPATCH_FAILURE'
           AND issue_number = ?
           AND branch = ?
-          AND datetime(created_at) >= datetime('now', f'-{within_seconds} seconds')
+          AND datetime(created_at) >= datetime('now', '-{within_seconds} seconds')
     """
 
     try:


### PR DESCRIPTION
## Summary

- `has_recent_specific_error` 的 SQL 查询使用普通字符串 `"""..."""`，但内嵌了 `f'-{within_seconds} seconds'` 的 f-string 语法，变量不会被插值
- SQLite 执行时抛出 `OperationalError`，被 `except Exception: return False` 静默吞掉
- dedup 检查始终返回 `False`，导致同一事件写入两条 ERROR（`E_API_RATE_LIMIT` + `E_DISPATCH_FAILURE`）
- 两条 ERROR 触发 FailedGate 阈值（2 errors / 10 min），阻断正常 dispatch

## Root Cause

[error_helpers.py:42](src/vibe3/services/error_helpers.py) — 字符串前缀 `"""` 应为 `f"""`，内部 `f'-{within_seconds} seconds'` 应为 `'-{within_seconds} seconds'`（去掉内层多余的 `f`）

## Fix

2 字符改动：将查询字符串由 `"""` 改为 `f"""`，并删掉内部 `f'` 前缀。

## Verification

- `has_recent_specific_error(#1717, 24h)` 修复后返回 `True`（能正确找到 `E_API_RATE_LIMIT`）
- 11 tests pass in `test_error_helpers.py`
- 7 tests pass in `test_dispatch.py`

## Contributors

- Yi Chen
- Claude Sonnet 4.6