### PR TITLE
refactor(execution): use public API imports instead of submodule imports

### DIFF
--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -9,7 +9,7 @@ from vibe3.execution.execution_lifecycle import (
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
-from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
+from vibe3.models import ExecutionLaunchResult, ExecutionRequest
 
 __all__ = [
     # Core services

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -6,11 +6,9 @@ from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
-from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.models import IssueInfo, IssueState
-from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
-from vibe3.models.worktree import WorktreeRequirement
-from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.clients import SQLiteClient
+from vibe3.models import ExecutionLaunchResult, ExecutionRequest, IssueInfo, IssueState, WorktreeRequirement
+from vibe3.orchestra import append_orchestra_event
 
 if TYPE_CHECKING:
     from vibe3.environment.session_registry import SessionRegistryService
@@ -158,10 +156,7 @@ class AutoSceneRecoveryService:
         except Exception as exc:
             append_orchestra_event(
                 "dispatcher",
-                (
-                    f"{request.role} auto-reset failed for #{request.target_id}: "
-                    f"{exc}"
-                ),
+                (f"{request.role} auto-reset failed for #{request.target_id}: {exc}"),
                 level="ERROR",
             )
             self.store.add_event(

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.models import ExecutionLaunchResult, ExecutionRequest, IssueInfo, IssueState, WorktreeRequirement
+from vibe3.models import (
+    ExecutionLaunchResult,
+    ExecutionRequest,
+    IssueInfo,
+    IssueState,
+    WorktreeRequirement,
+)
 from vibe3.orchestra import append_orchestra_event
 
 if TYPE_CHECKING:

--- a/src/vibe3/execution/capacity_service.py
+++ b/src/vibe3/execution/capacity_service.py
@@ -13,10 +13,9 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.protocols import BackendProtocol
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import BackendProtocol, SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models import OrchestraConfig
 
 if TYPE_CHECKING:
     pass

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -9,8 +9,7 @@ from typing import TYPE_CHECKING, cast
 from loguru import logger
 from typer import echo
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitClient, SQLiteClient
 
 if TYPE_CHECKING:
     from loguru import Logger
@@ -21,8 +20,8 @@ if TYPE_CHECKING:
         CodeagentResult,
     )
     from vibe3.exceptions.error_severity import ErrorSeverity
+from vibe3.config import VibeConfig
 from vibe3.config.role_policy import get_role_section
-from vibe3.config.settings import VibeConfig
 from vibe3.execution.codeagent_support import resolve_command_agent_options
 from vibe3.execution.execution_lifecycle import (
     execution_prefix,
@@ -30,10 +29,9 @@ from vibe3.execution.execution_lifecycle import (
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
-from vibe3.models.execution_request import ExecutionRequest
+from vibe3.models import ExecutionRequest
 from vibe3.models.review_runner import AgentOptions
-from vibe3.services.actor_support import format_agent_actor
-from vibe3.services.handoff_service import HandoffService
+from vibe3.services import HandoffService, format_agent_actor
 
 
 def _severity_event_type(role: str, severity: "ErrorSeverity") -> str:
@@ -96,8 +94,7 @@ class CodeagentExecutionService:
             log.info(f"Removed {handoff_label} label from #{issue_number}")
         except Exception as exc:
             log.warning(
-                f"Failed to remove {handoff_label} label from "
-                f"#{issue_number}: {exc}"
+                f"Failed to remove {handoff_label} label from #{issue_number}: {exc}"
             )
 
     @staticmethod

--- a/src/vibe3/execution/codeagent_support.py
+++ b/src/vibe3/execution/codeagent_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal, Sequence
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.models.review_runner import AgentOptions
 
 

--- a/src/vibe3/execution/contracts.py
+++ b/src/vibe3/execution/contracts.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 # Backward-compat re-exports — moved to models.execution_request
-from vibe3.models.execution_request import (  # noqa: F401
+from vibe3.models import (  # noqa: F401
     ExecutionLaunchResult,
     ExecutionRequest,
+    WorktreeRequirement,  # noqa: F401
 )
-from vibe3.models.worktree import WorktreeRequirement  # noqa: F401
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.async_launcher import AsyncExecutionHandle

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -9,19 +9,21 @@ from typing import Generator, Optional
 
 from loguru import logger
 
-from vibe3.clients.protocols import BackendProtocol
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import BackendProtocol, SQLiteClient
+from vibe3.environment import WorktreeManager
 from vibe3.environment.session_registry import SessionRegistryService
-from vibe3.environment.worktree import WorktreeManager
 from vibe3.execution.auto_scene_recovery import AutoSceneRecoveryService
 from vibe3.execution.capacity_service import CapacityService
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.contracts import _StartAsyncFactory
 from vibe3.execution.execution_lifecycle import execution_prefix
-from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.worktree import WorktreeRequirement
-from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.models import (
+    ExecutionLaunchResult,
+    ExecutionRequest,
+    OrchestraConfig,
+    WorktreeRequirement,
+)
+from vibe3.orchestra import append_orchestra_event
 
 # Reason code invariant for duplicate session handling:
 #

--- a/src/vibe3/execution/execution_lifecycle.py
+++ b/src/vibe3/execution/execution_lifecycle.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient
 
 ExecutionRole = Literal[
     "planner", "executor", "reviewer", "manager", "supervisor", "governance"

--- a/src/vibe3/execution/execution_role_policy.py
+++ b/src/vibe3/execution/execution_role_policy.py
@@ -6,11 +6,11 @@ from typing import Literal
 from loguru import logger
 
 from vibe3.agents.backends.codeagent_config import sync_models_json
+from vibe3.config import load_orchestra_config
 from vibe3.config.agent_preset import (
     resolve_effective_agent_options as resolve_backend_effective_agent_options,
 )
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models import OrchestraConfig
 from vibe3.models.review_runner import AgentOptions
 
 

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -12,13 +12,13 @@ from typing import Callable
 from loguru import logger
 from typer import echo
 
-from vibe3.agents.backends.codeagent import CodeagentBackend
+from vibe3.agents import CodeagentBackend
 from vibe3.clients.store_context import get_store
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config import load_orchestra_config
 from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.role_interfaces import GovernanceEventLogger, GovernanceFunctions
-from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
+from vibe3.models import ExecutionLaunchResult, ExecutionRequest
+from vibe3.services import record_dispatch_failure_if_unexpected
 
 
 def run_governance_sync(
@@ -112,8 +112,7 @@ def run_governance_sync(
 
         # Log successful completion
         append_event(
-            f"governance scan completed tick={tick_count} "
-            f"exit_code={result.exit_code}"
+            f"governance scan completed tick={tick_count} exit_code={result.exit_code}"
         )
         logger.bind(domain="governance", tick=tick_count).success(
             f"Governance scan completed: {result.exit_code}"
@@ -137,7 +136,7 @@ def run_governance_sync(
             f"Governance scan failed: {error_code} - {exc}"
         )
         append_event(
-            f"governance scan failed tick={tick_count} " f"error={error_code}: {exc}"
+            f"governance scan failed tick={tick_count} error={error_code}: {exc}"
         )
 
         # Re-raise for CLI exit code handling
@@ -295,7 +294,6 @@ def run_governance_async(
         echo(message)
     elif result:
         append_governance_event(
-            f"governance dispatch skipped: tick={tick_count} "
-            f"reason={result.reason}",
+            f"governance dispatch skipped: tick={tick_count} reason={result.reason}",
         )
         echo(f"Governance scan skipped: {result.reason}")

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -6,13 +6,10 @@ import os
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
-from vibe3.models import IssueInfo
-from vibe3.models.execution_request import ExecutionRequest
+from vibe3.models import ExecutionRequest, IssueInfo, SessionRole, WorktreeRequirement
 from vibe3.models.review_runner import AgentOptions
-from vibe3.models.session_types import SessionRole
-from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.definitions import IssueRoleSyncSpec as IssueRoleSyncSpecImpl
 
 

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import typer
 
-from vibe3.agents.backends.codeagent import CodeagentBackend
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.agents import CodeagentBackend
+from vibe3.clients import GitClient, SQLiteClient
+from vibe3.config import load_orchestra_config
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
 from vibe3.execution.session_service import load_session_id
-from vibe3.services.actor_support import format_agent_actor
-from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
-from vibe3.services.issue_context_loader import load_issue_info
+from vibe3.services import (
+    format_agent_actor,
+    load_issue_info,
+    record_dispatch_failure_if_unexpected,
+)
 
 
 def run_issue_role_async(

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -5,12 +5,12 @@ from typing import cast
 
 from loguru import logger
 
-from vibe3.agents.models import ExecutionRole
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.agents import ExecutionRole
+from vibe3.clients import SQLiteClient
 from vibe3.config.role_policy import get_role_output_contract
 from vibe3.models.verdict import VerdictRecord
 from vibe3.models.verdict_types import VerdictValue
-from vibe3.services.role_policy_helpers import get_role_block_function
+from vibe3.services import get_role_block_function
 
 # Loop prevention constants
 SINGLE_STEP_LIMIT = 3  # Max occurrences of same transition pair
@@ -108,7 +108,7 @@ def apply_unified_noop_gate(
             branch,
             EVENT_STATE_TRANSITIONED,
             actor,
-            detail=(f"Issue #{issue_number} closed by {role} " "(terminal transition)"),
+            detail=(f"Issue #{issue_number} closed by {role} (terminal transition)"),
             refs={
                 "before_state": str(before_state_label or ""),
                 "issue": str(issue_number),
@@ -261,8 +261,7 @@ def apply_unified_noop_gate(
                 issue_number=issue_number,
                 repo=repo,
                 reason=(
-                    f"transition count exceeded: {new_count} >= "
-                    f"{TRANSITION_LIMIT_HARD}"
+                    f"transition count exceeded: {new_count} >= {TRANSITION_LIMIT_HARD}"
                 ),
                 actor=actor,
             )
@@ -346,7 +345,7 @@ def apply_unified_noop_gate(
             issue_number=issue_number,
             branch=branch,
         ).warning(
-            f"No-op gate BLOCK: state unchanged after {role} " f"(still {state_desc})"
+            f"No-op gate BLOCK: state unchanged after {role} (still {state_desc})"
         )
         store.add_event(
             branch,
@@ -372,8 +371,7 @@ def apply_unified_noop_gate(
         issue_number=issue_number,
         branch=branch,
     ).info(
-        f"No-op gate PASS: state changed {before_state_label} -> "
-        f"{after_state_label}"
+        f"No-op gate PASS: state changed {before_state_label} -> {after_state_label}"
     )
     store.add_event(
         branch,

--- a/src/vibe3/execution/prompt_meta.py
+++ b/src/vibe3/execution/prompt_meta.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping
 
-from vibe3.models.prompt_meta import PromptContextMode
+from vibe3.models import PromptContextMode
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/execution/role_contracts.py
+++ b/src/vibe3/execution/role_contracts.py
@@ -9,7 +9,7 @@ from vibe3.config.role_gates import (
     SUPERVISOR_APPLY_GATE_CONFIG,
     SUPERVISOR_IDENTIFY_GATE_CONFIG,
 )
-from vibe3.models.worktree import WorktreeRequirement
+from vibe3.models import WorktreeRequirement
 
 __all__ = [
     "WorktreeRequirement",

--- a/src/vibe3/execution/role_interfaces.py
+++ b/src/vibe3/execution/role_interfaces.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any, Callable, Protocol, runtime_checkable
 
 # Import SessionRole from canonical source instead of redefining
-from vibe3.models.session_types import SessionRole
+from vibe3.models import SessionRole
 
 
 @runtime_checkable

--- a/src/vibe3/execution/role_request_factory.py
+++ b/src/vibe3/execution/role_request_factory.py
@@ -9,10 +9,8 @@ from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
     build_issue_sync_prompt_request,
 )
-from vibe3.models import IssueInfo
-from vibe3.models.execution_request import ExecutionRequest
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.services.convention_resolver import ConventionResolver
+from vibe3.models import ExecutionRequest, IssueInfo, OrchestraConfig
+from vibe3.services import ConventionResolver
 
 
 def build_role_async_request(

--- a/src/vibe3/execution/session_service.py
+++ b/src/vibe3/execution/session_service.py
@@ -4,11 +4,10 @@ import re
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitClient, SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.exceptions import SystemError, UserError
-from vibe3.models.session_types import SessionRole
+from vibe3.models import SessionRole
 
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 


### PR DESCRIPTION
Closes #1922

## Summary

Replace 57 submodule-level external imports with package-level public API imports across execution module. This refactoring improves code maintainability by using the public API surface rather than internal submodule imports.

## Changes

- Replace `from vibe3.clients.sqlite_client import SQLiteClient` with `from vibe3.clients import SQLiteClient`
- Replace `from vibe3.models.execution_request import ExecutionRequest` with `from vibe3.models import ExecutionRequest`
- Similar replacements for models, config, services, orchestra, agents, and environment imports
- Consolidate multiple imports from same package into single lines
- Fix import sorting with ruff format

## Scope

- **18 files modified** (all in execution module)
- **57 imports refactored** using public APIs
- **No behavior changes** (import-only refactoring)
- **Net code reduction**: +60/-74 lines

## Remaining Internal Imports

11 symbols without public API access remain as internal imports (Category B):
- SessionRegistryService (vibe3.environment.session_registry)
- VerdictRecord, VerdictValue (vibe3.models.verdict*)
- AgentOptions (vibe3.models.review_runner)
- get_role_output_contract, get_role_section (vibe3.config.role_policy)
- GOVERNANCE_GATE_CONFIG (vibe3.config.role_gates)
- sync_models_json (vibe3.agents.backends.codeagent_config)
- agent_preset symbols (vibe3.config.agent_preset)
- get_store (vibe3.clients.store_context)
- GitHubAPIError (vibe3.exceptions.runtime_errors)

These will have dependency issues filed separately.

## Verification

- ✅ **140/140 execution tests pass**
- ✅ **Type check**: mypy reports no issues (19 files)
- ✅ **Lint**: ruff all checks passed
- ✅ **Import verification**: All public API imports work correctly

## References

- Issue: #1922
- Follow-up: #1977 (dependency issues for symbols without public API)

---

## Contributors

claude/opus
