### PR TITLE
fix: Closed issue dispatch bug - prevent FailedGate blocking

### DIFF
--- a/src/vibe3/exceptions/error_classification.py
+++ b/src/vibe3/exceptions/error_classification.py
@@ -274,13 +274,16 @@ ERROR_REGISTRY: dict[str, ErrorHandlingContract] = {
     ),
     E_DISPATCH_FAILURE: ErrorHandlingContract(
         code=E_DISPATCH_FAILURE,
-        severity=ErrorSeverity.ERROR,
-        counts_toward_threshold=True,
+        severity=ErrorSeverity.WARNING,
+        counts_toward_threshold=False,
         record_in_error_log=True,
         write_timeline_event=True,
         issue_action="record_only",
-        gate_action="threshold",
-        description="Dispatch failure (launch_failed, worktree_unavailable, etc.)",
+        gate_action="ignore",
+        description=(
+            "Dispatch infrastructure failure (worktree/launch) "
+            "— does not block orchestra"
+        ),
     ),
     E_EXEC_FLOW_FAILURE: ErrorHandlingContract(
         code=E_EXEC_FLOW_FAILURE,

--- a/src/vibe3/orchestra/dispatch_health_check.py
+++ b/src/vibe3/orchestra/dispatch_health_check.py
@@ -88,17 +88,28 @@ class DispatchHealthCheckService:
         # Use CheckService for unified health check
         result = self._check_service.verify_branch(branch)
 
-        # Get flow status to determine if dispatch should proceed
+        # Get flow status BEFORE checking result.is_valid.
+        # verify_branch() may have just written an abort; reading here ensures
+        # we see the updated state and avoid calling block_flow on terminal flows.
         flow_state = self._store.get_flow_state(branch)
         flow_status = (
             flow_state.get("flow_status", "active") if flow_state else "active"
         )
 
-        # Determine dispatch eligibility:
+        # Terminal state takes priority: skip dispatch cleanly without block_flow.
+        # This handles flows auto-aborted by verify_branch (closed issue, missing
+        # branch, orphaned flow) as well as flows already in done/stale state.
+        if flow_status in ("done", "aborted", "stale"):
+            append_orchestra_event(
+                "dispatcher",
+                f"DispatchHealthCheckService: skipped #{issue.number} "
+                f"(flow is {flow_status})",
+            )
+            return False
+
+        # Determine dispatch eligibility for non-terminal flows:
         # - Fail-open for transient errors (network/auth) and missing flow records
         # - Return False for genuine consistency failures (issue closed, PR merged)
-        # - Return False if flow is done/aborted (terminal state)
-        # - Return True if flow is healthy and active
         if not result.is_valid:
             # Check if this is a transient/expected error that should fail-open
             transient_errors = [
@@ -143,14 +154,6 @@ class DispatchHealthCheckService:
                     f"DispatchHealthCheckService: blocked #{issue.number} "
                     f"(health check failed: {reason})",
                 )
-            return False
-
-        if flow_status in ("done", "aborted", "stale"):
-            append_orchestra_event(
-                "dispatcher",
-                f"DispatchHealthCheckService: skipped #{issue.number} "
-                f"(flow is {flow_status})",
-            )
             return False
 
         return True

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -388,7 +388,11 @@ class CheckService(CheckRemote):
                 self._flow_status_service.mark_flow_aborted(
                     branch, f"Task issue #{task_issue} is CLOSED (no open PR found)"
                 )
-                return CheckResult(is_valid=True, branch=branch, issues=[])
+                return CheckResult(
+                    is_valid=False,
+                    branch=branch,
+                    issues=[f"Task issue #{task_issue} is CLOSED (no open PR found)"],
+                )
 
             flow_status = flow_data.get("flow_status", "active")
 
@@ -408,9 +412,13 @@ class CheckService(CheckRemote):
                 self._flow_status_service.mark_flow_aborted(
                     branch, f"Branch '{branch}' no longer exists locally"
                 )
-                return CheckResult(is_valid=True, branch=branch, issues=[])
+                return CheckResult(
+                    is_valid=False,
+                    branch=branch,
+                    issues=[f"Branch '{branch}' no longer exists locally"],
+                )
 
-            # Handle orphaned active flow: no task issue + no worktree + stale
+                # Handle orphaned active flow: no task issue + no worktree + stale
             # Only clean up flows that have no issue binding and are
             # significantly behind
             if (
@@ -429,7 +437,14 @@ class CheckService(CheckRemote):
                             f"Orphaned flow '{branch}' is {behind_count} "
                             "commits behind main",
                         )
-                        return CheckResult(is_valid=True, branch=branch, issues=[])
+                        return CheckResult(
+                            is_valid=False,
+                            branch=branch,
+                            issues=[
+                                f"Orphaned flow '{branch}' is {behind_count} "
+                                "commits behind main"
+                            ],
+                        )
                 except Exception as exc:
                     logger.bind(domain="check", branch=branch).debug(
                         f"Could not count commits behind main: {exc}"

--- a/tests/vibe3/integration/test_health_check_e2e.py
+++ b/tests/vibe3/integration/test_health_check_e2e.py
@@ -50,7 +50,8 @@ def test_closed_issue_flow_gets_aborted_e2e(temp_store: SQLiteClient) -> None:
     result = service.verify_branch(branch)
 
     # Verify: flow marked as aborted
-    assert result.is_valid is True  # Valid because auto-fixed
+    assert result.is_valid is False  # Closed issue = not valid for dispatch
+    assert any("CLOSED" in issue for issue in result.issues)
     assert result.branch == branch
 
     # Verify database state using SQLiteClient API

--- a/tests/vibe3/orchestra/test_dispatch_state_transitions.py
+++ b/tests/vibe3/orchestra/test_dispatch_state_transitions.py
@@ -363,3 +363,40 @@ class TestLoggingBehavior:
         assert normalized_events[1] == (
             "planner launch failed for #467: Failed to resolve permanent worktree"
         )
+
+
+def test_health_check_skips_block_flow_for_aborted_flows(tmp_path) -> None:
+    """When check_service marks flow aborted and returns is_valid=False,
+    dispatch_health_check must NOT call block_flow (already in terminal state)."""
+    from unittest.mock import MagicMock
+
+    from vibe3.clients import SQLiteClient
+    from vibe3.models.orchestration import IssueInfo, IssueState
+    from vibe3.orchestra.dispatch_health_check import DispatchHealthCheckService
+    from vibe3.services.check_service import CheckResult, CheckService
+
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-1629"
+    store.update_flow_state(branch, flow_status="aborted")  # pre-aborted
+
+    mock_check_service = MagicMock(spec=CheckService)
+    mock_check_service.verify_branch.return_value = CheckResult(
+        is_valid=False,
+        branch=branch,
+        issues=["Task issue #1629 is CLOSED (no open PR found)"],
+    )
+
+    mock_flow_blocker = MagicMock()
+
+    service = DispatchHealthCheckService(
+        check_service=mock_check_service,
+        flow_blocker=mock_flow_blocker,
+        store=store,
+        flow_context_resolver=lambda n: (branch, None),
+    )
+
+    issue = IssueInfo(number=1629, state=IssueState.CLAIMED, title="closed issue")
+    result = service.check_issue_health(issue)
+
+    assert result is False
+    mock_flow_blocker.block_flow.assert_not_called()  # terminal = skip, not block

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -339,3 +339,19 @@ class TestFailedGateIntegration:
         status = gate.get_status()
         assert status.is_active, "Gate should be ACTIVE after threshold reached"
         assert status.blocked_ticks == 0, "No ticks counted yet"
+
+
+def test_dispatch_failure_does_not_trigger_failed_gate() -> None:
+    """E_DISPATCH_FAILURE must NOT count toward FailedGate threshold.
+    Infrastructure failures (worktree unavailable) should not block orchestra."""
+    from vibe3.exceptions.error_classification import ERROR_REGISTRY
+
+    contract = ERROR_REGISTRY["E_DISPATCH_FAILURE"]
+
+    assert contract.counts_toward_threshold is False, (
+        "E_DISPATCH_FAILURE must not count toward FailedGate threshold — "
+        "infrastructure failures should not block orchestra"
+    )
+    assert (
+        contract.gate_action == "ignore"
+    ), "E_DISPATCH_FAILURE gate_action must be 'ignore', not 'threshold'"

--- a/tests/vibe3/services/test_check_service_verify_branch.py
+++ b/tests/vibe3/services/test_check_service_verify_branch.py
@@ -321,3 +321,42 @@ def test_verify_branch_no_longer_reports_runtime_ownership_warnings(
     # Should NOT report any removed owner-session warnings
     assert all("owner session" not in issue for issue in result.issues)
     assert all("owner session" not in warning for warning in result.warnings)
+
+
+def test_verify_branch_closed_issue_returns_invalid(tmp_path: Path) -> None:
+    """Closed issue without open PR must return is_valid=False."""
+    from vibe3.clients.git_client import GitClient
+    from vibe3.clients.github_client import GitHubClient
+
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-1629"
+    store.update_flow_state(branch, flow_status="active")
+    store.add_issue_link(branch, 1629, "task")
+
+    mock_git = MagicMock(spec=GitClient)
+    mock_git.find_worktree_path_for_branch.return_value = None
+    mock_git.get_git_common_dir.return_value = tmp_path
+
+    mock_github = MagicMock(spec=GitHubClient)
+    mock_github.view_issue.return_value = {
+        "number": 1629,
+        "state": "CLOSED",
+        "labels": [],
+    }
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+    mock_github.close_issue_if_open.return_value = "already_closed"
+
+    service = CheckService(store=store, git_client=mock_git, github_client=mock_github)
+    service._initialize_pr_cache()
+
+    result = service.verify_branch(branch)
+
+    # Closed issue = NOT valid for dispatch
+    assert result.is_valid is False
+    assert any("CLOSED" in issue for issue in result.issues)
+
+    # Flow should still be aborted in DB
+    flow_data = store.get_flow_state(branch)
+    assert flow_data is not None
+    assert flow_data["flow_status"] == "aborted"


### PR DESCRIPTION
## Summary

Fixes issue where closed issues were dispatched by orchestra, causing FailedGate to block the entire system:

- **check_service**: Return `is_valid=False` when auto-aborting flows for closed issues, missing branches, and orphaned flows (3 locations fixed)
- **dispatch_health_check**: Check terminal flow state before calling `block_flow()` to avoid semantic conflict
- **error_classification**: Downgrade `E_DISPATCH_FAILURE` from ERROR to WARNING to prevent infrastructure failures from triggering FailedGate

## Root Cause

When `check_service._check_branch()` detected a closed issue, it would:
1. Call `mark_flow_aborted()` to set flow status to "aborted"
2. Return `is_valid=True` (incorrect - should signal "not valid for dispatch")

This caused `dispatch_health_check` to:
1. See `is_valid=False` (after Task 1 fix)
2. Call `block_flow()` on an already-aborted flow (semantic conflict)
3. Eventually trigger `E_DISPATCH_FAILURE` 
4. FailedGate would block after 2 infrastructure failures

## Changes

**Task 1: check_service.py** (3 locations)
- Closed issue without open PR: `is_valid=True` → `False` with issues list
- Missing local branch: `is_valid=True` → `False` with issues list  
- Orphaned flow: `is_valid=True` → `False` with issues list

**Task 2: test_health_check_e2e.py**
- Fixed incorrect assertion expecting `is_valid=True` for closed issues

**Task 3: dispatch_health_check.py**
- Moved terminal state check (`done/aborted/stale`) before `block_flow()` call
- Prevents calling `block_flow()` on already-terminal flows

**Task 4: error_classification.py**
- `E_DISPATCH_FAILURE`: ERROR → WARNING
- `counts_toward_threshold`: True → False
- `gate_action`: "threshold" → "ignore"

## Test Plan

- [x] New test: `test_verify_branch_closed_issue_returns_invalid` - verifies closed issue returns `is_valid=False`
- [x] Updated test: `test_closed_issue_flow_gets_aborted_e2e` - fixed incorrect assertion
- [x] New test: `test_health_check_skips_block_flow_for_aborted_flows` - verifies no `block_flow()` call for terminal flows
- [x] New test: `test_dispatch_failure_does_not_trigger_failed_gate` - verifies `E_DISPATCH_FAILURE` doesn't count toward threshold
- [x] All 815 affected tests pass
- [x] Mypy type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)