### PR TITLE
arch: 收敛 resolver 数量，消除命令层 pre-resolution 重复

### DIFF
--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -62,10 +62,10 @@ def blocked(
 
     if not flow_status:
         # Try to auto-create flow if branch matches task/dev convention
-        import re
+        from vibe3.services.convention_resolver import ConventionResolver
 
-        match = re.search(r"(?:task|dev)/issue-(\d+)", target_branch)
-        issue_number = int(match.group(1)) if match else None
+        convention = ConventionResolver.from_repo().resolve().branch
+        issue_number = convention.parse_issue_number(target_branch)
 
         if issue_number:
             logger.bind(

--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -8,11 +8,9 @@ from loguru import logger
 from vibe3.commands.common import enable_method_trace
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.services.branch_arg import resolve_branch_arg
-from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_context_loader import load_issue_info
-from vibe3.utils.issue_ref import try_parse_issue_number
 
 
 def blocked(
@@ -50,15 +48,7 @@ def blocked(
 
     service = FlowService()
 
-    # Early handling for issue number: resolve to canonical branch
-    # before resolve_branch_arg. This avoids UserError from
-    # resolve_issue_branch_input when flow doesn't exist
-    issue_number_input = try_parse_issue_number(branch) if branch else None
-    if issue_number_input is not None:
-        convention = ConventionResolver.from_repo().resolve().branch
-        target_branch = convention.canonical_branch(issue_number_input)
-    else:
-        target_branch = resolve_branch_arg(branch)
+    target_branch = resolve_branch_arg(branch)
 
     logger.bind(
         command="flow blocked",
@@ -72,8 +62,10 @@ def blocked(
 
     if not flow_status:
         # Try to auto-create flow if branch matches task/dev convention
-        convention = ConventionResolver.from_repo().resolve().branch
-        issue_number = convention.parse_issue_number(target_branch)
+        import re
+
+        match = re.search(r"(?:task|dev)/issue-(\d+)", target_branch)
+        issue_number = int(match.group(1)) if match else None
 
         if issue_number:
             logger.bind(
@@ -150,9 +142,7 @@ def rebuild(
     appends a rebuild handoff event, and clears blocked state through the
     label-auto resume path.
     """
-    branch = (
-        ConventionResolver.from_repo().resolve().branch.canonical_branch(issue_number)
-    )
+    branch = resolve_branch_arg(str(issue_number))
     if not yes:
         typer.echo(
             "[dry-run mode] Would hard rebuild "

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -174,24 +174,16 @@ def update(
     from vibe3.clients.git_client import GitClient
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.services.branch_arg import resolve_branch_arg
-    from vibe3.services.convention_resolver import ConventionResolver
     from vibe3.utils.issue_ref import try_parse_issue_number
 
-    # Early handling for issue number: resolve to canonical branch
-    # before resolve_branch_arg. This avoids UserError from
-    # resolve_issue_branch_input when flow doesn't exist
-    issue_number_input = try_parse_issue_number(branch) if branch else None
-    if issue_number_input is not None:
-        convention = ConventionResolver.from_repo().resolve().branch
-        target_branch = convention.canonical_branch(issue_number_input)
-    else:
-        target_branch = resolve_branch_arg(branch)
+    target_branch = resolve_branch_arg(branch)
 
     # Auto-create branch if:
     # 1. Positional argument was an issue number (not explicit branch name)
     # 2. Target branch doesn't exist in git
     # 3. Target branch matches task/dev convention
     git = GitClient()
+    issue_number_input = try_parse_issue_number(branch) if branch else None
     if issue_number_input is not None and not git.branch_exists(target_branch):
         # Create branch from scene_base_ref
         config = load_orchestra_config()

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -127,7 +127,7 @@ _SYMBOL_MODULES = {
     "resolve_branch_from_pr": "vibe3.services.pr_branch_resolver",
     "resolve_command_branch": "vibe3.services.pr_branch_resolver",
     "resolve_handoff_target": "vibe3.services.handoff_resolution",
-    "resolve_issue_branch_input": "vibe3.services.branch_arg",
+    "resolve_issue_branch_input": "vibe3.services.issue_branch_resolver",
     "sanitize_event_detail_paths": "vibe3.services.path_helpers",
     "should_skip_from_queue": "vibe3.services.label_utils",
 }

--- a/src/vibe3/services/branch_arg.py
+++ b/src/vibe3/services/branch_arg.py
@@ -1,25 +1,22 @@
 """Branch argument resolution for CLI commands.
 
-Reuses issue_branch_resolver for numeric resolution with flow lookup,
-adds current-branch fallback for None input.
+Thin wrapper around resolve_command_branch for backward compatibility.
 """
 
-from vibe3.clients.git_client import GitClient
 from vibe3.services.flow_service import FlowService
-from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
+from vibe3.services.pr_branch_resolver import resolve_command_branch
 
 
 def resolve_branch_arg(branch_arg: str | None) -> str:
     """Resolve --branch argument to a canonical branch name.
 
+    This is a thin wrapper around resolve_command_branch for backward
+    compatibility with existing command imports.
+
     Rules:
     - None → current git branch
-    - digits only → canonical task branch (task/issue-N)
+    - digits only → canonical task branch (task/issue-N) if no flow exists
     - otherwise → return as-is (explicit branch name)
-
-    Unlike resolve_issue_branch_input:
-    - Returns current branch for None (not None)
-    - Falls back to canonical name if no flow exists (not original digits)
 
     Args:
         branch_arg: Branch argument from CLI (may be None, digits, or branch name)
@@ -27,16 +24,9 @@ def resolve_branch_arg(branch_arg: str | None) -> str:
     Returns:
         Resolved branch name
     """
-    if branch_arg is None:
-        return GitClient().get_current_branch()
-
-    # Delegate to existing resolver (checks flow store for task/dev patterns)
-    resolved = resolve_issue_branch_input(branch_arg, FlowService())
-    if resolved is None:
-        return GitClient().get_current_branch()
-
-    # If resolver returned original digits (no flow), convert to canonical
-    if resolved.isdigit():
-        return f"task/issue-{resolved}"
-
-    return resolved
+    return resolve_command_branch(
+        position_arg=branch_arg,
+        flow_service=FlowService(),
+        allow_no_flow=False,
+        canonical_fallback=True,
+    )

--- a/src/vibe3/services/pr_branch_resolver.py
+++ b/src/vibe3/services/pr_branch_resolver.py
@@ -6,6 +6,7 @@ import typer
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.exceptions import UserError
+from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_branch_resolver import resolve_issue_branch_input
 
@@ -69,6 +70,7 @@ def resolve_command_branch(
     flow_service: FlowService,
     github_client: GitHubClient | None = None,
     allow_no_flow: bool = False,
+    canonical_fallback: bool = False,
 ) -> str:
     """Unified branch resolution for flow/handoff/task commands.
 
@@ -87,6 +89,10 @@ def resolve_command_branch(
         allow_no_flow: If True, return raw numeric string instead of raising
             UserError when no flows exist for an issue number. Only affects
             --branch and <position-arg> paths.
+        canonical_fallback: If True, return canonical branch name for issue
+            numbers without flows (e.g., "1234" → "task/issue-1234") instead
+            of raising UserError. Only applies when input is a pure issue
+            number (digits only). Takes precedence over allow_no_flow.
 
     Returns:
         Resolved branch name
@@ -115,12 +121,20 @@ def resolve_command_branch(
 
     # Step 2: Priority 1 - Explicit --branch
     if branch_opt is not None:
-        return (
-            resolve_issue_branch_input(
-                branch_opt, flow_service, allow_no_flow=allow_no_flow
-            )
-            or branch_opt
+        # When canonical_fallback is enabled, allow_no_flow should also be True
+        # so resolve_issue_branch_input returns None instead of raising
+        effective_allow_no_flow = allow_no_flow or canonical_fallback
+        resolved = resolve_issue_branch_input(
+            branch_opt, flow_service, allow_no_flow=effective_allow_no_flow
         )
+        if resolved is not None:
+            return resolved
+        # If unresolved and canonical_fallback enabled for issue numbers
+        if canonical_fallback and branch_opt.isdigit():
+            resolver = ConventionResolver.from_repo()
+            convention = resolver.resolve()
+            return convention.branch.canonical_branch(int(branch_opt))
+        return branch_opt
 
     # Step 3: Priority 2 - --pr option
     if pr_opt is not None:
@@ -131,12 +145,20 @@ def resolve_command_branch(
 
     # Step 4: Priority 3 - Positional argument
     if position_arg is not None:
-        return (
-            resolve_issue_branch_input(
-                position_arg, flow_service, allow_no_flow=allow_no_flow
-            )
-            or position_arg
+        # When canonical_fallback is enabled, allow_no_flow should also be True
+        # so resolve_issue_branch_input returns None instead of raising
+        effective_allow_no_flow = allow_no_flow or canonical_fallback
+        resolved = resolve_issue_branch_input(
+            position_arg, flow_service, allow_no_flow=effective_allow_no_flow
         )
+        if resolved is not None:
+            return resolved
+        # If unresolved and canonical_fallback enabled for issue numbers
+        if canonical_fallback and position_arg.isdigit():
+            resolver = ConventionResolver.from_repo()
+            convention = resolver.resolve()
+            return convention.branch.canonical_branch(int(position_arg))
+        return position_arg
 
     # Step 5: Priority 4 - Current branch (fallback)
     return flow_service.get_current_branch()

--- a/tests/vibe3/commands/test_flow_blocked.py
+++ b/tests/vibe3/commands/test_flow_blocked.py
@@ -110,28 +110,16 @@ def test_flow_blocked_no_longer_supports_by_alias() -> None:
 
 def test_flow_blocked_auto_creates_flow_for_issue_branch() -> None:
     """Auto-create flow when branch matches issue convention and no flow exists."""
-    from vibe3.models.branch_convention import BranchConvention
-
     flow_service = MagicMock()
     flow_service.get_flow_status.return_value = None  # No flow exists
-
-    # Mock ConventionResolver to return vibe_center convention
-    mock_convention = BranchConvention.vibe_center()
-    mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value.branch = mock_convention
 
     # Mock flow update command
     mock_update = MagicMock()
 
     with (
         patch("vibe3.commands.flow_lifecycle.FlowService", return_value=flow_service),
-        patch(
-            "vibe3.commands.flow_lifecycle.ConventionResolver"
-        ) as mock_resolver_class,
         patch("vibe3.commands.flow_manage.update", mock_update),
     ):
-        mock_resolver_class.from_repo.return_value = mock_resolver
-
         result = runner.invoke(
             app, ["flow", "blocked", "--branch", "task/issue-1212", "--task", "467"]
         )

--- a/tests/vibe3/commands/test_flow_rebuild_command.py
+++ b/tests/vibe3/commands/test_flow_rebuild_command.py
@@ -12,20 +12,18 @@ runner = CliRunner()
 
 
 @patch("vibe3.commands.flow_lifecycle.FlowRebuildUsecase")
-@patch("vibe3.commands.flow_lifecycle.ConventionResolver")
+@patch("vibe3.commands.flow_lifecycle.resolve_branch_arg")
 @patch("vibe3.commands.flow_lifecycle.load_orchestra_config")
 @patch("vibe3.commands.flow_lifecycle.load_issue_info")
 def test_flow_rebuild_invokes_explicit_rebuild(
     load_issue_info: MagicMock,
     load_config: MagicMock,
-    convention_cls: MagicMock,
+    resolve_branch_arg_mock: MagicMock,
     rebuild_cls: MagicMock,
 ) -> None:
     config = OrchestraConfig(repo="owner/repo")
     load_config.return_value = config
-    resolved = convention_cls.from_repo.return_value.resolve.return_value
-    branch_convention = resolved.branch
-    branch_convention.canonical_branch.return_value = "feature/303"
+    resolve_branch_arg_mock.return_value = "feature/303"
     issue = IssueInfo(
         number=303,
         title="Rebuild me",

--- a/tests/vibe3/commands/test_flow_update.py
+++ b/tests/vibe3/commands/test_flow_update.py
@@ -22,16 +22,16 @@ runner = CliRunner()
 
 @patch("vibe3.commands.flow_manage.render_flow_created")
 @patch("vibe3.commands.flow_manage.FlowService")
-@patch("vibe3.services.branch_arg.GitClient")
+@patch("vibe3.services.branch_arg.FlowService")
 def test_flow_update_idempotent(
-    git_client_cls,
+    flow_service_cls_branch_arg,
     flow_service_cls,
     _render_flow_created,
 ) -> None:
     """flow update should ensure flow exists."""
-    git_client = MagicMock()
-    git_client.get_current_branch.return_value = "task/set-default-flow"
-    git_client_cls.return_value = git_client
+    flow_service_branch_arg = MagicMock()
+    flow_service_branch_arg.get_current_branch.return_value = "task/set-default-flow"
+    flow_service_cls_branch_arg.return_value = flow_service_branch_arg
 
     flow_service = MagicMock()
     flow = FlowState(
@@ -186,12 +186,14 @@ class TestFlowAddStatusCheck:
     """Tests for flow add status checking."""
 
     @patch("vibe3.commands.flow_manage.FlowService")
-    @patch("vibe3.services.branch_arg.GitClient")
-    def test_unregistered_branch_creates_flow(self, mock_git_class, mock_service_class):
+    @patch("vibe3.services.branch_arg.FlowService")
+    def test_unregistered_branch_creates_flow(
+        self, mock_flow_service_class, mock_service_class
+    ):
         """A branch without any flow record should create a new flow."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "feature/test"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "feature/test"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service.resolve_flow_name.return_value = "new-flow"

--- a/tests/vibe3/commands/test_handoff_advanced_commands.py
+++ b/tests/vibe3/commands/test_handoff_advanced_commands.py
@@ -54,12 +54,12 @@ class TestHandoffAdvancedCommands:
         assert result.exit_code == 0
 
     @patch("vibe3.commands.handoff_write.HandoffService")
-    @patch("vibe3.services.branch_arg.GitClient")
-    def test_handoff_append_command(self, mock_git_class, mock_service_class):
+    @patch("vibe3.services.branch_arg.FlowService")
+    def test_handoff_append_command(self, mock_flow_service_class, mock_service_class):
         """Test handoff append command."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "task/test-branch"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "task/test-branch"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service.append_current_handoff.return_value = "/path/to/current.md"
@@ -88,12 +88,12 @@ class TestHandoffAdvancedCommands:
         )
 
     @patch("vibe3.commands.handoff_write.HandoffService")
-    @patch("vibe3.services.branch_arg.GitClient")
-    def test_handoff_plan_command(self, mock_git_class, mock_service_class):
+    @patch("vibe3.services.branch_arg.FlowService")
+    def test_handoff_plan_command(self, mock_flow_service_class, mock_service_class):
         """Test handoff plan command."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "task/test-branch"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "task/test-branch"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service_class.return_value = mock_service
@@ -119,12 +119,12 @@ class TestHandoffAdvancedCommands:
         )
 
     @patch("vibe3.commands.handoff_write.HandoffService")
-    @patch("vibe3.services.branch_arg.GitClient")
-    def test_handoff_report_command(self, mock_git_class, mock_service_class):
+    @patch("vibe3.services.branch_arg.FlowService")
+    def test_handoff_report_command(self, mock_flow_service_class, mock_service_class):
         """Test handoff report command."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "task/test-branch"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "task/test-branch"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service_class.return_value = mock_service
@@ -150,12 +150,12 @@ class TestHandoffAdvancedCommands:
         )
 
     @patch("vibe3.commands.handoff_write.HandoffService")
-    @patch("vibe3.services.branch_arg.GitClient")
-    def test_handoff_audit_command(self, mock_git_class, mock_service_class):
+    @patch("vibe3.services.branch_arg.FlowService")
+    def test_handoff_audit_command(self, mock_flow_service_class, mock_service_class):
         """Test handoff audit command."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "task/test-branch"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "task/test-branch"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service_class.return_value = mock_service
@@ -317,13 +317,15 @@ def test_handoff_next_sets_next_step_for_numeric_branch() -> None:
 
 
 def test_handoff_next_rejects_nonexistent_flow() -> None:
-    """Should fail-fast with UserError if no flow found."""
+    """Should fail-fast if no flow state exists for the resolved branch."""
     service = MagicMock()
 
     # Mock store with no flow binding and no unbound candidates
     mock_store = MagicMock()
     mock_store.get_flows_by_issue.return_value = []
-    mock_store.get_flow_state.return_value = None  # No unbound candidates either
+    mock_store.get_flow_state.return_value = (
+        None  # No unbound candidates, no flow state
+    )
     service.store = mock_store
 
     # Mock FlowService in branch_arg (resolver creates its own instance)
@@ -339,11 +341,11 @@ def test_handoff_next_rejects_nonexistent_flow() -> None:
             ["handoff", "next", "message", "--branch", "999"],
         )
 
+    # With canonical_fallback=True, resolver returns "task/issue-999"
+    # But command should still fail because there's no flow state
     assert result.exit_code == 1
-    # UserError should be captured in the exception attribute
-    assert result.exception is not None
-    assert "No flow found for issue #999" in str(result.exception)
-    # Should NOT call record_next_step when flow doesn't exist
+    assert "没有 flow" in result.output
+    # Should NOT call record_next_step when flow state doesn't exist
     service.record_next_step.assert_not_called()
 
 

--- a/tests/vibe3/commands/test_handoff_basic_commands.py
+++ b/tests/vibe3/commands/test_handoff_basic_commands.py
@@ -17,14 +17,14 @@ class TestHandoffBasicCommands:
 
     @pytest.mark.parametrize("force,expected_force", [(False, False), (True, True)])
     @patch("vibe3.commands.handoff_write.HandoffService")
-    @patch("vibe3.services.branch_arg.GitClient")
+    @patch("vibe3.services.branch_arg.FlowService")
     def test_handoff_init_command(
-        self, mock_git_class, mock_service_class, force, expected_force
+        self, mock_flow_service_class, mock_service_class, force, expected_force
     ):
         """Test handoff init command."""
-        mock_git = MagicMock()
-        mock_git.get_current_branch.return_value = "task/test-branch"
-        mock_git_class.return_value = mock_git
+        mock_flow_service = MagicMock()
+        mock_flow_service.get_current_branch.return_value = "task/test-branch"
+        mock_flow_service_class.return_value = mock_flow_service
 
         mock_service = MagicMock()
         mock_service.storage.ensure_current_handoff.return_value = "/path/to/current.md"

--- a/tests/vibe3/services/test_branch_arg.py
+++ b/tests/vibe3/services/test_branch_arg.py
@@ -1,0 +1,47 @@
+"""Tests for branch_arg resolver wrapper."""
+
+from unittest.mock import Mock, patch
+
+from vibe3.services.branch_arg import resolve_branch_arg
+
+
+class TestResolveBranchArg:
+    """测试 resolve_branch_arg 薄包装行为"""
+
+    def test_none_returns_current_branch(self):
+        """测试：None 输入返回当前分支"""
+        with patch("vibe3.services.branch_arg.FlowService") as mock_fs_cls:
+            mock_flow_service = Mock()
+            mock_fs_cls.return_value = mock_flow_service
+            mock_flow_service.get_current_branch.return_value = "dev/issue-123"
+
+            result = resolve_branch_arg(None)
+            assert result == "dev/issue-123"
+
+    def test_issue_number_returns_canonical_branch(self):
+        """测试：纯数字输入返回 canonical branch（无 flow 时）"""
+        with patch("vibe3.services.branch_arg.FlowService") as mock_fs_cls:
+            mock_flow_service = Mock()
+            mock_fs_cls.return_value = mock_flow_service
+
+            mock_store = Mock()
+            mock_flow_service.store = mock_store
+            mock_store.get_flows_by_issue.return_value = []
+            mock_store.get_flow_state.return_value = None
+
+            result = resolve_branch_arg("456")
+            assert result == "task/issue-456"
+
+    def test_branch_name_returns_as_is(self):
+        """测试：分支名输入返回原值"""
+        with patch("vibe3.services.branch_arg.FlowService") as mock_fs_cls:
+            mock_flow_service = Mock()
+            mock_fs_cls.return_value = mock_flow_service
+
+            mock_store = Mock()
+            mock_flow_service.store = mock_store
+            mock_store.get_flows_by_issue.return_value = []
+            mock_store.get_flow_state.return_value = None
+
+            result = resolve_branch_arg("dev/issue-789")
+            assert result == "dev/issue-789"

--- a/tests/vibe3/services/test_pr_branch_resolver.py
+++ b/tests/vibe3/services/test_pr_branch_resolver.py
@@ -191,6 +191,74 @@ class TestResolveCommandBranch:
         assert "PR #9999 不存在" in str(exc_info.value)
 
 
+class TestResolveCommandBranchCanonicalFallback:
+    """测试 canonical_fallback 参数"""
+
+    def test_canonical_fallback_with_issue_number_no_flow(self):
+        """测试：纯数字输入无 flow 时返回 canonical branch"""
+        from unittest.mock import Mock
+
+        from vibe3.services.pr_branch_resolver import resolve_command_branch
+
+        mock_store = Mock()
+        mock_store.get_flows_by_issue.return_value = []  # No flows
+        mock_store.get_flow_state.return_value = None  # No candidates
+
+        mock_flow_service = Mock()
+        mock_flow_service.store = mock_store
+        mock_flow_service.get_current_branch.return_value = "main"
+
+        result = resolve_command_branch(
+            branch_opt="1234",
+            flow_service=mock_flow_service,
+            canonical_fallback=True,
+        )
+
+        # Should return canonical branch, not raise UserError
+        assert result == "task/issue-1234"
+
+    def test_canonical_fallback_false_raises_error_no_flow(self):
+        """测试：canonical_fallback=False 时仍抛出 UserError"""
+        from unittest.mock import Mock
+
+        from vibe3.exceptions import UserError
+        from vibe3.services.pr_branch_resolver import resolve_command_branch
+
+        mock_store = Mock()
+        mock_store.get_flows_by_issue.return_value = []
+        mock_store.get_flow_state.return_value = None
+
+        mock_flow_service = Mock()
+        mock_flow_service.store = mock_store
+
+        with pytest.raises(UserError) as exc_info:
+            resolve_command_branch(
+                branch_opt="1234",
+                flow_service=mock_flow_service,
+                canonical_fallback=False,
+            )
+
+        assert "No flow found for issue #1234" in str(exc_info.value)
+
+    def test_canonical_fallback_ignored_for_branch_name(self):
+        """测试：非数字输入时 canonical_fallback 无效"""
+        from unittest.mock import Mock
+
+        from vibe3.services.pr_branch_resolver import resolve_command_branch
+
+        mock_flow_service = Mock()
+        mock_flow_service.get_current_branch.return_value = "main"
+
+        result = resolve_command_branch(
+            branch_opt="dev/issue-999",
+            flow_service=mock_flow_service,
+            canonical_fallback=True,
+        )
+
+        # Should return as-is (branch name)
+        assert result == "dev/issue-999"
+
+
 class TestCommandIntegration:
     """测试命令集成"""
 


### PR DESCRIPTION
## Summary

收敛 resolver 架构，消除命令层 pre-resolution 反模式：

1. **新增 `canonical_fallback` 参数**：`resolve_command_branch()` 支持返回 canonical branch 而非抛出 UserError
2. **重写 `resolve_branch_arg()`**：改为薄包装，代码量减少 25%
3. **删除命令层 pre-resolution**：flow_lifecycle.py 和 flow_manage.py 共删除 18 行反模式代码

### 架构变更

**变更前** (4 层，职责不清):
```
resolve_branch_arg()              ← 40 行，与下面重复
resolve_command_branch()          ← 80 行，缺少 canonical fallback
命令层 pre-resolution             ← 手动绕过 resolver (18 行反模式)
```

**变更后** (3 层，职责清晰):
```
resolve_branch_arg()              ← 32 行薄包装 (-25%)
  └→ resolve_command_branch()     ← 90 行，统一 canonical_fallback
       └→ resolve_issue_branch_input() ← 核心
命令层                            ← 直接调用，无 pre-resolution
```

### 代码质量改进

| 指标 | 变更前 | 变更后 | 改进 |
|------|--------|--------|------|
| `branch_arg.py` 行数 | 43 | 32 | -25% |
| `flow_lifecycle.py` pre-resolution | 9 行 | 1 行 | -89% |
| `flow_manage.py` pre-resolution | 9 行 | 1 行 | -89% |
| Resolver 重复逻辑 | 2 套 | 1 套 | -50% |
| 测试覆盖 | 27 tests | 33 tests | +22% |

## Test plan

- ✅ 所有 resolver 测试通过 (33 tests)
- ✅ 所有命令测试通过 (21 tests + 3 修复)
- ✅ 类型检查通过 (mypy)
- ✅ Pre-commit hooks 通过
- ✅ Pre-push 测试通过
- ✅ 手动集成测试：
  - `vibe3 flow blocked --branch 9999` → canonical branch resolution
  - `vibe3 flow update 8888` → auto-create branch + flow

## Related

- Closes #1851
- 前置：#1849（统一 resolve_task_issue_number）、#1850（删除 branch_resolver.py）

🤖 Generated with [Claude Code](https://claude.com/claude-code)