### PR TITLE
fix(commands): unify plan/review --branch default behavior

### DIFF
--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -24,7 +24,7 @@ from vibe3.services.handoff_resolution import resolve_handoff_target
 app = typer.Typer(
     name="plan",
     help="Create implementation plans for issues or specifications.",
-    no_args_is_help=True,
+    no_args_is_help=False,
     rich_markup_mode="rich",
 )
 

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -99,18 +99,14 @@ def default(
     if ctx.invoked_subcommand is not None:
         return
 
-    if branch is not None or ctx.args:
-        # --branch provided or positional arg (legacy issue number)
-        target_branch = resolve_branch_arg(branch)
-        _review_branch_impl(
-            branch=target_branch,
-            trace=trace,
-            dry_run=dry_run,
-            no_async=no_async,
-            show_prompt=show_prompt,
-        )
-        return
-    typer.echo(ctx.get_help())
+    target_branch = resolve_branch_arg(branch)
+    _review_branch_impl(
+        branch=target_branch,
+        trace=trace,
+        dry_run=dry_run,
+        no_async=no_async,
+        show_prompt=show_prompt,
+    )
 
 
 @app.command(name="issue", hidden=True)

--- a/tests/vibe3/commands/test_plan.py
+++ b/tests/vibe3/commands/test_plan.py
@@ -76,8 +76,13 @@ def test_plan_branch_basic_flow(monkeypatch) -> None:
 def test_plan_no_arg_defaults_to_current_branch(monkeypatch) -> None:
     """Test plan without --branch uses current branch."""
     mock_runner = _patch_plan_deps(monkeypatch)
+    mock_resolve = MagicMock(return_value="task/issue-42")
+    monkeypatch.setattr("vibe3.commands.plan.resolve_branch_arg", mock_resolve)
+
     result = runner.invoke(plan_app, [])
+
     assert result.exit_code == 0
+    mock_resolve.assert_called_once_with(None)
     mock_runner.assert_called_once()
 
 
@@ -92,6 +97,21 @@ def test_plan_branch_no_flow_error(monkeypatch) -> None:
     )
 
     result = runner.invoke(plan_app, ["--branch", "42"])
+    assert result.exit_code != 0
+    assert "No flow for branch" in result.output
+
+
+def test_plan_no_arg_no_flow_error(monkeypatch) -> None:
+    """Test plan without --branch and no flow shows clear error."""
+    mock_flow_service = MagicMock()
+    mock_flow_service.get_flow_status.return_value = None
+
+    monkeypatch.setattr("vibe3.commands.plan.FlowService", lambda: mock_flow_service)
+    monkeypatch.setattr(
+        "vibe3.commands.plan.resolve_branch_arg", lambda _: "feature/no-flow"
+    )
+
+    result = runner.invoke(plan_app, [])
     assert result.exit_code != 0
     assert "No flow for branch" in result.output
 

--- a/tests/vibe3/commands/test_plan.py
+++ b/tests/vibe3/commands/test_plan.py
@@ -73,6 +73,14 @@ def test_plan_branch_basic_flow(monkeypatch) -> None:
     assert call_kwargs["issue_number"] == 42
 
 
+def test_plan_no_arg_defaults_to_current_branch(monkeypatch) -> None:
+    """Test plan without --branch uses current branch."""
+    mock_runner = _patch_plan_deps(monkeypatch)
+    result = runner.invoke(plan_app, [])
+    assert result.exit_code == 0
+    mock_runner.assert_called_once()
+
+
 def test_plan_branch_no_flow_error(monkeypatch) -> None:
     """Test plan --branch with no flow shows error."""
     mock_flow_service = MagicMock()

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -7,7 +7,7 @@ Removal tests from test_review_help.py are in test_removed_commands.py.
 from __future__ import annotations
 
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -72,14 +72,20 @@ class TestReviewContextBuilderUsesAssembler:
 # ==============================================================================
 
 
-def test_review_no_args_shows_help():
-    """vibe review (no subcommand) -> shows help.
+def test_review_no_arg_defaults_to_current_branch():
+    """vibe review (no subcommand) -> executes review on current branch."""
+    with (
+        patch("vibe3.commands.review.validate_review_prerequisites") as mock_validate,
+        patch("vibe3.commands.review.run_issue_role_async") as mock_async,
+    ):
+        mock_flow = MagicMock()
+        mock_flow.task_issue_number = 42
+        mock_validate.return_value = (mock_flow, 42)
 
-    Exit 0 or 2 per typer no_args_is_help.
-    """
-    result = runner.invoke(app, [])
-    assert result.exit_code in (0, 2)
-    assert "Usage" in result.output or "base" in result.output
+        result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    mock_async.assert_called_once()
 
 
 def test_review_help_only_shows_supported_commands():

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -77,14 +77,17 @@ def test_review_no_arg_defaults_to_current_branch():
     with (
         patch("vibe3.commands.review.validate_review_prerequisites") as mock_validate,
         patch("vibe3.commands.review.run_issue_role_async") as mock_async,
+        patch("vibe3.commands.review.resolve_branch_arg") as mock_resolve,
     ):
         mock_flow = MagicMock()
         mock_flow.task_issue_number = 42
         mock_validate.return_value = (mock_flow, 42)
+        mock_resolve.return_value = "task/issue-42"
 
         result = runner.invoke(app, [])
 
     assert result.exit_code == 0
+    mock_resolve.assert_called_once_with(None)
     mock_async.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
Fixes #1903

Unifies the default behavior of \`--branch\` parameter in \`plan\` and \`review\` commands to use the current branch when no argument is provided, matching the behavior of \`vibe3 run\`.

## Problem
Previously, \`vibe3 plan\` and \`vibe3 review\` would show help text when called without the \`--branch\` parameter, instead of defaulting to the current branch like \`vibe3 run\` does.

## Solution
- **plan.py**: Set \`no_args_is_help=False\` to allow execution without arguments
- **review.py**: Simplified branch resolution logic to let \`resolve_branch_arg(None)\` handle default behavior
- **test_plan.py**: Added tests for default branch behavior
- **test_review.py**: Updated tests to verify new default behavior

## Acceptance Criteria ✅
- [x] \`vibe3 plan\` defaults to current branch when called without arguments
- [x] \`vibe3 review\` defaults to current branch when called without arguments
- [x] \`vibe3 plan --branch 1823\` correctly resolves issue ID
- [x] \`vibe3 review --branch 1823\` correctly resolves issue ID
- [x] Unit tests added for default branch behavior

## Test Results
All quality gates passed:
- Unit tests: ✅
- Type checks (mypy): ✅
- Linting (ruff): ✅

## Files Changed
- \`src/vibe3/commands/plan.py\` - 1 line changed
- \`src/vibe3/commands/review.py\` - 8 lines changed
- \`tests/vibe3/commands/test_plan.py\` - 8 lines added
- \`tests/vibe3/commands/test_review.py\` - 14 lines changed

Total: 31 insertions, 21 deletions

---

## Contributors

claude/opus
