### PR TITLE
refactor(vibe3): break 3 remaining circular dependencies (Phase 1)

### DIFF
--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -20,11 +20,11 @@ from typing import TYPE_CHECKING, Callable, cast
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
-from vibe3.domain import publish
 from vibe3.domain.protocols.dispatch_protocols import (
     IssueCollectionServiceProtocol,
 )
 from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
+from vibe3.domain.publisher import publish
 from vibe3.domain.qualify_gate import QualifyGateService
 from vibe3.domain.role_resolver import find_role_for_state
 from vibe3.models.orchestra_config import OrchestraConfig
@@ -182,7 +182,7 @@ class GlobalDispatchCoordinator:
         clean_old_state_labels(issue, role, self._config)
 
         branch, _ = self._flow_context(issue.number)
-        from vibe3.domain.events import DomainEvent
+        from vibe3.domain.events.base import DomainEvent
 
         publish(
             cast(

--- a/src/vibe3/domain/events/__init__.py
+++ b/src/vibe3/domain/events/__init__.py
@@ -11,16 +11,6 @@ Events are organized by execution chain:
 Reference: docs/standards/vibe3-worktree-ownership-standard.md §二
 """
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class DomainEvent:
-    """Base class for all domain events."""
-
-    pass
-
-
 # Import from submodules
 from vibe3.domain.events.flow_lifecycle import (  # noqa: E402
     ExecutorDispatchIntent,
@@ -42,6 +32,8 @@ from vibe3.domain.events.supervisor_apply import (  # noqa: E402
     SupervisorIssueIdentified,
     SupervisorPromptRendered,
 )
+
+from .base import DomainEvent
 
 __all__ = [
     # Base

--- a/src/vibe3/domain/events/base.py
+++ b/src/vibe3/domain/events/base.py
@@ -1,0 +1,14 @@
+"""Base class for all domain events."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DomainEvent:
+    """Base class for all domain events.
+
+    All domain events should inherit from this class.
+    Events are immutable (frozen) to ensure event integrity.
+    """
+
+    pass

--- a/src/vibe3/domain/events/flow_lifecycle.py
+++ b/src/vibe3/domain/events/flow_lifecycle.py
@@ -5,11 +5,7 @@ Events for agent execution lifecycle (planner, executor, reviewer).
 
 from dataclasses import dataclass
 
-# Import base class from parent module
-from vibe3.domain.events import DomainEvent as _DomainEvent
-
-# Re-export for convenience
-DomainEvent = _DomainEvent
+from .base import DomainEvent
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/domain/events/governance.py
+++ b/src/vibe3/domain/events/governance.py
@@ -5,11 +5,7 @@ Events for governance service lifecycle and periodic scans.
 
 from dataclasses import dataclass
 
-# Import base class from parent module
-from vibe3.domain.events import DomainEvent as _DomainEvent
-
-# Re-export for convenience
-DomainEvent = _DomainEvent
+from .base import DomainEvent
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/domain/events/supervisor_apply.py
+++ b/src/vibe3/domain/events/supervisor_apply.py
@@ -11,11 +11,7 @@ Reference: docs/standards/vibe3-worktree-ownership-standard.md §二 (L2)
 
 from dataclasses import dataclass
 
-# Import base class from parent module
-from vibe3.domain.events import DomainEvent as _DomainEvent
-
-# Re-export for convenience
-DomainEvent = _DomainEvent
+from .base import DomainEvent
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Implements Phase 1 solutions from #1971 to eliminate 3 low-risk circular dependencies without architectural changes.

**Impact**: Reduced length-2 cycles: 4 → 1 (-75%)

## Changes

### 1. DomainEvent Base Class Extraction

**Problem**: Parent module `domain.events/__init__.py` imports child modules, child modules import base class from parent.

**Solution**: Extract base class to independent file
- Created `domain/events/base.py` with `DomainEvent` base class
- Updated child modules (`governance.py`, `flow_lifecycle.py`, `supervisor_apply.py`) to import from `.base`
- Parent module imports from `.base` and re-export child classes

**Cycles Broken**:
- `vibe3.domain.events ↔ vibe3.domain.events.governance`
- `vibe3.domain.events ↔ vibe3.domain.events.flow_lifecycle`

### 2. dispatch_coordinator Direct Import

**Problem**: `dispatch_coordinator.py` imports `publish()` from parent module `vibe3.domain`

**Solution**: Import from source module
- Changed: `from vibe3.domain import publish`
- To: `from vibe3.domain.publisher import publish`

**Cycle Broken**: `vibe3.domain ↔ vibe3.domain.dispatch_coordinator`

## Remaining Work

**1 cycle remaining** (Phase 2, requires architectural design):
- `vibe3.services.flow_orchestrator_service ↔ vibe3.services.flow_rebuild_usecase`

This requires Protocol-based dependency injection (see #1971 Phase 2 proposal).

## Test Plan

✅ All tests passing: 2486 tests
✅ Domain/events tests: 101 tests passed
✅ dispatch_coordinator tests: 2 tests passed
✅ Type checking: mypy passes
✅ Linting: ruff/black pass

No functional changes, only import path refinements.

## References

- #1971: Detailed analysis and solution proposals
- #1967: First round (utils/services/server boundary)
- #1970: Second round (runtime/orchestra/adapters/analysis internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)