### PR TITLE
feat(review): add --show-prompt option to review base command

### DIFF
--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -148,6 +148,7 @@ def base(
     trace: _TRACE_OPT = False,
     dry_run: _DRY_RUN_OPT = False,
     no_async: _ASYNC_OPT = False,
+    show_prompt: _SHOW_PROMPT_OPT = False,
 ) -> None:
     """Review local branch changes against a base branch (compares codebase snapshots).
 
@@ -202,6 +203,7 @@ def base(
             instructions=instructions,
             issue_number=issue_number,
             branch=current_branch,
+            show_prompt=show_prompt,
         )
     else:
         result = execute_manual_review_async(

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -375,6 +375,7 @@ def execute_manual_review_sync(
     config: VibeConfig | None = None,
     flow_service: FlowService | None = None,
     context_builder: Callable[..., object] = make_review_context_builder,
+    show_prompt: bool = False,
 ) -> ReviewRunResult:
     """Execute manual review in sync mode (direct execution)."""
     _ = flow_service
@@ -391,6 +392,7 @@ def execute_manual_review_sync(
         config=cfg,
         branch=branch,
         issue_number=issue_number,
+        show_prompt=show_prompt,
     )
     result = CodeagentExecutionService(cfg).execute_sync(command)
     if dry_run:

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -168,3 +168,40 @@ class TestReviewBaseExitCodes:
             result = runner.invoke(app, ["base", "main", "--no-async"])
 
         assert result.exit_code == 1
+
+
+def test_review_base_help_mentions_show_prompt_option():
+    """vibe review base --help should mention --show-prompt option."""
+    result = runner.invoke(app, ["base", "--help"])
+    assert result.exit_code == 0
+    # Strip ANSI codes before checking
+    output = _strip_ansi(result.output)
+    assert "--show-prompt" in output
+
+
+def test_review_base_show_prompt_forwarded_to_sync():
+    """review base --show-prompt should forward the flag to
+    execute_manual_review_sync."""
+    with (
+        patch("vibe3.commands.review.ensure_flow_for_current_branch") as mock_flow,
+        patch("vibe3.commands.review.build_base_resolution_usecase") as mock_base,
+        patch("vibe3.commands.review.build_base_review_request") as mock_request,
+        patch("vibe3.commands.review.execute_manual_review_sync") as mock_execute,
+    ):
+        mock_flow.return_value = (object(), "feature/test")
+        mock_base.return_value.resolve_review_base.return_value = type(
+            "ResolvedBase",
+            (),
+            {"base_branch": "main", "auto_detected": False},
+        )()
+        mock_request.return_value = (object(), 123, None)
+        mock_execute.return_value = type(
+            "Result",
+            (),
+            {"verdict": "MINOR", "handoff_file": None},
+        )()
+
+        result = runner.invoke(app, ["base", "main", "--no-async", "--show-prompt"])
+
+    assert result.exit_code == 0
+    assert mock_execute.call_args.kwargs["show_prompt"] is True


### PR DESCRIPTION
## Summary
- Add `--show-prompt` parameter to the review base command, enabling users to display the full rendered prompt when using `--dry-run` mode
- This aligns the base command with the default and issue review commands

## Changes
- Add `show_prompt` parameter to `execute_manual_review_sync()` in `roles/review.py`
- Add `show_prompt` parameter to `base()` command in `commands/review.py`
- Add unit tests to verify `--show-prompt` is exposed and forwarded correctly

## Testing
- All tests pass (10/10)
- Type checking clean (mypy)
- Linting clean (ruff)
- Backward compatibility maintained (default `show_prompt=False`)

Closes #1906

---

## Contributors

claude/opus
