### PR TITLE
refactor: 将角色产出契约写入 RoleDefinition，统一 noop-gate ref 检查

### DIFF
--- a/docs/standards/v3/noop-gate-boundary-standard.md
+++ b/docs/standards/v3/noop-gate-boundary-standard.md
@@ -130,37 +130,36 @@ related_docs:
 
 ### 3.1.1 worker no-op 的正确语义
 
-对 `planner / executor / reviewer` 三类 worker，正确语义是：
+每个角色通过 `RoleOutputContract` 声明其必要产出，gate 依次检查：
 
-- agent 执行后 **required_ref 缺失**：
-  - 若 **state 改变** → `warning`（agent 推进了状态但未产出 ref，记录警告但不阻塞）
-  - 若 **state 未改变** → `blocked`（agent 既未产出 ref 也未推进状态）
-- agent 执行后 **state 未改变**（且 required_ref 存在）→ `blocked`（agent 未按 contract 推进状态）
-- agent 执行后 **两项都满足** → 通过
+1. **contract.required_ref 缺失**（若角色声明了 required_ref）→ `blocked`（硬要求，无论 state 是否改变）
+2. **contract.requires_verdict 且 latest_verdict 缺失**（reviewer 专属）→ `blocked`（硬要求）
+3. **state 未改变** → `blocked`（agent 未推进状态）
+4. **以上都满足** → 通过
 
-也就是说：
+各角色契约：
+
+| 角色 | required_ref | requires_verdict | 说明 |
+|------|-------------|-----------------|------|
+| planner | `plan_ref`（硬要求） | 否 | 缺失即 block，无论 state 是否改变 |
+| executor | 无 | 否 | 只检查 state 改变 |
+| reviewer | 无 | 是（`latest_verdict`） | audit_ref 不强制 |
+| manager | 无 | 否 | 只检查 state 改变 |
+
+具体示例：
 
 - planner 跑完但还在 `state/claimed` → `blocked`
 - executor 跑完但还在 `state/in-progress` → `blocked`
 - reviewer 跑完但还在 `state/review` → `blocked`
-- planner 跑完但没有 `plan_ref`：
-  - 若 state 改变（如 `claimed` → `planned`）→ `warning`，通过 gate
-  - 若 state 未改变 → `blocked`
-- executor 跑完但没有 `report_ref`：
-  - 若 state 改变（如 `in-progress` → `review`）→ `warning`，通过 gate
-  - 若 state 未改变 → `blocked`
-- reviewer 跑完但没有 `audit_ref`：
-  - 若 `latest_verdict` 缺失 → `blocked`（必须先持久化 verdict）
-  - 若 verdict 为 `MINOR`/`MAJOR` 且 `audit_ref` 缺失 → `blocked`（非 PASS verdict 必须产出 audit_ref）
-  - 若 verdict 为 `PASS` → 通过 gate（PASS 不要求 audit_ref）
+- planner 跑完但没有 `plan_ref` → `blocked`（state 是否改变无影响，plan_ref 是硬要求）
+- executor 跑完，无论有没有 `report_ref` → 只看 state 是否改变
+- reviewer 跑完但 `latest_verdict` 缺失 → `blocked`
+- reviewer 跑完，verdict 为 `PASS`/`MINOR`/`MAJOR`/`BLOCK`，无 `audit_ref` → 通过 verdict 检查（只要 state 改变即可）
 
-**注意**：reviewer 的 ref 检查是 verdict-aware，不是 state-change-aware。verdict 存在性和值优先于 state 改变判断。
-
-gate 检查顺序（state-change-aware）：
-1. required_ref 缺失 + state 改变 → warning，继续检查 state transition
-2. required_ref 缺失 + state 未变 → block（agent 既未产出 ref 也未推进状态）
-3. required_ref 存在 + state 未变 → block（agent 未按 contract 推进状态）
-4. required_ref 存在 + state 改变 → pass
+**关于 audit_ref**：`audit_ref` 是 reviewer agent 的可选产出，不是 gate 强制要求。
+reviewer 是否写入 audit_ref 取决于是否有实质审计内容（PASS 通常无需写），
+但 gate 不以此为 block 依据。下游（如 manager handoff）可读取 audit_ref 辅助决策，
+但 gate 不依赖它。
 
 manager 角色不受 ref 检查约束（只有 state change 检查）。
 
@@ -337,7 +336,7 @@ Re-dispatch
 2. stale flow record 指向不存在的分支
 3. 下游 dispatch 基于 stale flow 派发 reviewer
 4. reviewer 从未实际运行
-5. domain event handler 的 `require_authoritative_ref` 发现无 audit_ref → block
+5. domain event handler 的 `require_authoritative_ref` 发现无 ref → block
 6. `force=True` 覆盖 failed 状态为 blocked
 7. 循环往复，每 30 秒一次
 

--- a/src/vibe3/config/role_policy.py
+++ b/src/vibe3/config/role_policy.py
@@ -6,6 +6,8 @@ eliminating scattered mappings across multiple modules.
 
 from typing import Literal
 
+from vibe3.roles.definitions import RoleOutputContract
+
 # Role to config section mapping
 # Note: Uses str instead of ExecutionRole because it includes "manager"
 # which is not part of ExecutionRole (only planner/executor/reviewer)
@@ -22,19 +24,22 @@ def get_role_section(role: str) -> Literal["manager", "plan", "run", "review"]:
     return ROLE_TO_SECTION[role]
 
 
-# Role to required ref key mapping for no-op gate
-# Used by unified no-op gate to check if agent produced required ref
-ROLE_TO_REQUIRED_REF_KEY: dict[str, str | None] = {
-    "planner": "plan_ref",
-    "executor": "report_ref",
-    "reviewer": None,
-    "manager": None,  # manager 不受 ref 检查约束
+# Role output contracts for the unified no-op gate.
+# Mirrors the output_contract field on each role's TriggerableRoleDefinition,
+# kept here as a separate lookup so noop_gate can resolve contracts by role
+# name string without importing from roles/ (which would create a cycle via
+# roles/plan.py → execution/codeagent_runner.py → execution/noop_gate.py).
+ROLE_OUTPUT_CONTRACTS: dict[str, RoleOutputContract] = {
+    "planner": RoleOutputContract(required_ref="plan_ref"),
+    "executor": RoleOutputContract(),
+    "reviewer": RoleOutputContract(requires_verdict=True),
+    "manager": RoleOutputContract(),
 }
 
 
-def get_role_required_ref_key(role: str) -> str | None:
-    """Get the required ref key for a given role's no-op gate check.
+def get_role_output_contract(role: str) -> RoleOutputContract:
+    """Return the output contract for a given role name.
 
-    Returns None for roles that should skip the ref check (e.g., manager).
+    Falls back to an empty contract (no requirements) for unknown roles.
     """
-    return ROLE_TO_REQUIRED_REF_KEY.get(role)
+    return ROLE_OUTPUT_CONTRACTS.get(role, RoleOutputContract())

--- a/src/vibe3/config/role_policy.py
+++ b/src/vibe3/config/role_policy.py
@@ -2,11 +2,35 @@
 
 This module provides a single source of truth for role-specific policies,
 eliminating scattered mappings across multiple modules.
+
+NOTE: This module MUST remain free of vibe3 imports to avoid circular
+imports. The import chain roles/definitions.py → execution/contracts.py →
+execution/__init__.py → codeagent_runner.py → config/role_policy.py must
+not loop back into roles/.
 """
 
+from dataclasses import dataclass
 from typing import Literal
 
-from vibe3.roles.definitions import RoleOutputContract
+
+@dataclass(frozen=True)
+class RoleOutputContract:
+    """Declarative contract for what a role must produce after execution.
+
+    Used by the unified no-op gate to validate post-execution outputs.
+    Each role declares its own contract in its TriggerableRoleDefinition.
+
+    Attributes:
+        required_ref: flow_state key that must be non-empty after execution.
+            Gate blocks if the key is absent or empty, regardless of whether
+            the state label changed. None means no ref is required.
+        requires_verdict: If True, flow_state["latest_verdict"] must be set.
+            Used exclusively by the reviewer role.
+    """
+
+    required_ref: str | None = None
+    requires_verdict: bool = False
+
 
 # Role to config section mapping
 # Note: Uses str instead of ExecutionRole because it includes "manager"

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         CodeagentResult,
     )
     from vibe3.exceptions.error_severity import ErrorSeverity
-from vibe3.config.role_policy import get_role_required_ref_key, get_role_section
+from vibe3.config.role_policy import get_role_section
 from vibe3.config.settings import VibeConfig
 from vibe3.execution.codeagent_support import resolve_command_agent_options
 from vibe3.execution.contracts import ExecutionRequest
@@ -314,11 +314,8 @@ class CodeagentExecutionService:
                 event_type=f"codeagent_{execution_prefix(command.role)}_completed",  # type: ignore[arg-type]
             )
 
-            # Read flow state ONCE here, used by both ref check and passive recording
+            # Read flow state ONCE here, used by both gate check and passive recording
             flow_state = ctx.store.get_flow_state(ctx.branch) if ctx.store else {}
-
-            # Get required ref key for this role
-            required_ref_key = get_role_required_ref_key(command.role)
 
             # Planner commit detection: check for unauthorized commits
             if command.role == "planner" and ctx.commit_count_before is not None:
@@ -343,7 +340,6 @@ class CodeagentExecutionService:
                     role=command.role,
                     before_state_label=ctx.before_state_label,
                     repo=getattr(self.config, "repo", None),
-                    required_ref_key=required_ref_key,
                     flow_state=flow_state,
                     tick_id=command.tick_id,
                     before_issue_is_closed=ctx.before_issue_is_closed,

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -7,10 +7,10 @@ from loguru import logger
 
 from vibe3.agents.models import ExecutionRole
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.config.role_policy import get_role_output_contract
 from vibe3.models.verdict import VerdictRecord
 from vibe3.models.verdict_types import VerdictValue
 from vibe3.services.role_policy_helpers import get_role_block_function
-from vibe3.services.verdict_policy import requires_audit_ref
 
 # Loop prevention constants
 SINGLE_STEP_LIMIT = 3  # Max occurrences of same transition pair
@@ -49,7 +49,6 @@ def apply_unified_noop_gate(
     role: ExecutionRole,
     before_state_label: str | None,
     repo: str | None = None,
-    required_ref_key: str | None = None,
     flow_state: dict | None = None,
     tick_id: int = 0,
     before_issue_is_closed: bool = False,
@@ -58,7 +57,8 @@ def apply_unified_noop_gate(
 
     Rules:
     - if the issue has no state/ label, skip (not managed by state machine)
-    - if required_ref is missing (for worker roles), block
+    - if the role's required_ref is missing from flow_state, block
+    - if the role requires a verdict and latest_verdict is absent, block
     - if the agent did not change the issue's state/ label, block
     - if the agent changed the issue's state/ label, record and pass
     """
@@ -71,6 +71,7 @@ def apply_unified_noop_gate(
     )
 
     _block_fn = get_role_block_function(role)
+    _contract = get_role_output_contract(role)
 
     if not before_state_label:
         logger.bind(
@@ -267,8 +268,46 @@ def apply_unified_noop_gate(
             )
             return
 
-    # --- NEW: reviewer verdict-aware checks ---
-    if role == "reviewer":
+    # --- Contract-driven output checks ---
+    # Each role declares its required outputs in RoleOutputContract.
+    # These checks run before the state-change check so that a missing
+    # required output blocks even when the state label happened to change.
+
+    if _contract.required_ref and flow_state is not None:
+        ref_value = flow_state.get(_contract.required_ref)
+        if not ref_value:
+            logger.bind(
+                domain="codeagent",
+                role=role,
+                issue_number=issue_number,
+                branch=branch,
+            ).warning(
+                f"No-op gate BLOCK: required ref {_contract.required_ref} "
+                f"missing after {role}"
+            )
+            store.add_event(
+                branch,
+                EVENT_REQUIRED_REF_MISSING,
+                actor,
+                detail=(
+                    f"Required ref {_contract.required_ref} missing after {role}: "
+                    f"state was {before_state_label}"
+                ),
+                refs={
+                    "before_state": str(before_state_label or ""),
+                    "issue": str(issue_number),
+                    "required_ref": _contract.required_ref,
+                },
+            )
+            _block_fn(
+                issue_number=issue_number,
+                repo=repo,
+                reason=f"required ref missing: {_contract.required_ref}",
+                actor=actor,
+            )
+            return
+
+    if _contract.requires_verdict:
         latest_verdict = _extract_latest_verdict(flow_state)
         if latest_verdict is None:
             logger.bind(
@@ -298,108 +337,6 @@ def apply_unified_noop_gate(
                 actor=actor,
             )
             return
-
-        if requires_audit_ref(latest_verdict):
-            ref_value = flow_state.get("audit_ref") if flow_state else None
-            if not ref_value:
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).warning(
-                    f"No-op gate BLOCK: required ref audit_ref missing after {role} "
-                    f"for verdict {latest_verdict}"
-                )
-                store.add_event(
-                    branch,
-                    EVENT_REQUIRED_REF_MISSING,
-                    actor,
-                    detail=(
-                        f"Required ref audit_ref missing after {role} "
-                        f"for verdict {latest_verdict}: state was {before_state_label}"
-                    ),
-                    refs={
-                        "before_state": str(before_state_label or ""),
-                        "issue": str(issue_number),
-                        "required_ref": "audit_ref",
-                        "verdict": latest_verdict,
-                    },
-                )
-                _block_fn(
-                    issue_number=issue_number,
-                    repo=repo,
-                    reason=(
-                        f"required ref missing for verdict {latest_verdict}: "
-                        "audit_ref"
-                    ),
-                    actor=actor,
-                )
-                return
-    elif required_ref_key is not None and flow_state is not None:
-        ref_value = flow_state.get(required_ref_key)
-        if not ref_value:
-            if before_state_label != after_state_label:
-                # State changed but missing ref → WARNING only, pass gate
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).warning(
-                    f"No-op gate WARNING: required ref {required_ref_key} "
-                    f"missing after {role} but state changed, passing gate"
-                )
-                store.add_event(
-                    branch,
-                    EVENT_REQUIRED_REF_MISSING,
-                    actor,
-                    detail=(
-                        f"Required ref {required_ref_key} missing after {role} "
-                        f"but state changed: {before_state_label} -> "
-                        f"{after_state_label}"
-                    ),
-                    refs={
-                        "before_state": str(before_state_label or ""),
-                        "after_state": str(after_state_label or ""),
-                        "issue": str(issue_number),
-                        "required_ref": required_ref_key,
-                        "severity": "warning",
-                    },
-                )
-                # Do NOT block — fall through to state transition check
-            else:
-                # State unchanged AND missing ref → BLOCK
-                logger.bind(
-                    domain="codeagent",
-                    role=role,
-                    issue_number=issue_number,
-                    branch=branch,
-                ).warning(
-                    f"No-op gate BLOCK: required ref {required_ref_key} "
-                    f"missing after {role} AND state unchanged"
-                )
-                store.add_event(
-                    branch,
-                    EVENT_REQUIRED_REF_MISSING,
-                    actor,
-                    detail=(
-                        f"Required ref {required_ref_key} missing after {role}: "
-                        f"state was {before_state_label}"
-                    ),
-                    refs={
-                        "before_state": str(before_state_label or ""),
-                        "issue": str(issue_number),
-                        "required_ref": required_ref_key,
-                    },
-                )
-                _block_fn(
-                    issue_number=issue_number,
-                    repo=repo,
-                    reason=f"required ref missing: {required_ref_key}",
-                    actor=actor,
-                )
-                return
 
     if before_state_label == after_state_label:
         state_desc = before_state_label or "(no state)"

--- a/src/vibe3/roles/__init__.py
+++ b/src/vibe3/roles/__init__.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from vibe3.roles.definitions import (
     IssueRoleSyncSpec,
     RoleDefinition,
+    RoleOutputContract,
     TriggerableRoleDefinition,
     TriggerName,
 )
@@ -206,6 +207,7 @@ __all__ = [
     # definitions (eager)
     "IssueRoleSyncSpec",
     "RoleDefinition",
+    "RoleOutputContract",
     "TriggerName",
     "TriggerableRoleDefinition",
     # registry (lazy)
@@ -291,6 +293,7 @@ __all__ = [
 _eager_exports = {
     "IssueRoleSyncSpec",
     "RoleDefinition",
+    "RoleOutputContract",
     "TriggerName",
     "TriggerableRoleDefinition",
 }

--- a/src/vibe3/roles/definitions.py
+++ b/src/vibe3/roles/definitions.py
@@ -16,6 +16,25 @@ TriggerName = Literal["manager", "plan", "run", "review", "blocked"]
 
 
 @dataclass(frozen=True)
+class RoleOutputContract:
+    """Declarative contract for what a role must produce after execution.
+
+    Used by the unified no-op gate to validate post-execution outputs.
+    Each role declares its own contract in its definition file.
+
+    Attributes:
+        required_ref: flow_state key that must be non-empty after execution.
+            Gate blocks if the key is absent or empty, regardless of whether
+            the state label changed. None means no ref is required.
+        requires_verdict: If True, flow_state["latest_verdict"] must be set.
+            Used exclusively by the reviewer role.
+    """
+
+    required_ref: str | None = None
+    requires_verdict: bool = False
+
+
+@dataclass(frozen=True)
 class RoleDefinition:
     """Minimal declarative definition for a runtime role."""
 
@@ -24,6 +43,7 @@ class RoleDefinition:
     worktree: WorktreeRequirement
     trigger_name: TriggerName | None = None
     trigger_state: IssueState | None = None
+    output_contract: RoleOutputContract = field(default_factory=RoleOutputContract)
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/roles/definitions.py
+++ b/src/vibe3/roles/definitions.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Literal
 
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.config.role_policy import RoleOutputContract
 from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.role_contracts import WorktreeRequirement
 from vibe3.execution.session_service import SessionRole
@@ -13,25 +14,6 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 
 TriggerName = Literal["manager", "plan", "run", "review", "blocked"]
-
-
-@dataclass(frozen=True)
-class RoleOutputContract:
-    """Declarative contract for what a role must produce after execution.
-
-    Used by the unified no-op gate to validate post-execution outputs.
-    Each role declares its own contract in its definition file.
-
-    Attributes:
-        required_ref: flow_state key that must be non-empty after execution.
-            Gate blocks if the key is absent or empty, regardless of whether
-            the state label changed. None means no ref is required.
-        requires_verdict: If True, flow_state["latest_verdict"] must be set.
-            Used exclusively by the reviewer role.
-    """
-
-    required_ref: str | None = None
-    requires_verdict: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -26,7 +26,11 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.prompts.template_loader import resolve_prompts_path
-from vibe3.roles.definitions import IssueRoleSyncSpec, TriggerableRoleDefinition
+from vibe3.roles.definitions import (
+    IssueRoleSyncSpec,
+    RoleOutputContract,
+    TriggerableRoleDefinition,
+)
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.issue_failure_service import fail_manager_issue
 
@@ -36,6 +40,7 @@ MANAGER_ROLE = TriggerableRoleDefinition(
     worktree=MANAGER_GATE_CONFIG,
     trigger_name="manager",
     trigger_state=IssueState.READY,
+    output_contract=RoleOutputContract(),
 )
 
 HANDOFF_MANAGER_ROLE = TriggerableRoleDefinition(
@@ -44,6 +49,7 @@ HANDOFF_MANAGER_ROLE = TriggerableRoleDefinition(
     worktree=MANAGER_GATE_CONFIG,
     trigger_name="manager",
     trigger_state=IssueState.HANDOFF,
+    output_contract=RoleOutputContract(),
 )
 
 

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -34,7 +34,7 @@ from vibe3.execution.role_request_factory import (
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
-from vibe3.roles.definitions import TriggerableRoleDefinition
+from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 from vibe3.services.issue_failure_service import fail_planner_issue
@@ -45,6 +45,7 @@ PLANNER_ROLE = TriggerableRoleDefinition(
     worktree=PLANNER_GATE_CONFIG,
     trigger_name="plan",
     trigger_state=IssueState.CLAIMED,
+    output_contract=RoleOutputContract(required_ref="plan_ref"),
 )
 
 

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -36,7 +36,7 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.review import ReviewRequest, ReviewScope
 from vibe3.models.snapshot import StructureDiff
-from vibe3.roles.definitions import TriggerableRoleDefinition
+from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.roles.review_helpers import (
     ReviewRunResult,
     finalize_review_output,
@@ -90,6 +90,7 @@ REVIEWER_ROLE = TriggerableRoleDefinition(
     worktree=REVIEWER_GATE_CONFIG,
     trigger_name="review",
     trigger_state=IssueState.REVIEW,
+    output_contract=RoleOutputContract(requires_verdict=True),
 )
 
 

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -14,7 +14,7 @@ from vibe3.execution.issue_role_support import (
 )
 from vibe3.execution.role_contracts import EXECUTOR_GATE_CONFIG
 from vibe3.models.orchestration import IssueState
-from vibe3.roles.definitions import TriggerableRoleDefinition
+from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.services.flow_service import FlowService
 
 if TYPE_CHECKING:
@@ -56,6 +56,7 @@ EXECUTOR_ROLE = TriggerableRoleDefinition(
     worktree=EXECUTOR_GATE_CONFIG,
     trigger_name="run",
     trigger_state=IssueState.IN_PROGRESS,
+    output_contract=RoleOutputContract(),
 )
 
 EXECUTOR_PUBLISH_ROLE = TriggerableRoleDefinition(
@@ -64,6 +65,7 @@ EXECUTOR_PUBLISH_ROLE = TriggerableRoleDefinition(
     worktree=EXECUTOR_GATE_CONFIG,
     trigger_name="run",
     trigger_state=IssueState.MERGE_READY,
+    output_contract=RoleOutputContract(),
 )
 
 

--- a/tests/vibe3/execution/test_noop_gate_ref_check.py
+++ b/tests/vibe3/execution/test_noop_gate_ref_check.py
@@ -1,4 +1,4 @@
-"""Unit tests for ref-check logic in no-op gate."""
+"""Unit tests for contract-driven ref-check logic in no-op gate."""
 
 import json
 from unittest.mock import MagicMock, patch
@@ -20,10 +20,20 @@ def _make_github_issue_payload(state_label: str = "state/plan") -> dict:
 
 
 class TestRefCheck:
-    """Tests for required_ref_key logic in no-op gate."""
+    """Tests for contract-driven output checks in no-op gate.
 
-    def test_passes_when_state_changed_but_ref_missing(self) -> None:
-        """Gate passes with warning when state changed but required ref is missing."""
+    Contracts (defined in config/role_policy.py ROLE_OUTPUT_CONTRACTS):
+      planner  → required_ref="plan_ref"  (hard: block if missing)
+      executor → no required_ref          (state change sufficient)
+      reviewer → requires_verdict=True    (audit_ref not required)
+      manager  → no requirements          (state change sufficient)
+    """
+
+    def test_planner_blocks_when_plan_ref_missing_even_if_state_changed(self) -> None:
+        """Planner gate BLOCKS when plan_ref is absent, even if state changed.
+
+        plan_ref is a hard requirement per PLANNER_ROLE output_contract.
+        """
         store = _make_mock_store()
 
         with (
@@ -42,18 +52,16 @@ class TestRefCheck:
                 actor="agent:plan",
                 role="planner",
                 before_state_label="state/plan",
-                required_ref_key="plan_ref",
                 flow_state={},  # plan_ref missing
             )
 
-        mock_block.assert_not_called()
-        # Should have two events: ref_missing warning and state_transitioned
-        assert store.add_event.call_count == 2
-        event_calls = [call[0][1] for call in store.add_event.call_args_list]
-        assert "required_ref_missing" in event_calls
-        assert "state_transitioned" in event_calls
+        mock_block.assert_called_once()
+        assert "required ref missing" in mock_block.call_args[1]["reason"]
+        assert "plan_ref" in mock_block.call_args[1]["reason"]
+        store.add_event.assert_called_once()
+        assert store.add_event.call_args[0][1] == "required_ref_missing"
 
-    def test_blocks_when_ref_missing_and_state_unchanged(self) -> None:
+    def test_planner_blocks_when_ref_missing_and_state_unchanged(self) -> None:
         """Gate blocks when required ref is missing AND state unchanged."""
         store = _make_mock_store()
 
@@ -63,7 +71,6 @@ class TestRefCheck:
                 "vibe3.services.role_policy_helpers.block_planner_noop_issue"
             ) as mock_block,
         ):
-            # State unchanged: before and after are the same
             mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
                 "state/plan"
             )
@@ -74,7 +81,6 @@ class TestRefCheck:
                 actor="agent:plan",
                 role="planner",
                 before_state_label="state/plan",
-                required_ref_key="plan_ref",
                 flow_state={},  # plan_ref missing
             )
 
@@ -82,12 +88,36 @@ class TestRefCheck:
         call_kwargs = mock_block.call_args[1]
         assert "required ref missing" in call_kwargs["reason"]
         assert "plan_ref" in call_kwargs["reason"]
-        store.add_event.assert_called_once()
-        event_args = store.add_event.call_args
-        assert event_args[0][1] == "required_ref_missing"
 
-    def test_passes_when_ref_present_and_state_changed(self) -> None:
-        """Gate passes when ref is present and state changed."""
+    def test_planner_passes_when_plan_ref_present_and_state_changed(self) -> None:
+        """Gate passes when plan_ref is present and state changed."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.role_policy_helpers.block_planner_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/in-progress"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=42,
+                branch="task/issue-42",
+                actor="agent:plan",
+                role="planner",
+                before_state_label="state/plan",
+                flow_state={"plan_ref": "docs/plans/plan.md"},
+            )
+
+        mock_block.assert_not_called()
+        store.add_event.assert_called_once()
+        assert store.add_event.call_args[0][1] == "state_transitioned"
+
+    def test_executor_passes_without_report_ref_when_state_changed(self) -> None:
+        """Executor has no required_ref; state change alone passes the gate."""
         store = _make_mock_store()
 
         with (
@@ -106,17 +136,41 @@ class TestRefCheck:
                 actor="agent:run",
                 role="executor",
                 before_state_label="state/run",
-                required_ref_key="report_ref",
-                flow_state={"report_ref": "path/to/report.md"},
+                flow_state={},  # no report_ref — that is fine for executor
             )
 
         mock_block.assert_not_called()
         store.add_event.assert_called_once()
-        event_args = store.add_event.call_args
-        assert event_args[0][1] == "state_transitioned"
+        assert store.add_event.call_args[0][1] == "state_transitioned"
 
-    def test_blocks_when_ref_present_but_state_unchanged(self) -> None:
-        """Gate blocks when ref is present but state unchanged."""
+    def test_executor_blocks_when_state_unchanged(self) -> None:
+        """Gate blocks executor when state is unchanged (even with report_ref)."""
+        store = _make_mock_store()
+
+        with (
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch(
+                "vibe3.services.role_policy_helpers.block_executor_noop_issue"
+            ) as mock_block,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/run"
+            )
+            apply_unified_noop_gate(
+                store=store,
+                issue_number=55,
+                branch="task/issue-55",
+                actor="agent:run",
+                role="executor",
+                before_state_label="state/run",
+                flow_state={"report_ref": "path/to/report.md"},
+            )
+
+        mock_block.assert_called_once()
+        assert "state unchanged" in mock_block.call_args[1]["reason"]
+
+    def test_reviewer_pass_verdict_no_audit_ref_passes(self) -> None:
+        """PASS verdict passes gate without audit_ref (audit_ref not required)."""
         store = _make_mock_store()
 
         with (
@@ -126,7 +180,7 @@ class TestRefCheck:
             ) as mock_block,
         ):
             mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
-                "state/review"
+                "state/handoff"
             )
             apply_unified_noop_gate(
                 store=store,
@@ -135,9 +189,7 @@ class TestRefCheck:
                 actor="agent:review",
                 role="reviewer",
                 before_state_label="state/review",
-                required_ref_key="audit_ref",
                 flow_state={
-                    "audit_ref": "path/to/audit.md",
                     "latest_verdict": json.dumps(
                         {
                             "verdict": "PASS",
@@ -146,31 +198,16 @@ class TestRefCheck:
                             "timestamp": "2026-05-22T00:00:00+00:00",
                             "flow_branch": "task/issue-55",
                         }
-                    ),
+                    )
                 },
             )
 
-        mock_block.assert_called_once()
-        call_kwargs = mock_block.call_args[1]
-        assert "state unchanged" in call_kwargs["reason"]
-        store.add_event.assert_called_once()
-        event_args = store.add_event.call_args
-        assert event_args[0][1] == "state_unchanged"
+        mock_block.assert_not_called()
+        assert store.add_event.call_args[0][1] == "state_transitioned"
 
-    def test_reviewer_pass_without_audit_ref_is_allowed(self) -> None:
-        """PASS verdict should not require audit_ref."""
+    def test_reviewer_minor_without_audit_ref_passes(self) -> None:
+        """MINOR verdict passes gate without audit_ref (audit_ref not required)."""
         store = _make_mock_store()
-        store.get_flow_state.return_value = {
-            "latest_verdict": json.dumps(
-                {
-                    "verdict": "PASS",
-                    "actor": "reviewer",
-                    "role": "reviewer",
-                    "timestamp": "2026-05-22T00:00:00+00:00",
-                    "flow_branch": "task/issue-55",
-                }
-            )
-        }
 
         with (
             patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
@@ -178,7 +215,6 @@ class TestRefCheck:
                 "vibe3.services.role_policy_helpers.block_reviewer_noop_issue"
             ) as mock_block,
         ):
-            latest_verdict = store.get_flow_state.return_value["latest_verdict"]
             mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
                 "state/handoff"
             )
@@ -189,52 +225,21 @@ class TestRefCheck:
                 actor="agent:review",
                 role="reviewer",
                 before_state_label="state/review",
-                required_ref_key="audit_ref",
-                flow_state={"latest_verdict": latest_verdict},
+                flow_state={
+                    "latest_verdict": json.dumps(
+                        {
+                            "verdict": "MINOR",
+                            "actor": "reviewer",
+                            "role": "reviewer",
+                            "timestamp": "2026-05-22T00:00:00+00:00",
+                            "flow_branch": "task/issue-55",
+                        }
+                    )
+                },
             )
 
         mock_block.assert_not_called()
-        event_args = store.add_event.call_args
-        assert event_args[0][1] == "state_transitioned"
-
-    def test_reviewer_minor_without_audit_ref_blocks(self) -> None:
-        """MINOR verdict still requires audit_ref."""
-        store = _make_mock_store()
-        store.get_flow_state.return_value = {
-            "latest_verdict": json.dumps(
-                {
-                    "verdict": "MINOR",
-                    "actor": "reviewer",
-                    "role": "reviewer",
-                    "timestamp": "2026-05-22T00:00:00+00:00",
-                    "flow_branch": "task/issue-55",
-                }
-            )
-        }
-
-        with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
-            patch(
-                "vibe3.services.role_policy_helpers.block_reviewer_noop_issue"
-            ) as mock_block,
-        ):
-            latest_verdict = store.get_flow_state.return_value["latest_verdict"]
-            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
-                "state/handoff"
-            )
-            apply_unified_noop_gate(
-                store=store,
-                issue_number=55,
-                branch="task/issue-55",
-                actor="agent:review",
-                role="reviewer",
-                before_state_label="state/review",
-                required_ref_key="audit_ref",
-                flow_state={"latest_verdict": latest_verdict},
-            )
-
-        mock_block.assert_called_once()
-        assert "audit_ref" in mock_block.call_args.kwargs["reason"]
+        assert store.add_event.call_args[0][1] == "state_transitioned"
 
     def test_reviewer_missing_verdict_blocks_even_if_state_changed(self) -> None:
         """Reviewer must persist a verdict before passing the gate."""
@@ -256,15 +261,14 @@ class TestRefCheck:
                 actor="agent:review",
                 role="reviewer",
                 before_state_label="state/review",
-                required_ref_key="audit_ref",
                 flow_state={},
             )
 
         mock_block.assert_called_once()
-        assert "latest verdict missing" in mock_block.call_args.kwargs["reason"]
+        assert "latest verdict missing" in mock_block.call_args[1]["reason"]
 
     def test_manager_skips_ref_check_state_changed_passes(self) -> None:
-        """Manager role skips ref check; only state change matters."""
+        """Manager role has no required outputs; only state change matters."""
         store = _make_mock_store()
 
         with (
@@ -283,11 +287,9 @@ class TestRefCheck:
                 actor="agent:manager",
                 role="manager",
                 before_state_label="state/ready",
-                required_ref_key=None,  # manager has no required ref
                 flow_state=None,
             )
 
         mock_block.assert_not_called()
         store.add_event.assert_called_once()
-        event_args = store.add_event.call_args
-        assert event_args[0][1] == "state_transitioned"
+        assert store.add_event.call_args[0][1] == "state_transitioned"

--- a/tests/vibe3/execution/test_noop_gate_transition_count.py
+++ b/tests/vibe3/execution/test_noop_gate_transition_count.py
@@ -39,7 +39,7 @@ class TestTransitionCount:
     def test_transition_count_incremented_on_state_change(self) -> None:
         """transition_count is incremented when state changes."""
         store = _make_mock_store()
-        flow_state = {"transition_count": 3}
+        flow_state = {"transition_count": 3, "plan_ref": "docs/plans/plan.md"}
         mock_conn = _make_mock_conn()
 
         with (
@@ -71,7 +71,7 @@ class TestTransitionCount:
     def test_transition_count_not_incremented_on_state_unchanged(self) -> None:
         """transition_count is NOT incremented when state is unchanged."""
         store = _make_mock_store()
-        flow_state = {"transition_count": 3}
+        flow_state = {"transition_count": 3, "plan_ref": "docs/plans/plan.md"}
 
         with (
             patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
@@ -302,7 +302,7 @@ class TestTransitionCount:
         store = _make_mock_store()
         store.count_specific_pair = Mock(return_value=2)  # Below limit
         store.record_transition = Mock()
-        flow_state: dict[str, int] = {}
+        flow_state: dict[str, object] = {"plan_ref": "docs/plans/plan.md"}
         mock_conn = _make_mock_conn()
 
         with (
@@ -333,7 +333,7 @@ class TestTransitionCount:
         store = _make_mock_store()
         store.count_specific_pair = Mock(return_value=3)  # At limit
         store.record_transition = Mock()
-        flow_state: dict[str, int] = {}
+        flow_state: dict[str, object] = {"plan_ref": "docs/plans/plan.md"}
         mock_conn = _make_mock_conn()
 
         with (
@@ -364,7 +364,7 @@ class TestTransitionCount:
         store = _make_mock_store()
         store.count_specific_pair = Mock(return_value=2)  # Below limit
         store.record_transition = Mock()
-        flow_state: dict[str, int] = {}
+        flow_state: dict[str, object] = {"plan_ref": "docs/plans/plan.md"}
         mock_conn = _make_mock_conn()
 
         with (
@@ -399,7 +399,7 @@ class TestTransitionCount:
         store = _make_mock_store()
         store.count_specific_pair = Mock(return_value=0)  # No previous occurrences
         store.record_transition = Mock()
-        flow_state: dict[str, int] = {}
+        flow_state: dict[str, object] = {"plan_ref": "docs/plans/plan.md"}
         mock_conn = _make_mock_conn()
 
         with (

--- a/tests/vibe3/execution/test_retry_counter_persistence.py
+++ b/tests/vibe3/execution/test_retry_counter_persistence.py
@@ -55,7 +55,6 @@ class TestRetryCounterPersistence:
                     role="executor",
                     before_state_label="state/running",
                     repo="owner/repo",
-                    required_ref_key="plan_ref",
                     flow_state=flow_state,
                 )
 
@@ -90,7 +89,6 @@ class TestRetryCounterPersistence:
                     role="executor",
                     before_state_label="state/running",
                     repo="owner/repo",
-                    required_ref_key="plan_ref",
                     flow_state=flow_state,
                 )
 
@@ -128,7 +126,6 @@ class TestRetryCounterPersistence:
                 role="executor",
                 before_state_label="state/running",
                 repo="owner/repo",
-                required_ref_key="plan_ref",
                 flow_state=flow_state,
             )
 
@@ -166,7 +163,6 @@ class TestRetryCounterPersistence:
                     role="executor",
                     before_state_label="state/running",
                     repo="owner/repo",
-                    required_ref_key="plan_ref",
                     flow_state=flow_state,
                 )
 


### PR DESCRIPTION
## Summary

- 新增 RoleOutputContract dataclass 到 roles/definitions.py
- 各角色实例在定义处内联 output_contract（planner: plan_ref hard; executor: 无; reviewer: requires_verdict; manager: 无）
- config/role_policy.py：ROLE_OUTPUT_CONTRACTS 替换 ROLE_TO_REQUIRED_REF_KEY
- execution/noop_gate.py：删除 required_ref_key 参数和 if role==reviewer 硬编码，改为契约驱动；移除 audit_ref 强制检查
- execution/codeagent_runner.py：删除 get_role_required_ref_key 调用

Closes #1869