### PR TITLE
fix(rebuild): fail fast when rebuilt worktree is missing

### DIFF
--- a/src/vibe3/services/flow_rebuild_postconditions.py
+++ b/src/vibe3/services/flow_rebuild_postconditions.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from typing import Any
 
 
+def _refresh_worktree_cache(git_client: Any) -> None:
+    """Force the next worktree lookup to read current git metadata."""
+    if hasattr(git_client, "_worktree_list_cache"):
+        git_client._worktree_list_cache = None
+
+
 def assert_rebuild_postconditions(
     *,
     branch: str,
@@ -21,6 +27,7 @@ def assert_rebuild_postconditions(
         failures.append(f"branch does not exist: {branch}")
 
     if ensure_worktree:
+        _refresh_worktree_cache(git_client)
         worktree_path = git_client.find_worktree_path_for_branch(branch)
         if worktree_path is None:
             failures.append(f"git worktree not registered for branch: {branch}")

--- a/src/vibe3/services/flow_rebuild_postconditions.py
+++ b/src/vibe3/services/flow_rebuild_postconditions.py
@@ -1,0 +1,56 @@
+"""Postcondition checks for destructive flow rebuilds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def assert_rebuild_postconditions(
+    *,
+    branch: str,
+    result: dict[str, Any] | None,
+    ensure_worktree: bool,
+    git_client: Any,
+    store: Any,
+) -> None:
+    """Fail fast when rebuild did not produce a dispatchable scene."""
+    failures: list[str] = []
+
+    if not git_client.branch_exists(branch):
+        failures.append(f"branch does not exist: {branch}")
+
+    if ensure_worktree:
+        worktree_path = git_client.find_worktree_path_for_branch(branch)
+        if worktree_path is None:
+            failures.append(f"git worktree not registered for branch: {branch}")
+        else:
+            resolved_path = Path(worktree_path)
+            if not resolved_path.exists():
+                failures.append(f"worktree path does not exist: {resolved_path}")
+
+            result_path = (
+                result.get("worktree_path") if isinstance(result, dict) else None
+            )
+            if result_path and Path(str(result_path)) != resolved_path:
+                failures.append(
+                    "bootstrap result worktree_path mismatch: "
+                    f"{result_path} != {resolved_path}"
+                )
+
+            flow_state = store.get_flow_state(branch)
+            recorded_path = (
+                flow_state.get("worktree_path")
+                if isinstance(flow_state, dict)
+                else None
+            )
+            if recorded_path and Path(str(recorded_path)) != resolved_path:
+                failures.append(
+                    "flow_state worktree_path mismatch: "
+                    f"{recorded_path} != {resolved_path}"
+                )
+
+    if failures:
+        raise RuntimeError(
+            f"Rebuild postcondition failed for {branch}: {'; '.join(failures)}"
+        )

--- a/src/vibe3/services/flow_rebuild_usecase.py
+++ b/src/vibe3/services/flow_rebuild_usecase.py
@@ -16,6 +16,7 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.models.orchestration import IssueInfo
 from vibe3.services.flow_cleanup_service import FlowCleanupService
 from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+from vibe3.services.flow_rebuild_postconditions import assert_rebuild_postconditions
 from vibe3.services.handoff_service import HandoffService
 
 LabelResume = Callable[..., None]
@@ -92,6 +93,13 @@ class FlowRebuildUsecase:
             initiated_by=source,
             ensure_worktree=ensure_worktree,
             reactivate_existing=False,
+        )
+        assert_rebuild_postconditions(
+            branch=branch,
+            result=result,
+            ensure_worktree=ensure_worktree,
+            git_client=self.git_client,
+            store=self.store,
         )
 
         HandoffService(

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -259,12 +259,10 @@ class FlowRecoveryService:
         ensure_worktree: bool = True,
         include_remote: bool = False,
     ) -> None:
-        """Hard rebuild: cleanup + bootstrap (NO resume -- caller does that)."""
+        """Hard rebuild through the canonical rebuild usecase."""
         from vibe3.config.orchestra_settings import load_orchestra_config
         from vibe3.models.orchestration import IssueInfo, IssueState
-        from vibe3.services.flow_cleanup_service import FlowCleanupService
-        from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
-        from vibe3.services.handoff_service import HandoffService
+        from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
         from vibe3.services.issue_context_loader import load_issue_info
 
         # Load issue info from GitHub
@@ -281,49 +279,15 @@ class FlowRecoveryService:
                 state=IssueState.READY,
             )
 
-        # Step 1: Cleanup old scene
-        cleanup_results = FlowCleanupService(
-            git_client=self.git_client,
-            store=self.store,
-        ).cleanup_flow_scene(
-            branch,
-            include_remote=include_remote,
-            terminate_sessions=True,
-            keep_flow_record=False,
-            force_delete=True,
-        )
-        failed_steps = [s for s, ok in cleanup_results.items() if not ok]
-        if failed_steps:
-            raise RuntimeError(
-                f"Cleanup failed for: {', '.join(failed_steps)}. "
-                "Cannot rebuild in dirty state."
-            )
-
-        # Step 2: Bootstrap new flow + worktree
-        orchestrator = FlowOrchestratorService(
-            config,
-            store=self.store,
-            git=self.git_client,
-            github=self.github_client,
-        )
-        orchestrator.bootstrap_issue_flow(
-            issue_info,
-            branch=branch,
-            slug=f"issue-{issue_number}",
-            source="flow:rebuild",
-            initiated_by="flow:rebuild",
-            ensure_worktree=ensure_worktree,
-            reactivate_existing=False,
-        )
-
-        # Step 3: Handoff record
-        HandoffService(
+        FlowRebuildUsecase(
             store=self.store,
             git_client=self.git_client,
             github_client=self.github_client,
-        ).append_current_handoff(
-            message=f"Flow rebuilt: {reason}",
-            actor="vibe3:flow_rebuild",
-            kind="milestone",
+            label_resume=lambda **_: None,
+        ).rebuild_issue_flow(
+            issue=issue_info,
             branch=branch,
+            reason=reason,
+            ensure_worktree=ensure_worktree,
+            include_remote=include_remote,
         )

--- a/tests/vibe3/services/test_flow_rebuild_postconditions.py
+++ b/tests/vibe3/services/test_flow_rebuild_postconditions.py
@@ -1,0 +1,46 @@
+"""Tests for rebuild postcondition checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from vibe3.services.flow_rebuild_postconditions import assert_rebuild_postconditions
+
+
+class CachedGitClient:
+    """Tiny fake that exposes the same worktree cache shape as GitClient."""
+
+    def __init__(self, worktree_path: Path) -> None:
+        self._worktree_list_cache = [("/tmp/old-worktree", "refs/heads/task/issue-303")]
+        self.worktree_path = worktree_path
+
+    def branch_exists(self, branch: str) -> bool:
+        return branch == "task/issue-303"
+
+    def find_worktree_path_for_branch(self, branch: str) -> Path | None:
+        if self._worktree_list_cache is not None:
+            return Path(self._worktree_list_cache[0][0])
+        if branch == "task/issue-303":
+            return self.worktree_path
+        return None
+
+
+def test_rebuild_postcondition_refreshes_stale_worktree_cache(
+    tmp_path: Path,
+) -> None:
+    worktree_path = tmp_path / "repo" / ".worktrees" / "task" / "issue-303"
+    worktree_path.mkdir(parents=True)
+    git = CachedGitClient(worktree_path)
+    store = MagicMock()
+    store.get_flow_state.return_value = {"worktree_path": str(worktree_path)}
+
+    assert_rebuild_postconditions(
+        branch="task/issue-303",
+        result={"worktree_path": str(worktree_path)},
+        ensure_worktree=True,
+        git_client=git,
+        store=store,
+    )
+
+    assert git._worktree_list_cache is None

--- a/tests/vibe3/services/test_flow_rebuild_usecase.py
+++ b/tests/vibe3/services/test_flow_rebuild_usecase.py
@@ -1,14 +1,23 @@
 """Tests for explicit flow rebuild usecase."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 
 
-def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume() -> None:
+def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume(
+    tmp_path: Path,
+) -> None:
+    worktree_path = tmp_path / "repo" / ".worktrees" / "task" / "issue-303"
+    worktree_path.mkdir(parents=True)
     store = MagicMock()
     git = MagicMock()
+    git.branch_exists.return_value = True
+    git.find_worktree_path_for_branch.return_value = worktree_path
     github = MagicMock()
     orchestrator = MagicMock()
     orchestrator.bootstrap_issue_flow.return_value = {"branch": "task/issue-303"}
@@ -74,3 +83,57 @@ def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume() -
         reason="missing worktree",
     )
     assert result == {"branch": "task/issue-303"}
+
+
+def test_rebuild_issue_flow_fails_when_rebuilt_worktree_is_missing() -> None:
+    store = MagicMock()
+    git = MagicMock()
+    git.branch_exists.return_value = True
+    git.find_worktree_path_for_branch.return_value = None
+    github = MagicMock()
+    orchestrator = MagicMock()
+    orchestrator.bootstrap_issue_flow.return_value = {
+        "branch": "task/issue-303",
+        "worktree_path": "/tmp/repo/.worktrees/task/issue-303",
+    }
+    label_resume = MagicMock()
+
+    usecase = FlowRebuildUsecase(
+        store=store,
+        git_client=git,
+        github_client=github,
+        orchestrator=orchestrator,
+        label_resume=label_resume,
+    )
+
+    issue = IssueInfo(
+        number=303,
+        title="Rebuild me",
+        state=IssueState.READY,
+        labels=[IssueState.READY.to_label()],
+    )
+
+    with (
+        patch("vibe3.services.flow_rebuild_usecase.FlowCleanupService") as cleanup_cls,
+        patch("vibe3.services.flow_rebuild_usecase.HandoffService") as handoff_cls,
+        pytest.raises(RuntimeError, match="Rebuild postcondition failed"),
+    ):
+        cleanup = cleanup_cls.return_value
+        cleanup.cleanup_flow_scene.return_value = {
+            "worktree": True,
+            "local_branch": True,
+            "remote_branch": True,
+            "handoff": True,
+            "flow_record": True,
+        }
+
+        usecase.rebuild_issue_flow(
+            issue=issue,
+            branch="task/issue-303",
+            reason="missing worktree",
+            include_remote=True,
+            ensure_worktree=True,
+        )
+
+    handoff_cls.return_value.append_current_handoff.assert_not_called()
+    label_resume.assert_not_called()

--- a/tests/vibe3/services/test_flow_recovery_service.py
+++ b/tests/vibe3/services/test_flow_recovery_service.py
@@ -128,3 +128,32 @@ class TestRecover:
                 reason="manual",
                 auto=False,
             )
+
+    def test_auto_rebuild_fails_when_rebuilt_worktree_is_missing(self):
+        svc = _make_service(worktree_path=None, flow_state={})
+        svc.git_client.branch_exists.return_value = True
+        svc.git_client.find_worktree_path_for_branch.return_value = None
+
+        with (
+            patch(
+                "vibe3.services.issue_context_loader.load_issue_info",
+                return_value=MagicMock(number=1),
+            ),
+            patch(
+                "vibe3.services.flow_rebuild_usecase.FlowRebuildUsecase"
+            ) as rebuild_cls,
+            pytest.raises(RuntimeError, match="Rebuild postcondition failed"),
+        ):
+            rebuild_cls.return_value.rebuild_issue_flow.side_effect = RuntimeError(
+                "Rebuild postcondition failed for task/issue-1: "
+                "git worktree not registered for branch: task/issue-1"
+            )
+
+            svc._do_rebuild(
+                "task/issue-1",
+                1,
+                "health check",
+                ensure_worktree=True,
+            )
+
+        rebuild_cls.return_value.rebuild_issue_flow.assert_called_once()


### PR DESCRIPTION
## Summary

- Add a shared rebuild postcondition check that fails fast when a rebuilt flow does not produce a dispatchable branch/worktree scene.
- Route both explicit `flow rebuild` and automatic recovery rebuilds through the canonical `FlowRebuildUsecase` instead of keeping duplicate cleanup/bootstrap/handoff logic.
- Add regression tests covering fake-success rebuilds where bootstrap returns but git cannot find the rebuilt worktree.

## Root Cause

`flow rebuild` and orchestra dispatch were using different success contracts. Rebuild could write flow/handoff/resume success markers after cleanup/bootstrap, while orchestra later required a concrete git branch, registered worktree, existing worktree path, and matching DB `worktree_path`. That allowed a fake-success rebuild to delete old state, report success, then fail again on the next dispatch tick.

## Validation

- `uv run pytest tests/vibe3/services/test_flow_rebuild_usecase.py tests/vibe3/services/test_flow_recovery_service.py tests/vibe3/services/test_task_resume_label_state.py tests/vibe3/services/test_check_service.py -q`
- `uv run ruff check src/vibe3/services/flow_rebuild_usecase.py src/vibe3/services/flow_recovery_service.py src/vibe3/services/flow_rebuild_postconditions.py tests/vibe3/services/test_flow_rebuild_usecase.py tests/vibe3/services/test_flow_recovery_service.py`
- Pre-push hook: `uv run pytest tests/vibe3/services -q --tb=short` (`663 passed, 2 warnings`)
- Real rebuild smoke test for #1629, #1647, #1648: all rebuilt successfully; local branches and git worktrees exist; `vibe3 task status` moved them from blocked to claimed and dispatch is active.

## Contributors

- Yi Chen
- Codex
