### PR TITLE
docs: align command names in architecture docs to V3 standard

### DIFF
--- a/docs/v3/architecture/capacity-control.md
+++ b/docs/v3/architecture/capacity-control.md
@@ -27,7 +27,7 @@ CapacityService 提供单一的容量检查点,结合 live session count 和 in-
 
 #### 路径2: CLI 手动触发
 
-- **触发源**: `vibe3 internal issue-role-sync` CLI 命令
+- **触发源**: `vibe3 [run|plan|review|internal manager] <issue>` 等 CLI 命令
 - **调度方式**: 手动触发,用于特定 issue-role 组合
 - **适用场景**: 紧急修复、手动干预、测试验证
 - **实现位置**: `src/vibe3/execution/issue_role_sync_runner.py`

--- a/docs/v3/architecture/infrastructure-guide.md
+++ b/docs/v3/architecture/infrastructure-guide.md
@@ -152,7 +152,7 @@ CapacityService 提供单一的容量检查点，结合 live session count 和 i
 **容量检查触发路径**（详见 [capacity-control.md](capacity-control.md)）：
 
 - **Heartbeat 自动调度**: GlobalDispatchCoordinator 通过 heartbeat 定期扫描
-- **CLI 手动触发**: `vibe3 internal issue-role-sync` 命令
+- **CLI 手动触发**: `vibe3 [run|plan|review|internal manager] <issue>` 等命令
 
 两条路径共享同一个 `_shared_in_flight_dispatches`，确保容量计数一致。
 


### PR DESCRIPTION
Closes #1859. Aligned command names in infrastructure-guide.md and capacity-control.md to follow the V3 'vibe3 group subcommand' pattern and fixed the non-existent 'issue-role-sync' command reference.