### PR TITLE
refactor(models): expose IssueInfo/IssueState via vibe3.models public API

### DIFF
--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -10,9 +10,9 @@ from vibe3.commands.status_render_utils import (
     parse_epic_dependencies,
     render_task_item_details,
 )
+from vibe3.models import IssueState
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
 from vibe3.services.task_status_classifier import TaskStatusBucket
 from vibe3.ui.console import console
 

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -10,7 +10,7 @@ import typer
 from vibe3.commands.command_options import FormatOption
 from vibe3.commands.common import enable_method_trace
 from vibe3.exceptions import SystemError, UserError
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 from vibe3.observability.logger import setup_logging
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -27,8 +27,8 @@ from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
 from vibe3.domain.publisher import publish
 from vibe3.domain.qualify_gate import QualifyGateService
 from vibe3.domain.role_resolver import find_role_for_state
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.queue_entry import QueueEntry
 from vibe3.observability.degraded_mode import get_degraded_manager
 

--- a/src/vibe3/domain/flow_manager.py
+++ b/src/vibe3/domain/flow_manager.py
@@ -14,8 +14,8 @@ from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_flow_service import IssueFlowService

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -13,7 +13,7 @@ from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.flow_lifecycle import ManagerDispatchIntent
 from vibe3.domain.handler_registry import register_handler
 from vibe3.exceptions import CapacityDeferredError
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.roles.manager import build_manager_request
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 from vibe3.services.issue_failure_service import block_manager_noop_issue

--- a/src/vibe3/domain/handlers/supervisor_scan.py
+++ b/src/vibe3/domain/handlers/supervisor_scan.py
@@ -15,7 +15,7 @@ from vibe3.clients.store_context import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.domain.handler_registry import register_handler
-from vibe3.models.orchestration import IssueInfo
+from vibe3.models import IssueInfo
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -17,8 +17,8 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain import publish
 from vibe3.domain.events.governance import GovernanceScanStarted
+from vibe3.models import IssueInfo
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo
 from vibe3.runtime import ServiceBase
 
 if TYPE_CHECKING:

--- a/src/vibe3/domain/protocols/dispatch_protocols.py
+++ b/src/vibe3/domain/protocols/dispatch_protocols.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
     from vibe3.models.queue_entry import QueueEntry
 
 

--- a/src/vibe3/domain/protocols/flow_protocols.py
+++ b/src/vibe3/domain/protocols/flow_protocols.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from vibe3.clients.git_client import GitClient
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
 
 
 class FlowManagerProtocol(Protocol):

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -13,10 +13,10 @@ from loguru import logger
 
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.coordination_truth import CoordinationTruth
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.coordination_resolver import CoordinationResolver
 from vibe3.services.flow_resume_resolver import infer_resume_label

--- a/src/vibe3/domain/role_resolver.py
+++ b/src/vibe3/domain/role_resolver.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from vibe3.models.orchestration import IssueState
+    from vibe3.models import IssueState
     from vibe3.roles.definitions import TriggerableRoleDefinition
 
 

--- a/src/vibe3/domain/state_machine.py
+++ b/src/vibe3/domain/state_machine.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 from vibe3.exceptions import InvalidTransitionError
-from vibe3.models.orchestration import (
-    ALLOWED_TRANSITIONS,
-    FORBIDDEN_TRANSITIONS,
-    IssueState,
-)
+from vibe3.models import IssueState
+from vibe3.models.orchestration import ALLOWED_TRANSITIONS, FORBIDDEN_TRANSITIONS
 
 VIBE_TASK_LABEL = "vibe-task"
 

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.worktree import WorktreeRequirement
 from vibe3.orchestra.logging import append_orchestra_event
 

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Iterable
 
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
+from vibe3.models import IssueInfo
 from vibe3.models.execution_request import ExecutionRequest
-from vibe3.models.orchestration import IssueInfo
 from vibe3.models.review_runner import AgentOptions
 from vibe3.models.session_types import SessionRole
 from vibe3.models.worktree import WorktreeRequirement

--- a/src/vibe3/execution/role_request_factory.py
+++ b/src/vibe3/execution/role_request_factory.py
@@ -9,9 +9,9 @@ from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
     build_issue_sync_prompt_request,
 )
+from vibe3.models import IssueInfo
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo
 from vibe3.services.convention_resolver import ConventionResolver
 
 

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -13,6 +13,7 @@ from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
 from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
 from vibe3.models.inspection import CallNode, CommandInspection
 from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.models.queue_entry import QueueEntry
 from vibe3.models.session_types import SessionRole
@@ -56,6 +57,8 @@ __all__: list[str] = [
     "LayerCoverage",
     "ModuleChange",
     "ModuleSnapshot",
+    "IssueInfo",
+    "IssueState",
     "OrchestraConfig",
     "PRSource",
     "PromptContextMode",

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -15,7 +15,6 @@ from vibe3.clients.git_client import GitClient
 
 # Module-level re-exports from models/ (safe, no cycle risk)
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 
 # Lazy imports via __getattr__ for everything else to avoid circular dependencies
 if TYPE_CHECKING:
@@ -178,8 +177,6 @@ def __getattr__(name: str) -> object:
 __all__ = [
     # Models
     "OrchestraConfig",
-    "IssueInfo",
-    "IssueState",
     # Orchestra submodules
     "QueueEntry",
     "append_orchestra_event",

--- a/src/vibe3/orchestra/dispatch_health_check.py
+++ b/src/vibe3/orchestra/dispatch_health_check.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.orchestra.protocols import (
     CheckServiceProtocol,

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -11,7 +11,7 @@ from vibe3.models.orchestra_config import OrchestraConfig
 if TYPE_CHECKING:
     from vibe3.clients.github_client import GitHubClient
     from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
     from vibe3.orchestra.protocols import FlowManagerProtocol
 
 
@@ -57,7 +57,7 @@ def load_issue(
     issue_number: int, config: OrchestraConfig, github: "GitHubClient"
 ) -> "IssueInfo | None":
     """Load the current issue snapshot for an already-frozen issue."""
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
 
     try:
         payload = github.view_issue(issue_number, repo=config.repo)

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -11,7 +11,7 @@ The definition below is maintained for backward compatibility during migration.
 from typing import Protocol
 
 from vibe3.clients.git_client import GitClient
-from vibe3.models.orchestration import IssueInfo
+from vibe3.models import IssueInfo
 from vibe3.services.check_service import CheckResult
 
 

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Callable
 
 from vibe3.domain.qualify_gate import QualifyGateService
 from vibe3.domain.role_resolver import find_role_for_state
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.queue_entry import QueueEntry
 from vibe3.orchestra.issue_loader import (
     get_flow_context,

--- a/src/vibe3/orchestra/queue_ordering.py
+++ b/src/vibe3/orchestra/queue_ordering.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from vibe3.models.orchestration import IssueInfo
+from vibe3.models import IssueInfo
 
 # Pipeline stage ordering: issues closer to completion are dispatched first.
 # Key is "<trigger_name>:<trigger_state>" matching

--- a/src/vibe3/orchestra/queue_persistence_service.py
+++ b/src/vibe3/orchestra/queue_persistence_service.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.queue_entry import QueueEntry
 from vibe3.orchestra.queue_operations import promote_progressed_entries
 from vibe3.services.label_utils import should_skip_from_queue

--- a/src/vibe3/roles/definitions.py
+++ b/src/vibe3/roles/definitions.py
@@ -7,9 +7,9 @@ from typing import Any, Callable, Literal
 
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.role_policy import RoleOutputContract
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.session_types import SessionRole
 from vibe3.models.worktree import WorktreeRequirement
 

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -21,9 +21,9 @@ from vibe3.execution.issue_role_support import (
     build_task_flow_branch_resolver,
     resolve_orchestra_repo_root,
 )
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.prompts.manifest import PromptManifest, PromptProvider
 from vibe3.prompts.template_loader import resolve_prompts_path
 from vibe3.roles.definitions import (

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -30,9 +30,9 @@ from vibe3.execution.role_request_factory import (
     build_role_async_request,
     build_role_sync_request,
 )
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
 from vibe3.models.worktree import WorktreeRequirement
 from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition

--- a/src/vibe3/roles/registry.py
+++ b/src/vibe3/roles/registry.py
@@ -8,7 +8,7 @@ from vibe3.domain.events import (
     PlannerDispatchIntent,
     ReviewerDispatchIntent,
 )
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.roles.definitions import TriggerableRoleDefinition
 from vibe3.roles.manager import HANDOFF_MANAGER_ROLE, MANAGER_ROLE
 from vibe3.roles.plan import (

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -31,9 +31,9 @@ from vibe3.execution.issue_role_support import (
     resolve_env_overridable_agent_options,
 )
 from vibe3.execution.prompt_meta import build_prompt_meta
+from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.review import ReviewRequest, ReviewScope
 from vibe3.models.snapshot import StructureDiff
 from vibe3.models.worktree import WorktreeRequirement

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -13,7 +13,7 @@ from vibe3.execution.issue_role_support import (
     build_task_flow_branch_resolver,
     resolve_env_overridable_agent_options,
 )
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
 from vibe3.services.flow_service import FlowService
 

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -17,9 +17,9 @@ from vibe3.execution.role_request_factory import (
     build_role_async_request,
     build_role_sync_request,
 )
+from vibe3.models import IssueInfo
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.run_helpers import (
     EXECUTOR_ROLE,
     RUN_BRANCH_RESOLVER,

--- a/src/vibe3/roles/supervisor.py
+++ b/src/vibe3/roles/supervisor.py
@@ -13,9 +13,9 @@ from vibe3.config.role_gates import (
 from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.execution.issue_role_support import use_current_branch
+from vibe3.models import IssueInfo
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.definitions import IssueRoleSyncSpec, RoleDefinition
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.issue_flow_service import IssueFlowService

--- a/src/vibe3/services/abandon_flow_service.py
+++ b/src/vibe3/services/abandon_flow_service.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 
 if TYPE_CHECKING:
     from vibe3.services.flow_service import FlowService

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING, Literal
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
+from vibe3.models import IssueState
 from vibe3.models.issue_body import FlowStateProjection
-from vibe3.models.orchestration import IssueState
 from vibe3.services.blocked_state_types import BlockedState
 from vibe3.services.issue_body_service import merge_projection, parse_projection
 from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients.github_client import GitHubClient
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 from vibe3.services.blocked_state_io import BlockedStateIO
 from vibe3.services.blocked_state_types import (
     BlockedState,

--- a/src/vibe3/services/check_remote.py
+++ b/src/vibe3/services/check_remote.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, cast
 from loguru import logger
 
 from vibe3.clients.github_issues_ops import parse_linked_issues
+from vibe3.models import IssueState
 from vibe3.models.flow import IssueLink
-from vibe3.models.orchestration import IssueState
 
 
 @dataclass

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -13,7 +13,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.config.settings import VibeConfig
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 from vibe3.models.pr import PRState
 from vibe3.services.check_lock import check_lock
 from vibe3.services.check_pr_service import CheckPRService

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -25,7 +25,7 @@ from vibe3.services.task_service import TaskService
 
 if TYPE_CHECKING:
     from vibe3.config.orchestra_config import OrchestraConfig
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
     from vibe3.services.orchestra_status_service import OrchestraSnapshot
 
 

--- a/src/vibe3/services/flow_rebuild_usecase.py
+++ b/src/vibe3/services/flow_rebuild_usecase.py
@@ -13,7 +13,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.models.orchestration import IssueInfo
+from vibe3.models import IssueInfo
 from vibe3.services.flow_cleanup_service import FlowCleanupService
 from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
 from vibe3.services.flow_rebuild_postconditions import assert_rebuild_postconditions
@@ -132,8 +132,8 @@ class FlowRebuildUsecase:
         Post-rebuild: consistency is guaranteed (we just rebuilt), so we
         skip the classify step and go straight to clearing blocked state.
         """
+        from vibe3.models import IssueState
         from vibe3.models.flow import FlowState
-        from vibe3.models.orchestration import IssueState
         from vibe3.services.blocked_state_service import BlockedStateService
         from vibe3.services.flow_resume_resolver import infer_resume_label
 

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -214,8 +214,8 @@ class FlowRecoveryService:
         Raises:
             RuntimeError: If label write fails (RC2: prevents silent failure)
         """
+        from vibe3.models import IssueState
         from vibe3.models.flow import FlowState
-        from vibe3.models.orchestration import IssueState
         from vibe3.services.blocked_state_service import BlockedStateService
         from vibe3.services.flow_resume_resolver import infer_resume_label
 
@@ -261,7 +261,7 @@ class FlowRecoveryService:
     ) -> None:
         """Hard rebuild through the canonical rebuild usecase."""
         from vibe3.config.orchestra_settings import load_orchestra_config
-        from vibe3.models.orchestration import IssueInfo, IssueState
+        from vibe3.models import IssueInfo, IssueState
         from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
         from vibe3.services.issue_context_loader import load_issue_info
 

--- a/src/vibe3/services/flow_resume_resolver.py
+++ b/src/vibe3/services/flow_resume_resolver.py
@@ -4,8 +4,8 @@ Provides pure logic to infer the correct GitHub state label for a flow based
 on its local reference states (pr_ref, audit_ref, plan_ref, report_ref).
 """
 
+from vibe3.models import IssueState
 from vibe3.models.flow import FlowState
-from vibe3.models.orchestration import IssueState
 from vibe3.models.verdict_types import VerdictValue
 from vibe3.services.verdict_policy import passes_review
 

--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -7,7 +7,7 @@ from loguru import logger
 from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 
 
 class FlowStatusService:
@@ -48,7 +48,7 @@ class FlowStatusService:
             if issue_number is None:
                 return False
 
-        from vibe3.models.orchestration import IssueInfo
+        from vibe3.models import IssueInfo
 
         issue = IssueInfo(
             number=issue_number,

--- a/src/vibe3/services/issue_collection_service.py
+++ b/src/vibe3/services/issue_collection_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from vibe3.clients.github_client import GitHubClient
-from vibe3.models.orchestration import IssueInfo
+from vibe3.models import IssueInfo
 
 
 class IssueCollectionService:

--- a/src/vibe3/services/issue_context_loader.py
+++ b/src/vibe3/services/issue_context_loader.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from vibe3.clients.github_client import GitHubClient
 from vibe3.exceptions import UserError
+from vibe3.models import IssueInfo
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueInfo
 
 
 def load_issue_info(

--- a/src/vibe3/services/issue_dispatch_policy.py
+++ b/src/vibe3/services/issue_dispatch_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.services.label_utils import has_manager_assignee
 
 

--- a/src/vibe3/services/label_service.py
+++ b/src/vibe3/services/label_service.py
@@ -18,10 +18,8 @@ from vibe3.domain.state_machine import (
     validate_transition,
 )
 from vibe3.exceptions import InvalidTransitionError, SystemError
-from vibe3.models.orchestration import (
-    IssueState,
-    StateTransition,
-)
+from vibe3.models import IssueState
+from vibe3.models.orchestration import StateTransition
 
 
 class LabelService:

--- a/src/vibe3/services/label_utils.py
+++ b/src/vibe3/services/label_utils.py
@@ -11,7 +11,7 @@ from vibe3.clients.github_labels import GhIssueLabelPort
 from vibe3.models.orchestra_config import OrchestraConfig
 
 if TYPE_CHECKING:
-    from vibe3.models.orchestration import IssueInfo
+    from vibe3.models import IssueInfo
     from vibe3.roles import TriggerableRoleDefinition
 
 

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -12,8 +12,8 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.github_issues_ops import parse_blocked_by
 from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.models import IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
 from vibe3.orchestra.logging import orchestra_events_log_path
 from vibe3.services.flow_reader import FlowReader
 from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -14,7 +14,7 @@ from vibe3.clients import SQLiteClient
 from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models import IssueInfo, IssueState
 from vibe3.orchestra.queue_ordering import (
     resolve_priority,
     resolve_roadmap_rank,

--- a/src/vibe3/services/task_resume_candidates.py
+++ b/src/vibe3/services/task_resume_candidates.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 
 if TYPE_CHECKING:
     from vibe3.models.flow import FlowStatusResponse

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable
 
 from vibe3.exceptions import UserError
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 
 if TYPE_CHECKING:
     from vibe3.clients.git_client import GitClient

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -9,9 +9,9 @@ from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.models import IssueState
 from vibe3.models.flow import FlowStatusResponse, IssueLink
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
 from vibe3.models.pr import PRResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/task_status_classifier.py
+++ b/src/vibe3/services/task_status_classifier.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from vibe3.models.orchestration import IssueState
+from vibe3.models import IssueState
 from vibe3.services.label_utils import has_manager_assignee
 
 

--- a/src/vibe3/services/task_status_service.py
+++ b/src/vibe3/services/task_status_service.py
@@ -3,9 +3,9 @@
 from dataclasses import dataclass
 from typing import Any, cast
 
+from vibe3.models import IssueState
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.orchestration import IssueState
 from vibe3.services.flow_service import FlowService
 from vibe3.services.orchestra_status_service import OrchestraSnapshot
 from vibe3.services.status_query_service import StatusQueryService, is_auto_task_branch


### PR DESCRIPTION
Closes (follow-up to code review of #1978)

## Summary

- Add `IssueInfo` and `IssueState` to `vibe3.models.__init__` public API
- Update all 53 import sites to use `from vibe3.models import` instead of submodule `from vibe3.models.orchestration import`
- Remove `IssueInfo`/`IssueState` re-exports from `vibe3.orchestra.__init__` — model types belong in `vibe3.models`, not in the orchestra functional module

## Motivation

PR #1978 code review flagged that `IssueInfo`/`IssueState` were being accessed via `vibe3.orchestra`, which violates module boundary: data models should be in `vibe3.models`, not re-exported through a functional module.

## Changes

- `vibe3.models.__init__`: add `IssueInfo`, `IssueState` to imports and `__all__`
- `vibe3.orchestra.__init__`: remove `IssueInfo`, `IssueState` from re-exports and `__all__`
- 51 consumer files: `from vibe3.models.orchestration import IssueInfo/IssueState` → `from vibe3.models import IssueInfo/IssueState`
- `domain/state_machine.py`, `services/label_service.py`: split mixed imports (domain constants stay at submodule level, model types move to public API)

## No behavior changes

Pure import path refactoring. All 2515 tests pass, mypy clean.

## Verification

- ✅ 2515/2515 tests pass
- ✅ mypy: no errors (full src/vibe3/ check)
- ✅ ruff: all checks passed

## Contributors

claude/sonnet-4-6