### PR TITLE
fix(init): add next-steps guidance after vibe init

### DIFF
--- a/lib/init.sh
+++ b/lib/init.sh
@@ -424,28 +424,33 @@ vibe_init() {
 
     echo "Next steps:"
     if [[ "$PROFILE_NAME" == "minimal" ]]; then
-        echo "  1. Your project is ready with minimal runtime"
-        echo "  2. Policies and prompts from: ${CYAN}~/.vibe/assets${NC}"
-        echo "  3. Start using vibe commands"
+        echo "  1. Run ${CYAN}/vibe-project-check${NC} to verify your environment"
+        echo "  2. Configure manager-bot token (${CYAN}VIBE_MANAGER_GITHUB_TOKEN${NC}) if you need orchestra"
+        echo "  3. Optional: start orchestra with ${CYAN}vibe3 serve${NC}"
+        echo "  4. Policies and prompts from: ${CYAN}~/.vibe/assets${NC}"
     elif [[ "$PROFILE_NAME" == "github-flow" ]]; then
-        echo "  1. Review created directories: ${CYAN}.agent/${NC} and ${CYAN}.claude/${NC}"
+        echo "  1. Run ${CYAN}/vibe-project-check${NC} to verify your environment"
+        echo "  2. Configure manager-bot token (${CYAN}VIBE_MANAGER_GITHUB_TOKEN${NC}) if you need orchestra"
         if [[ "$SKIP_LABELS" == true ]]; then
-            echo "  2. Create GitHub labels manually if needed"
+            echo "  3. Create GitHub labels manually if needed"
         else
-            echo "  2. Check GitHub labels: ${CYAN}gh label list | grep ${STATE_PREFIX}${NC}"
+            echo "  3. Check GitHub labels: ${CYAN}gh label list | grep ${STATE_PREFIX}${NC}"
         fi
-        echo "  3. Policies and prompts from: ${CYAN}~/.vibe/assets${NC}"
-        echo "  4. Start using vibe flow/task commands"
+        echo "  4. Optional: start orchestra with ${CYAN}vibe3 serve${NC}"
+        echo "  5. Review created directories: ${CYAN}.agent/${NC} and ${CYAN}.claude/${NC}"
+        echo "  6. Policies and prompts from: ${CYAN}~/.vibe/assets${NC}"
     elif [[ "$PROFILE_NAME" == "vibe-center" ]]; then
-        echo "  1. Review created directories: ${CYAN}.agent/${NC}, ${CYAN}skills/${NC}, ${CYAN}.claude/${NC}"
+        echo "  1. Run ${CYAN}/vibe-project-check${NC} to verify your environment"
+        echo "  2. Configure manager-bot token (${CYAN}VIBE_MANAGER_GITHUB_TOKEN${NC}) if you need orchestra"
         if [[ "$SKIP_LABELS" == true ]]; then
-            echo "  2. Create GitHub labels manually if needed"
+            echo "  3. Create GitHub labels manually if needed"
         else
-            echo "  2. Check GitHub labels: ${CYAN}gh label list | grep ${STATE_PREFIX}${NC}"
+            echo "  3. Check GitHub labels: ${CYAN}gh label list | grep ${STATE_PREFIX}${NC}"
         fi
-        echo "  3. Policies and prompts from: ${CYAN}.agent/policies${NC} and ${CYAN}config/prompts${NC}"
-        echo "  4. Supervisor orchestration: ${CYAN}.agent/supervisor/${NC}"
-        echo "  5. Start using full Vibe Center capabilities"
+        echo "  4. Optional: start orchestra with ${CYAN}vibe3 serve${NC}"
+        echo "  5. Review created directories: ${CYAN}.agent/${NC}, ${CYAN}skills/${NC}, ${CYAN}.claude/${NC}"
+        echo "  6. Policies and prompts from: ${CYAN}.agent/policies${NC} and ${CYAN}config/prompts${NC}"
+        echo "  7. Supervisor orchestration: ${CYAN}.agent/supervisor/${NC}"
     fi
     echo ""
 }

--- a/tests/vibe2/integration/test_init_claude_md_template.bats
+++ b/tests/vibe2/integration/test_init_claude_md_template.bats
@@ -97,3 +97,24 @@ setup() {
   # Intentional behavior: minimal profile does not check for AGENTS.md
   [[ ! "$output" =~ "Missing: AGENTS.md" ]]
 }
+
+@test "vibe init output guides users to project check and manager token setup" {
+  local fixture
+  fixture="$(mktemp -d)"
+  git -C "$fixture" init >/dev/null 2>&1
+
+  run zsh -c "
+    export VIBE_ROOT='$REPO_ROOT'
+    export VIBE_LIB='$REPO_ROOT/lib'
+    export GREEN='' RED='' YELLOW='' CYAN='' BOLD='' NC=''
+    source '$REPO_ROOT/lib/profiles.sh'
+    source '$REPO_ROOT/lib/init.sh'
+    cd '$fixture'
+    vibe_init --profile minimal --yes --skip-labels 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "/vibe-project-check" ]]
+  [[ "$output" =~ "VIBE_MANAGER_GITHUB_TOKEN" ]]
+  [[ "$output" =~ "vibe3 serve" ]]
+}


### PR DESCRIPTION
## Summary
- Corrects #1866 to the real init surface: V2 `vibe init` in `lib/init.sh`, not a new `vibe3 init` command.
- Adds post-init guidance to run `/vibe-project-check`, configure `VIBE_MANAGER_GITHUB_TOKEN`, and optionally start orchestra with `vibe3 serve`.
- Adds V2 bats coverage for the output guidance.

## Scope
- No new `vibe3 init` command.
- No new configuration/file-creation logic beyond existing `vibe init` behavior.
- Keeps business checks in `/vibe-project-check`.

## Test Plan
- [x] `uv run bats tests/vibe2/integration/test_init_claude_md_template.bats`
- [x] `uv run bats tests/vibe2/integration/test_init_no_remote.bats`
- [x] `uv run bats tests/vibe2/integration/test_init_legacy_fallback.bats`
- [x] `uv run python src/vibe3/cli.py --help >/tmp/vibe3_help_check.txt && rg -n "init|flow|task" /tmp/vibe3_help_check.txt`
- [x] pre-commit hooks on commit
- [x] pre-push checks

Closes #1866

---

## Contributors

codex/gpt-5
