### PR TITLE
test: harden DB isolation against ErrorTrackingService singleton reuse

### DIFF
--- a/tests/vibe3/conftest.py
+++ b/tests/vibe3/conftest.py
@@ -61,15 +61,20 @@ def isolate_database():
     """
     from vibe3.clients.git_client import GitClient
     from vibe3.clients.sqlite_base import _close_global_connection
+    from vibe3.services.error_tracking_service import ErrorTrackingService
 
     # Create temporary directory for this test
     with tempfile.TemporaryDirectory() as tmpdir:
         # Patch get_git_common_dir to return temp directory
         with patch.object(GitClient, "get_git_common_dir", return_value=tmpdir):
-            # Clear global connection to force re-initialization with temp DB
+            # Clear process-wide state to force re-initialization with temp DB.
+            # ErrorTrackingService may otherwise reuse a default singleton from a
+            # previous test, including a store bound to another database path.
             _close_global_connection()
+            ErrorTrackingService.clear_instance()
 
             yield Path(tmpdir)
 
-            # Cleanup: close global connection after test
+            # Cleanup: close global connection and drop service singletons after test
             _close_global_connection()
+            ErrorTrackingService.clear_instance()

--- a/tests/vibe3/test_database_isolation.py
+++ b/tests/vibe3/test_database_isolation.py
@@ -1,0 +1,48 @@
+"""Regression tests for Vibe3 test database isolation."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.services.error_helpers import record_error
+from vibe3.services.error_tracking_service import ErrorTrackingService
+
+
+def test_default_sqlite_client_uses_isolated_database(isolate_database: Path) -> None:
+    """Default SQLiteClient should derive handoff.db inside the test tempdir."""
+    store = SQLiteClient()
+
+    expected_db_path = isolate_database / "vibe3" / "handoff.db"
+    assert Path(store.db_path) == expected_db_path
+    assert expected_db_path.exists()
+
+
+def test_default_error_tracking_singleton_uses_isolated_database(
+    isolate_database: Path,
+) -> None:
+    """record_error(store=None) should not reuse a stale non-isolated singleton."""
+    record_error(
+        error_code="E_EXEC_UNKNOWN",
+        error_message="isolation regression marker",
+        issue_number=1857,
+        branch="test/database-isolation",
+    )
+
+    expected_db_path = isolate_database / "vibe3" / "handoff.db"
+    instance = ErrorTrackingService.get_instance()
+    assert Path(instance.db_path) == expected_db_path
+
+    with sqlite3.connect(expected_db_path) as conn:
+        count = conn.execute(
+            """
+            SELECT COUNT(*) FROM error_log
+            WHERE issue_number = ?
+              AND branch = ?
+              AND error_message = ?
+            """,
+            (1857, "test/database-isolation", "isolation regression marker"),
+        ).fetchone()[0]
+
+    assert count == 1


### PR DESCRIPTION
### Motivation

- Tests previously isolated the SQLite `handoff.db` by monkeypatching `GitClient.get_git_common_dir()`, but a process-wide `ErrorTrackingService` singleton could still be bound to a non-isolated DB and leak state across tests. 
- This could allow pytest mock errors or other test artifacts to be recorded into the production DB and trigger `FailedGate` in the main serve process, defeating the isolation measure.

### Description

- Clear `ErrorTrackingService` singletons at the start and end of the autouse `isolate_database` fixture in `tests/vibe3/conftest.py` to ensure per-test reinitialization of error-tracking state. 
- Also call the existing `_close_global_connection()` to reset the module-level SQLite connection so `SQLiteClient()` will pick up the temp test DB. 
- Add `tests/vibe3/test_database_isolation.py` with regression tests that assert `SQLiteClient()` and `record_error(store=None)` use the per-test temporary `{tmpdir}/vibe3/handoff.db` and that an isolation marker is written into the test DB. 
- Changes touch `tests/vibe3/conftest.py` (singleton clearing) and add the new regression test file `tests/vibe3/test_database_isolation.py`.

### Testing

- Ran targeted pytest: `uv run pytest tests/vibe3/test_database_isolation.py tests/vibe3/services/test_error_helpers.py tests/vibe3/services/test_error_helpers_exception.py tests/vibe3/orchestra/test_failed_gate.py` and all tests passed (`35 passed, 0 failed`).
- Ran linters and type checks: `uv run ruff check tests/vibe3/conftest.py tests/vibe3/test_database_isolation.py` and `uv run pyright tests/vibe3/conftest.py tests/vibe3/test_database_isolation.py`, both succeeded with no issues.
- Confirmed production DB was not created/populated by the regression marker using a small runtime check (`uv run python - <<'PY' ... PY`) which showed `.git/vibe3/handoff.db` missing in this worktree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7aa016a4832b92d2623557915234)