### PR TITLE
feat(server): add /web Orchestra status dashboard (#1931)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Orchestra HTTP Server",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": ["run", "python", "src/vibe3/cli.py", "serve", "start", "--no-async"],
+      "port": 8080,
+      "url": "http://localhost:8080/web"
+    }
+  ]
+}

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -204,7 +204,7 @@ def start(
     instance_info, is_valid = _validate_pid_file(config.pid_file)
     if is_valid and instance_info is not None:
         typer.echo(f"Orchestra server already running (PID: {instance_info.pid})")
-        raise typer.Exit(1)
+        raise typer.Exit(0)
     elif instance_info is not None:
         typer.echo(f"Cleaning up stale PID file (dead process {instance_info.pid})")
         config.pid_file.unlink(missing_ok=True)

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -9,6 +9,7 @@ import subprocess
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
@@ -158,6 +159,12 @@ def _build_server_with_launch_cwd(
     async def get_status() -> OrchestraSnapshot:
         """Get current orchestra status snapshot."""
         return await run_in_threadpool(status_service.snapshot)
+
+    @fastapi_app.get("/web", response_class=HTMLResponse)
+    async def get_web_dashboard() -> str:
+        """Serve the Orchestra status web console."""
+        html_path = Path(__file__).parent / "static" / "status.html"
+        return html_path.read_text(encoding="utf-8")
 
     # Mount MCP server (gracefully degrades if not available)
     try:

--- a/src/vibe3/server/static/status.html
+++ b/src/vibe3/server/static/status.html
@@ -89,21 +89,37 @@ const STATE_LABEL = {
   'ready': 'Ready', 'blocked': 'Blocked'
 };
 
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function safeInt(v) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
 function stateBadge(state) {
   const s = (state || '').toLowerCase().replace('state/', '').replace('-', '_');
   const cls = STATE_ORDER.includes(s) ? `state-${s}` : 'state-other';
-  return `<span class="badge ${cls}">${state || 'unknown'}</span>`;
+  return `<span class="badge ${cls}">${escapeHtml(state || 'unknown')}</span>`;
 }
 
 function roadBadge(r) {
   if (!r) return '';
   const cls = r === 'p0' ? 'road-p0' : r === 'p1' ? 'road-p1' : 'road-p2';
-  return `<span class="badge ${cls}">${r}</span>`;
+  return `<span class="badge ${cls}">${escapeHtml(r)}</span>`;
 }
 
 function normalizeState(s) {
   return (s || '').toLowerCase().replace('state/', '').replace('-', '_');
 }
+
+const BASE_URL = 'https://github.com/jacobcy/vibe-coding-control-center';
 
 function renderIssues(issues) {
   if (!issues.length) return '<div class="empty">No active issues</div>';
@@ -121,25 +137,35 @@ function renderIssues(issues) {
   keys.forEach(key => {
     const label = STATE_LABEL[key] || key;
     const rows = groups[key];
-    html += `<div class="section"><div class="section-title">${label} (${rows.length})</div>
+    html += `<div class="section"><div class="section-title">${escapeHtml(label)} (${rows.length})</div>
     <table><thead><tr>
       <th>#</th><th>Issue</th><th>Title</th><th>State</th>
       <th>Road</th><th>Pri</th><th>PR / Blocked</th>
     </tr></thead><tbody>`;
     rows.forEach(e => {
-      const rank = e.queue_rank != null ? e.queue_rank : '-';
-      const prCell = e.has_pr
-        ? `<a class="pr-link" href="https://github.com/jacobcy/vibe-coding-control-center/pull/${e.pr_number}" target="_blank">#${e.pr_number}</a>`
+      const rank = safeInt(e.queue_rank) ?? '-';
+      const issueNum = safeInt(e.number);
+      const prNum = safeInt(e.pr_number);
+
+      const issueCell = issueNum
+        ? `<a href="${BASE_URL}/issues/${issueNum}" target="_blank">#${issueNum}</a>`
+        : '';
+
+      const prCell = e.has_pr && prNum
+        ? `<a class="pr-link" href="${BASE_URL}/pull/${prNum}" target="_blank">#${prNum}</a>`
         : e.blocked_by && e.blocked_by.length
-          ? `<span class="blocked-by">blocked: ${e.blocked_by.map(n=>'#'+n).join(', ')}</span>`
+          ? `<span class="blocked-by">blocked: ${e.blocked_by.map(n => { const i = safeInt(n); return i ? '#'+i : ''; }).filter(Boolean).join(', ')}</span>`
           : '';
+
+      const pri = safeInt(e.priority) ?? '';
+
       html += `<tr>
         <td class="rank">${rank}</td>
-        <td class="issue-num"><a href="https://github.com/jacobcy/vibe-coding-control-center/issues/${e.number}" target="_blank">#${e.number}</a></td>
-        <td class="issue-title" title="${(e.title||'').replace(/"/g,'&quot;')}">${e.title || ''}</td>
+        <td class="issue-num">${issueCell}</td>
+        <td class="issue-title" title="${escapeHtml(e.title)}">${escapeHtml(e.title)}</td>
         <td>${stateBadge(e.state)}</td>
         <td>${roadBadge(e.roadmap)}</td>
-        <td style="color:#64748b;font-size:12px">${e.priority || ''}</td>
+        <td style="color:#64748b;font-size:12px">${pri}</td>
         <td>${prCell}</td>
       </tr>`;
     });

--- a/src/vibe3/server/static/status.html
+++ b/src/vibe3/server/static/status.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Orchestra Status</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }
+
+  .banner { padding: 10px 20px; font-size: 13px; font-weight: 600; text-align: center; display: none; }
+  .banner.blocked { display: block; background: #7f1d1d; color: #fca5a5; border-bottom: 1px solid #991b1b; }
+  .banner.gate-ok { display: none; }
+
+  header { padding: 16px 24px; border-bottom: 1px solid #1e293b; display: flex; align-items: center; gap: 12px; }
+  .logo { font-size: 18px; font-weight: 700; color: #f8fafc; letter-spacing: -0.5px; }
+  .status-dot { width: 8px; height: 8px; border-radius: 50%; background: #22c55e; box-shadow: 0 0 6px #22c55e; flex-shrink: 0; }
+  .status-dot.offline { background: #ef4444; box-shadow: 0 0 6px #ef4444; }
+  .status-text { font-size: 13px; color: #64748b; }
+  .refresh-info { margin-left: auto; font-size: 12px; color: #334155; }
+
+  .stats { display: flex; gap: 1px; background: #1e293b; border-bottom: 1px solid #1e293b; }
+  .stat { flex: 1; padding: 12px 20px; background: #0f1117; text-align: center; }
+  .stat-val { font-size: 22px; font-weight: 700; color: #f1f5f9; line-height: 1; }
+  .stat-label { font-size: 11px; color: #475569; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+
+  .section { padding: 16px 24px 0; }
+  .section-title { font-size: 11px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 8px; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 16px; }
+  th { text-align: left; padding: 6px 10px; font-size: 11px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid #1e293b; }
+  td { padding: 8px 10px; border-bottom: 1px solid #0d1420; vertical-align: middle; }
+  tr:hover td { background: #161d2e; }
+
+  .rank { color: #334155; font-size: 12px; width: 32px; }
+  .issue-num { font-family: monospace; color: #60a5fa; font-size: 12px; white-space: nowrap; }
+  .issue-num a { color: inherit; text-decoration: none; }
+  .issue-num a:hover { text-decoration: underline; }
+  .issue-title { color: #cbd5e1; max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .badge { display: inline-block; padding: 2px 7px; border-radius: 3px; font-size: 11px; font-weight: 600; white-space: nowrap; }
+
+  .state-in-progress { background: #1e3a5f; color: #60a5fa; }
+  .state-claimed     { background: #2d1f4e; color: #a78bfa; }
+  .state-ready       { background: #1c3028; color: #4ade80; }
+  .state-blocked     { background: #3b1414; color: #f87171; }
+  .state-review      { background: #2d2a10; color: #fbbf24; }
+  .state-other       { background: #1e293b; color: #94a3b8; }
+
+  .road-p0 { background: #7f1d1d; color: #fca5a5; }
+  .road-p1 { background: #1c2f4e; color: #93c5fd; }
+  .road-p2 { background: #1e293b; color: #64748b; }
+
+  .pr-link { font-family: monospace; font-size: 11px; color: #22d3ee; text-decoration: none; }
+  .pr-link:hover { text-decoration: underline; }
+  .blocked-by { font-size: 11px; color: #f87171; }
+
+  .empty { color: #334155; font-size: 13px; padding: 20px 0; text-align: center; }
+  .error-state { color: #ef4444; padding: 40px; text-align: center; }
+
+  .footer { padding: 12px 24px; color: #1e293b; font-size: 11px; border-top: 1px solid #1e293b; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<div id="gate-banner" class="banner"></div>
+
+<header>
+  <div id="status-dot" class="status-dot offline"></div>
+  <div class="logo">Orchestra</div>
+  <div id="status-text" class="status-text">connecting...</div>
+  <div class="refresh-info" id="refresh-info">auto-refresh 30s</div>
+</header>
+
+<div class="stats">
+  <div class="stat"><div class="stat-val" id="s-flows">-</div><div class="stat-label">Active Flows</div></div>
+  <div class="stat"><div class="stat-val" id="s-wt">-</div><div class="stat-label">Worktrees</div></div>
+  <div class="stat"><div class="stat-val" id="s-queued">-</div><div class="stat-label">Queued</div></div>
+  <div class="stat"><div class="stat-val" id="s-total">-</div><div class="stat-label">Total Issues</div></div>
+</div>
+
+<div id="main-content"></div>
+
+<div class="footer" id="footer"></div>
+
+<script>
+const STATE_ORDER = ['in_progress', 'review', 'claimed', 'ready', 'blocked'];
+const STATE_LABEL = {
+  'in_progress': 'In Progress', 'review': 'Review', 'claimed': 'Claimed',
+  'ready': 'Ready', 'blocked': 'Blocked'
+};
+
+function stateBadge(state) {
+  const s = (state || '').toLowerCase().replace('state/', '').replace('-', '_');
+  const cls = STATE_ORDER.includes(s) ? `state-${s}` : 'state-other';
+  return `<span class="badge ${cls}">${state || 'unknown'}</span>`;
+}
+
+function roadBadge(r) {
+  if (!r) return '';
+  const cls = r === 'p0' ? 'road-p0' : r === 'p1' ? 'road-p1' : 'road-p2';
+  return `<span class="badge ${cls}">${r}</span>`;
+}
+
+function normalizeState(s) {
+  return (s || '').toLowerCase().replace('state/', '').replace('-', '_');
+}
+
+function renderIssues(issues) {
+  if (!issues.length) return '<div class="empty">No active issues</div>';
+
+  const groups = {};
+  issues.forEach(e => {
+    const s = normalizeState(e.state);
+    const key = STATE_ORDER.includes(s) ? s : 'other';
+    (groups[key] = groups[key] || []).push(e);
+  });
+
+  let html = '';
+  const keys = [...STATE_ORDER.filter(k => groups[k]), ...(groups.other ? ['other'] : [])];
+
+  keys.forEach(key => {
+    const label = STATE_LABEL[key] || key;
+    const rows = groups[key];
+    html += `<div class="section"><div class="section-title">${label} (${rows.length})</div>
+    <table><thead><tr>
+      <th>#</th><th>Issue</th><th>Title</th><th>State</th>
+      <th>Road</th><th>Pri</th><th>PR / Blocked</th>
+    </tr></thead><tbody>`;
+    rows.forEach(e => {
+      const rank = e.queue_rank != null ? e.queue_rank : '-';
+      const prCell = e.has_pr
+        ? `<a class="pr-link" href="https://github.com/jacobcy/vibe-coding-control-center/pull/${e.pr_number}" target="_blank">#${e.pr_number}</a>`
+        : e.blocked_by && e.blocked_by.length
+          ? `<span class="blocked-by">blocked: ${e.blocked_by.map(n=>'#'+n).join(', ')}</span>`
+          : '';
+      html += `<tr>
+        <td class="rank">${rank}</td>
+        <td class="issue-num"><a href="https://github.com/jacobcy/vibe-coding-control-center/issues/${e.number}" target="_blank">#${e.number}</a></td>
+        <td class="issue-title" title="${(e.title||'').replace(/"/g,'&quot;')}">${e.title || ''}</td>
+        <td>${stateBadge(e.state)}</td>
+        <td>${roadBadge(e.roadmap)}</td>
+        <td style="color:#64748b;font-size:12px">${e.priority || ''}</td>
+        <td>${prCell}</td>
+      </tr>`;
+    });
+    html += '</tbody></table></div>';
+  });
+  return html;
+}
+
+async function load() {
+  try {
+    const r = await fetch('/status');
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const d = await r.json();
+
+    // Header
+    document.getElementById('status-dot').className = 'status-dot' + (d.server_running ? '' : ' offline');
+    const ts = new Date(d.timestamp * 1000).toLocaleTimeString();
+    document.getElementById('status-text').textContent = `running · ${ts}`;
+
+    // FailedGate banner
+    const banner = document.getElementById('gate-banner');
+    if (d.dispatch_blocked) {
+      banner.className = 'banner blocked';
+      banner.textContent = `FailedGate ACTIVE — ${d.blocked_reason || 'dispatch blocked'}`;
+    } else {
+      banner.className = 'banner';
+    }
+
+    // Stats
+    document.getElementById('s-flows').textContent = d.active_flows ?? '-';
+    document.getElementById('s-wt').textContent = d.active_worktrees ?? '-';
+    document.getElementById('s-queued').textContent = (d.queued_issues || []).length;
+    document.getElementById('s-total').textContent = (d.active_issues || []).length;
+
+    // Issues
+    document.getElementById('main-content').innerHTML = renderIssues(d.active_issues || []);
+
+    // Footer
+    document.getElementById('footer').textContent =
+      `interval ${d.polling_interval}s · port ${d.port} · circuit ${d.circuit_breaker_state}`;
+
+  } catch(e) {
+    document.getElementById('status-dot').className = 'status-dot offline';
+    document.getElementById('status-text').textContent = 'error';
+    document.getElementById('main-content').innerHTML =
+      `<div class="error-state">Failed to load status: ${e.message}</div>`;
+  }
+}
+
+load();
+let countdown = 30;
+setInterval(() => {
+  countdown--;
+  document.getElementById('refresh-info').textContent = `refresh in ${countdown}s`;
+  if (countdown <= 0) { countdown = 30; load(); }
+}, 1000);
+</script>
+</body>
+</html>

--- a/src/vibe3/server/static/status.html
+++ b/src/vibe3/server/static/status.html
@@ -258,6 +258,13 @@ async function load() {
     document.getElementById('footer').textContent =
       `interval ${d.polling_interval}s · port ${d.port} · circuit ${d.circuit_breaker_state}`;
 
+    // Sync refresh interval to orchestra polling_interval
+    const pi = safeInt(d.polling_interval);
+    if (pi && pi !== refreshInterval) {
+      refreshInterval = pi;
+      countdown = pi;
+    }
+
   } catch(e) {
     document.getElementById('status-dot').className = 'status-dot offline';
     document.getElementById('status-text').textContent = 'error';
@@ -266,12 +273,13 @@ async function load() {
   }
 }
 
+let refreshInterval = 30;
+let countdown = refreshInterval;
 load();
-let countdown = 30;
 setInterval(() => {
   countdown--;
   document.getElementById('refresh-info').textContent = `refresh in ${countdown}s`;
-  if (countdown <= 0) { countdown = 30; load(); }
+  if (countdown <= 0) { countdown = refreshInterval; load(); }
 }, 1000);
 </script>
 </body>

--- a/src/vibe3/server/static/status.html
+++ b/src/vibe3/server/static/status.html
@@ -5,38 +5,74 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Orchestra Status</title>
 <style>
+  :root {
+    --bg:        #0f1117;
+    --bg-stat:   #0f1117;
+    --bg-hover:  #161d2e;
+    --border:    #1e293b;
+    --border-td: #0d1420;
+    --text:      #e2e8f0;
+    --text-dim:  #64748b;
+    --text-mute: #334155;
+    --text-title:#cbd5e1;
+    --logo:      #f8fafc;
+    --stat-val:  #f1f5f9;
+    --link:      #60a5fa;
+    --pr-link:   #22d3ee;
+    --blocked-c: #f87171;
+    --footer-c:  #1e293b;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg:        #f8fafc;
+      --bg-stat:   #ffffff;
+      --bg-hover:  #f1f5f9;
+      --border:    #e2e8f0;
+      --border-td: #f1f5f9;
+      --text:      #0f172a;
+      --text-dim:  #64748b;
+      --text-mute: #94a3b8;
+      --text-title:#334155;
+      --logo:      #0f172a;
+      --stat-val:  #0f172a;
+      --link:      #2563eb;
+      --pr-link:   #0891b2;
+      --blocked-c: #dc2626;
+      --footer-c:  #94a3b8;
+    }
+  }
+
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
 
   .banner { padding: 10px 20px; font-size: 13px; font-weight: 600; text-align: center; display: none; }
   .banner.blocked { display: block; background: #7f1d1d; color: #fca5a5; border-bottom: 1px solid #991b1b; }
-  .banner.gate-ok { display: none; }
 
-  header { padding: 16px 24px; border-bottom: 1px solid #1e293b; display: flex; align-items: center; gap: 12px; }
-  .logo { font-size: 18px; font-weight: 700; color: #f8fafc; letter-spacing: -0.5px; }
+  header { padding: 16px 24px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; }
+  .logo { font-size: 18px; font-weight: 700; color: var(--logo); letter-spacing: -0.5px; }
   .status-dot { width: 8px; height: 8px; border-radius: 50%; background: #22c55e; box-shadow: 0 0 6px #22c55e; flex-shrink: 0; }
   .status-dot.offline { background: #ef4444; box-shadow: 0 0 6px #ef4444; }
-  .status-text { font-size: 13px; color: #64748b; }
-  .refresh-info { margin-left: auto; font-size: 12px; color: #334155; }
+  .status-text { font-size: 13px; color: var(--text-dim); }
+  .refresh-info { margin-left: auto; font-size: 12px; color: var(--text-mute); }
 
-  .stats { display: flex; gap: 1px; background: #1e293b; border-bottom: 1px solid #1e293b; }
-  .stat { flex: 1; padding: 12px 20px; background: #0f1117; text-align: center; }
-  .stat-val { font-size: 22px; font-weight: 700; color: #f1f5f9; line-height: 1; }
-  .stat-label { font-size: 11px; color: #475569; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .stats { display: flex; gap: 1px; background: var(--border); border-bottom: 1px solid var(--border); }
+  .stat { flex: 1; padding: 12px 20px; background: var(--bg-stat); text-align: center; }
+  .stat-val { font-size: 22px; font-weight: 700; color: var(--stat-val); line-height: 1; }
+  .stat-label { font-size: 11px; color: var(--text-dim); margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
 
   .section { padding: 16px 24px 0; }
-  .section-title { font-size: 11px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 8px; }
+  .section-title { font-size: 11px; font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 8px; }
 
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 16px; }
-  th { text-align: left; padding: 6px 10px; font-size: 11px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid #1e293b; }
-  td { padding: 8px 10px; border-bottom: 1px solid #0d1420; vertical-align: middle; }
-  tr:hover td { background: #161d2e; }
+  th { text-align: left; padding: 6px 10px; font-size: 11px; font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid var(--border); }
+  td { padding: 8px 10px; border-bottom: 1px solid var(--border-td); vertical-align: middle; }
+  tr:hover td { background: var(--bg-hover); }
 
-  .rank { color: #334155; font-size: 12px; width: 32px; }
-  .issue-num { font-family: monospace; color: #60a5fa; font-size: 12px; white-space: nowrap; }
+  .rank { color: var(--text-mute); font-size: 12px; width: 32px; }
+  .issue-num { font-family: monospace; color: var(--link); font-size: 12px; white-space: nowrap; }
   .issue-num a { color: inherit; text-decoration: none; }
   .issue-num a:hover { text-decoration: underline; }
-  .issue-title { color: #cbd5e1; max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .issue-title { color: var(--text-title); max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .badge { display: inline-block; padding: 2px 7px; border-radius: 3px; font-size: 11px; font-weight: 600; white-space: nowrap; }
 
   .state-in-progress { background: #1e3a5f; color: #60a5fa; }
@@ -46,18 +82,33 @@
   .state-review      { background: #2d2a10; color: #fbbf24; }
   .state-other       { background: #1e293b; color: #94a3b8; }
 
+  @media (prefers-color-scheme: light) {
+    .state-in-progress { background: #dbeafe; color: #1d4ed8; }
+    .state-claimed     { background: #ede9fe; color: #6d28d9; }
+    .state-ready       { background: #dcfce7; color: #15803d; }
+    .state-blocked     { background: #fee2e2; color: #b91c1c; }
+    .state-review      { background: #fef9c3; color: #a16207; }
+    .state-other       { background: #f1f5f9; color: #64748b; }
+  }
+
   .road-p0 { background: #7f1d1d; color: #fca5a5; }
   .road-p1 { background: #1c2f4e; color: #93c5fd; }
   .road-p2 { background: #1e293b; color: #64748b; }
 
-  .pr-link { font-family: monospace; font-size: 11px; color: #22d3ee; text-decoration: none; }
-  .pr-link:hover { text-decoration: underline; }
-  .blocked-by { font-size: 11px; color: #f87171; }
+  @media (prefers-color-scheme: light) {
+    .road-p0 { background: #fee2e2; color: #b91c1c; }
+    .road-p1 { background: #dbeafe; color: #1d4ed8; }
+    .road-p2 { background: #f1f5f9; color: #64748b; }
+  }
 
-  .empty { color: #334155; font-size: 13px; padding: 20px 0; text-align: center; }
+  .pr-link { font-family: monospace; font-size: 11px; color: var(--pr-link); text-decoration: none; }
+  .pr-link:hover { text-decoration: underline; }
+  .blocked-by { font-size: 11px; color: var(--blocked-c); }
+
+  .empty { color: var(--text-mute); font-size: 13px; padding: 20px 0; text-align: center; }
   .error-state { color: #ef4444; padding: 40px; text-align: center; }
 
-  .footer { padding: 12px 24px; color: #1e293b; font-size: 11px; border-top: 1px solid #1e293b; margin-top: 8px; }
+  .footer { padding: 12px 24px; color: var(--footer-c); font-size: 11px; border-top: 1px solid var(--border); margin-top: 8px; }
 </style>
 </head>
 <body>

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -528,7 +528,7 @@ def test_start_blocks_when_instance_running(monkeypatch, tmp_path: Path) -> None
         runner = CliRunner()
         result = runner.invoke(app, ["serve", "start"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0  # already running is idempotent (not an error)
     assert "already running" in result.stdout.lower()
 
 


### PR DESCRIPTION
## Summary

- Add `GET /web` route in `registry.py` returning an HTML dashboard
- New `src/vibe3/server/static/status.html` — single-file console (HTML + CSS + JS)
- Dashboard fetches `/status`, groups issues by state, auto-refreshes at `polling_interval`
- Light/dark mode via `prefers-color-scheme` CSS media query
- Fix `serve start` exit code: already-running now returns 0 (idempotent, for `preview_start` compatibility)
- Fix `launch.json`: use `--no-async` + `"url": "/web"` for preview tool

## Security

- All user-data interpolations escaped via `escapeHtml()` (XSS fix)
- URL fields (`number`, `pr_number`, `blocked_by`) validated as positive integers via `safeInt()`

## Test plan

- [ ] `GET /web` returns HTML page with issue list
- [ ] Page auto-refreshes at orchestra `polling_interval` (shown in footer)
- [ ] `FailedGate ACTIVE` banner appears when `dispatch_blocked=true`
- [ ] Light mode renders correctly on macOS light appearance
- [ ] `vibe3 serve start` on already-running server exits 0
- [ ] `test_start_blocks_when_instance_running` passes

Closes #1931