### PR TITLE
feat: add public API exports for 11 internal symbols

### DIFF
--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -33,9 +33,14 @@ Types:
 - ``PromptContextMode`` — literal type for prompt context mode
   (bootstrap/resume)
 - ``RunPromptMode`` — literal type for run prompt mode (coding/retry)
+
+Backend Config:
+- ``sync_models_json`` — sync effective backend/model settings to
+  ``~/.codeagent/models.json``
 """
 
 from vibe3.agents.backends.codeagent import CodeagentBackend
+from vibe3.agents.backends.codeagent_config import sync_models_json
 from vibe3.agents.base import AgentBackend
 from vibe3.agents.models import (
     CodeagentCommand,
@@ -94,4 +99,5 @@ __all__ = [
     # Types
     "PromptContextMode",
     "RunPromptMode",
+    "sync_models_json",
 ]

--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -9,6 +9,7 @@ from vibe3.clients.serena_client import (
     extract_function_names,
 )
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients.store_context import get_store
 
 __all__ = [
     "BackendProtocol",
@@ -19,4 +20,5 @@ __all__ = [
     "count_references",
     "extract_function_names",
     "find_repo_root",
+    "get_store",
 ]

--- a/src/vibe3/config/__init__.py
+++ b/src/vibe3/config/__init__.py
@@ -34,11 +34,19 @@ __all__ = [
     "MergeGateConfig",
     # Lazy imports
     "ConventionResolver",
+    "get_role_output_contract",
+    "get_role_section",
+    "GOVERNANCE_GATE_CONFIG",
+    "resolve_effective_agent_options",
 ]
 
 # Lazy import mapping for symbols to avoid circular dependencies
 _SYMBOL_MODULES = {
     "ConventionResolver": "vibe3.config.convention_resolver",
+    "get_role_output_contract": "vibe3.config.role_policy",
+    "get_role_section": "vibe3.config.role_policy",
+    "GOVERNANCE_GATE_CONFIG": "vibe3.config.role_gates",
+    "resolve_effective_agent_options": "vibe3.config.agent_preset",
 }
 
 

--- a/src/vibe3/environment/__init__.py
+++ b/src/vibe3/environment/__init__.py
@@ -10,6 +10,7 @@ from vibe3.environment.session import (
     SessionManager,
     TmuxSessionContext,
 )
+from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.environment.worktree import WorktreeManager
 from vibe3.environment.worktree_context import WorktreeContext
 
@@ -19,6 +20,7 @@ __all__ = [
     "TmuxSessionContext",
     "CodeagentSessionContext",
     "SessionManager",
+    "SessionRegistryService",
     "resolve_prompt_config",
     "resolve_runtime_asset",
     "runtime_assets_root",

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -235,3 +235,24 @@ class InvalidTransitionError(UserError):
 #
 # Error recording helper (convenience function in services layer):
 #   from vibe3.services.error_helpers import record_error
+
+
+from vibe3.exceptions.runtime_errors import GitHubAPIError  # noqa: E402
+
+__all__ = [
+    "VibeError",
+    "UserError",
+    "ConfigError",
+    "AgentPresetNotFoundError",
+    "SkillNotAvailableError",
+    "SystemError",
+    "AgentExecutionError",
+    "ModelsJsonSyncError",
+    "GitError",
+    "GitHubError",
+    "SerenaError",
+    "PRNotFoundError",
+    "CapacityDeferredError",
+    "InvalidTransitionError",
+    "GitHubAPIError",
+]

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -16,6 +16,7 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 from vibe3.models.prompt_meta import PromptContextMode
 from vibe3.models.queue_entry import QueueEntry
+from vibe3.models.review_runner import AgentOptions
 from vibe3.models.session_types import SessionRole
 from vibe3.models.snapshot import (
     DependencyChange,
@@ -32,9 +33,12 @@ from vibe3.models.snapshot import (
     StructureSnapshot,
 )
 from vibe3.models.trace import ExecutionStep, TraceOutput
+from vibe3.models.verdict import VerdictRecord
+from vibe3.models.verdict_types import VerdictValue
 from vibe3.models.worktree import WorktreeRequirement
 
 __all__: list[str] = [
+    "AgentOptions",
     "BranchSource",
     "CallNode",
     "ChangeSource",
@@ -69,5 +73,7 @@ __all__: list[str] = [
     "StructureSnapshot",
     "TraceOutput",
     "UncommittedSource",
+    "VerdictRecord",
+    "VerdictValue",
     "WorktreeRequirement",
 ]

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -82,3 +82,15 @@ def test_environment_all_contains_session_registry():
     from vibe3.environment import __all__
 
     assert "SessionRegistryService" in __all__
+
+
+def test_clients_get_store_importable():
+    from vibe3.clients import get_store
+
+    assert callable(get_store)
+
+
+def test_clients_all_contains_get_store():
+    from vibe3.clients import __all__
+
+    assert "get_store" in __all__

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -1,0 +1,27 @@
+"""Tests for public API exports across all packages."""
+
+
+def test_models_verdict_record_importable():
+    from vibe3.models import VerdictRecord
+
+    assert VerdictRecord is not None
+
+
+def test_models_verdict_value_importable():
+    from vibe3.models import VerdictValue
+
+    assert VerdictValue is not None
+
+
+def test_models_agent_options_importable():
+    from vibe3.models import AgentOptions
+
+    assert AgentOptions is not None
+
+
+def test_models_all_contains_verdict_symbols():
+    from vibe3.models import __all__
+
+    assert "VerdictRecord" in __all__
+    assert "VerdictValue" in __all__
+    assert "AgentOptions" in __all__

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -25,3 +25,36 @@ def test_models_all_contains_verdict_symbols():
     assert "VerdictRecord" in __all__
     assert "VerdictValue" in __all__
     assert "AgentOptions" in __all__
+
+
+def test_config_get_role_output_contract_importable():
+    from vibe3.config import get_role_output_contract
+
+    assert callable(get_role_output_contract)
+
+
+def test_config_get_role_section_importable():
+    from vibe3.config import get_role_section
+
+    assert callable(get_role_section)
+
+
+def test_config_governance_gate_config_importable():
+    from vibe3.config import GOVERNANCE_GATE_CONFIG
+
+    assert GOVERNANCE_GATE_CONFIG is not None
+
+
+def test_config_resolve_effective_agent_options_importable():
+    from vibe3.config import resolve_effective_agent_options
+
+    assert callable(resolve_effective_agent_options)
+
+
+def test_config_all_contains_role_symbols():
+    from vibe3.config import __all__
+
+    assert "get_role_output_contract" in __all__
+    assert "get_role_section" in __all__
+    assert "GOVERNANCE_GATE_CONFIG" in __all__
+    assert "resolve_effective_agent_options" in __all__

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -58,3 +58,15 @@ def test_config_all_contains_role_symbols():
     assert "get_role_section" in __all__
     assert "GOVERNANCE_GATE_CONFIG" in __all__
     assert "resolve_effective_agent_options" in __all__
+
+
+def test_agents_sync_models_json_importable():
+    from vibe3.agents import sync_models_json
+
+    assert callable(sync_models_json)
+
+
+def test_agents_all_contains_sync_models_json():
+    from vibe3.agents import __all__
+
+    assert "sync_models_json" in __all__

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -94,3 +94,15 @@ def test_clients_all_contains_get_store():
     from vibe3.clients import __all__
 
     assert "get_store" in __all__
+
+
+def test_exceptions_github_api_error_importable():
+    from vibe3.exceptions import GitHubAPIError
+
+    assert GitHubAPIError is not None
+
+
+def test_exceptions_all_contains_github_api_error():
+    from vibe3.exceptions import __all__
+
+    assert "GitHubAPIError" in __all__

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -70,3 +70,15 @@ def test_agents_all_contains_sync_models_json():
     from vibe3.agents import __all__
 
     assert "sync_models_json" in __all__
+
+
+def test_environment_session_registry_importable():
+    from vibe3.environment import SessionRegistryService
+
+    assert SessionRegistryService is not None
+
+
+def test_environment_all_contains_session_registry():
+    from vibe3.environment import __all__
+
+    assert "SessionRegistryService" in __all__


### PR DESCRIPTION
## Summary

为 6 个 package 添加公共 API 导出（`__init__.py` + `__all__`），使 11 个内部符号可通过 `from vibe3.X import Y` 访问，无需深入子模块路径。

Closes #1977

## Changes

| Package | Symbols | Pattern |
|---------|---------|---------|
| `models` | `VerdictRecord`, `VerdictValue`, `AgentOptions` | Direct import |
| `config` | `get_role_output_contract`, `get_role_section`, `GOVERNANCE_GATE_CONFIG`, `resolve_effective_agent_options` | Lazy `__getattr__` |
| `agents` | `sync_models_json` | Direct import |
| `environment` | `SessionRegistryService` | Direct import |
| `clients` | `get_store` | Direct import |
| `exceptions` | `GitHubAPIError` | Re-export + `__all__` added |

## Verification

- 17/17 tests pass in `tests/vibe3/test_public_api_exports.py`
- mypy clean on all 6 modified `__init__.py` files
- Each package gets an atomic commit

## Follow-up

- Task 8 (execution module import migration) tracked as follow-up issue #TBD

## Related

- #1977 (this issue)
- #1922 (execution module import refactor — completed)
- #1626 (Epic: module public interface unification)

## Contributors

- Planner: Yi Chen (human)
- Executor: Claude (agent) on branch dev/issue-1977