### PR TITLE
fix(skills): prioritize task status over flow status in vibe-check

### DIFF
--- a/skills/vibe-check/SKILL.md
+++ b/skills/vibe-check/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: vibe-check
-description: Use when the user wants to inspect the current runtime scene with vibe3 task status or vibe3 flow status, verify whether flow/task state is synchronized with vibe3 check, resume blocked issues with vibe3 task resume, or mentions "/vibe-check" or "check runtime". Do not use for roadmap prioritization or roadmap-task mapping.
+description: Use when the user wants to inspect the current runtime scene with vibe3 task status, verify whether flow/task state is synchronized with vibe3 check, resume blocked issues with vibe3 task resume, or mentions "/vibe-check" or "check runtime". Do not use for roadmap prioritization or roadmap-task mapping.
 ---
 
 # /vibe-check (/check) - task-flow 审计驱动修复
 
 现场观察与修复分三类命令：
 
-- `vibe3 task status`：看 orchestra 与 task 现场
-- `uv run python src/vibe3/cli.py flow status` / `flow show`：看当前或全局 flow 现场
+- `vibe3 task status`：看 orchestra 与 task 现场（首选入口）
+- `uv run python src/vibe3/cli.py flow status` / `flow show`：看当前或特定 flow 详细信息（补充）
 - `uv run python src/vibe3/cli.py check`：只检查 flow 与 task 是否同步
 - `uv run python src/vibe3/cli.py task resume ...`：清除 blocked 状态，恢复 issue 到 ready（非破坏性，保留 worktree）
 
@@ -67,18 +67,13 @@ description: Use when the user wants to inspect the current runtime scene with v
 优先运行：
 
 ```bash
-uv run python src/vibe3/cli.py flow status
-```
-
-如果需要看全局 task 现场，再补：
-
-```bash
 vibe3 task status
 ```
 
-如果是当前分支现场，再补：
+如果需要看当前分支或特定 flow 详细信息，再补：
 
 ```bash
+uv run python src/vibe3/cli.py flow status
 uv run python src/vibe3/cli.py flow show
 ```
 


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-1879` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-1879
```


---

## Summary
- Updated vibe-check skill to use `vibe3 task status` as primary command instead of `flow status`
- Aligned skill documentation with correct usage pattern (task status is the preferred entry point)

## Changes
- **Frontmatter**: Removed redundant "or vibe3 flow status" from description
- **Command list**: Marked `task status` as "首选入口" (preferred entry) and `flow status` as "补充" (supplementary)
- **Step 1 example**: Reordered to show `task status` first

## Context
Fixes #1879 - The vibe-check skill should prioritize `vibe3 task status` over `flow status` as the primary command for inspecting runtime scene, aligning with the correct usage pattern where task status shows orchestra and task context, while flow status/show are supplementary for viewing specific flow details.

## Test Plan
- [x] Verify scope: Only `skills/vibe-check/SKILL.md` modified (+5/-10 lines)
- [x] All 3 planned changes correctly implemented
- [x] No code changes, no regression risk
- [x] Review: PASS (claude/opus)
- [x] LOC checks: Passed (0 files exceed CI block threshold)

---

## Contributors

claude/opus
