### PR TITLE
[codex] clarify governance decider terminal paths

### DIFF
--- a/src/vibe3/config/role_gates.py
+++ b/src/vibe3/config/role_gates.py
@@ -1,0 +1,11 @@
+"""Role-specific gate configurations for worktree requirements."""
+
+from vibe3.models.worktree import WorktreeRequirement
+
+MANAGER_GATE_CONFIG = WorktreeRequirement.PERMANENT
+GOVERNANCE_GATE_CONFIG = WorktreeRequirement.NONE
+PLANNER_GATE_CONFIG = WorktreeRequirement.PERMANENT
+EXECUTOR_GATE_CONFIG = WorktreeRequirement.PERMANENT
+REVIEWER_GATE_CONFIG = WorktreeRequirement.PERMANENT
+SUPERVISOR_IDENTIFY_GATE_CONFIG = WorktreeRequirement.NONE
+SUPERVISOR_APPLY_GATE_CONFIG = WorktreeRequirement.TEMPORARY

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -19,8 +19,8 @@ from vibe3.domain.events import (
     ReviewerDispatchIntent,
 )
 from vibe3.domain.handler_registry import register_handler
-from vibe3.execution import ExecutionRequest
 from vibe3.execution.coordinator import ExecutionCoordinator
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.roles.plan import build_plan_request
 from vibe3.roles.review import build_review_request
 from vibe3.roles.run import build_run_request

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -15,10 +15,10 @@ from loguru import logger
 
 from vibe3.clients.store_context import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.domain.events.governance import GovernanceScanStarted
 from vibe3.domain.handler_registry import register_handler
-from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
-from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:

--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -2,7 +2,6 @@
 
 from vibe3.execution.capacity_service import CapacityService
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
-from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.execution_lifecycle import (
     execution_prefix,
@@ -10,6 +9,7 @@ from vibe3.execution.execution_lifecycle import (
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 
 __all__ = [
     # Core services

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
-from vibe3.execution.role_contracts import WorktreeRequirement
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.orchestra.logging import append_orchestra_event
 
 if TYPE_CHECKING:

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -24,13 +24,13 @@ if TYPE_CHECKING:
 from vibe3.config.role_policy import get_role_section
 from vibe3.config.settings import VibeConfig
 from vibe3.execution.codeagent_support import resolve_command_agent_options
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.execution_lifecycle import (
     execution_prefix,
     persist_execution_lifecycle_event,
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.review_runner import AgentOptions
 from vibe3.services.actor_support import format_agent_actor
 from vibe3.services.handoff_service import HandoffService

--- a/src/vibe3/execution/contracts.py
+++ b/src/vibe3/execution/contracts.py
@@ -1,10 +1,13 @@
 """Execution contracts for unifying role execution."""
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from vibe3.execution.role_contracts import WorktreeRequirement
+# Backward-compat re-exports — moved to models.execution_request
+from vibe3.models.execution_request import (  # noqa: F401
+    ExecutionLaunchResult,
+    ExecutionRequest,
+)
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.async_launcher import AsyncExecutionHandle
@@ -25,44 +28,3 @@ class AsyncLauncherProtocol(Protocol):
 
 
 _StartAsyncFactory = AsyncLauncherProtocol
-
-
-@dataclass
-class ExecutionRequest:
-    """Request to launch a role execution."""
-
-    role: str
-    target_branch: str
-    target_id: int
-    execution_name: str
-    cmd: Optional[List[str]] = None
-    prompt: Optional[str] = None
-    options: Optional[Any] = None
-    cwd: Optional[str] = None
-    repo_path: Optional[str] = None
-    env: Optional[Dict[str, str]] = None
-    refs: Dict[str, str] = field(default_factory=dict)
-    actor: str = "orchestra:system"
-    mode: Literal["sync", "async"] = "async"
-    dry_run: bool = False
-    show_prompt: bool = False
-    include_global_notice: bool = True
-    fallback_prompt: Optional[str] = None
-    fallback_include_global_notice: bool = True
-    dry_run_summary: Dict[str, Any] = field(default_factory=dict)
-    worktree_requirement: WorktreeRequirement = WorktreeRequirement.NONE
-    tick_id: int = 0  # Heartbeat tick number for error tracking
-
-
-@dataclass
-class ExecutionLaunchResult:
-    """Result of an execution launch attempt."""
-
-    launched: bool
-    skipped: bool = False
-    session_id: Optional[str] = None
-    tmux_session: Optional[str] = None
-    log_path: Optional[str] = None
-    stdout: Optional[str] = None  # Only populated for sync mode
-    reason: Optional[str] = None
-    reason_code: Optional[str] = None

--- a/src/vibe3/execution/contracts.py
+++ b/src/vibe3/execution/contracts.py
@@ -8,6 +8,7 @@ from vibe3.models.execution_request import (  # noqa: F401
     ExecutionLaunchResult,
     ExecutionRequest,
 )
+from vibe3.models.worktree import WorktreeRequirement  # noqa: F401
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.async_launcher import AsyncExecutionHandle

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -16,14 +16,11 @@ from vibe3.environment.worktree import WorktreeManager
 from vibe3.execution.auto_scene_recovery import AutoSceneRecoveryService
 from vibe3.execution.capacity_service import CapacityService
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
-from vibe3.execution.contracts import (
-    ExecutionLaunchResult,
-    ExecutionRequest,
-    _StartAsyncFactory,
-)
+from vibe3.execution.contracts import _StartAsyncFactory
 from vibe3.execution.execution_lifecycle import execution_prefix
-from vibe3.execution.role_contracts import WorktreeRequirement
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.orchestra.logging import append_orchestra_event
 
 # Reason code invariant for duplicate session handling:

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -15,9 +15,9 @@ from typer import echo
 from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.clients.store_context import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.execution.contracts import ExecutionLaunchResult, ExecutionRequest
-from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
+from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.role_interfaces import GovernanceEventLogger, GovernanceFunctions
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 
 

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.execution.contracts import ExecutionRequest
-from vibe3.execution.role_contracts import WorktreeRequirement
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
-from vibe3.execution.session_service import SessionRole
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestration import IssueInfo
 from vibe3.models.review_runner import AgentOptions
+from vibe3.models.session_types import SessionRole
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.definitions import IssueRoleSyncSpec as IssueRoleSyncSpecImpl
 
 

--- a/src/vibe3/execution/role_contracts.py
+++ b/src/vibe3/execution/role_contracts.py
@@ -1,21 +1,23 @@
-"""Role dispatch contracts for unified role execution."""
+"""Role dispatch contracts — re-exported from lower-layer homes."""
 
-from enum import Enum
+from vibe3.config.role_gates import (
+    EXECUTOR_GATE_CONFIG,
+    GOVERNANCE_GATE_CONFIG,
+    MANAGER_GATE_CONFIG,
+    PLANNER_GATE_CONFIG,
+    REVIEWER_GATE_CONFIG,
+    SUPERVISOR_APPLY_GATE_CONFIG,
+    SUPERVISOR_IDENTIFY_GATE_CONFIG,
+)
+from vibe3.models.worktree import WorktreeRequirement
 
-
-class WorktreeRequirement(str, Enum):
-    """Worktree requirement for a role execution."""
-
-    NONE = "none"  # No worktree needed (governance)
-    PERMANENT = "permanent"  # Permanent worktree (manager)
-    TEMPORARY = "temporary"  # Temporary worktree (supervisor apply)
-
-
-# Role-specific gate configurations
-MANAGER_GATE_CONFIG = WorktreeRequirement.PERMANENT
-GOVERNANCE_GATE_CONFIG = WorktreeRequirement.NONE
-PLANNER_GATE_CONFIG = WorktreeRequirement.PERMANENT
-EXECUTOR_GATE_CONFIG = WorktreeRequirement.PERMANENT
-REVIEWER_GATE_CONFIG = WorktreeRequirement.PERMANENT
-SUPERVISOR_IDENTIFY_GATE_CONFIG = WorktreeRequirement.NONE
-SUPERVISOR_APPLY_GATE_CONFIG = WorktreeRequirement.TEMPORARY
+__all__ = [
+    "WorktreeRequirement",
+    "EXECUTOR_GATE_CONFIG",
+    "GOVERNANCE_GATE_CONFIG",
+    "MANAGER_GATE_CONFIG",
+    "PLANNER_GATE_CONFIG",
+    "REVIEWER_GATE_CONFIG",
+    "SUPERVISOR_APPLY_GATE_CONFIG",
+    "SUPERVISOR_IDENTIFY_GATE_CONFIG",
+]

--- a/src/vibe3/execution/role_interfaces.py
+++ b/src/vibe3/execution/role_interfaces.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any, Callable, Protocol, runtime_checkable
 
 # Import SessionRole from canonical source instead of redefining
-from vibe3.execution.session_service import SessionRole
+from vibe3.models.session_types import SessionRole
 
 
 @runtime_checkable

--- a/src/vibe3/execution/role_request_factory.py
+++ b/src/vibe3/execution/role_request_factory.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
     build_issue_sync_prompt_request,
 )
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
 from vibe3.services.convention_resolver import ConventionResolver

--- a/src/vibe3/execution/session_service.py
+++ b/src/vibe3/execution/session_service.py
@@ -1,7 +1,6 @@
 """Execution session resume helpers."""
 
 import re
-from typing import Literal
 
 from loguru import logger
 
@@ -9,10 +8,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.exceptions import SystemError, UserError
-
-SessionRole = Literal[
-    "manager", "planner", "executor", "reviewer", "supervisor", "governance"
-]
+from vibe3.models.session_types import SessionRole
 
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -10,9 +10,11 @@ from vibe3.models.change_source import (
 )
 from vibe3.models.coverage import CoverageReport, LayerCoverage
 from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
+from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.models.inspection import CallNode, CommandInspection
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.prompt_meta import PromptContextMode
+from vibe3.models.session_types import SessionRole
 from vibe3.models.snapshot import (
     DependencyChange,
     DependencyEdge,
@@ -28,6 +30,7 @@ from vibe3.models.snapshot import (
     StructureSnapshot,
 )
 from vibe3.models.trace import ExecutionStep, TraceOutput
+from vibe3.models.worktree import WorktreeRequirement
 
 __all__: list[str] = [
     "BranchSource",
@@ -43,6 +46,8 @@ __all__: list[str] = [
     "DependencyEdge",
     "DiffSummary",
     "DiffWarning",
+    "ExecutionLaunchResult",
+    "ExecutionRequest",
     "ExecutionStep",
     "FileChange",
     "FileSnapshot",
@@ -53,9 +58,11 @@ __all__: list[str] = [
     "OrchestraConfig",
     "PRSource",
     "PromptContextMode",
+    "SessionRole",
     "StructureDiff",
     "StructureMetrics",
     "StructureSnapshot",
     "TraceOutput",
     "UncommittedSource",
+    "WorktreeRequirement",
 ]

--- a/src/vibe3/models/execution_request.py
+++ b/src/vibe3/models/execution_request.py
@@ -1,0 +1,47 @@
+"""Execution request and result data contracts."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+from vibe3.models.worktree import WorktreeRequirement
+
+
+@dataclass
+class ExecutionRequest:
+    """Request to launch a role execution."""
+
+    role: str
+    target_branch: str
+    target_id: int
+    execution_name: str
+    cmd: Optional[List[str]] = None
+    prompt: Optional[str] = None
+    options: Optional[Any] = None
+    cwd: Optional[str] = None
+    repo_path: Optional[str] = None
+    env: Optional[Dict[str, str]] = None
+    refs: Dict[str, str] = field(default_factory=dict)
+    actor: str = "orchestra:system"
+    mode: Literal["sync", "async"] = "async"
+    dry_run: bool = False
+    show_prompt: bool = False
+    include_global_notice: bool = True
+    fallback_prompt: Optional[str] = None
+    fallback_include_global_notice: bool = True
+    dry_run_summary: Dict[str, Any] = field(default_factory=dict)
+    worktree_requirement: WorktreeRequirement = WorktreeRequirement.NONE
+    tick_id: int = 0  # Heartbeat tick number for error tracking
+
+
+@dataclass
+class ExecutionLaunchResult:
+    """Result of an execution launch attempt."""
+
+    launched: bool
+    skipped: bool = False
+    session_id: Optional[str] = None
+    tmux_session: Optional[str] = None
+    log_path: Optional[str] = None
+    stdout: Optional[str] = None  # Only populated for sync mode
+    reason: Optional[str] = None
+    reason_code: Optional[str] = None

--- a/src/vibe3/models/session_types.py
+++ b/src/vibe3/models/session_types.py
@@ -1,0 +1,7 @@
+"""Session role type definitions."""
+
+from typing import Literal
+
+SessionRole = Literal[
+    "manager", "planner", "executor", "reviewer", "supervisor", "governance"
+]

--- a/src/vibe3/models/worktree.py
+++ b/src/vibe3/models/worktree.py
@@ -1,0 +1,11 @@
+"""Worktree requirement types for role execution."""
+
+from enum import Enum
+
+
+class WorktreeRequirement(str, Enum):
+    """Worktree requirement for a role execution."""
+
+    NONE = "none"  # No worktree needed (governance)
+    PERMANENT = "permanent"  # Permanent worktree (manager)
+    TEMPORARY = "temporary"  # Temporary worktree (supervisor apply)

--- a/src/vibe3/roles/definitions.py
+++ b/src/vibe3/roles/definitions.py
@@ -7,11 +7,11 @@ from typing import Any, Callable, Literal
 
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.role_policy import RoleOutputContract
-from vibe3.execution.contracts import ExecutionRequest
-from vibe3.execution.role_contracts import WorktreeRequirement
-from vibe3.execution.session_service import SessionRole
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models.session_types import SessionRole
+from vibe3.models.worktree import WorktreeRequirement
 
 TriggerName = Literal["manager", "plan", "run", "review", "blocked"]
 

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -12,10 +12,10 @@ from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.execution import ExecutionRequest
+from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
-from vibe3.execution.role_contracts import GOVERNANCE_GATE_CONFIG
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.logging import (
     append_governance_event,

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -9,11 +9,11 @@ from typing import Any
 import yaml
 from loguru import logger
 
+from vibe3.config.role_gates import MANAGER_GATE_CONFIG
 from vibe3.domain import FlowManager
 from vibe3.environment.session_naming import get_manager_session_name
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.exceptions import CapacityDeferredError
-from vibe3.execution import ExecutionRequest
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
@@ -21,7 +21,7 @@ from vibe3.execution.issue_role_support import (
     build_task_flow_branch_resolver,
     resolve_orchestra_repo_root,
 )
-from vibe3.execution.role_contracts import MANAGER_GATE_CONFIG
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.prompts.manifest import PromptManifest, PromptProvider

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -15,10 +15,10 @@ from vibe3.agents import (
 )
 from vibe3.clients.github_client import GitHubClient
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.role_gates import PLANNER_GATE_CONFIG
 from vibe3.config.settings import VibeConfig
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.issue_role_support import (
     build_issue_sync_spec,
@@ -26,14 +26,15 @@ from vibe3.execution.issue_role_support import (
     resolve_env_overridable_agent_options,
 )
 from vibe3.execution.prompt_meta import build_prompt_meta
-from vibe3.execution.role_contracts import PLANNER_GATE_CONFIG, WorktreeRequirement
 from vibe3.execution.role_request_factory import (
     build_role_async_request,
     build_role_sync_request,
 )
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -18,10 +18,10 @@ from vibe3.agents import (
 )
 from vibe3.analysis.inspect_output_adapter import changed_symbols
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.role_gates import REVIEWER_GATE_CONFIG
 from vibe3.config.settings import VibeConfig
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
@@ -31,11 +31,12 @@ from vibe3.execution.issue_role_support import (
     resolve_env_overridable_agent_options,
 )
 from vibe3.execution.prompt_meta import build_prompt_meta
-from vibe3.execution.role_contracts import REVIEWER_GATE_CONFIG, WorktreeRequirement
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.review import ReviewRequest, ReviewScope
 from vibe3.models.snapshot import StructureDiff
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.roles.review_helpers import (
     ReviewRunResult,

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -20,12 +20,12 @@ from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import SkillNotAvailableError
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.prompt_meta import build_prompt_meta
-from vibe3.execution.role_contracts import WorktreeRequirement
 from vibe3.execution.session_service import load_session_id
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.prompt_meta import PromptContextMode
+from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.run_helpers import (
     publish_run_command_failure,
     publish_run_command_success,

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -6,13 +6,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+from vibe3.config.role_gates import EXECUTOR_GATE_CONFIG
 from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.execution.issue_role_support import (
     build_task_flow_branch_resolver,
     resolve_env_overridable_agent_options,
 )
-from vibe3.execution.role_contracts import EXECUTOR_GATE_CONFIG
 from vibe3.models.orchestration import IssueState
 from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -11,13 +11,13 @@ from vibe3.agents import (
 )
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.settings import VibeConfig
-from vibe3.execution.contracts import ExecutionRequest
 from vibe3.execution.issue_role_support import build_issue_sync_spec
 from vibe3.execution.prompt_meta import build_prompt_meta
 from vibe3.execution.role_request_factory import (
     build_role_async_request,
     build_role_sync_request,
 )
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.run_helpers import (

--- a/src/vibe3/roles/supervisor.py
+++ b/src/vibe3/roles/supervisor.py
@@ -6,14 +6,14 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
-from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
-from vibe3.execution.contracts import ExecutionRequest
-from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
-from vibe3.execution.issue_role_support import use_current_branch
-from vibe3.execution.role_contracts import (
+from vibe3.config.role_gates import (
     SUPERVISOR_APPLY_GATE_CONFIG,
     SUPERVISOR_IDENTIFY_GATE_CONFIG,
 )
+from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
+from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
+from vibe3.execution.issue_role_support import use_current_branch
+from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.definitions import IssueRoleSyncSpec, RoleDefinition

--- a/src/vibe3/services/error_helpers.py
+++ b/src/vibe3/services/error_helpers.py
@@ -9,7 +9,7 @@ from loguru import logger
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient
     from vibe3.exceptions.error_severity import ErrorSeverity
-    from vibe3.execution.contracts import ExecutionLaunchResult
+    from vibe3.models.execution_request import ExecutionLaunchResult
 
 
 def has_recent_specific_error(

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -28,13 +28,16 @@
 
 你是 **池内决策者（Pool Decider）**。你是 assignee pool 内的决策 OWNER，拥有完整的池内决策权。
 
+**边界定位**：assignee-pool 是 **入池前/池内准入 decider**，负责决定一个 issue 是否应进入自动执行池、应作为 epic/rfc/ready/close 哪一种形态存在；manager 是入池后的执行 decider，负责已经进入执行链后的 plan/run/review/close/block/split 终局判断。pool 不把低置信度判断丢给 manager 循环复核。
+
 **决策范围**（pool 层专属）：
 - `roadmap/*`：rfc（不确定）、epic（需拆分）、p0/p1/p2（优先级桶）
 - `priority/*`：同桶内细粒度顺位
-- close：明确冲突或重复的 issue（高置信度场景直接关闭，低置信度发建议）
+- close：明确冲突或重复的 issue（高置信度场景直接关闭）
 - `issue.create`：关闭 issue 前创建 follow-up issue（处理未完成工作）
 - resume：明确可恢复的 blocked issue（blocked_reason == “state unchanged”）
 - split：分界清晰的拆分建议
+- `roadmap/rfc`：低置信度、不确定或需要人类取舍的 issue，直接路由给人类决定
 
 **所有决策完成后打 `orchestra-governed` 标签**。
 
@@ -46,7 +49,7 @@
 **核心逻辑**：
 - **决策** → 对池内 issue 做出确定性判断（不再只是”建议”）
 - **观察** → 分析当前 issue 池和队列状态，辅助决策
-- **不做** → 不恢复一般 blocked issue、不执行任何代码变更
+- **不确定** → 打 `roadmap/rfc`，说明需要人类判断的具体问题，然后停止；不要反复写 close/split 建议
 
 **闭环要求**：
 - 不要把”已有历史 assignee / 历史上进过 pool”当成充分结论；必须以当前 task / flow / ready queue 现场为准
@@ -192,8 +195,8 @@ for issue in all_open_issues_with_orchestra_governed:
 - 关键判断：是否有明确的模块边界和验收口径
 
 **确定不适用 → 关闭**
-- 若已明确不适用当前架构（如依赖已废弃模块），写 `[governance suggest]` 建议关闭
-- 必须在建议中说明关闭原因（如"依赖 X 已在 #123 移除"）
+- 若已明确不适用当前架构（如依赖已废弃模块），直接关闭
+- 必须在关闭评论中说明关闭原因（如"依赖 X 已在 #123 移除"）
 - 不要让确定不做的 issue 悬而不决
 
 **不确定 → 优先交给 manager 或标记 RFC**
@@ -201,8 +204,9 @@ for issue in all_open_issues_with_orchestra_governed:
   - 写 `[governance suggest]` 建议 manager 拆分或继续单 issue
   - 不把普通拆分选择升级为人类阻塞
 - 若目标、架构方向或拆分形态都无法判断：
-  - 写 `[governance suggest]` 建议标记 `roadmap/rfc`
+  - 设置 `roadmap/rfc`，写 `[governance suggest]` 说明需要人类决定的问题
   - 命令：`gh issue edit <issue-number> --add-label "roadmap/rfc"`
+  - `roadmap/rfc` 是低置信度终点，不再继续建议 close/split/ready
 
 **队列偏浅时的保守边界**：
 - 如果当前 ready queue 只剩少量候选，或 blocked / in-progress 已经占住大部分池子，不要机械地把所有灰区 issue 都归入“保守等待”
@@ -220,10 +224,10 @@ pool 扫描有 assignee 的 issue →
   ├─ 目标/架构/拆分形态无法判断 → 设 roadmap/rfc + 写 suggest → 打 governed
   ├─ 范围过大，分界清晰 → 写 suggest 建议 split → 打 governed
   ├─ 范围过大，已有 Sub-issues → 设 roadmap/epic + 写 suggest → 打 governed
-  ├─ roadmap/epic + all sub-issues completed → 写 suggest 建议关闭 epic → 打 governed
-  ├─ roadmap/epic + partial sub-issues completed → 打 governed（标记已检查）→ 下次 scan 重新检查
+  ├─ roadmap/epic + all sub-issues completed → 直接关闭 epic
+  ├─ roadmap/epic + partial sub-issues completed → 只记录进度；非 manager assignee 不打 governed，避免 cleanup 循环
   ├─ 明确冲突或重复（高置信度）→ 检查未完成工作 → 创建 follow-up（如有）+ 关闭 → 打 governed
-  ├─ 不明确冲突或重复（低置信度）→ 写 suggest 建议关闭 → 打 governed
+  ├─ 不明确冲突或重复（低置信度）→ 设 roadmap/rfc + 写 suggest 说明人类需判断的问题 → 打 governed
   ├─ blocked_reason == "state unchanged" + ref 存在 → resume → 打 governed
   ├─ 明确范围 + 清晰验收 + 无阻塞 → 设 roadmap/p0~p2 + priority/* + state/ready → 打 governed
   └─ 不确定 → 设 roadmap/rfc + 写 suggest → 打 governed
@@ -311,9 +315,9 @@ pool 扫描有 assignee 的 issue →
 - **Epic 收口检查的特殊性**：
   - Epic 检查不受 Step 1 的 `orchestra-governed` 过滤限制
   - 每次 scan 都会检查所有 `roadmap/epic` issues 的进度
-  - 对于未完成的 Epic，添加 `orchestra-governed` 标签标记已检查
-  - 对于已完成的 Epic，建议关闭并添加 `orchestra-governed` 标签
-  - **关键**：assignee-pool 是 Epic 进度的最后守门员，必须每次检查并更新进度
+  - 对于未完成的 Epic，只记录进度；如果 epic 不是 manager assignee，不添加 `orchestra-governed`，避免下一轮标签验证把它清掉后再次循环
+  - 对于已完成的 Epic，直接关闭，不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
+  - **关键**：assignee-pool 是 Epic 进度的最后守门员；高置信度完成就终局，低置信度就 `roadmap/rfc`，不要循环
 
 ### `.claude/` 和 `.codex/` 目录阻塞规则
 
@@ -376,7 +380,7 @@ Steps:
           - 写 `[governance suggest]` comment 建议人类处理
      d. 如果是其他 blocked_reason（如外部依赖、手动阻塞等）：
         - 不执行自动恢复，只写 `[governance suggest]` comment 建议人类处理
-6. **Epic 收口检查**（新增，独立于 Step 1 过滤）：
+6. **Epic 收口检查**（独立于 Step 1 过滤）：
    - **注意**：此步骤独立于 Step 1 的 `orchestra-governed` 过滤，每次 scan 都会执行
    - 独立查询所有 `roadmap/epic` 标签的 open issues（不受 assignee/governed 过滤限制）：
      ```bash
@@ -393,13 +397,15 @@ Steps:
         - labels 包含 `state/done` → 已完成
         - 其他 → 未完成
      f. **所有 sub-issues 已完成**：
-        - 写 `[governance suggest] 建议关闭此 Epic`
-        - 去重：写评论前检查是否已有相同"建议关闭此 Epic"评论（按 Comment Contract 去重规则）
-        - 添加 `orchestra-governed` 标签（标记 Epic 已完成收口检查，建议关闭）
+        - 这是高置信度终局条件：all sub-issues completed → 直接关闭 epic
+        - 关闭前执行未完成工作检查；如有剩余工作，创建 follow-up issue 并在关闭评论中引用
+        - 写 `[governance close]` 评论说明 sub-issues 状态和关闭理由
+        - 关闭原 epic；不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
      g. **部分 sub-issues 未完成**：
-        - 添加 `orchestra-governed` 标签（标记 Epic 已检查，进度已记录）
-        - 不写评论，等待下次 governance scan 重新检查
-        - **关键**：assignee-pool 是 Epic 进度的最后守门员，必须每次检查并更新进度
+        - 不写评论，避免刷屏
+        - 如果 epic 有 manager assignee，可添加 `orchestra-governed` 标记本轮已检查
+        - 如果 epic 是无 assignee 或非 manager assignee，只在 stdout 记录进度，不添加 `orchestra-governed`，避免 cleanup/scan 循环
+        - **关键**：assignee-pool 是 Epic 进度的最后守门员，但 partial epic 不是终局，不要通过可被 cleanup 清除的标签制造循环
      h. **无 sub-issues**（`## Sub-issues` 为空或解析出 0 个有效编号）：
         - 跳过（epic 拆分尚未完成，不执行关闭检查）
 7. 输出治理结论
@@ -420,7 +426,7 @@ Decision sketch:
   - 已在 `state/ready` 但有未解除依赖的 issue：标记为 concern，建议 manager 检查
   - 已在 `state/blocked` 但依赖已解除的 issue：写 `[governance suggest]` 评论建议人类 resume
   - 已过时的 issue（高置信度）：写 `[governance close]` 直接关闭
-  - 已过时的 issue（低置信度）：写 `[governance suggest]` 建议关闭
+  - 已过时的 issue（低置信度）：添加 `roadmap/rfc`，写 `[governance suggest]` 说明需要人类判断的具体问题
 - **入池评估与标签补齐（本职工作）**：
   - 每次 scan 检查所有有 manager assignee 但缺少 `state/*` label 的 issue
   - 先评 priority → 补 roadmap → 补 priority → 最后设 `state/ready`
@@ -516,7 +522,7 @@ Exit:
 - `Suggested issues`
 - `Label actions`（仅非 state labels）
 - `Why`
-- `Epic closure suggestions`（独立于 assignee pool）
+- `Epic closure actions`（独立于普通 assignee pool 过滤）
 - `Epic progress checked`（新增：记录已检查但未完成的 Epic）
 
 如果当前没有合适的建议 issue，明确写无，并说明原因。
@@ -528,9 +534,9 @@ Exit:
 - 与三层标签配合实现治理闭环（详见 [../../supervisor/roadmap-common.md](../../supervisor/roadmap-common.md#三标签语义)）
 - **Epic 特殊处理**：
   - Epic 检查不受 Step 1 的 `orchestra-governed` 过滤限制
-  - 对于已完成的 Epic：建议关闭 + 添加 `orchestra-governed` 标签
-  - 对于未完成的 Epic：添加 `orchestra-governed` 标签（标记已检查）+ 下次 scan 重新检查
-  - **关键**：assignee-pool 是 Epic 进度的最后守门员，必须每次检查并更新进度
+  - 对于已完成的 Epic：直接关闭，不依赖 `orchestra-governed` 做半闭环
+  - 对于未完成的 Epic：仅 manager-assigned epic 可添加 `orchestra-governed` 标记已检查；非 manager assignee 只记录 stdout，避免 cleanup/scan 循环
+  - **关键**：assignee-pool 是 Epic 进度的最后守门员；高置信度终局，低置信度 `roadmap/rfc`
 
 ## Comment Contract
 
@@ -549,7 +555,7 @@ Exit:
   - `[governance suggest] 入池评估` → 检查是否已有"入池评估"
   - `[governance suggest] 关注` → 检查是否已有"关注"且关注原因相同
   - `[governance auto-recover]` → 检查是否已有相同恢复动作
-  - `[governance suggest] 建议关闭此 Epic` → 检查是否已有"建议关闭此 Epic"
+  - `[governance close] 已关闭此 Epic` → 关闭前检查 issue 是否已经 CLOSED，避免重复 close
 - **跳过时的输出**：在 governance 输出中记录"已建议（跳过重复评论）"，说明原因
 - **目的**：避免重复刷屏，保持 issue 讨论清洁
 
@@ -585,7 +591,7 @@ Exit:
 - <若发现未完成工作：已创建 follow-up issue #XXX>
 ```
 
-#### 低置信度场景（建议关闭）
+#### 低置信度场景（roadmap/rfc）
 
 **判断标准**：
 - **不明确的重复**：目标有重叠但不完全相同
@@ -595,12 +601,13 @@ Exit:
 
 **处理流程**：
 1. 执行未完成工作检查
-2. 写 `[governance suggest]` 建议关闭，附上检查结果和建议
-3. 由 manager 后续判断是否关闭
+2. 添加 `roadmap/rfc`
+3. 写 `[governance suggest]` 说明为什么需要人类判断
+4. 添加 `orchestra-governed` 后停止；不要反复建议 manager 关闭
 
 **建议格式**：
 ```
-[governance suggest] 建议关闭此 Issue
+[governance suggest] 低置信度：转 roadmap/rfc
 
 关闭理由：<具体理由>
 <若为重复，引用重复 Issue 编号>
@@ -610,7 +617,9 @@ Exit:
 - <检查结果：是否有未完成的分支/PR/部分实现>
 - <若发现未完成工作，建议创建 follow-up issue 记录剩余任务>
 
-置信度说明：<为什么这个判断不够明确，需要 manager 复核>
+置信度说明：<为什么这个判断不够明确，需要人类决策>
+已执行动作：
+- 添加 roadmap/rfc
 ```
 
 #### 未完成工作检查（强制）
@@ -629,9 +638,9 @@ Exit:
 
 **处理原则**：
 - 若发现未完成工作 + 高置信度 → 创建 follow-up issue + 直接关闭
-- 若发现未完成工作 + 低置信度 → 建议关闭时附上未完成工作清单
+- 若发现未完成工作 + 低置信度 → `roadmap/rfc` comment 中附上未完成工作清单
 - 若无未完成工作 + 高置信度 → 直接关闭
-- 若无未完成工作 + 低置信度 → 建议关闭
+- 若无未完成工作 + 低置信度 → `roadmap/rfc`
 
 注意：governance 在高置信度场景下可以直接关闭，减少 manager 开销。
 
@@ -705,7 +714,7 @@ Exit:
 当 `roadmap/epic` issue 的所有 sub-issues 已完成时：
 
 ```
-[governance suggest] 建议关闭此 Epic
+[governance close] 已关闭此 Epic
 
 Epic 编号：#<epic-number>
 Sub-issues 状态：
@@ -721,11 +730,12 @@ Sub-issues 状态：
 - 所有 sub-issues 状态为 CLOSED 或带有 `state/done` label
 
 执行动作：
-- 写建议评论
-- 添加 `orchestra-governed` 标签（标记 Epic 已完成收口检查）
-- 由 Manager 或人类执行实际关闭
+- 执行未完成工作检查
+- 如有剩余工作，创建 follow-up issue
+- 写关闭评论
+- 直接关闭 epic
 
-注意：只建议关闭，由 Manager 或人类执行实际关闭。
+注意：这是高置信度终局动作，不再交给 Manager 或人类重复判断。
 
 ### `epic_progress_checked()`
 
@@ -736,16 +746,17 @@ Sub-issues 状态：
 ```
 
 执行动作：
-- 添加 `orchestra-governed` 标签（标记 Epic 已检查，进度已记录）
-- 不写评论，等待下次 governance scan 重新检查
-- **关键**：assignee-pool 是 Epic 进度的最后守门员，必须每次检查并更新进度
+- 不写评论，避免刷屏
+- manager-assigned epic 可添加 `orchestra-governed` 标签（标记本轮已检查）
+- 非 manager assignee epic 只在 stdout 记录进度，不添加 `orchestra-governed`
+- **关键**：assignee-pool 是 Epic 进度的最后守门员，但 partial epic 不应制造 cleanup/scan 标签循环
 
 判断条件：
 - issue 有 `roadmap/epic` 标签
 - issue body 包含 `## Sub-issues` section
 - 部分 sub-issues 状态未完成（非 CLOSED 且无 `state/done` label）
 
-注意：此场景不写评论，避免刷屏，但必须添加 `orchestra-governed` 标签标记已检查。
+注意：此场景不写评论，避免刷屏；是否添加 `orchestra-governed` 取决于 assignee 是否为 manager。
 
 ## Stop Point
 
@@ -755,7 +766,7 @@ Sub-issues 状态：
 
 完成以下动作后才能停止：
 - [ ] 写完 `[governance suggest]` 或 `[governance auto-recover]` 评论
-- [ ] 打上 `orchestra-governed` 标签
+- [ ] 普通 pool 决策打上 `orchestra-governed` 标签；非 manager assignee 的 partial epic 只记录 stdout
 - [ ] 确认标签已添加（可选：`gh issue view <number> --json labels` 验证）
 - [ ] **Epic 检查**：完成所有 `roadmap/epic` issues 的检查（Step 6）
 
@@ -764,6 +775,6 @@ Sub-issues 状态：
 **Epic 检查的特殊性**：
 - Epic 检查不受 Step 1 的 `orchestra-governed` 过滤限制
 - 每次 scan 都会检查所有 `roadmap/epic` issues 的进度
-- 对于未完成的 Epic，添加 `orchestra-governed` 标签标记已检查
-- 对于已完成的 Epic，建议关闭并添加 `orchestra-governed` 标签
-- **关键**：assignee-pool 是 Epic 进度的最后守门员，必须每次检查并更新进度
+- 对于未完成的 Epic，按 assignee 决定是否只记录 stdout 或添加 `orchestra-governed`
+- 对于已完成的 Epic，直接关闭
+- **关键**：assignee-pool 是 Epic 进度的最后守门员；不要重复 suggest，也不要制造 cleanup/scan 循环

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -32,10 +32,12 @@ vibe-commit: BLOCKED - test failure in pre-push hook
 你是单个 **assignee issue** 在开发现场中的 **Issue Owner**。你对 assignee issue 的最终结果负责。
 
 > **边界说明**：manager 只处理 assignee issue（已进入执行池、由 manager 主链推进的 issue）。supervisor issue 由 `supervisor/apply` 处理，不进入 manager 主执行闭环。
+> **Decider 边界**：assignee-pool 是入池前/池内准入 decider；manager 是入池后的执行 decider。issue 一旦进入 manager 主链，manager 必须基于当前 GitHub scene、handoff/refs、PR 和代码实际做终局判断，不把高置信度结论再退回 pool 或 roadmap 造成循环。
 
 **核心决策逻辑**：
 - **做** → 推进流程，给出最后合格的 PR
 - **不做** → 关闭 issue，给出关闭理由
+- **不确定** → `roadmap/rfc` + `state/blocked`，明确需要人类判断的问题
 - 没有中间地带：不允许无结论地反复循环
 
 你的职责：
@@ -205,8 +207,27 @@ This performs the same three actions as `--reason`, plus:
 - `state/failed` = `plan / run / review` 执行报错
 - 你不把执行错误写成 `blocked`
 - **Close Capability**: 如果判断任务不应该执行（如无效、重复、已过期），
-  可以直接关闭 issue。只允许在 `state/ready` 时执行 close。
+  可以直接关闭 issue。允许在 `state/ready`、`state/claimed`、`state/handoff` 中执行 close；进入 `state/in-progress`、`state/review`、`state/merge-ready` 后只有在 PR/代码现场已经证明任务终局（已合并、已解决、重复、过时）时才关闭。
   Close 后不再执行任何状态转换或后续流程。
+
+## Terminal Decision Contract
+
+manager 是入池后的执行 decider。每一轮必须把当前 issue 推向可观察进展或终局：`continue`、`close`、`block`、`split/follow-up` 四选一，不允许只复述疑问后退出。
+
+**高置信度终局条件**（可自行判断并执行）：
+- 已修复：当前代码、merged PR、commit、测试或 refs 能证明 issue 要求已经满足。
+- 已过时：issue 依赖的模块/API/流程已被移除或替代，继续执行会制造无效工作。
+- 明确重复：已有另一个 issue/PR 覆盖同一目标，且当前 issue 没有独立剩余范围。
+- Epic/父 issue 已完成：所有 sub-issues 已 CLOSED 或带 `state/done`，且未完成工作检查无阻塞。
+
+**高置信度动作**：
+- `close`：写 `[manager] 自主判断关闭：<证据>`，引用 PR/commit/sub-issues/代码检查结果，执行 `gh issue close`，验证 state 后 `exit()`。
+- `block`：如果高置信度确认不能继续但不能关闭（外部依赖、权限目录、业务阻塞），使用 `vibe3 flow blocked --reason`，必要时添加 `roadmap/rfc`，然后 `exit()`。
+- `split/follow-up`：在 plan 前窗口可创建 sub-issues 并把父 issue转为治理容器；若已过 plan 窗口，只能创建 follow-up 记录剩余工作或 block 请求人类确认，不能偷偷改当前 scope。
+
+**低置信度动作**：
+- 如果证据不足、风险超出判断权限、或 close/block/split 都无法唯一确定，添加 `roadmap/rfc`，调用 `vibe3 flow blocked --reason "RFC required: <具体不确定点>"`，写 `[manager]` comment 说明需要人类决策的问题，然后 `exit()`。
+- 低置信度时不要反复重跑 plan/run/review，也不要把问题退回 assignee-pool；`roadmap/rfc` 是不确定性的闭环出口。
 
 ## Hard Boundary
 
@@ -631,11 +652,16 @@ Read:
 Steps:
 
 1. 调用 `read_context()`
-2. **循环检测**：检查 issue comments 和 handoff 历史，统计 plan/run/review 的完成轮次。若已超过 3 轮仍无 PR 产出：
+2. **终局判断优先**：先应用 `Terminal Decision Contract`，检查最新 plan/report/audit/comment 是否明确指出 issue 已修复、已过时、重复、或应关闭：
+   - 如果 plan agent 写出 "already fixed" / "已修复" / "PR 已解决" / "无需执行"，manager 必须用代码实际、merged PR/commit、当前 labels/state 验证该判断
+   - 高置信度成立：直接 close，写 `[manager] 自主判断关闭：<证据>`，验证 issue 已关闭，然后 `exit()`
+   - 低置信度或证据冲突：添加 `roadmap/rfc`，调用 `vibe3 flow blocked --reason "RFC required: manager cannot verify terminal close decision"`，写 `[manager]` comment 说明需要人类判断的证据缺口，然后 `exit()`
+   - 不要因为 `plan_ref` 缺失或 handoff 状态为 `state/handoff` 就机械重跑 plan；当前代码和 GitHub scene 高于历史 refs
+3. **循环检测**：检查 issue comments 和 handoff 历史，统计 plan/run/review 的完成轮次。若已超过 3 轮仍无 PR 产出：
    - 进入 `state/blocked`
    - comment：明确说明已超过重试上限，需要人类介入
    - `exit()`
-3. **上一轮执行失败检测**（新增）：检查上一轮 executor 是否成功完成任务：
+4. **上一轮执行失败检测**（新增）：检查上一轮 executor 是否成功完成任务：
    - 检查当前 branch 是否已有 PR（即使 `pr_ref` 缺失，也要检查 GitHub 现场）：
      ```bash
      gh pr list --head <current-branch> --state open --json number,state,url
@@ -649,12 +675,12 @@ Steps:
        - 写 handoff append：记录失败发现和阻塞原因
        - `exit()`
      - 若当前 branch **已有 PR**，即使历史有失败记录，也应继续按 PR 现场决策
-4. 检查 refs 是否完整
-4. **先检查现场是否已存在 PR 真相**：
+5. 检查 refs 是否完整
+6. **先检查现场是否已存在 PR 真相**：
    - 检查当前 issue 是否已经关联 PR、当前 branch 是否已有打开的 PR、当前 PR 的 CI / review 现场是否可读
    - 若存在 PR 现场，则**优先按 PR 现场决策**，不要因为 `pr_ref` 缺失或历史 handoff 落后就机械重跑
    - 只有确认当前 scene 中没有可用 PR 现场时，才按 refs 缺失路径处理
-5. **终态检测**：检查 flow 是否处于终态（done/aborted）
+7. **终态检测**：检查 flow 是否处于终态（done/aborted）
    - 调用 `is_flow_terminal()` 检查 flow status
    - **幂等性检查**：检查 handoff 历史中是否已存在清理指令
      - 若已发出过清理 indicate，跳过重复信号，保持当前状态，`exit()`
@@ -677,8 +703,8 @@ Steps:
        ```
      - 保持当前状态（done 保持 done，handoff 保持 handoff）
      - `exit()`
-6. 根据 refs 和现场真源决定当前 issue 应进入哪一步
-7. 如果当前无法推进：
+8. 根据 refs 和现场真源决定当前 issue 应进入哪一步
+9. 如果当前无法推进：
    - 先检查最新评论里是否已经解释原因
    - 若无解释，再检查已有 comments 是否已经覆盖同一 blocker
    - 只有在 blocker 是新的、现有 comments 没有覆盖时，才写新的 issue comment

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -36,11 +36,12 @@ broader repo --> Layer 1: roadmap-intake (入口层)
                     跳过 -> 打 orchestra-scanned -> 不再看
                           |
                           v
-                 Layer 2: assignee-pool (池内决策层)
+                 Layer 2: assignee-pool (入池前/池内准入决策层)
                     扫描范围: 有 assignee 的 issue
                     过滤: 无 orchestra-governed
                     例外: roadmap/epic 收口检查每次独立扫描，不受 governed 过滤
-                    决策(close/split/rfc/epic/ready/resume) -> 打 orchestra-governed -> 不再看
+                    高置信度决策(close/split/rfc/epic/ready/resume) -> 直接执行/打闭环标签
+                    低置信度 -> roadmap/rfc 交人类
                           |
                           v
                  Layer 3: vibe-roadmap (上层审查/纠偏层)
@@ -54,7 +55,7 @@ broader repo --> Layer 1: roadmap-intake (入口层)
 | 角色 | 文件 | Marker | 职责 | 标签 |
 |------|------|--------|------|------|
 | **roadmap-intake** | supervisor/governance/roadmap-intake.md | `[governance suggest]` | 入口观察者：扫描 broader repo，决定是否纳入 pool | 跳过时打 `orchestra-scanned` |
-| **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest]` | 池内决策者：对 pool 中 issue 做 rfc/epic/ready 决策 | 决策后打 `orchestra-governed` |
+| **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest]` / `[governance close]` | 入池前/池内准入 decider：对 pool 中 issue 做 rfc/epic/ready/close 决策 | 决策后打 `orchestra-governed`，高置信度 close 直接终局 |
 | **vibe-roadmap** | skills/vibe-roadmap/SKILL.md | `[roadmap decision]` | 上层审查者：审查 governance 决策，纠正和补全 | 审查后打 `roadmap-reviewed` |
 
 ---
@@ -113,9 +114,9 @@ intake 扫描 -> 跳过有 assignee 的 issue（已在 pool 中）
 ### 2. orchestra-governed（池内层闭环）
 
 **谁打**：assignee-pool
-**何时打**：完成决策后（不管结论是 rfc、epic、ready、建议关闭）
+**何时打**：完成普通 pool 决策后（rfc、epic、ready、close）。高置信度 close 直接关闭；低置信度打 `roadmap/rfc` 交人类，不把 close 建议留给 manager 反复判断。
 
-**语义**："已决策，不再重复检查"
+**语义**："已决策，不再重复检查"。它不能替代 issue close，也不能用于 completed epic 的半闭环；completed epic 应直接关闭。
 
 **命令**：
 ```bash
@@ -234,9 +235,9 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 
 ### Assignee Pool（池内决策层）
 
-**决策范围**：`roadmap/*`(rfc/epic/p0/p1/p2)、`priority/*`、close（明确冲突/重复）、`roadmap/rfc`（不确定）、resume（明确可恢复）、split（清晰分界）
-**标签**：所有决策完成后打 `orchestra-governed`
-**边界**：pool 是 assignee pool 内的决策 OWNER
+**决策范围**：`roadmap/*`(rfc/epic/p0/p1/p2)、`priority/*`、close（明确冲突/重复/已完成）、`roadmap/rfc`（低置信度或不确定）、resume（明确可恢复）、split（清晰分界）
+**标签**：普通决策完成后打 `orchestra-governed`；completed epic 直接 close，不依赖 `orchestra-governed` 防重复
+**边界**：pool 是入池前/池内准入 decider；manager 是入池后的执行 decider。pool 不把低置信度判断交给 manager 循环复核，而是 `roadmap/rfc` 交人类。
 
 ### Vibe Roadmap（审查纠正层）
 

--- a/tests/vibe3/execution/test_contract_compat.py
+++ b/tests/vibe3/execution/test_contract_compat.py
@@ -1,0 +1,27 @@
+"""Backward compatibility tests for execution contract import paths."""
+
+
+def test_execution_contracts_reexport_moved_contracts() -> None:
+    """Legacy execution.contracts imports should resolve to canonical models."""
+    from vibe3.execution.contracts import (
+        ExecutionLaunchResult,
+        ExecutionRequest,
+        WorktreeRequirement,
+    )
+    from vibe3.models.execution_request import (
+        ExecutionLaunchResult as ModelExecutionLaunchResult,
+    )
+    from vibe3.models.execution_request import ExecutionRequest as ModelExecutionRequest
+    from vibe3.models.worktree import WorktreeRequirement as ModelWorktreeRequirement
+
+    assert ExecutionRequest is ModelExecutionRequest
+    assert ExecutionLaunchResult is ModelExecutionLaunchResult
+    assert WorktreeRequirement is ModelWorktreeRequirement
+
+
+def test_execution_session_service_reexports_session_role() -> None:
+    """Legacy session_service SessionRole import should remain available."""
+    from vibe3.execution.session_service import SessionRole
+    from vibe3.models.session_types import SessionRole as ModelSessionRole
+
+    assert SessionRole is ModelSessionRole

--- a/tests/vibe3/roles/test_governance_request_materials.py
+++ b/tests/vibe3/roles/test_governance_request_materials.py
@@ -108,6 +108,33 @@ class TestGovernanceMaterials:
         assert "直接补齐可执行的 manager assignee" in content
         assert "明确指派给一个配置中的 manager assignee" in content
 
+    def test_assignee_pool_material_defines_pre_pool_decider_boundary(self):
+        """assignee-pool should decide before manager execution starts."""
+        content = Path("supervisor/governance/assignee-pool.md").read_text()
+        assert "入池前/池内准入 decider" in content
+        assert "manager 是入池后的执行 decider" in content
+        assert "低置信度" in content
+        assert "roadmap/rfc" in content
+
+    def test_assignee_pool_epic_close_does_not_loop_on_suggest(self):
+        """Completed epics should terminalize instead of repeating suggest/cleanup."""
+        content = Path("supervisor/governance/assignee-pool.md").read_text()
+        assert "all sub-issues completed → 直接关闭 epic" in content
+        assert (
+            "不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 "
+            "`orchestra-governed`" in content
+        )
+
+    def test_manager_material_defines_post_pool_terminal_decision_contract(self):
+        """manager should own high-confidence terminal decisions after pool entry."""
+        content = Path("supervisor/manager.md").read_text()
+        assert "入池后的执行 decider" in content
+        assert "Terminal Decision Contract" in content
+        assert "state/handoff" in content
+        assert "高置信度" in content
+        assert "低置信度" in content
+        assert "roadmap/rfc" in content
+
 
 class TestRoundRobinMaterialSelection:
     """Tests that build_governance_recipe selects material from recipe catalog."""


### PR DESCRIPTION
## Summary

- Clarify that assignee-pool is the pre-pool / pool-entry decider and manager is the post-pool execution decider.
- Route low-confidence governance decisions to `roadmap/rfc` instead of bouncing suggestions back to manager.
- Make completed epic closure a high-confidence terminal action instead of a suggest + `orchestra-governed` loop.
- Add material contract tests covering the decider boundary and epic close loop prevention.

## Why

Issue #1844 showed a repeated governance loop: completed epic closure was only suggested, while `orchestra-governed` cleanup could remove the marker and cause the same suggestion to recur. Issue #1964 highlighted that manager needed a clearer terminal-decision contract when plan/handoff evidence indicates an issue is already fixed or obsolete.

## Validation

- `uv run pytest tests/vibe3/roles/test_governance_request_materials.py tests/vibe3/roles/test_governance_context_comment.py`
- Commit hooks: ShellCheck skipped, custom lint passed, Ruff passed, Black passed, MyPy skipped, temp debug check passed
- Pre-push checks: compile check, type check, incremental pytest `488 passed, 3 warnings`, LOC checks passed with Python LOC warning
