### PR TITLE
feat(vibe-commit): add LOC enforcement check before PR creation

### DIFF
--- a/.agent/workflows/vibe:commit.md
+++ b/.agent/workflows/vibe:commit.md
@@ -21,6 +21,10 @@ tags: [workflow, vibe, git, commit, orchestration]
    - 不允许使用 `--no-verify` 跳过
    - 任何错误（mypy、shellcheck、LOC 超限等）必须修复后才能继续
    - 格式化修改将分散到后续各功能 commit 中，不保留单独的格式化 commit
+   - **LOC 强制检查**（PR 创建前 hard block）：
+     - `ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-per-file-loc.sh`
+     - `ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-test-file-loc.sh`
+     - 任何文件超限必须修复，不允许创建 PR
 4. 在任何 commit 分组前，先做最小 metadata preflight：
    - 读取 `vibe flow show --json`
    - 若存在 `current_task`，继续读取 `vibe3 task status --json`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,14 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      - id: check-test-file-loc
+        name: "Check test file LOC (default: 200, max: 300)"
+        entry: scripts/hooks/check-test-file-loc.sh
+        language: script
+        pass_filenames: false
+        files: ^tests/.*\.py$
+        stages: [pre-push]
+
       - id: pre-push-checks
         name: Pre-push checks (coverage + risk-based review)
         entry: scripts/hooks/pre-push.sh

--- a/skills/vibe-commit/SKILL.md
+++ b/skills/vibe-commit/SKILL.md
@@ -77,6 +77,10 @@ PR 创建后停止，输出：
   │   └─ 依次验证、发 PR
   │
   ├─ Step 8: 发 PR 前复核
+  │   ├─ LOC 强制检查（Hard Block）
+  │   │   ├─ ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-per-file-loc.sh
+  │   │   ├─ ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-test-file-loc.sh
+  │   │   └─ 任何文件超限必须修复，禁止创建 PR
   │   ├─ 工作区已干净
   │   ├─ commit 只服务一个交付目标
   │   └─ uv run python src/vibe3/cli.py pr create --base <ref>
@@ -328,6 +332,36 @@ ls debug_*.py debug_*.sh tmp_*.py 2>/dev/null || echo "No debug files found"
 
 ### Step 8: 发 PR 前复核
 
+**LOC 强制检查（Hard Block）**：
+
+在发 PR 前，必须确认所有文件（含测试文件）未超过 LOC 限制。
+
+**执行命令**：
+
+```bash
+# 检查源代码文件 LOC
+ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-per-file-loc.sh
+
+# 检查测试文件 LOC
+ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-test-file-loc.sh
+```
+
+**Hard Block 规则**：
+
+- 任何文件超过 CI block threshold（默认 400 行）时，禁止创建 PR
+- 必须先修复（重构、拆分、或申请 exception）再继续
+- 不允许跳过此检查
+
+**修复方案**（按优先级）：
+
+1. 提取函数/类到新模块（推荐）
+2. 拆分测试文件为多个 test_*.py
+3. 在 `config/v3/loc_limits.yaml` 中申请 exception（需有合理理由）
+
+**注意**：此检查使用 `ENFORCE_LOC_LIMITS=true` 模式，与 CI 一致。即使 pre-push hook 仅 advisory，此步骤始终强制执行。
+
+---
+
 先读取：
 
 ```bash
@@ -467,6 +501,10 @@ uv run python src/vibe3/cli.py handoff append "vibe-commit: PR created" --kind n
   - 必须在组织 commit 分组前完成 pre-commit 验证
   - 格式化流程：对所有改动统一格式化 → 提交临时 commit → 软重置（检查是否为临时 commit）→ 分组提交
   - 不得保留单独的格式化 commit，格式化修改必须分散到各功能 commit 中
+- **LOC 强制检查**：
+  - 发 PR 前必须通过 LOC 检查（`ENFORCE_LOC_LIMITS=true`）
+  - 超限文件必须修复或申请 exception，不允许跳过
+  - 此检查与 CI 保持一致，确保本地和远程行为相同
 - **主分支同步**：
   - 提交前必须检查 `origin/main` 是否有新提交
   - 冲突未解决前禁止提交


### PR DESCRIPTION
## Summary

Add mandatory LOC check (ENFORCE_LOC_LIMITS=true) in vibe-commit Step 8 to block PR creation when files exceed CI limits.

## Root Cause

LOC checks were advisory-only locally, allowing PRs with violations to be created, wasting CI resources.

## Changes

1. **skills/vibe-commit/SKILL.md**:
   - Add LOC check to Step 8 flowchart and detailed instructions
   - Add LOC hard block rule to Restrictions section
   - Commands: check-per-file-loc.sh and check-test-file-loc.sh

2. **.agent/workflows/vibe:commit.md**:
   - Add LOC enforcement check to pre-commit verification step
   - Clarify hard block behavior for PR creation

3. **.pre-commit-config.yaml**:
   - Register check-test-file-loc.sh as pre-push hook
   - Ensures consistency with check-per-file-loc.sh

## Verification

✅ Both LOC scripts execute correctly with ENFORCE_LOC_LIMITS=true
✅ Current state: 0 files exceed 400-line CI block threshold
✅ All pre-commit checks passed
✅ Pre-push hooks passed (smoke tests, type checks, LOC checks)

## Impact

- Low risk: Documentation and configuration changes only, no Python code logic changes
- Solution reuses existing tested scripts
- Ensures consistency between local and CI behavior

Closes #1832

---

## Contributors

claude/opus
