### PR TITLE
refactor(observability): move orchestra logging API to observability module

### DIFF
--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -31,6 +31,7 @@ from vibe3.models import IssueInfo, IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.queue_entry import QueueEntry
 from vibe3.observability.degraded_mode import get_degraded_manager
+from vibe3.observability.orchestra_log import append_orchestra_event
 
 # Note: orchestra internal services remain in orchestra layer
 # GlobalDispatchCoordinator depends on them via protocols
@@ -39,7 +40,6 @@ from vibe3.orchestra.issue_loader import (
     get_flow_context,
     load_issue,
 )
-from vibe3.orchestra.logging import append_orchestra_event
 from vibe3.orchestra.protocols import (
     CapacityServiceProtocol,
     CheckServiceProtocol,

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -71,7 +71,7 @@ def handle_governance_scan_started(
         resolve_async_cli_project_root,
         resolve_orchestra_repo_root,
     )
-    from vibe3.orchestra.logging import append_governance_event
+    from vibe3.observability.orchestra_log import append_governance_event
     from vibe3.roles.governance import build_governance_execution_name
 
     config = load_orchestra_config()

--- a/src/vibe3/domain/handlers/supervisor_scan.py
+++ b/src/vibe3/domain/handlers/supervisor_scan.py
@@ -28,7 +28,7 @@ def handle_supervisor_issue_identified(
 ) -> None:
     """Dispatch supervisor apply via CLI self-invocation."""
     from vibe3.execution.issue_role_support import build_issue_async_cli_request
-    from vibe3.orchestra.logging import append_orchestra_event
+    from vibe3.observability.orchestra_log import append_orchestra_event
     from vibe3.roles.supervisor import SUPERVISOR_APPLY_ROLE
 
     config = load_orchestra_config()

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -146,7 +146,7 @@ class OrchestrationFacade(ServiceBase):
         Args:
             tick_id: Current tick number from HeartbeatServer (default: 0)
         """
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
 
         self.on_heartbeat_tick()
 

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -69,7 +69,7 @@ class QualifyGateService:
             )
             return
 
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
 
         append_orchestra_event(
             "dispatcher",
@@ -179,6 +179,7 @@ class QualifyGateService:
         Returns:
             Target IssueState to dispatch to, or None if still blocked.
         """
+
         if issue.github_state and issue.github_state.upper() == "CLOSED":
             flow = self._flow_manager.get_flow_for_issue(issue.number)
             branch = str(flow.get("branch") or "").strip() if flow else ""
@@ -213,7 +214,7 @@ class QualifyGateService:
         Ensures local flow_state has flow_status='blocked' and blocked fields
         match the remote truth. Adds state/blocked label if missing.
         """
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
         from vibe3.services.blocked_state_service import BlockedStateService
 
         blocked_label = self._convention.state_label(self._convention.blocked_label)
@@ -328,7 +329,7 @@ class QualifyGateService:
         Clears local blocked cache and removes state/blocked label.
         """
         from vibe3.models.flow import FlowState
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
 
         if flow_state:
             fs_obj = FlowState.model_validate(flow_state)
@@ -388,7 +389,7 @@ class QualifyGateService:
         Returns True if worktree is healthy (dispatch can continue),
         False if blocked due to structural failure.
         """
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
 
         worktree_path = truth.worktree_path
         if not worktree_path or not isinstance(worktree_path, str):

--- a/src/vibe3/observability/__init__.py
+++ b/src/vibe3/observability/__init__.py
@@ -4,6 +4,7 @@ This module provides unified management of logging and tracing:
 - logger.py: Structured logging configuration
 - trace_method.py: Method-level tracing via @trace_method decorator
 - audit.py: Audit logging (future use)
+- orchestra_log.py: Orchestra event logging (filesystem-backed)
 
 Design Principles:
 - Agent-friendly structured logging with semantic context
@@ -15,6 +16,16 @@ Design Principles:
 from .audit import AuditEntry, AuditLogger
 from .degraded_mode import DegradedModeManager, DegradedModeReason, get_degraded_manager
 from .logger import setup_logging
+from .orchestra_log import (
+    append_governance_event,
+    append_orchestra_event,
+    append_orchestra_run_separator,
+    governance_dry_run_dir,
+    governance_events_log_path,
+    governance_log_dir,
+    orchestra_events_log_path,
+    orchestra_log_dir,
+)
 from .trace_method import set_trace_max_lines, set_trace_min_ms, trace_method
 
 __all__ = [
@@ -22,7 +33,15 @@ __all__ = [
     "AuditLogger",
     "DegradedModeManager",
     "DegradedModeReason",
+    "append_governance_event",
+    "append_orchestra_event",
+    "append_orchestra_run_separator",
+    "governance_dry_run_dir",
+    "governance_events_log_path",
+    "governance_log_dir",
     "get_degraded_manager",
+    "orchestra_events_log_path",
+    "orchestra_log_dir",
     "set_trace_max_lines",
     "set_trace_min_ms",
     "setup_logging",

--- a/src/vibe3/observability/orchestra_log.py
+++ b/src/vibe3/observability/orchestra_log.py
@@ -1,0 +1,166 @@
+"""Observability module for orchestra event logging."""
+
+from __future__ import annotations
+
+import atexit
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import IO
+
+
+def orchestra_log_dir(repo_root: Path | None = None) -> Path:
+    override_dir = os.environ.get("VIBE3_ASYNC_LOG_DIR", "").strip()
+    if override_dir:
+        path = Path(override_dir).expanduser().resolve() / "orchestra"
+    else:
+        from vibe3.clients.git_client import find_repo_root
+
+        root = repo_root or find_repo_root()
+        path = root / "temp" / "logs" / "orchestra"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def orchestra_events_log_path(repo_root: Path | None = None) -> Path:
+    return orchestra_log_dir(repo_root) / "events.log"
+
+
+def governance_log_dir(repo_root: Path | None = None) -> Path:
+    path = orchestra_log_dir(repo_root) / "governance"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def governance_events_log_path(repo_root: Path | None = None) -> Path:
+    return governance_log_dir(repo_root) / "governance.log"
+
+
+def governance_dry_run_dir(repo_root: Path | None = None) -> Path:
+    path = governance_log_dir(repo_root) / "dry-run"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+# Module-level persistent file handle for events.log
+# Avoids opening/closing on every tick, preventing FD exhaustion
+_events_handle: IO[str] | None = None
+_events_path: Path | None = None  # Track current log path to detect repo_root changes
+
+
+def _open_events_log(repo_root: Path | None = None) -> tuple[IO[str], Path]:
+    """Open events.log in append mode, creating parent dirs if needed.
+
+    Returns:
+        Tuple of (file handle, resolved path) to enable path tracking
+    """
+    path = orchestra_events_log_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a", encoding="utf-8")
+    return handle, path
+
+
+def _close_events_log() -> None:
+    """Close the persistent events log handle."""
+    global _events_handle, _events_path
+    if _events_handle is not None:
+        try:
+            _events_handle.close()
+        except Exception:
+            pass
+        _events_handle = None
+        _events_path = None
+
+
+atexit.register(_close_events_log)
+
+
+def _ensure_events_handle(repo_root: Path | None = None) -> IO[str]:
+    """Ensure the persistent events handle is open and pointing at the right path."""
+    global _events_handle, _events_path
+    target_path = orchestra_events_log_path(repo_root)
+    if _events_handle is None or _events_path != target_path:
+        if _events_handle is not None:
+            try:
+                _events_handle.close()
+            except Exception:
+                pass
+        _events_handle, _events_path = _open_events_log(repo_root)
+    return _events_handle
+
+
+def append_orchestra_event(
+    component: str,
+    message: str,
+    *,
+    level: str = "INFO",
+    repo_root: Path | None = None,
+) -> Path:
+    """Append an event to the orchestra events log.
+
+    Levels: DEBUG, INFO, WARNING, ERROR
+    Default is INFO. Use VIBE3_ORCHESTRA_LOG_LEVEL to filter (default: INFO).
+
+    Uses a module-level persistent file handle to avoid FD exhaustion
+    from repeated open/close on every heartbeat tick.
+
+    Returns:
+        Path to the events.log file (consistent return type)
+    """
+    if os.environ.get("VIBE3_ORCHESTRA_EVENT_LOG") != "1":
+        return orchestra_events_log_path(repo_root)
+
+    # Check log level filter (no I/O for filtered-out events)
+    current_level = os.environ.get("VIBE3_ORCHESTRA_LOG_LEVEL", "INFO").upper()
+    levels = {"DEBUG": 0, "INFO": 1, "WARNING": 2, "ERROR": 3}
+    if levels.get(level.upper(), 1) < levels.get(current_level, 1):
+        return orchestra_events_log_path(repo_root)
+
+    handle = _ensure_events_handle(repo_root)
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    if not message:
+        handle.write("\n")
+    else:
+        handle.write(f"[{timestamp}] [{component}] {message}\n")
+    handle.flush()
+    assert _events_path is not None
+    return _events_path
+
+
+def append_orchestra_run_separator(
+    *,
+    repo_root: Path | None = None,
+    title: str = "server run start",
+) -> Path:
+    """Append a run separator to events.log, preserving history.
+
+    Uses append mode to keep previous runs instead of overwriting.
+    Uses the persistent file handle to avoid FD exhaustion.
+
+    Returns:
+        Path to the events.log file (consistent return type)
+    """
+    if os.environ.get("VIBE3_ORCHESTRA_EVENT_LOG") != "1":
+        return orchestra_events_log_path(repo_root)
+
+    handle = _ensure_events_handle(repo_root)
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    handle.write(f"\n========== {title} @ {timestamp} ==========\n")
+    handle.flush()
+    assert _events_path is not None
+    return _events_path
+
+
+def append_governance_event(message: str, *, repo_root: Path | None = None) -> Path:
+    """Append a governance event to both governance.log and events.log.
+
+    Uses append mode and delegates to append_orchestra_event for events.log
+    to benefit from persistent file handle.
+    """
+    path = governance_events_log_path(repo_root)
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{timestamp}] {message}\n")
+    # Delegate to append_orchestra_event to use persistent handle
+    append_orchestra_event("governance", message, repo_root=repo_root)
+    return path

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -22,17 +22,17 @@ if TYPE_CHECKING:
     from vibe3.domain.qualify_gate import QualifyGateService
     from vibe3.domain.role_resolver import find_role_for_state
     from vibe3.models.queue_entry import QueueEntry
+    from vibe3.observability.orchestra_log import (
+        append_orchestra_event,
+        append_orchestra_run_separator,
+        orchestra_events_log_path,
+        orchestra_log_dir,
+    )
     from vibe3.orchestra.dispatch_health_check import DispatchHealthCheckService
     from vibe3.orchestra.issue_loader import (
         get_flow_context,
         is_auto_task_branch,
         load_issue,
-    )
-    from vibe3.orchestra.logging import (
-        append_orchestra_event,
-        append_orchestra_run_separator,
-        orchestra_events_log_path,
-        orchestra_log_dir,
     )
     from vibe3.orchestra.protocols import (
         CapacityServiceProtocol,
@@ -65,19 +65,19 @@ def __getattr__(name: str) -> object:
 
         return QueueEntry
     if name == "append_orchestra_event":
-        from vibe3.orchestra.logging import append_orchestra_event
+        from vibe3.observability.orchestra_log import append_orchestra_event
 
         return append_orchestra_event
     if name == "append_orchestra_run_separator":
-        from vibe3.orchestra.logging import append_orchestra_run_separator
+        from vibe3.observability.orchestra_log import append_orchestra_run_separator
 
         return append_orchestra_run_separator
     if name == "orchestra_events_log_path":
-        from vibe3.orchestra.logging import orchestra_events_log_path
+        from vibe3.observability.orchestra_log import orchestra_events_log_path
 
         return orchestra_events_log_path
     if name == "orchestra_log_dir":
-        from vibe3.orchestra.logging import orchestra_log_dir
+        from vibe3.observability.orchestra_log import orchestra_log_dir
 
         return orchestra_log_dir
     if name == "sort_ready_issues":

--- a/src/vibe3/orchestra/logging.py
+++ b/src/vibe3/orchestra/logging.py
@@ -1,166 +1,23 @@
-"""Filesystem-backed orchestration logs."""
+"""Compatibility shell — re-exports from vibe3.observability.orchestra_log."""
 
-from __future__ import annotations
+from vibe3.observability.orchestra_log import (
+    append_governance_event,
+    append_orchestra_event,
+    append_orchestra_run_separator,
+    governance_dry_run_dir,
+    governance_events_log_path,
+    governance_log_dir,
+    orchestra_events_log_path,
+    orchestra_log_dir,
+)
 
-import atexit
-import os
-from datetime import datetime
-from pathlib import Path
-from typing import IO
-
-
-def orchestra_log_dir(repo_root: Path | None = None) -> Path:
-    override_dir = os.environ.get("VIBE3_ASYNC_LOG_DIR", "").strip()
-    if override_dir:
-        path = Path(override_dir).expanduser().resolve() / "orchestra"
-    else:
-        from vibe3.clients.git_client import find_repo_root
-
-        root = repo_root or find_repo_root()
-        path = root / "temp" / "logs" / "orchestra"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def orchestra_events_log_path(repo_root: Path | None = None) -> Path:
-    return orchestra_log_dir(repo_root) / "events.log"
-
-
-def governance_log_dir(repo_root: Path | None = None) -> Path:
-    path = orchestra_log_dir(repo_root) / "governance"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def governance_events_log_path(repo_root: Path | None = None) -> Path:
-    return governance_log_dir(repo_root) / "governance.log"
-
-
-def governance_dry_run_dir(repo_root: Path | None = None) -> Path:
-    path = governance_log_dir(repo_root) / "dry-run"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-# Module-level persistent file handle for events.log
-# Avoids opening/closing on every tick, preventing FD exhaustion
-_events_handle: IO[str] | None = None
-_events_path: Path | None = None  # Track current log path to detect repo_root changes
-
-
-def _open_events_log(repo_root: Path | None = None) -> tuple[IO[str], Path]:
-    """Open events.log in append mode, creating parent dirs if needed.
-
-    Returns:
-        Tuple of (file handle, resolved path) to enable path tracking
-    """
-    path = orchestra_events_log_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    handle = path.open("a", encoding="utf-8")
-    return handle, path
-
-
-def _close_events_log() -> None:
-    """Close the persistent events log handle."""
-    global _events_handle, _events_path
-    if _events_handle is not None:
-        try:
-            _events_handle.close()
-        except Exception:
-            pass
-        _events_handle = None
-        _events_path = None
-
-
-atexit.register(_close_events_log)
-
-
-def _ensure_events_handle(repo_root: Path | None = None) -> IO[str]:
-    """Ensure the persistent events handle is open and pointing at the right path."""
-    global _events_handle, _events_path
-    target_path = orchestra_events_log_path(repo_root)
-    if _events_handle is None or _events_path != target_path:
-        if _events_handle is not None:
-            try:
-                _events_handle.close()
-            except Exception:
-                pass
-        _events_handle, _events_path = _open_events_log(repo_root)
-    return _events_handle
-
-
-def append_orchestra_event(
-    component: str,
-    message: str,
-    *,
-    level: str = "INFO",
-    repo_root: Path | None = None,
-) -> Path:
-    """Append an event to the orchestra events log.
-
-    Levels: DEBUG, INFO, WARNING, ERROR
-    Default is INFO. Use VIBE3_ORCHESTRA_LOG_LEVEL to filter (default: INFO).
-
-    Uses a module-level persistent file handle to avoid FD exhaustion
-    from repeated open/close on every heartbeat tick.
-
-    Returns:
-        Path to the events.log file (consistent return type)
-    """
-    if os.environ.get("VIBE3_ORCHESTRA_EVENT_LOG") != "1":
-        return orchestra_events_log_path(repo_root)
-
-    # Check log level filter (no I/O for filtered-out events)
-    current_level = os.environ.get("VIBE3_ORCHESTRA_LOG_LEVEL", "INFO").upper()
-    levels = {"DEBUG": 0, "INFO": 1, "WARNING": 2, "ERROR": 3}
-    if levels.get(level.upper(), 1) < levels.get(current_level, 1):
-        return orchestra_events_log_path(repo_root)
-
-    handle = _ensure_events_handle(repo_root)
-    timestamp = datetime.now().isoformat(timespec="seconds")
-    if not message:
-        handle.write("\n")
-    else:
-        handle.write(f"[{timestamp}] [{component}] {message}\n")
-    handle.flush()
-    assert _events_path is not None
-    return _events_path
-
-
-def append_orchestra_run_separator(
-    *,
-    repo_root: Path | None = None,
-    title: str = "server run start",
-) -> Path:
-    """Append a run separator to events.log, preserving history.
-
-    Uses append mode to keep previous runs instead of overwriting.
-    Uses the persistent file handle to avoid FD exhaustion.
-
-    Returns:
-        Path to the events.log file (consistent return type)
-    """
-    if os.environ.get("VIBE3_ORCHESTRA_EVENT_LOG") != "1":
-        return orchestra_events_log_path(repo_root)
-
-    handle = _ensure_events_handle(repo_root)
-    timestamp = datetime.now().isoformat(timespec="seconds")
-    handle.write(f"\n========== {title} @ {timestamp} ==========\n")
-    handle.flush()
-    assert _events_path is not None
-    return _events_path
-
-
-def append_governance_event(message: str, *, repo_root: Path | None = None) -> Path:
-    """Append a governance event to both governance.log and events.log.
-
-    Uses append mode and delegates to append_orchestra_event for events.log
-    to benefit from persistent file handle.
-    """
-    path = governance_events_log_path(repo_root)
-    timestamp = datetime.now().isoformat(timespec="seconds")
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"[{timestamp}] {message}\n")
-    # Delegate to append_orchestra_event to use persistent handle
-    append_orchestra_event("governance", message, repo_root=repo_root)
-    return path
+__all__ = [
+    "append_governance_event",
+    "append_orchestra_event",
+    "append_orchestra_run_separator",
+    "governance_dry_run_dir",
+    "governance_events_log_path",
+    "governance_log_dir",
+    "orchestra_events_log_path",
+    "orchestra_log_dir",
+]

--- a/tests/vibe3/domain/handlers/test_governance_scan.py
+++ b/tests/vibe3/domain/handlers/test_governance_scan.py
@@ -9,7 +9,7 @@ from vibe3.execution.contracts import ExecutionLaunchResult
 class TestGovernanceScanHandler:
     """governance_scan handler dispatches governance agent via CLI self-invocation."""
 
-    @patch("vibe3.orchestra.logging.append_governance_event")
+    @patch("vibe3.observability.orchestra_log.append_governance_event")
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
@@ -54,7 +54,7 @@ class TestGovernanceScanHandler:
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
     @patch("vibe3.orchestra.flow_dispatch.FlowManager")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
-    @patch("vibe3.orchestra.logging.append_governance_event")
+    @patch("vibe3.observability.orchestra_log.append_governance_event")
     @patch("vibe3.domain.handlers.governance_scan.load_orchestra_config")
     def test_normal_dispatch(
         self,
@@ -106,7 +106,7 @@ class TestGovernanceScanHandler:
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
     @patch("vibe3.orchestra.flow_dispatch.FlowManager")
-    @patch("vibe3.orchestra.logging.append_governance_event")
+    @patch("vibe3.observability.orchestra_log.append_governance_event")
     @patch("vibe3.domain.handlers.governance_scan.load_orchestra_config")
     def test_no_dispatch_when_circuit_breaker_open(
         self,
@@ -143,7 +143,7 @@ class TestGovernanceScanHandler:
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
     @patch("vibe3.orchestra.flow_dispatch.FlowManager")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
-    @patch("vibe3.orchestra.logging.append_governance_event")
+    @patch("vibe3.observability.orchestra_log.append_governance_event")
     @patch("vibe3.domain.handlers.governance_scan.load_orchestra_config")
     def test_coordinator_failure_logged(
         self,
@@ -187,7 +187,7 @@ class TestGovernanceScanHandler:
     @patch("vibe3.services.orchestra_status_service.OrchestraStatusService")
     @patch("vibe3.orchestra.flow_dispatch.FlowManager")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
-    @patch("vibe3.orchestra.logging.append_governance_event")
+    @patch("vibe3.observability.orchestra_log.append_governance_event")
     @patch("vibe3.domain.handlers.governance_scan.load_orchestra_config")
     def test_exception_during_dispatch_logged(
         self,

--- a/tests/vibe3/domain/handlers/test_supervisor_scan.py
+++ b/tests/vibe3/domain/handlers/test_supervisor_scan.py
@@ -9,7 +9,7 @@ from vibe3.execution.contracts import ExecutionLaunchResult
 class TestSupervisorScanHandler:
     """supervisor_scan handler dispatches supervisor apply via CLI self-invocation."""
 
-    @patch("vibe3.orchestra.logging.append_orchestra_event")
+    @patch("vibe3.observability.orchestra_log.append_orchestra_event")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.supervisor_scan.load_orchestra_config")
@@ -110,7 +110,7 @@ class TestSupervisorScanHandler:
         mock_coordinator_cls.assert_not_called()
         mock_get_store.assert_not_called()
 
-    @patch("vibe3.orchestra.logging.append_orchestra_event")
+    @patch("vibe3.observability.orchestra_log.append_orchestra_event")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.supervisor_scan.load_orchestra_config")
@@ -144,7 +144,7 @@ class TestSupervisorScanHandler:
 
         mock_coordinator.dispatch_execution.assert_called_once()
 
-    @patch("vibe3.orchestra.logging.append_orchestra_event")
+    @patch("vibe3.observability.orchestra_log.append_orchestra_event")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")
     @patch("vibe3.execution.coordinator.ExecutionCoordinator")
     @patch("vibe3.domain.handlers.supervisor_scan.load_orchestra_config")

--- a/tests/vibe3/domain/test_no_orchestra_imports.py
+++ b/tests/vibe3/domain/test_no_orchestra_imports.py
@@ -38,7 +38,6 @@ def is_orchestra_import(import_str: str, file_path: Path | None = None) -> bool:
     """Check if an import is from orchestra layer.
 
     Allowed imports (infrastructure exceptions):
-    - orchestra.logging (infrastructure service)
     - orchestra.protocols (TYPE_CHECKING only)
     - orchestra.failed_gate (TYPE_CHECKING only)
     - orchestra internal services (used via protocol injection):

--- a/tests/vibe3/domain/test_no_orchestra_imports.py
+++ b/tests/vibe3/domain/test_no_orchestra_imports.py
@@ -60,7 +60,6 @@ def is_orchestra_import(import_str: str, file_path: Path | None = None) -> bool:
 
     # Allowed imports (infrastructure services)
     allowed_orchestra_modules = {
-        "vibe3.orchestra.logging",  # Infrastructure logging
         "vibe3.orchestra.protocols",  # TYPE_CHECKING only (checked by caller)
         "vibe3.orchestra.failed_gate",  # TYPE_CHECKING only (checked by caller)
         # Orchestra internal services (used via protocol injection)
@@ -148,8 +147,7 @@ def test_domain_layer_no_orchestra_imports():
             f"Found {len(violations)} orchestra imports in domain layer:\n"
             f"{violation_list}\n\n"
             "Domain layer should not import from orchestra layer.\n"
-            "Allowed exceptions: orchestra.logging (infrastructure), "
-            "orchestra.protocols/failed_gate (TYPE_CHECKING only)."
+            "Allowed exceptions: orchestra.protocols/failed_gate (TYPE_CHECKING only)."
         )
 
     print(f"✓ Verified {len(list(domain_dir.rglob('*.py')))} domain files")

--- a/tests/vibe3/domain/test_orchestration_facade.py
+++ b/tests/vibe3/domain/test_orchestration_facade.py
@@ -128,7 +128,7 @@ class TestOrchestrationFacade:
         assert "Manual review required" in call_args.args[1]
 
     @pytest.mark.asyncio
-    @patch("vibe3.orchestra.logging.append_orchestra_event")
+    @patch("vibe3.observability.orchestra_log.append_orchestra_event")
     async def test_on_tick_blocks_dispatch_when_failed_gate_is_closed(
         self,
         mock_append_event: MagicMock,

--- a/tests/vibe3/domain/test_qualify_gate_logging.py
+++ b/tests/vibe3/domain/test_qualify_gate_logging.py
@@ -39,7 +39,9 @@ def test_blocked_skip_log_includes_truth_details() -> None:
             "resolve_coordination",
             return_value=truth,
         ),
-        patch("vibe3.orchestra.logging.append_orchestra_event") as append_event,
+        patch(
+            "vibe3.observability.orchestra_log.append_orchestra_event"
+        ) as append_event,
     ):
         result = service.run_qualify_gate(
             issue=issue,
@@ -82,7 +84,9 @@ def test_blocked_skip_log_reports_aligned_label_state() -> None:
             return_value=truth,
         ),
         patch("vibe3.services.label_service.LabelService") as label_service,
-        patch("vibe3.orchestra.logging.append_orchestra_event") as append_event,
+        patch(
+            "vibe3.observability.orchestra_log.append_orchestra_event"
+        ) as append_event,
     ):
         result = service.run_qualify_gate(
             issue=IssueInfo(

--- a/tests/vibe3/orchestra/test_logging.py
+++ b/tests/vibe3/orchestra/test_logging.py
@@ -1,6 +1,6 @@
 """Test orchestra logging functions."""
 
-from vibe3.orchestra.logging import orchestra_events_log_path
+from vibe3.observability.orchestra_log import orchestra_events_log_path
 
 
 class TestOrchestraLogging:


### PR DESCRIPTION
Closes #1889

## Summary

- Move orchestra logging API from `vibe3.orchestra.logging` to `vibe3.observability.orchestra_log`
- Update all domain layer imports to use observability module
- Maintain backward compatibility via compat shell in `orchestra/logging.py`
- Update architecture guard test to enforce domain → observability dependency

## Changes

**New files:**
- `src/vibe3/observability/orchestra_log.py` - New home for orchestra logging API

**Modified files:**
- 5 domain files updated to import from observability
- `src/vibe3/orchestra/__init__.py` - Re-export observability.orchestra_log symbols
- `src/vibe3/orchestra/logging.py` - Converted to compat shell (backward compatibility)
- `tests/vibe3/domain/test_no_orchestra_imports.py` - Architecture guard updated

## Verification

- ✅ All 108 tests pass
- ✅ Type checking clean (mypy)
- ✅ Linting clean (ruff)
- ✅ Architecture guard enforces domain → observability dependency
- ✅ Backward compatibility maintained

## Test plan

- [x] Run full test suite (108 tests pass)
- [x] Verify architecture guard catches domain → orchestra imports
- [x] Confirm backward compatibility via compat shell
- [x] Check type safety with mypy

---

## Contributors

claude/opus
