### PR TITLE
fix(resume): reset transition counters to prevent deadlock after unblock

### DIFF
--- a/src/vibe3/clients/sqlite_transition_history_repo.py
+++ b/src/vibe3/clients/sqlite_transition_history_repo.py
@@ -120,3 +120,18 @@ class SQLiteTransitionHistoryRepo:
             """,
             (branch, from_state, to_state, datetime.now().isoformat(), actor, event_id),
         )
+
+    def clear_transition_history(self, conn: sqlite3.Connection, branch: str) -> None:
+        """Clear all transition history records for a branch.
+
+        Called during flow resume to reset loop detection counters.
+
+        Args:
+            conn: SQLite connection
+            branch: Flow branch name
+        """
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM transition_history WHERE branch = ?",
+            (branch,),
+        )

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -8,6 +8,7 @@ This module handles reading/writing blocked state to individual sources:
 
 from __future__ import annotations
 
+import sqlite3
 from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
@@ -150,8 +151,6 @@ class BlockedStateIO:
         )
 
         # Clear transition history to reset per-pair loop detection
-        import sqlite3
-
         try:
             with sqlite3.connect(self.store.db_path) as conn:
                 self.store.clear_transition_history(conn, branch)

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -130,17 +130,38 @@ class BlockedStateIO:
         )
 
     def clear_database_cache(self, branch: str, actor: str) -> None:
-        """Clear blocked state from database cache."""
+        """Clear blocked state from database cache.
+
+        Also resets transition counters to allow flow to continue after
+        being blocked by loop protection.
+        """
         if not self.store:
             return
+
+        # Reset transition_count to allow flow to continue
         self.store.update_flow_state(
             branch,
             flow_status="active",
             blocked_reason=None,
             failed_reason=None,  # Also clear failed_reason for consistency
             blocked_by_issue=None,
+            transition_count=0,  # Reset loop protection counter
             latest_actor=actor,
         )
+
+        # Clear transition history to reset per-pair loop detection
+        import sqlite3
+
+        try:
+            with sqlite3.connect(self.store.db_path) as conn:
+                self.store.clear_transition_history(conn, branch)
+        except Exception as exc:
+            # Non-critical: log and continue
+            logger.bind(
+                domain="blocked_state",
+                action="clear_database_cache",
+                branch=branch,
+            ).warning(f"Failed to clear transition history: {exc}")
 
     def write_label_state(
         self,

--- a/tests/vibe3/clients/test_sqlite_transition_history_repo.py
+++ b/tests/vibe3/clients/test_sqlite_transition_history_repo.py
@@ -173,3 +173,33 @@ class TestTransitionHistoryRepo:
             ("new-branch",),
         )
         assert cursor.fetchone()[0] == event_id
+
+    def test_clear_transition_history_removes_all_records(self, repo, db_conn):
+        """clear_transition_history should delete all records for a branch."""
+        # Record some transitions
+        repo.record_transition(
+            db_conn, "test-branch", "state/claimed", "state/handoff", "actor1"
+        )
+        repo.record_transition(
+            db_conn, "test-branch", "state/handoff", "state/claimed", "actor2"
+        )
+        repo.record_transition(
+            db_conn, "other-branch", "state/ready", "state/claimed", "actor3"
+        )
+
+        # Clear test-branch
+        repo.clear_transition_history(db_conn, "test-branch")
+
+        # Verify test-branch records deleted
+        cursor = db_conn.cursor()
+        count_test = cursor.execute(
+            "SELECT COUNT(*) FROM transition_history WHERE branch = ?",
+            ("test-branch",),
+        ).fetchone()[0]
+        count_other = cursor.execute(
+            "SELECT COUNT(*) FROM transition_history WHERE branch = ?",
+            ("other-branch",),
+        ).fetchone()[0]
+
+        assert count_test == 0, "test-branch records should be deleted"
+        assert count_other == 1, "other-branch records should remain"

--- a/tests/vibe3/execution/test_resume_resets_transition_count.py
+++ b/tests/vibe3/execution/test_resume_resets_transition_count.py
@@ -122,6 +122,17 @@ def test_resume_resets_hard_limit_counter(tmp_path):
         latest_actor="system",
     )
 
+    # Simulate transition history
+    with sqlite3.connect(db.db_path) as conn:
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+
+    # Verify transition history recorded
+    with sqlite3.connect(db.db_path) as conn:
+        count = db.count_specific_pair(conn, branch, "state/claimed", "state/handoff")
+    assert count == 3
+
     # Mock GitHub client
     github_client = MagicMock()
     github_client.get_issue_labels.return_value = [{"name": "state/blocked"}]
@@ -149,3 +160,35 @@ def test_resume_resets_hard_limit_counter(tmp_path):
     assert flow.get("transition_count") == 0, "Hard limit counter should be reset"
     assert flow.get("blocked_reason") is None
     assert flow.get("flow_status") == "active"
+
+    # Verify transition_history cleared
+    with sqlite3.connect(db.db_path) as conn:
+        count_after = db.count_specific_pair(
+            conn, branch, "state/claimed", "state/handoff"
+        )
+    assert count_after == 0, "transition_history should be cleared"
+
+    # Verify flow can transition again without blocking
+    mock_block_fn = MagicMock()
+    with patch(
+        "vibe3.execution.noop_gate.get_role_block_function",
+        return_value=mock_block_fn,
+    ):
+        with patch(
+            "vibe3.execution.state_verification.StateVerificationService.get_issue_state_label"
+        ) as mock_state:
+            mock_state.return_value = ("state/handoff", False)
+
+            apply_unified_noop_gate(
+                store=db,
+                issue_number=issue_number,
+                branch=branch,
+                actor="test",
+                role="executor",
+                before_state_label="state/claimed",
+                repo="test/repo",
+                flow_state=flow,
+            )
+
+    # Should NOT have called block function (no re-blocking)
+    mock_block_fn.assert_not_called()

--- a/tests/vibe3/execution/test_resume_resets_transition_count.py
+++ b/tests/vibe3/execution/test_resume_resets_transition_count.py
@@ -51,10 +51,14 @@ def test_resume_resets_single_step_limit_counter(tmp_path):
     github_client.update_issue_labels.return_value = True
     github_client.update_issue_body.return_value = True
 
+    # Mock label service
+    label_service = MagicMock()
+    label_service.confirm_issue_state.return_value = "advanced"
+
     # Resume: clear blocked state
     service = BlockedStateService(
         github_client=github_client,
-        label_service=None,
+        label_service=label_service,
         store=db,
     )
     result = service.unblock(
@@ -140,10 +144,14 @@ def test_resume_resets_hard_limit_counter(tmp_path):
     github_client.update_issue_labels.return_value = True
     github_client.update_issue_body.return_value = True
 
+    # Mock label service
+    label_service = MagicMock()
+    label_service.confirm_issue_state.return_value = "advanced"
+
     # Resume
     service = BlockedStateService(
         github_client=github_client,
-        label_service=None,
+        label_service=label_service,
         store=db,
     )
     result = service.unblock(

--- a/tests/vibe3/execution/test_resume_resets_transition_count.py
+++ b/tests/vibe3/execution/test_resume_resets_transition_count.py
@@ -1,0 +1,151 @@
+"""End-to-end test: flow resume should reset transition counters.
+
+This test verifies the fix for issue #1880:
+- Flow gets blocked by single-step limit (3 occurrences)
+- task resume clears blocked_reason AND resets counters
+- Flow can continue without immediate re-blocking
+"""
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.execution.noop_gate import apply_unified_noop_gate
+from vibe3.models.orchestration import IssueState
+from vibe3.services.blocked_state_service import BlockedStateService
+
+
+def test_resume_resets_single_step_limit_counter(tmp_path):
+    """Flow blocked by single-step limit should resume successfully."""
+    db = SQLiteClient(db_path=str(tmp_path / "test.db"))
+
+    branch = "test-branch"
+    issue_number = 123
+
+    # Setup: Create flow state
+    db.update_flow_state(
+        branch,
+        flow_status="active",
+        transition_count=5,
+        latest_actor="test",
+    )
+
+    # Simulate 3 occurrences of same transition pair
+    with sqlite3.connect(db.db_path) as conn:
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+        db.record_transition(conn, branch, "state/claimed", "state/handoff", "actor")
+
+    # Verify 3 occurrences recorded
+    with sqlite3.connect(db.db_path) as conn:
+        count = db.count_specific_pair(conn, branch, "state/claimed", "state/handoff")
+    assert count == 3
+
+    # Mock GitHub client
+    github_client = MagicMock()
+    github_client.get_issue_labels.return_value = [
+        {"name": "state/blocked"},
+        {"name": "priority/8"},
+    ]
+    github_client.get_issue_body.return_value = ""
+    github_client.update_issue_labels.return_value = True
+    github_client.update_issue_body.return_value = True
+
+    # Resume: clear blocked state
+    service = BlockedStateService(
+        github_client=github_client,
+        label_service=None,
+        store=db,
+    )
+    result = service.unblock(
+        branch=branch,
+        target_state=IssueState.READY,
+        issue_number=issue_number,
+        actor="human:resume",
+    )
+
+    assert result.db_cleared, "DB should be cleared"
+    assert result.label_cleared, "Label should be cleared"
+
+    # Verify transition_count reset
+    flow = db.get_flow_state(branch)
+    assert flow is not None
+    assert flow.get("transition_count") == 0, "transition_count should be reset"
+
+    # Verify transition_history cleared
+    with sqlite3.connect(db.db_path) as conn:
+        count_after = db.count_specific_pair(
+            conn, branch, "state/claimed", "state/handoff"
+        )
+    assert count_after == 0, "transition_history should be cleared"
+
+    # Verify flow can transition again without blocking
+    # (Simulate one more transition - should not block)
+    mock_block_fn = MagicMock()
+    with patch(
+        "vibe3.execution.noop_gate.get_role_block_function",
+        return_value=mock_block_fn,
+    ):
+        with patch(
+            "vibe3.execution.state_verification.StateVerificationService.get_issue_state_label"
+        ) as mock_state:
+            mock_state.return_value = ("state/handoff", False)
+
+            apply_unified_noop_gate(
+                store=db,
+                issue_number=issue_number,
+                branch=branch,
+                actor="test",
+                role="executor",
+                before_state_label="state/claimed",
+                repo="test/repo",
+                flow_state=flow,
+            )
+
+    # Should NOT have called block function (no re-blocking)
+    mock_block_fn.assert_not_called()
+
+
+def test_resume_resets_hard_limit_counter(tmp_path):
+    """Flow blocked by hard limit (20 transitions) should resume successfully."""
+    db = SQLiteClient(db_path=str(tmp_path / "test.db"))
+
+    branch = "test-branch"
+    issue_number = 456
+
+    # Setup: Create flow state at hard limit
+    db.update_flow_state(
+        branch,
+        flow_status="blocked",
+        blocked_reason="transition count exceeded hard limit",
+        transition_count=20,
+        latest_actor="system",
+    )
+
+    # Mock GitHub client
+    github_client = MagicMock()
+    github_client.get_issue_labels.return_value = [{"name": "state/blocked"}]
+    github_client.get_issue_body.return_value = ""
+    github_client.update_issue_labels.return_value = True
+    github_client.update_issue_body.return_value = True
+
+    # Resume
+    service = BlockedStateService(
+        github_client=github_client,
+        label_service=None,
+        store=db,
+    )
+    result = service.unblock(
+        branch=branch,
+        target_state=IssueState.READY,
+        issue_number=issue_number,
+        actor="human:resume",
+    )
+
+    assert result.db_cleared
+
+    # Verify counter reset
+    flow = db.get_flow_state(branch)
+    assert flow.get("transition_count") == 0, "Hard limit counter should be reset"
+    assert flow.get("blocked_reason") is None
+    assert flow.get("flow_status") == "active"

--- a/tests/vibe3/services/test_blocked_state_io.py
+++ b/tests/vibe3/services/test_blocked_state_io.py
@@ -26,3 +26,46 @@ def test_clear_database_cache_resets_transition_count(tmp_path):
     assert flow.get("transition_count") == 0, "transition_count should be reset to 0"
     assert flow.get("blocked_reason") is None
     assert flow.get("flow_status") == "active"
+
+
+def test_clear_database_cache_returns_early_when_store_is_none():
+    """clear_database_cache should return early when store is None."""
+    from vibe3.services.blocked_state_io import BlockedStateIO
+
+    io = BlockedStateIO(store=None)
+    # Should not raise any exception
+    io.clear_database_cache("test-branch", actor="human:resume")
+
+
+def test_clear_database_cache_handles_transition_history_exception(
+    tmp_path, monkeypatch
+):
+    """clear_database_cache should handle exception from clear_transition_history."""
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.blocked_state_io import BlockedStateIO
+
+    db = SQLiteClient(db_path=str(tmp_path / "test.db"))
+
+    # Create flow state
+    db.update_flow_state(
+        "test-branch",
+        flow_status="blocked",
+        blocked_reason="test",
+        latest_actor="system",
+    )
+
+    # Mock clear_transition_history to raise exception
+    def mock_clear_history(conn, branch):
+        raise RuntimeError("Database error")
+
+    monkeypatch.setattr(db, "clear_transition_history", mock_clear_history)
+
+    io = BlockedStateIO(store=db)
+    # Should not raise exception, just log warning
+    io.clear_database_cache("test-branch", actor="human:resume")
+
+    # Verify flow state was still updated (transition_count reset)
+    flow = db.get_flow_state("test-branch")
+    assert flow is not None
+    assert flow.get("transition_count") == 0
+    assert flow.get("flow_status") == "active"

--- a/tests/vibe3/services/test_blocked_state_io.py
+++ b/tests/vibe3/services/test_blocked_state_io.py
@@ -1,0 +1,28 @@
+"""Tests for blocked_state_io module."""
+
+
+def test_clear_database_cache_resets_transition_count(tmp_path):
+    """clear_database_cache should reset transition_count to 0."""
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.blocked_state_io import BlockedStateIO
+
+    db = SQLiteClient(db_path=str(tmp_path / "test.db"))
+
+    # Create flow with non-zero transition_count
+    db.update_flow_state(
+        "test-branch",
+        flow_status="blocked",
+        blocked_reason="transition count exceeded",
+        transition_count=15,
+        latest_actor="system",
+    )
+
+    io = BlockedStateIO(store=db)
+    io.clear_database_cache("test-branch", actor="human:resume")
+
+    # Verify transition_count reset
+    flow = db.get_flow_state("test-branch")
+    assert flow is not None
+    assert flow.get("transition_count") == 0, "transition_count should be reset to 0"
+    assert flow.get("blocked_reason") is None
+    assert flow.get("flow_status") == "active"


### PR DESCRIPTION
## Summary

Fixes critical deadlock where flows blocked by transition limits could not resume because transition counters weren't reset.

**Root Cause**: Two-layer loop protection mechanism wasn't being reset when flows resumed:
- `transition_count` field (hard limit: 20 total transitions)
- `transition_history` table (single-step limit: 3 occurrences of same state pair)

When `task resume` cleared `blocked_reason` but left counters intact, flows immediately re-blocked on next transition.

**Solution**: Extended `BlockedStateIO.clear_database_cache()` to reset both counters:
- Set `transition_count=0` in flow_state table
- Clear all `transition_history` records for the branch
- Maintained unified path through `BlockedStateService.unblock()` (no independent database methods)

## Changes

**Core Implementation**:
- `src/vibe3/clients/sqlite_transition_history_repo.py`: Added `clear_transition_history()` method
- `src/vibe3/services/blocked_state_io.py`: Reset both counters in `clear_database_cache()`

**Test Coverage**:
- Unit tests for `clear_transition_history()` method
- Unit tests for `clear_database_cache()` counter reset + error paths
- E2E tests verifying resume after single-step limit (3 occurrences)
- E2E tests verifying resume after hard limit (20 transitions)

## Verification

✅ All tests passing: 2423 passed, 1 skipped, 7 xfailed, 1 xpassed
✅ Both counter mechanisms verified reset
✅ Flows can continue without immediate re-blocking

## Impact

**Affected flows**: #1644 and #1647 can now be successfully resumed.

Fixes #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)