### PR TITLE
docs: align stale documentation and remove legacy aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ This project has **two parallel implementations**:
 1. **V2 (Shell)** — Zsh alias 和环境工具（`bin/`, `lib/`, `config/shell/aliases.sh`）
 2. **V3 (Python)** — issue/flow/PR 管理主系统（`src/vibe3/`, `tests/vibe3/`）
 
-> V2 主要提供 alias（`wtnew`、`vup`）和环境工具；branch 生命周期优先直接使用 `git`，issue / PR 远端操作优先直接使用 `gh`，`vibe3` 负责本地 flow scene、events 与 handoff 增强。
+> branch 生命周期优先直接使用 `git`，issue / PR 远端操作优先直接使用 `gh`，`vibe3` 负责本地 flow scene、events 与 handoff 增强。
 
 ## 📍 Workspace Structure
 

--- a/docs/standards/supervisor-handoff-standard.md
+++ b/docs/standards/supervisor-handoff-standard.md
@@ -205,6 +205,6 @@ async def on_tick(self):
 | 文件 | 职责 |
 |------|------|
 | `docs/standards/v3/event-driven-standard.md` | L2 事件层级定义 |
-| `docs/standards/vibe3-worktree-ownership-standard.md` | L2 临时 worktree 语义 |
+| `docs/standards/v3/worktree-lifecycle-standard.md` | L2 临时 worktree 语义 |
 | `docs/standards/v3/noop-gate-boundary-standard.md` | Gate 边界定义 |
 | `docs/standards/github-labels-reference.md` | Label 语义参考 |


### PR DESCRIPTION
Closes #1854.

This PR addresses the stale documentation findings in issue #1854:
1. Removed legacy alias references ('wtnew', 'vup') in AGENTS.md.
2. Updated stale reference to 'vibe3-worktree-ownership-standard.md' in docs/standards/supervisor-handoff-standard.md to point to 'docs/standards/v3/worktree-lifecycle-standard.md'.
3. Verified that docs/standards/doc-organization.md is already clean of the reported stale reference.
