### PR TITLE
docs: align core docs with V3 architecture and path standards (#1839)

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -218,41 +218,51 @@ bash scripts/tools/metrics.sh  # V2 Legacy 仪表盘
 ### Step 1：创建工作区
 
 ```bash
-# 在项目根目录
-bin/vibe flow start <feature-name>
-# 例如：bin/vibe flow start add-vibe-doctor
+# 在项目根目录，使用 git worktree 创建隔离工作空间
+git worktree add ../wt-task-1839 task/issue-1839
+cd ../wt-task-1839
+
+# 注册并同步 flow 状态
+vibe3 flow update
 ```
 
-> V3 不使用 `bin/vibe flow start` 创建 worktree；worktree 由 orchestra 自动创建或通过 `git worktree add` 手动管理。开发前通过 `uv run python src/vibe3/cli.py flow show` 查看当前 flow 上下文。
+> V3 优先使用 `vibe3 flow update` 注册当前分支为活跃 flow；worktree 建议使用原生 `git worktree` 管理或由 orchestra 自动调度。开发前通过 `vibe3 flow show` 查看当前 flow 上下文。
 
 这会：
-- 创建 `wt-claude-<feature>` 目录（git worktree）
-- 切换到新分支
-- 自动运行 `scripts/init.sh` 准备环境
-- 生成 `docs/prds/<feature>.md` 的 PRD 模板
+- 创建独立的物理工作目录
+- 自动检测并同步分支对应的 flow 状态
+- 准备技能环境（通过 `scripts/init.sh`）
+- 使当前目录成为该 flow 的权威执行区
 
-### Step 2：写 PRD（先写需求，再写代码）
+### Step 2：写计划（Plan Gate）
 
-打开 `docs/prds/<feature>.md`，填写：
-- 背景：为什么需要这个功能
-- 目标：这个功能做什么
-- 需求清单：具体的验收条件
-
-**不写 PRD，不开始写代码。**
-
-### Step 3：写代码 + 验证（边写边测）
-
-每改一次代码，运行三个命令：
+使用 `/vibe-task` 或 `/vibe-new` 技能明确任务范围，然后创建执行计划：
 
 ```bash
-# 1. 语法和质量检查
-bash scripts/hooks/lint.sh
+vibe3 plan --branch @current
+```
+
+**不通过 Plan Gate，不开始写代码。**
+
+### Step 3：执行任务（Run Gate）
+
+利用 `/vibe-*` 系列技能执行具体动作：
+- 使用 `/vibe-review-docs` 审查文档
+- 使用 `/vibe-review-code` 审查代码
+- 使用 `/vibe-commit` 自动提交并创建 PR
+
+每改一次代码，运行验证命令：
+
+```bash
+# 1. 语法和质量检查 (V3)
+uv run ruff check .
+uv run mypy src/vibe3
 
 # 2. 运行所有测试
-bats tests/
+uv run pytest tests/vibe3
 
 # 3. 查看健康度
-bash scripts/tools/metrics.sh
+vibe3 snapshot show
 ```
 
 **出现 ❌ 立刻修复，不要积累问题。**
@@ -260,15 +270,19 @@ bash scripts/tools/metrics.sh
 ### Step 4：Review + 创建 PR
 
 ```bash
-bin/vibe flow review   # 交互式 review
-bin/vibe flow pr       # 生成 PR
-```
+# 使用技能执行标准化审查
+/vibe-team-review
 
-> V3: 使用 `gh pr create` 创建 PR，或通过 agent workflow `/vibe-commit` 自动完成提交与 PR 创建。
+# 提交并推送到远端
+/vibe-commit
+```
 
 ### Step 5：清理工作区
 
-> V3: 使用 `git worktree remove` 手动清理，或由 orchestra 自动管理 worktree 生命周期。
+```bash
+# 完成后移除 worktree
+git worktree remove .
+```
 
 ---
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -89,9 +89,9 @@ vibe-center/
 │
 ├── .agent/                      # AI 工作区
 │   ├── README.md                # AI 工作区说明
-│   ├── context/                 # AI 上下文
-│   │   ├── memory/              # [TRACKED] AI 上下文记忆（已迁移至 claude-memory MCP 工具）
-│   │   └── ...                  # 动态上下文（如 handoff）由 vibe3 管理，见 .git/vibe3/
+├── context/                 # AI 上下文
+│   ├── memory/              # [TRACKED] AI 上下文记忆（详见 docs/standards/v3/v3-memory-standard.md）
+│   └── ...                  # 动态上下文（如 handoff）由 vibe3 管理，见 .git/vibe3/
 │   ├── templates/               # 文档模板（AI 工具）
 │   │   ├── prd.md               # PRD 模板
 │   │   ├── tech-spec.md         # Spec 模板

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -56,7 +56,7 @@ Publisher.publish(event) → EventPublisher 查找订阅者 → 调用 handlers
 - ❌ 忘记注册 handler → 事件"断线"
 - ❌ Handler 没有类型注解 → mypy 报错
 
-**详细文档**: [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md)
+**详细文档**: [event-driven-standard.md](standards/v3/event-driven-standard.md)
 ---
 
 ## 3-Tier 架构模型
@@ -120,7 +120,7 @@ def register_dispatch_handlers() -> None:
     subscribe("ManagerDispatchIntent", handle_manager_dispatch_intent)
 ```
 
-**详细文档**: [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md) §三
+**详细文档**: [event-driven-standard.md](standards/v3/event-driven-standard.md) §三
 
 ---
 
@@ -133,7 +133,7 @@ def register_dispatch_handlers() -> None:
 - 不是 agent 的 handoff 行为，是系统的解析行为
 - 区别于 `handoff_plan` / `handoff_report` / `handoff_indicate`（agent 主动提交）
 
-**详细文档**: [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md) §1.2
+**详细文档**: [event-driven-standard.md](standards/v3/event-driven-standard.md) §1.2
 
 ---
 
@@ -142,7 +142,7 @@ def register_dispatch_handlers() -> None:
 ### 修改事件相关代码时
 
 1. **阅读架构文档**：
-   - [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md)
+   - [event-driven-standard.md](standards/v3/event-driven-standard.md)
    
 2. **关键检查点**：
    - ✅ 事件定义：`src/vibe3/domain/events/*.py`
@@ -173,8 +173,8 @@ def register_dispatch_handlers() -> None:
 ### 修改 Orchestra 相关代码时
 
 1. **阅读架构文档**：
-   - [v3/orchestra-runtime-standard.md](standards/v3/orchestra-runtime-standard.md)
-   - [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md)
+   - [orchestra-runtime-standard.md](standards/v3/orchestra-runtime-standard.md)
+   - [event-driven-standard.md](standards/v3/event-driven-standard.md)
 
 2. **关键检查点**：
    - ✅ 理解 Driver/Tick/Async Child 架构
@@ -211,7 +211,7 @@ def register_dispatch_handlers() -> None:
 5. 更新文档
 6. 提交变更
 
-**详细指南**: [vibe3-event-driven-standard.md](standards/vibe3-event-driven-standard.md) §5.5
+**详细指南**: [event-driven-standard.md](standards/v3/event-driven-standard.md) §5.5
 
 ---
 
@@ -231,6 +231,10 @@ def register_dispatch_handlers() -> None:
 - **代码为准**: 最终实现以代码为准，文档记录意图
 
 ---
+
+**维护者**: Vibe Team
+**最后更新**: 2026-06-01
+--
 
 **维护者**: Vibe Team
 **最后更新**: 2026-06-01

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,8 @@ docs/
 **必读文档**：
 - **[glossary.md](standards/glossary.md)** - 项目术语真源，统一概念定义与别称边界
 - **[action-verbs.md](standards/action-verbs.md)** - 高频动作词真源，统一默认含义与执行提醒
-- **[vibe3-architecture-convergence-standard.md](standards/vibe3-architecture-convergence-standard.md)** - Vibe3 目标架构总纲
-- **[vibe3-role-checks-and-balances-standard.md](standards/vibe3-role-checks-and-balances-standard.md)** - Vibe3 角色制衡架构标准
+- **[v3/architecture-convergence-standard.md](standards/v3/architecture-convergence-standard.md)** - Vibe3 目标架构总纲
+- **[v3/role-checks-and-balances-standard.md](standards/v3/role-checks-and-balances-standard.md)** - Vibe3 角色制衡架构标准
 - **[agent-debugging-standard.md](standards/agent-debugging-standard.md)** - Agent 调试标准
 - **[doc-organization.md](standards/doc-organization.md)** - 文档组织标准
 

--- a/docs/standards/agent-workflow-standard.md
+++ b/docs/standards/agent-workflow-standard.md
@@ -65,19 +65,18 @@ Plan → Run → Review → Commit
 vibe3 plan --branch <branch_or_issue_number>
 vibe3 plan                    # 使用当前 branch
 
-# 从 spec 文件/Issue/别名创建 plan（更新当前 flow 的 spec_ref 并创建计划）
-vibe3 plan --spec docs/specs/feature.md
-vibe3 plan --spec #123
-vibe3 plan --spec @spec
+# 使用技能进行更智能的规划
+/vibe-new  # 启动新任务流
+/vibe-task # 分析并规划任务
 ```
 
-**Step 2: 执行 Plan（使用 Agent）**
+**Step 2: 执行 Plan（使用 Agent 或技能）**
 
 ```bash
 # 使用现有 plan 执行
 vibe3 run --plan
 
-# 使用自定义指令执行
+# 使用技能进行针对性开发
 vibe3 run "Focus on test coverage"
 
 # 使用指定 agent 执行
@@ -87,16 +86,12 @@ vibe3 run --agent planner-pro --plan
 **Step 3: 审查结果**
 
 ```bash
+# 使用技能进行标准化审查
+/vibe-review-code
+/vibe-review-docs
+
 # 查看当前 flow 的 handoff 链路
 vibe3 handoff show @current
-
-# 查看指定 artifact
-vibe3 handoff show @plan
-vibe3 handoff show docs/reports/run-1.md
-
-# 查看 agent 做了哪些修改
-git status
-git diff
 
 # 运行测试验证
 uv run pytest tests/vibe3
@@ -443,6 +438,14 @@ vibe3 run --plan --timeout 1800  # 30 分钟
 - [SOUL.md](../../SOUL.md) - 项目宪法
 - [quality-control-standard.md](./quality-control-standard.md) - 质量检查标准
 - [error-handling.md](./error-handling.md) - 错误处理规范
+- [.agent/policies/run.md](../../.agent/policies/run.md) - Run 命令策略
+
+---
+
+**文档版本**：v1.0
+**最后更新**：2026-03-25
+**维护者**：Vibe Center Team
+.md) - 错误处理规范
 - [.agent/policies/run.md](../../.agent/policies/run.md) - Run 命令策略
 
 ---


### PR DESCRIPTION
Align core documentation with V3 architecture, directory structure, and skill-based workflows.

### Changes:
1. **docs/ARCHITECTURE_GUIDE.md**: Fixed broken links to V3 standards in `docs/standards/v3/`.
2. **docs/README.md**: Updated internal links to standards that moved to the `v3/` subfolder.
3. **STRUCTURE.md**: Clarified the status of `.agent/context/memory/` and linked to the V3 memory standard.
4. **DEVELOPER.md**: De-emphasized V2 shell workflows; prioritized V3 flow registration (`vibe3 flow update`) and `/vibe-*` skill-based development cycle.
5. **docs/standards/agent-workflow-standard.md**: Aligned the manual workflow with the automated orchestra/skill-based workflow.

Closes #1839