### PR TITLE
refactor: migrate execution module internal imports to public API

### DIFF
--- a/src/vibe3/config/__init__.py
+++ b/src/vibe3/config/__init__.py
@@ -24,6 +24,8 @@ from vibe3.config.role_gates import (
     MANAGER_GATE_CONFIG,
     PLANNER_GATE_CONFIG,
     REVIEWER_GATE_CONFIG,
+    SUPERVISOR_APPLY_GATE_CONFIG,
+    SUPERVISOR_IDENTIFY_GATE_CONFIG,
 )
 from vibe3.config.role_policy import (
     RoleOutputContract,
@@ -71,6 +73,8 @@ __all__ = [
     "PRScoringConfig",
     "QualityConfig",
     "REVIEWER_GATE_CONFIG",
+    "SUPERVISOR_APPLY_GATE_CONFIG",
+    "SUPERVISOR_IDENTIFY_GATE_CONFIG",
     "ReviewConfig",
     "ReviewScopeConfig",
     "RoleOutputContract",

--- a/src/vibe3/execution/auto_scene_recovery.py
+++ b/src/vibe3/execution/auto_scene_recovery.py
@@ -17,7 +17,7 @@ from vibe3.models import (
 from vibe3.orchestra import append_orchestra_event
 
 if TYPE_CHECKING:
-    from vibe3.environment.session_registry import SessionRegistryService
+    from vibe3.environment import SessionRegistryService
 
 
 def _read_worktree_head(worktree_path: Path) -> str | None:

--- a/src/vibe3/execution/capacity_service.py
+++ b/src/vibe3/execution/capacity_service.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients import BackendProtocol, SQLiteClient
-from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.environment import SessionRegistryService
 from vibe3.models import OrchestraConfig
 
 if TYPE_CHECKING:

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -20,8 +20,7 @@ if TYPE_CHECKING:
         CodeagentResult,
     )
     from vibe3.exceptions.error_severity import ErrorSeverity
-from vibe3.config import VibeConfig
-from vibe3.config.role_policy import get_role_section
+from vibe3.config import VibeConfig, get_role_section
 from vibe3.execution.codeagent_support import resolve_command_agent_options
 from vibe3.execution.execution_lifecycle import (
     execution_prefix,
@@ -29,8 +28,7 @@ from vibe3.execution.execution_lifecycle import (
 )
 from vibe3.execution.noop_gate import apply_unified_noop_gate
 from vibe3.execution.session_service import load_session_id
-from vibe3.models import ExecutionRequest
-from vibe3.models.review_runner import AgentOptions
+from vibe3.models import AgentOptions, ExecutionRequest
 from vibe3.services import HandoffService, format_agent_actor
 
 

--- a/src/vibe3/execution/codeagent_support.py
+++ b/src/vibe3/execution/codeagent_support.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Literal, Sequence
 
 from vibe3.config import VibeConfig
-from vibe3.models.review_runner import AgentOptions
+from vibe3.models import AgentOptions
 
 
 def resolve_command_agent_options(

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -10,8 +10,7 @@ from typing import Generator, Optional
 from loguru import logger
 
 from vibe3.clients import BackendProtocol, SQLiteClient
-from vibe3.environment import WorktreeManager
-from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.environment import SessionRegistryService, WorktreeManager
 from vibe3.execution.auto_scene_recovery import AutoSceneRecoveryService
 from vibe3.execution.capacity_service import CapacityService
 from vibe3.execution.codeagent_runner import CodeagentExecutionService

--- a/src/vibe3/execution/execution_role_policy.py
+++ b/src/vibe3/execution/execution_role_policy.py
@@ -5,13 +5,12 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.agents.backends.codeagent_config import sync_models_json
+from vibe3.agents import sync_models_json
 from vibe3.config import load_orchestra_config
-from vibe3.config.agent_preset import (
+from vibe3.config import (
     resolve_effective_agent_options as resolve_backend_effective_agent_options,
 )
-from vibe3.models import OrchestraConfig
-from vibe3.models.review_runner import AgentOptions
+from vibe3.models import AgentOptions, OrchestraConfig
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -13,9 +13,8 @@ from loguru import logger
 from typer import echo
 
 from vibe3.agents import CodeagentBackend
-from vibe3.clients.store_context import get_store
-from vibe3.config import load_orchestra_config
-from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
+from vibe3.clients import get_store
+from vibe3.config import GOVERNANCE_GATE_CONFIG, load_orchestra_config
 from vibe3.execution.role_interfaces import GovernanceEventLogger, GovernanceFunctions
 from vibe3.models import ExecutionLaunchResult, ExecutionRequest
 from vibe3.services import record_dispatch_failure_if_unexpected
@@ -160,7 +159,7 @@ def run_governance_async(
         material_override: Optional governance role to override material rotation
         build_execution_name: Optional injected execution name builder (for decoupling)
     """
-    from vibe3.environment.session_registry import SessionRegistryService
+    from vibe3.environment import SessionRegistryService
     from vibe3.execution.coordinator import ExecutionCoordinator
     from vibe3.execution.issue_role_support import (
         resolve_async_cli_project_root,

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -8,8 +8,13 @@ from typing import Any, Callable, Iterable
 
 from vibe3.clients import SQLiteClient
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
-from vibe3.models import ExecutionRequest, IssueInfo, SessionRole, WorktreeRequirement
-from vibe3.models.review_runner import AgentOptions
+from vibe3.models import (
+    AgentOptions,
+    ExecutionRequest,
+    IssueInfo,
+    SessionRole,
+    WorktreeRequirement,
+)
 from vibe3.roles.definitions import IssueRoleSyncSpec as IssueRoleSyncSpecImpl
 
 

--- a/src/vibe3/execution/noop_gate.py
+++ b/src/vibe3/execution/noop_gate.py
@@ -7,9 +7,8 @@ from loguru import logger
 
 from vibe3.agents import ExecutionRole
 from vibe3.clients import SQLiteClient
-from vibe3.config.role_policy import get_role_output_contract
-from vibe3.models.verdict import VerdictRecord
-from vibe3.models.verdict_types import VerdictValue
+from vibe3.config import get_role_output_contract
+from vibe3.models import VerdictRecord, VerdictValue
 from vibe3.services import get_role_block_function
 
 # Loop prevention constants

--- a/src/vibe3/execution/role_contracts.py
+++ b/src/vibe3/execution/role_contracts.py
@@ -1,6 +1,6 @@
 """Role dispatch contracts — re-exported from lower-layer homes."""
 
-from vibe3.config.role_gates import (
+from vibe3.config import (
     EXECUTOR_GATE_CONFIG,
     GOVERNANCE_GATE_CONFIG,
     MANAGER_GATE_CONFIG,

--- a/src/vibe3/execution/session_service.py
+++ b/src/vibe3/execution/session_service.py
@@ -5,7 +5,7 @@ import re
 from loguru import logger
 
 from vibe3.clients import GitClient, SQLiteClient
-from vibe3.environment.session_registry import SessionRegistryService
+from vibe3.environment import SessionRegistryService
 from vibe3.exceptions import SystemError, UserError
 from vibe3.models import SessionRole
 

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 from loguru import logger
 
-from vibe3.exceptions.runtime_errors import GitHubAPIError
+from vibe3.exceptions import GitHubAPIError
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient


### PR DESCRIPTION
## Summary

Migrate 19 internal imports in `execution/` module to use public API paths (package-level imports via `__init__.py`).

## Changes

| Old Path | New Path | Files |
|----------|----------|-------|
| `vibe3.models.verdict` / `vibe3.models.verdict_types` | `vibe3.models` | noop_gate.py |
| `vibe3.models.review_runner` | `vibe3.models` | 4 files |
| `vibe3.config.role_policy` | `vibe3.config` | noop_gate.py, codeagent_runner.py |
| `vibe3.config.agent_preset` | `vibe3.config` | execution_role_policy.py |
| `vibe3.config.role_gates` | `vibe3.config` | governance_sync_runner.py, role_contracts.py |
| `vibe3.agents.backends.codeagent_config` | `vibe3.agents` | execution_role_policy.py |
| `vibe3.environment.session_registry` | `vibe3.environment` | 5 files |
| `vibe3.clients.store_context` | `vibe3.clients` | governance_sync_runner.py |
| `vibe3.exceptions.runtime_errors` | `vibe3.exceptions` | state_verification.py |

Also added `SUPERVISOR_APPLY_GATE_CONFIG` and `SUPERVISOR_IDENTIFY_GATE_CONFIG` to `config/__init__.py` exports (previously missing).

## Verification

- mypy clean on all modified files
- 17/17 public API export tests pass
- 12 files changed, net -3 lines

Closes #1995

## Related

- #1994 (public API exports — merged)
- #1977 (original issue)
- #1626 (Epic: module public interface unification)

## Contributors

- Planner: Yi Chen (human)
- Executor: Claude (agent) on branch dev/issue-1995

---

## Contributors

Yi Chen
