### PR TITLE
fix(check): sync orchestration_state after multi-label auto-fix

### DIFF
--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -174,7 +174,7 @@ class CheckService(CheckRemote):
 
     def _check_multiple_state_labels(
         self, issue_number: int, issue_payload: dict
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str], IssueState | None]:
         """Check for multiple state/* labels and auto-fix the anomaly.
 
         An issue should have exactly one state/* label. Having multiple
@@ -201,7 +201,7 @@ class CheckService(CheckRemote):
         ]
 
         if len(state_labels) <= 1:
-            return ([], [])
+            return ([], [], None)
 
         # Determine which state to keep (highest priority)
         priority_order = [
@@ -235,6 +235,7 @@ class CheckService(CheckRemote):
                     f"({', '.join(state_labels)}) with unknown state, "
                     f"manual fix required"
                 ],
+                None,
             )
 
         # Auto-fix using LabelService (atomic: add new, remove old)
@@ -254,6 +255,7 @@ class CheckService(CheckRemote):
                     f"{target_state.to_label()}"
                 ],
                 [],
+                target_state,
             )
         except Exception as exc:
             logger.bind(domain="check", action="fix").warning(
@@ -265,6 +267,7 @@ class CheckService(CheckRemote):
                     f"Issue #{issue_number} has multiple state labels "
                     f"({', '.join(state_labels)}), manual fix required"
                 ],
+                None,
             )
 
     def _check_branch(self, branch: str) -> CheckResult:
@@ -333,11 +336,13 @@ class CheckService(CheckRemote):
                         task_issue_closed = True
 
                     # Check for multiple state/* labels (anomaly)
-                    label_warnings, label_issues = self._check_multiple_state_labels(
-                        task_issue, issue_payload
+                    label_warnings, label_issues, fixed_state = (
+                        self._check_multiple_state_labels(task_issue, issue_payload)
                     )
                     warnings.extend(label_warnings)
                     issues.extend(label_issues)
+                    if fixed_state is not None:
+                        orchestration_state = fixed_state
 
             # only one task issue per branch
             if len(task_issues) > 1:

--- a/tests/vibe3/services/test_check_multiple_state_labels.py
+++ b/tests/vibe3/services/test_check_multiple_state_labels.py
@@ -40,7 +40,7 @@ def test_no_state_labels_returns_empty(check_service):
     """Test that issue with no state labels returns empty warnings/issues."""
     issue_payload = {"labels": []}
 
-    warnings, issues = check_service._check_multiple_state_labels(123, issue_payload)
+    warnings, issues, _ = check_service._check_multiple_state_labels(123, issue_payload)
 
     assert warnings == []
     assert issues == []
@@ -50,7 +50,7 @@ def test_single_state_label_returns_empty(check_service):
     """Test that issue with single state label returns empty warnings/issues."""
     issue_payload = {"labels": [{"name": "state/blocked"}]}
 
-    warnings, issues = check_service._check_multiple_state_labels(123, issue_payload)
+    warnings, issues, _ = check_service._check_multiple_state_labels(123, issue_payload)
 
     assert warnings == []
     assert issues == []
@@ -70,7 +70,7 @@ def test_multiple_state_labels_auto_fix_success(check_service):
         mock_label_service = MagicMock()
         mock_cls.return_value = mock_label_service
 
-        warnings, issues = check_service._check_multiple_state_labels(
+        warnings, issues, _ = check_service._check_multiple_state_labels(
             123, issue_payload
         )
 
@@ -104,7 +104,7 @@ def test_multiple_state_labels_priority_order(check_service):
             mock_label_service = MagicMock()
             mock_cls.return_value = mock_label_service
 
-            warnings, issues = check_service._check_multiple_state_labels(
+            warnings, issues, _ = check_service._check_multiple_state_labels(
                 123, issue_payload
             )
 
@@ -122,7 +122,7 @@ def test_unknown_state_labels_flagged_for_manual_fix(check_service):
         ]
     }
 
-    warnings, issues = check_service._check_multiple_state_labels(123, issue_payload)
+    warnings, issues, _ = check_service._check_multiple_state_labels(123, issue_payload)
 
     # Should return issue (manual fix required), not warning
     assert len(warnings) == 0
@@ -144,7 +144,7 @@ def test_mixed_known_unknown_state_labels_keeps_known(check_service):
         mock_label_service = MagicMock()
         mock_cls.return_value = mock_label_service
 
-        warnings, issues = check_service._check_multiple_state_labels(
+        warnings, issues, _ = check_service._check_multiple_state_labels(
             123, issue_payload
         )
 
@@ -171,7 +171,7 @@ def test_auto_fix_failure_returns_manual_fix_issue(check_service):
         mock_label_service.set_state.side_effect = Exception("GitHub API error")
         mock_cls.return_value = mock_label_service
 
-        warnings, issues = check_service._check_multiple_state_labels(
+        warnings, issues, _ = check_service._check_multiple_state_labels(
             123, issue_payload
         )
 
@@ -195,7 +195,7 @@ def test_merge_ready_included_in_priority_list(check_service):
         mock_label_service = MagicMock()
         mock_cls.return_value = mock_label_service
 
-        warnings, issues = check_service._check_multiple_state_labels(
+        warnings, issues, _ = check_service._check_multiple_state_labels(
             123, issue_payload
         )
 


### PR DESCRIPTION
## Summary

- `_check_multiple_state_labels` now returns the applied `IssueState` as a third element
- Caller in `_check_branch` updates `orchestration_state` when a fix was applied

## Problem

`issue_state_from_payload` returns the **first** matching state label in the list, not the highest priority one. When `_check_multiple_state_labels` removed excess labels and kept `target_state`, the in-memory `orchestration_state` was never updated — so the rest of `_check_branch` continued reasoning from the pre-fix (potentially wrong) state.

## Fix

Return `target_state` from `_check_multiple_state_labels` and update `orchestration_state` immediately after the fix succeeds. No DB writes, no remote reads — pure in-memory sync within the same check pass.

## Test Plan

- [x] mypy passes
- [x] Existing tests pass (`test_check_service.py` 3/3)

---

## Contributors

claude/opus