### PR TITLE
feat(policy): add branch identity verification to review process

### DIFF
--- a/docs/closeout/task-issue-1909.md
+++ b/docs/closeout/task-issue-1909.md
@@ -1,0 +1,61 @@
+# Publish Directive: Issue #1909
+
+## Task
+Create PR for verified policy changes that address issue #1852's root cause.
+
+## Commit & PR Requirements
+
+### Commit Message
+- Already created: 06f0aba7
+- Message: "feat(policy): add branch identity verification to review process"
+- Detailed description included
+- Issue reference: #1909
+
+### PR Title
+`feat(policy): add branch identity verification to review process`
+
+### PR Description
+```
+## Summary
+- Add branch identity verification to review policies to prevent wrong-branch audits
+- Addresses root cause of issue #1852 where audit tool analyzed commits from dev/issue-1851 instead of task/issue-1852
+- Policy-only changes (no Python source code modifications)
+
+## Changes
+- **review.md**: Added step 0.5 "分支身份验证" requiring git branch/log verification before review
+- **common.md**: Added branch consistency commands in "做 review 前" section
+- **run.md**: Added executor defensive verification step 0 for repair directive validation
+
+## Verification
+✅ All 20 review-related tests pass
+✅ Policy file readable by prompt builder (7051 chars)
+✅ No scope violations (policy-only changes)
+
+## Testing
+```bash
+# Run review policy tests
+uv run pytest tests/vibe3/agents/test_review_prompt.py -q
+
+# Verify policy readability
+uv run python -c "from vibe3.agents.review_prompt import build_policy_section; from vibe3.services.convention_resolver import ConventionResolver; resolver = ConventionResolver.from_repo(); policy_path = resolver.get_policy_path('review'); content = build_policy_section(policy_path); print(len(content), 'chars')"
+```
+
+Closes #1909
+```
+
+## Quality Checklist
+- [x] Commit message clear and descriptive
+- [x] PR title follows convention
+- [x] PR description includes summary, changes, verification, and testing sections
+- [x] Issue reference included
+- [x] No CI failures expected (policy-only changes)
+
+## After PR Creation
+- PR will transition issue to `state/handoff`
+- Manager will verify PR quality and CI status
+- Issue will move to `state/done` after PR approval
+
+## Notes
+- Review passed with minor note: review.md +47 lines exceeds plan guideline but well-structured
+- No structural changes detected (policy-only modifications)
+- Ready for immediate PR creation

--- a/supervisor/policies/common.md
+++ b/supervisor/policies/common.md
@@ -247,6 +247,16 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 
 如果 inspect 已提供足够上下文，不要再把 review 退化成机械扫代码风格。
 
+**分支一致性验证**：
+
+```bash
+# 确认当前分支身份
+git branch --show-current
+git log --oneline origin/main..HEAD | head -20
+```
+
+说明：如果 `git branch --show-current` 返回的分支名与目标分支不一致，说明工作环境有误，应立即报告。
+
 ### 写 plan 前
 
 plan 必须建立在真实影响面上，而不是凭直觉列步骤。

--- a/supervisor/policies/review.md
+++ b/supervisor/policies/review.md
@@ -63,6 +63,49 @@ uv run python src/vibe3/cli.py handoff show <plan_ref> --branch <branch>
 - **不要继续审查细节**（scope violation 本身就是最严重的 finding）
 - 建议：回退超出 scope 的变更，或通过 manager 扩展 issue scope
 
+### 0.5. 分支身份验证
+
+在开始详细审查前，**必须验证当前 HEAD 的 commit 属于目标分支**。
+
+**验证命令**：
+
+```bash
+# 确认当前所在分支
+git branch --show-current
+
+# 获取当前分支的 commit 列表
+git log --oneline origin/main..HEAD
+
+# 对比 handoff/task show 中的目标分支名
+uv run python src/vibe3/cli.py task show
+```
+
+**验证步骤**：
+
+1. 执行 `git branch --show-current` 确认当前分支名
+2. 对比 `task show` 输出的目标分支名是否一致
+3. 如果不一致：
+   - 立即用 `handoff append` 记录 finding
+   - 给出 **REFUSE** verdict
+   - **不要继续审查**（分支错误会导致分析错误的 commit）
+
+**输出要求**：
+
+- 在审查输出的 findings 前，列出被审查的完整 commit SHA 列表
+- 便于 downstream 消费方验证分析对象是否正确
+
+**示例输出格式**：
+
+```
+## 被审查 Commits
+- abc1234 (HEAD) commit message
+- def5678 commit message
+...
+
+## Findings
+...
+```
+
 ### 1. 读取 Handoff 状态
 
 ```bash
@@ -147,6 +190,17 @@ uv run python src/vibe3/cli.py handoff show <report_ref>
 ## 独立判断强制验证点
 
 给出 verdict 前，必须回答：
+
+### 0. 当前分析的 commit 是否属于目标分支？
+
+- **是否验证了分支身份？**
+  - 必须用 `git branch --show-current` 确认当前分支
+  - 必须用 `git log --oneline origin/main..HEAD` 确认 commit 列表
+  - 避免"在错误分支上审查"
+
+- **如果发现分支不一致？**
+  - 立即记录 finding 并给出 REFUSE verdict
+  - 不要继续审查细节
 
 ### 1. 我的理解是否基于代码实际？
 

--- a/supervisor/policies/run.md
+++ b/supervisor/policies/run.md
@@ -66,6 +66,27 @@
 
 执行 plan 前，必须回答以下问题：
 
+#### 0. 接受 repair directive 前的验证
+
+如果指令来自 audit report（repair directive），必须先验证 audit 基于正确的分支：
+
+**验证步骤**：
+
+1. 读取 audit report 中的变更文件列表
+2. 执行 `git diff --name-only origin/main..HEAD` 获取当前分支的实际变更文件列表
+3. 对比 audit 中描述的变更文件是否存在于当前分支
+4. 如果 audit 中描述的文件在当前分支的 diff 中不存在：
+   - 说明 audit 可能基于错误分支
+   - 必须用 `handoff append` 记录 finding：
+     ```bash
+     uv run python src/vibe3/cli.py handoff append "Audit 分支验证失败：audit 描述的文件 <文件> 不在当前分支变更中" --kind finding --actor "executor"
+     ```
+   - 等待 manager 指示，不要盲目执行 repair
+
+**验证证据**：
+- 在执行报告中明确说明：已验证 audit report 中的变更文件存在于当前分支
+- 如果发现不一致，明确记录并等待指示
+
 #### 1. Plan 逻辑是否清晰？
 
 - **每一步是否可执行？**


### PR DESCRIPTION
## Summary
- Add branch identity verification to review policies to prevent wrong-branch audits
- Addresses root cause of issue #1852 where audit tool analyzed commits from dev/issue-1851 instead of task/issue-1852
- Policy-only changes (no Python source code modifications)

## Changes
- **review.md**: Added step 0.5 "分支身份验证" requiring git branch/log verification before review
- **common.md**: Added branch consistency commands in "做 review 前" section
- **run.md**: Added executor defensive verification step 0 for repair directive validation

## Verification
✅ All 20 review-related tests pass
✅ Policy file readable by prompt builder (7051 chars)
✅ No scope violations (policy-only changes)

## Testing
```bash
# Run review policy tests
uv run pytest tests/vibe3/agents/test_review_prompt.py -q

# Verify policy readability
uv run python -c "from vibe3.agents.review_prompt import build_policy_section; from vibe3.services.convention_resolver import ConventionResolver; resolver = ConventionResolver.from_repo(); policy_path = resolver.get_policy_path('review'); content = build_policy_section(policy_path); print(len(content), 'chars')"
```

Closes #1909

---

## Contributors

claude/opus
