### PR TITLE
feat(governance): add code-auditor role for automated module quality audit

### DIFF
--- a/config/prompts/prompt-recipes.yaml
+++ b/config/prompts/prompt-recipes.yaml
@@ -223,6 +223,10 @@ recipes:
         source:
           kind: file
           path: supervisor/governance/cron-supervisor.md
+      - name: supervisor/governance/code-auditor.md
+        source:
+          kind: file
+          path: supervisor/governance/code-auditor.md
     variables:
       server_status:
         kind: provider

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -35,11 +35,10 @@ from vibe3.prompts.template_loader import DEFAULT_PROMPTS_PATH
 from vibe3.roles.definitions import RoleDefinition
 from vibe3.roles.governance_utils import (
     build_broader_repo_entries,
+    build_code_auditor_context,
     build_issue_context,
     find_material_in_catalog,
     get_governed_issue_numbers,
-    resolve_test_path,
-    select_audit_module,
 )
 from vibe3.services.orchestra_status_service import OrchestraStatusService
 
@@ -169,24 +168,7 @@ def build_governance_snapshot_context(
         )
 
     if material_name == "code-auditor.md":
-        module_path = select_audit_module(tick_count)
-        test_path = resolve_test_path(module_path)
-        return build_issue_context(
-            (),
-            server_running=snapshot.server_running,
-            active_flows=snapshot.active_flows,
-            active_worktrees=snapshot.active_worktrees,
-            queued_issues=snapshot.queued_issues,
-            circuit_breaker_state=snapshot.circuit_breaker_state,
-            circuit_breaker_failures=snapshot.circuit_breaker_failures,
-            issue_scope_name="代码质量审计",
-            scope_note=(
-                f"## 本次审计目标\n"
-                f"- 模块路径：`{module_path}`\n"
-                f"- 对应测试目录：`{test_path}`\n\n"
-                f"请使用 Read、Grep 等工具检查该模块，寻找代码质量反模式。"
-            ),
-        )
+        return build_code_auditor_context(snapshot, tick_count=tick_count)
 
     # Default: assignee-pool path
     github = github or GitHubClient()

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -38,6 +38,8 @@ from vibe3.roles.governance_utils import (
     build_issue_context,
     find_material_in_catalog,
     get_governed_issue_numbers,
+    resolve_test_path,
+    select_audit_module,
 )
 from vibe3.services.orchestra_status_service import OrchestraStatusService
 
@@ -163,6 +165,26 @@ def build_governance_snapshot_context(
             scope_note=(
                 "以下候选来自 broader repo 文档范围；"
                 "目标是挑选最多 5 个需要语义对齐的过时文档对象。"
+            ),
+        )
+
+    if material_name == "code-auditor.md":
+        module_path = select_audit_module(tick_count)
+        test_path = resolve_test_path(module_path)
+        return build_issue_context(
+            (),
+            server_running=snapshot.server_running,
+            active_flows=snapshot.active_flows,
+            active_worktrees=snapshot.active_worktrees,
+            queued_issues=snapshot.queued_issues,
+            circuit_breaker_state=snapshot.circuit_breaker_state,
+            circuit_breaker_failures=snapshot.circuit_breaker_failures,
+            issue_scope_name="代码质量审计",
+            scope_note=(
+                f"## 本次审计目标\n"
+                f"- 模块路径：`{module_path}`\n"
+                f"- 对应测试目录：`{test_path}`\n\n"
+                f"请使用 Read、Grep 等工具检查该模块，寻找代码质量反模式。"
             ),
         )
 

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -179,6 +179,42 @@ def get_governed_issue_numbers(
     return numbers
 
 
+def select_audit_module(tick_count: int, repo_root: Path | None = None) -> Path:
+    """Select a module from src/vibe3/ for audit using tick-based rotation.
+
+    Excludes __init__.py files and __pycache__ directories.
+    Returns a deterministic but rotating selection based on tick_count.
+    """
+    root = repo_root or Path(".").resolve()
+    src_root = root / "src" / "vibe3"
+    candidates = sorted(
+        p
+        for p in src_root.rglob("*.py")
+        if p.name != "__init__.py" and "__pycache__" not in p.parts
+    )
+    if not candidates:
+        return src_root / "cli.py"
+    return candidates[tick_count % len(candidates)]
+
+
+def resolve_test_path(module_path: Path, repo_root: Path | None = None) -> Path:
+    """Resolve the test directory for a given module path.
+
+    Maps src/vibe3/{subdir}/foo.py -> tests/vibe3/{subdir}/
+    so the agent knows where to look for corresponding tests.
+    """
+    root = repo_root or Path(".").resolve()
+    src_vibe3 = root / "src" / "vibe3"
+    try:
+        rel = module_path.relative_to(src_vibe3)
+    except ValueError:
+        try:
+            rel = module_path.relative_to("src/vibe3")
+        except ValueError:
+            return root / "tests" / "vibe3"
+    return root / "tests" / "vibe3" / rel.parent
+
+
 def normalize_material_name(material_name: str) -> str:
     """Normalize material name to canonical form for comparison.
 

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -215,6 +215,37 @@ def resolve_test_path(module_path: Path, repo_root: Path | None = None) -> Path:
     return root / "tests" / "vibe3" / rel.parent
 
 
+def build_code_auditor_context(
+    snapshot: Any,
+    *,
+    tick_count: int = 0,
+) -> dict[str, Any]:
+    """Build governance context for code-auditor material.
+
+    Selects a module via tick-based rotation and returns a minimal context
+    containing only the module and test paths — the agent reads the code
+    itself using its own tools (Read/Grep), avoiding prompt bloat.
+    """
+    module_path = select_audit_module(tick_count)
+    test_path = resolve_test_path(module_path)
+    return build_issue_context(
+        (),
+        server_running=snapshot.server_running,
+        active_flows=snapshot.active_flows,
+        active_worktrees=snapshot.active_worktrees,
+        queued_issues=snapshot.queued_issues,
+        circuit_breaker_state=snapshot.circuit_breaker_state,
+        circuit_breaker_failures=snapshot.circuit_breaker_failures,
+        issue_scope_name="代码质量审计",
+        scope_note=(
+            f"## 本次审计目标\n"
+            f"- 模块路径：`{module_path}`\n"
+            f"- 对应测试目录：`{test_path}`\n\n"
+            "请使用 Read、Grep 等工具检查该模块，寻找代码质量反模式。"
+        ),
+    )
+
+
 def normalize_material_name(material_name: str) -> str:
     """Normalize material name to canonical form for comparison.
 

--- a/supervisor/governance/code-auditor.md
+++ b/supervisor/governance/code-auditor.md
@@ -7,6 +7,25 @@
 - 功能：每轮随机抽查一个模块，检查代码质量反模式，发现问题后创建 GitHub issue
 - 和其他 governance 材料并列轮转，不替代 assignee-pool / roadmap-intake / cron-supervisor
 
+## Design Rationale
+
+**Minimal Context Strategy（最小上下文策略）**：
+
+本材料采用"仅传递路径，不预加载代码"的设计策略，这是有意为之的设计决策：
+
+- **只传递两个路径**：`module_path`（模块路径）和 `test_dir`（测试目录路径）
+- **不预加载**：`module_code`、`git_history`、`existing_audit_issues` 均不预先加载到上下文中
+- **Agent 自主探索**：Agent 使用自己的 Read/Grep 工具按需读取代码，动态探索相关文件
+
+**设计理由**：
+
+1. **避免 Prompt Bloat**：预加载源代码会快速耗尽上下文窗口，导致 agent 性能下降
+2. **动态探索更灵活**：Agent 可根据初步发现决定深入哪些文件，比预加载更高效
+3. **Git 历史价值有限**：代码质量反模式主要依赖静态代码分析，git 历史不是必需的
+4. **去重交由 agent**：Agent 使用 `issue.read` 工具动态搜索，比预加载 open issues 列表更节省上下文
+
+**不要修改此设计**：如果未来发现需要预加载某些信息，请在 issue 中详细说明理由，经过评审后再修改。当前设计是基于上下文效率的权衡结果。
+
 ## Role
 
 你是 **代码质量审计员（Code Auditor）**。

--- a/supervisor/governance/code-auditor.md
+++ b/supervisor/governance/code-auditor.md
@@ -1,0 +1,115 @@
+# Code Auditor 代码质量审计材料
+
+## 概念说明
+
+这是 governance supervisor material，供 governance scan agent 使用。
+- governance scan：无临时 worktree 的观察 / 派单 agent（本材料的使用者）
+- 功能：每轮随机抽查一个模块，检查代码质量反模式，发现问题后创建 GitHub issue
+- 和其他 governance 材料并列轮转，不替代 assignee-pool / roadmap-intake / cron-supervisor
+
+## Role
+
+你是 **代码质量审计员（Code Auditor）**。
+
+每轮只做一件事：**检查当前轮分配的模块，对发现的代码质量反模式创建 GitHub issue**。
+
+**审计目标**：从 Scope 字段中读取本次要检查的模块路径。
+
+## 代码质量反模式清单
+
+对被分配的模块，检查以下五类问题。每类问题独立判断，只对确有证据的问题发 issue。
+
+### 1. 死代码（Dead Code）
+
+- 定义了但从未被调用的函数、类或变量（全局可 grep 确认）
+- 永远不会执行的分支：`if False:`、无法满足的条件（与已知常量冲突）
+- 导入后从未引用的模块
+
+**识别方式**：Grep 整个 `src/` 搜索该符号，若只有定义无引用则为死代码候选。
+
+### 2. 自我检测/自我实现代码（Self-Checking Code）
+
+- 测试只验证 mock 被调用，不验证业务输出结果（测试测试本身）
+- 模块内有专门用来验证自身代码存在的逻辑（如检查自身文件路径）
+- 测试的 assertion 只检查是否存在某个属性，而不检查其值
+
+**识别方式**：看测试 assertion，若只有 `assert mock.called` 无输出验证则为候选。
+
+### 3. 已废弃的测试（Orphaned Tests）
+
+- 测试引用的生产函数、类或模块已不存在（import 会 fail）
+- 测试文件头部 import 指向已迁移到其他路径的符号
+- 测试针对已被删除的 CLI 参数或 API
+
+**识别方式**：检查 import 语句，确认生产代码中的符号是否仍存在。
+
+### 4. 绕路逻辑（Roundabout Logic）
+
+本项目已出现过的典型反例：
+
+- **文件目录推断代替数据库查询**：扫描 `.git/vibe3/` 目录结构推断 flow 状态，而 `FlowService`/`SQLite` 有直接查询接口
+- **Issue→PR→Branch 链式查找**：通过 GitHub API 先找 issue、再找关联 PR、再取 branch name，而 `git branch --show-current` 或 `vibe3 flow show` 可直接获取
+- **多跳 API 调用**：当存在更短路径的 API 时，使用多步中间查询组装结果
+
+**识别方式**：找到 `os.walk` / `glob` / `Path.iterdir` 操作 `.git/` 目录的代码；找到链式调用多个 GitHub API 最终只为获取 branch 名的代码。
+
+### 5. 过滤代替删除（Filter-Instead-of-Delete）
+
+- 全量加载后过滤，而数据库查询层可直接限定范围（`WHERE` 条件）
+- 用列表推导过滤保留，而逻辑上可以在写入时就排除
+- 累积全量数据再丢弃大部分，而非只收集需要的部分
+
+**识别方式**：找到先 `SELECT *` 再 Python 过滤的模式；找到 `[x for x in all_items if condition]` 且 `all_items` 来自全量查询的代码。
+
+## 执行约束
+
+- 每轮最多发 **3 个 issue**（避免 issue 洪水）
+- 有疑问时宁可不发，不要低置信度发 issue
+- 不直接修改代码，不进入 plan/run/review 执行链
+- 先检查已有 open issue 中是否有相同问题，避免重复
+
+## Permission Contract
+
+Allowed:
+- `code`: read（使用 Read、Grep、Bash 工具检查模块及其测试）
+- `issue.read`: read open issues（用于去重检查）
+- `issue.create`: 对确认的反模式创建 issue
+- `comment.write`: 不用（本角色直接创建 issue，不在现有 issue 下评论）
+
+Forbidden:
+- 直接修改代码或文档
+- 进入 plan/run/review 执行链
+- 修改任何 label、state
+- 修改调度配置
+- 创建超过 3 个 issue（每轮上限）
+- 对低置信度（没有具体行号证据）的问题发 issue
+
+## What It Reads
+
+- 被分配的模块文件（`Read` 或 `Grep`）
+- 对应的测试目录/文件（检查 orphaned tests）
+- 项目其他模块（`Grep` 验证符号是否被引用）
+- 现有 open issues（去重用）
+
+## What It Produces
+
+对每个确认的反模式，创建一个 GitHub issue，包含：
+
+- **标题**：`[code-auditor] <反模式类型>: <模块名> <具体问题描述>`
+- **Body**：
+  - 文件路径和行号范围
+  - 反模式类型说明
+  - 具体代码片段（引用）
+  - 修复建议方向
+  - 标签：`refactor` + `priority/5`（重要但非紧急）
+
+## Execution Pattern
+
+1. 从 Scope 字段读取 `模块路径` 和 `对应测试目录`
+2. 用 Read 读取模块文件全文（或 Grep 快速扫描关键模式）
+3. 用 Read/Grep 检查对应测试目录
+4. 对每类反模式执行检查：
+   - 发现候选 → Grep 全仓库验证（排除误报）→ 有证据则记录
+5. 在创建 issue 前，先搜索现有 open issues 确认无重复
+6. 对每个确认问题创建 issue（最多 3 个）
+7. 输出本轮审计摘要后停止

--- a/tests/vibe3/roles/test_governance_code_audit.py
+++ b/tests/vibe3/roles/test_governance_code_audit.py
@@ -1,0 +1,275 @@
+"""Tests for code-auditor governance role utilities and context building."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from vibe3.models.orchestra_config import GovernanceConfig, OrchestraConfig
+from vibe3.roles.governance import build_governance_snapshot_context
+from vibe3.roles.governance_utils import resolve_test_path, select_audit_module
+from vibe3.services.orchestra_status_service import OrchestraSnapshot
+
+# ---------------------------------------------------------------------------
+# select_audit_module
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAuditModule:
+    def test_returns_path_object(self, tmp_path: Path) -> None:
+        _make_fake_src(tmp_path, ["services/flow_service.py"])
+        result = select_audit_module(0, repo_root=tmp_path)
+        assert isinstance(result, Path)
+
+    def test_deterministic_for_same_tick(self, tmp_path: Path) -> None:
+        _make_fake_src(tmp_path, ["services/flow_service.py", "commands/flow.py"])
+        assert select_audit_module(0, tmp_path) == select_audit_module(0, tmp_path)
+
+    def test_rotates_with_tick(self, tmp_path: Path) -> None:
+        _make_fake_src(
+            tmp_path,
+            ["services/flow_service.py", "commands/flow.py", "models/flow.py"],
+        )
+        results = {select_audit_module(i, tmp_path) for i in range(3)}
+        assert len(results) == 3
+
+    def test_wraps_around_modulo(self, tmp_path: Path) -> None:
+        files = ["a.py", "b.py"]
+        _make_fake_src(tmp_path, files)
+        assert select_audit_module(0, tmp_path) == select_audit_module(2, tmp_path)
+        assert select_audit_module(1, tmp_path) == select_audit_module(3, tmp_path)
+
+    def test_excludes_init_files(self, tmp_path: Path) -> None:
+        _make_fake_src(
+            tmp_path,
+            ["services/__init__.py", "services/flow_service.py"],
+        )
+        result = select_audit_module(0, tmp_path)
+        assert result.name != "__init__.py"
+
+    def test_excludes_pycache(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "vibe3"
+        src.mkdir(parents=True)
+        cache = src / "__pycache__"
+        cache.mkdir()
+        (cache / "flow.cpython-312.pyc").touch()
+        (src / "cli.py").write_text("")
+        result = select_audit_module(0, tmp_path)
+        assert "__pycache__" not in result.parts
+
+    def test_fallback_when_no_candidates(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "vibe3"
+        src.mkdir(parents=True)
+        (src / "__init__.py").touch()
+        result = select_audit_module(0, tmp_path)
+        assert result == src / "cli.py"
+
+    def test_selection_is_sorted_stable(self, tmp_path: Path) -> None:
+        _make_fake_src(tmp_path, ["z_module.py", "a_module.py"])
+        first = select_audit_module(0, tmp_path)
+        assert first.name == "a_module.py"
+
+    def test_uses_cwd_when_no_repo_root(self, tmp_path: Path, monkeypatch) -> None:
+        _make_fake_src(tmp_path, ["services/flow_service.py"])
+        monkeypatch.chdir(tmp_path)
+        result = select_audit_module(0)
+        assert result.name == "flow_service.py"
+
+
+# ---------------------------------------------------------------------------
+# resolve_test_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTestPath:
+    def test_top_level_module(self, tmp_path: Path) -> None:
+        module = tmp_path / "src" / "vibe3" / "cli.py"
+        result = resolve_test_path(module, repo_root=tmp_path)
+        assert result == tmp_path / "tests" / "vibe3"
+
+    def test_subpackage_module(self, tmp_path: Path) -> None:
+        module = tmp_path / "src" / "vibe3" / "services" / "flow_service.py"
+        result = resolve_test_path(module, repo_root=tmp_path)
+        assert result == tmp_path / "tests" / "vibe3" / "services"
+
+    def test_nested_subpackage(self, tmp_path: Path) -> None:
+        module = tmp_path / "src" / "vibe3" / "domain" / "handlers" / "manager.py"
+        result = resolve_test_path(module, repo_root=tmp_path)
+        assert result == tmp_path / "tests" / "vibe3" / "domain" / "handlers"
+
+    def test_returns_path_object(self, tmp_path: Path) -> None:
+        module = tmp_path / "src" / "vibe3" / "cli.py"
+        result = resolve_test_path(module, repo_root=tmp_path)
+        assert isinstance(result, Path)
+
+    def test_fallback_for_unrecognized_path(self, tmp_path: Path) -> None:
+        module = tmp_path / "some" / "other" / "path.py"
+        result = resolve_test_path(module, repo_root=tmp_path)
+        assert result == tmp_path / "tests" / "vibe3"
+
+    def test_uses_cwd_when_no_repo_root(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        module = Path("src/vibe3/services/flow_service.py")
+        result = resolve_test_path(module)
+        assert result == tmp_path / "tests" / "vibe3" / "services"
+
+
+# ---------------------------------------------------------------------------
+# build_governance_snapshot_context (code-auditor branch)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGovernanceSnapshotContextCodeAuditor:
+    def test_returns_dict_for_code_auditor_material(self, tmp_path: Path) -> None:
+        snapshot = _make_snapshot()
+        config = _make_config()
+        _make_fake_src(tmp_path, ["services/flow_service.py"])
+
+        with (
+            patch(
+                "vibe3.roles.governance.select_audit_module",
+                return_value=tmp_path
+                / "src"
+                / "vibe3"
+                / "services"
+                / "flow_service.py",
+            ),
+            patch(
+                "vibe3.roles.governance.resolve_test_path",
+                return_value=tmp_path / "tests" / "vibe3" / "services",
+            ),
+        ):
+            result = build_governance_snapshot_context(
+                snapshot,
+                config=config,
+                tick_count=0,
+                material_override="code-auditor",
+            )
+
+        assert isinstance(result, dict)
+
+    def test_scope_note_contains_module_path(self, tmp_path: Path) -> None:
+        snapshot = _make_snapshot()
+        config = _make_config()
+        module_path = tmp_path / "src" / "vibe3" / "services" / "flow_service.py"
+
+        with (
+            patch(
+                "vibe3.roles.governance.select_audit_module", return_value=module_path
+            ),
+            patch(
+                "vibe3.roles.governance.resolve_test_path",
+                return_value=tmp_path / "tests" / "vibe3" / "services",
+            ),
+        ):
+            result = build_governance_snapshot_context(
+                snapshot,
+                config=config,
+                tick_count=0,
+                material_override="code-auditor",
+            )
+
+        assert str(module_path) in result["scope_note"]
+
+    def test_scope_note_contains_test_path(self, tmp_path: Path) -> None:
+        snapshot = _make_snapshot()
+        config = _make_config()
+        module_path = tmp_path / "src" / "vibe3" / "services" / "flow_service.py"
+        test_path = tmp_path / "tests" / "vibe3" / "services"
+
+        with (
+            patch(
+                "vibe3.roles.governance.select_audit_module", return_value=module_path
+            ),
+            patch("vibe3.roles.governance.resolve_test_path", return_value=test_path),
+        ):
+            result = build_governance_snapshot_context(
+                snapshot,
+                config=config,
+                tick_count=0,
+                material_override="code-auditor",
+            )
+
+        assert str(test_path) in result["scope_note"]
+
+    def test_issue_scope_name_indicates_audit(self, tmp_path: Path) -> None:
+        snapshot = _make_snapshot()
+        config = _make_config()
+
+        with (
+            patch(
+                "vibe3.roles.governance.select_audit_module",
+                return_value=tmp_path / "src" / "vibe3" / "cli.py",
+            ),
+            patch(
+                "vibe3.roles.governance.resolve_test_path",
+                return_value=tmp_path / "tests" / "vibe3",
+            ),
+        ):
+            result = build_governance_snapshot_context(
+                snapshot,
+                config=config,
+                tick_count=0,
+                material_override="code-auditor",
+            )
+
+        assert "审计" in result["issue_scope_name"]
+
+    def test_does_not_call_github(self, tmp_path: Path) -> None:
+        snapshot = _make_snapshot()
+        config = _make_config()
+
+        with (
+            patch(
+                "vibe3.roles.governance.select_audit_module",
+                return_value=tmp_path / "src" / "vibe3" / "cli.py",
+            ),
+            patch(
+                "vibe3.roles.governance.resolve_test_path",
+                return_value=tmp_path / "tests" / "vibe3",
+            ),
+            patch("vibe3.roles.governance.GitHubClient") as mock_github,
+        ):
+            build_governance_snapshot_context(
+                snapshot,
+                config=config,
+                tick_count=0,
+                material_override="code-auditor",
+            )
+
+        mock_github.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_src(root: Path, relative_paths: list[str]) -> None:
+    """Create fake Python source files under root/src/vibe3/."""
+    base = root / "src" / "vibe3"
+    base.mkdir(parents=True, exist_ok=True)
+    for rel in relative_paths:
+        target = base / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"# {rel}\n")
+
+
+def _make_snapshot() -> OrchestraSnapshot:
+    return OrchestraSnapshot(
+        timestamp=0.0,
+        server_running=True,
+        active_issues=(),
+        active_flows=0,
+        active_worktrees=0,
+        circuit_breaker_state="closed",
+        circuit_breaker_failures=0,
+        queued_issues=(),
+    )
+
+
+def _make_config() -> OrchestraConfig:
+    return OrchestraConfig(
+        repo="owner/repo",
+        governance=GovernanceConfig(),
+    )

--- a/tests/vibe3/roles/test_governance_code_audit.py
+++ b/tests/vibe3/roles/test_governance_code_audit.py
@@ -127,7 +127,7 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
 
         with (
             patch(
-                "vibe3.roles.governance.select_audit_module",
+                "vibe3.roles.governance_utils.select_audit_module",
                 return_value=tmp_path
                 / "src"
                 / "vibe3"
@@ -135,7 +135,7 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
                 / "flow_service.py",
             ),
             patch(
-                "vibe3.roles.governance.resolve_test_path",
+                "vibe3.roles.governance_utils.resolve_test_path",
                 return_value=tmp_path / "tests" / "vibe3" / "services",
             ),
         ):
@@ -155,10 +155,11 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
 
         with (
             patch(
-                "vibe3.roles.governance.select_audit_module", return_value=module_path
+                "vibe3.roles.governance_utils.select_audit_module",
+                return_value=module_path,
             ),
             patch(
-                "vibe3.roles.governance.resolve_test_path",
+                "vibe3.roles.governance_utils.resolve_test_path",
                 return_value=tmp_path / "tests" / "vibe3" / "services",
             ),
         ):
@@ -179,9 +180,12 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
 
         with (
             patch(
-                "vibe3.roles.governance.select_audit_module", return_value=module_path
+                "vibe3.roles.governance_utils.select_audit_module",
+                return_value=module_path,
             ),
-            patch("vibe3.roles.governance.resolve_test_path", return_value=test_path),
+            patch(
+                "vibe3.roles.governance_utils.resolve_test_path", return_value=test_path
+            ),
         ):
             result = build_governance_snapshot_context(
                 snapshot,
@@ -198,11 +202,11 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
 
         with (
             patch(
-                "vibe3.roles.governance.select_audit_module",
+                "vibe3.roles.governance_utils.select_audit_module",
                 return_value=tmp_path / "src" / "vibe3" / "cli.py",
             ),
             patch(
-                "vibe3.roles.governance.resolve_test_path",
+                "vibe3.roles.governance_utils.resolve_test_path",
                 return_value=tmp_path / "tests" / "vibe3",
             ),
         ):
@@ -221,11 +225,11 @@ class TestBuildGovernanceSnapshotContextCodeAuditor:
 
         with (
             patch(
-                "vibe3.roles.governance.select_audit_module",
+                "vibe3.roles.governance_utils.select_audit_module",
                 return_value=tmp_path / "src" / "vibe3" / "cli.py",
             ),
             patch(
-                "vibe3.roles.governance.resolve_test_path",
+                "vibe3.roles.governance_utils.resolve_test_path",
                 return_value=tmp_path / "tests" / "vibe3",
             ),
             patch("vibe3.roles.governance.GitHubClient") as mock_github,

--- a/tests/vibe3/roles/test_governance_request_materials.py
+++ b/tests/vibe3/roles/test_governance_request_materials.py
@@ -152,14 +152,14 @@ class TestRoundRobinMaterialSelection:
         assert val == "supervisor/governance/cron-supervisor.md"
 
     def test_tick_wraps_around(self):
-        """tick_count wraps around material catalog (3 materials, tick 3 -> index 0)."""
-        recipe = build_governance_recipe(_make_config(), tick_count=3)
+        """tick_count wraps around material catalog (4 materials, tick 4 -> index 0)."""
+        recipe = build_governance_recipe(_make_config(), tick_count=4)
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/assignee-pool.md"
 
     def test_large_tick_uses_modulo(self):
-        """tick_count=7 wraps around 3 materials to index 1 (7 % 3 = 1)."""
-        recipe = build_governance_recipe(_make_config(), tick_count=7)
+        """tick_count=9 wraps around 4 materials to index 1 (9 % 4 = 1)."""
+        recipe = build_governance_recipe(_make_config(), tick_count=9)
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/roadmap-intake.md"
 


### PR DESCRIPTION
## Summary

Implements a new `code-auditor` governance role that joins the tick-rotation catalog as the 4th material, enabling automated random-sampling code quality audits alongside existing governance scans.

- **Trigger**: Every 4th governance tick (`tick_count % 4 == 3`), the code-auditor material is selected
- **Design**: Agent receives only two path strings (module + test directory) — no code content is pre-loaded, avoiding prompt bloat. The agent uses its own Read/Grep tools to inspect the module
- **Output**: Up to 3 GitHub issues per tick for confirmed anti-patterns (dead code, roundabout logic, filter-instead-of-delete, etc.)

## Anti-Pattern Categories

1. **Dead code** — unreachable functions, unused imports, infinite-false branches
2. **Self-checking code** — tests verifying only mock calls, not business output
3. **Orphaned tests** — tests referencing deleted production symbols
4. **Roundabout logic** — file-dir inference instead of DB query; issue→PR→branch chain instead of direct `git branch --show-current`
5. **Filter-instead-of-delete** — SELECT * then Python filter, when DB WHERE clause would suffice

## Changes

| File | Change |
|------|--------|
| `supervisor/governance/code-auditor.md` | New supervisor material with audit rules and permission contract |
| `config/prompts/prompt-recipes.yaml` | Register code-auditor.md in governance.scan material_catalog |
| `src/vibe3/roles/governance_utils.py` | Add `select_audit_module()`, `resolve_test_path()`, `build_code_auditor_context()` |
| `src/vibe3/roles/governance.py` | Add code-auditor.md branch → delegates to `build_code_auditor_context` |
| `tests/vibe3/roles/test_governance_code_audit.py` | 20 new tests covering all utilities and context building |
| `tests/vibe3/roles/test_governance_request_materials.py` | Update modulo expectations (3→4 materials) |

## Test Plan

- [x] 20 new tests pass (`test_governance_code_audit.py`)
- [x] Existing governance tests pass (38/38)
- [x] `uv run mypy` — zero errors
- [x] LOC gate — `governance.py` 390 lines (under 400 limit)
- [x] Pre-push checks — 244 tests pass

## Context

Long-term automated mechanism for #2000 (deprecated/dead code cleanup).
Issue: closes #2011

## Contributors

- Claude Sonnet 4.6 (AI Agent) — implementation