### PR TITLE
fix(execution): add publish path safety net for executor state transition

### DIFF
--- a/config/prompts/prompt-recipes.yaml
+++ b/config/prompts/prompt-recipes.yaml
@@ -85,6 +85,15 @@ recipes:
           - run.skill_content
           - run.exit_contract
 
+  run.publish:
+    template_key: run.skill
+    description: Executor prompt for publish path (commit_mode, merge-ready → handoff).
+    variants:
+      default:
+        sections:
+          - run.skill_content
+          - run.publish_exit_contract
+
   # Planner role assembly.
   #
   # Design intent:

--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -432,6 +432,20 @@ run:
     Replace `<ISSUE_NUMBER>` with the actual issue number (check your branch name, e.g. `task/issue-476-*` means issue #476).
     WARNING: If you skip this step, the no-op gate will BLOCK this issue and the pipeline will stall.
 
+  # Static: executor exit contract for publish path (commit_mode).
+  # Used when executor is dispatched from state/merge-ready.
+  # Recipe section name: run.publish_exit_contract
+  publish_task: |
+    The auto-saved executor artifact is only for shared handoff or audit and is not the authoritative `report_ref`.
+
+    ### MANDATORY EXIT STEP — you MUST do this before exit():
+    Run this command to change the issue state label:
+    ```bash
+    gh issue edit <ISSUE_NUMBER> --add-label "state/handoff" --remove-label "state/merge-ready"
+    ```
+    Replace `<ISSUE_NUMBER>` with the actual issue number (check your branch name, e.g. `task/issue-476-*` means issue #476).
+    WARNING: If you skip this step, the no-op gate will BLOCK this issue and the pipeline will stall.
+
   # Static: coding-mode guidance.
   # Recipe section name: run.coding_task
   # Injected only for plan/flow_plan/lightweight executor modes.

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -153,8 +153,8 @@ code_limits:
         limit: 650
         reason: "No-op gate 聚合，包含 verdict-aware ref 检查（PASS 可省略 audit_ref，MINOR/MAJOR/BLOCK 仍需）、单步转换限制检查、全局转换计数检查、state 验证、GitHub API 错误处理、retry counter 机制（3次重试 + 即时持久化）、error/block 分离（GitHub API 失败记录 error_log 不触发 flow block）等多层防御机制，职责单一但紧密耦合"
       - path: "src/vibe3/execution/codeagent_runner.py"
-        limit: 580
-        reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；rebase 后新增 tick_id 参数传递和 before_issue_is_closed 检测逻辑"
+        limit: 610
+        reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；新增 publish path safety net（+25行）确保 executor 完成后状态正确转换，解决 #1830"
       - path: "src/vibe3/services/orchestra_status_service.py"
         limit: 540
         reason: "Orchestra 状态查询服务，包含状态快照和格式化逻辑、IssueState 反序列化类型安全处理、HTTP fetch 集成、live snapshot 解析、pr_number 类型强制转换防御逻辑等紧密耦合逻辑；新增 get_manager_usernames 静态方法提供统一的服务层 API 供 governance.py 和 status.py 使用（#1783），职责单一但方法较多"

--- a/skills/vibe-commit/SKILL.md
+++ b/skills/vibe-commit/SKILL.md
@@ -168,8 +168,8 @@ git log HEAD..origin/main --oneline
 # 记录原因
 uv run python src/vibe3/cli.py handoff append "vibe-commit: 不再需要提交，理由：<具体原因>" --kind note
 
-# 更新 issue 标签为 state/handoff
-gh issue edit <issue-number> --add-label "state/handoff"
+# 更新 issue 标签为 state/handoff (移除 state/merge-ready)
+gh issue edit <issue-number> --add-label "state/handoff" --remove-label "state/merge-ready"
 
 # 停止，等待 manager 决定
 ```

--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -17,7 +17,8 @@ Prompt Builders:
 - ``build_plan_prompt_body`` / ``make_plan_context_builder`` — plan agent
   prompt construction
 - ``build_run_prompt_body`` / ``make_run_context_builder`` /
-  ``make_skill_context_builder`` — run agent prompt construction
+  ``make_skill_context_builder`` / ``make_publish_context_builder`` — run
+  agent prompt construction
 - ``build_review_prompt_body`` / ``make_review_context_builder`` — review
   agent prompt construction
 - ``build_tools_guide_section`` — shared utility for building tools guide

--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -67,6 +67,7 @@ from vibe3.agents.run_prompt import (
     RunPromptMode,
     build_run_prompt_body,
     describe_run_plan_sections,
+    make_publish_context_builder,
     make_run_context_builder,
     make_skill_context_builder,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "build_run_prompt_body",
     "make_run_context_builder",
     "make_skill_context_builder",
+    "make_publish_context_builder",
     "build_review_prompt_body",
     "make_review_context_builder",
     "build_tools_guide_section",

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -141,6 +141,10 @@ def _build_run_prompt_providers(
         "run.exit_contract": lambda: build_run_task_section(
             getattr(run_config, "run_task", None) if run_config else None
         ),
+        # Publish path exit contract for commit_mode execution (merge-ready → handoff).
+        "run.publish_exit_contract": lambda: build_run_task_section(
+            getattr(run_config, "publish_task", None) if run_config else None
+        ),
         # Backward-compatible alias for local recipe overrides.
         "run.task": lambda: build_run_task_section(
             getattr(run_config, "run_task", None) if run_config else None
@@ -253,6 +257,34 @@ def make_skill_context_builder(
     def build() -> str:
         return PromptManifest.load_default().render_sections(
             recipe_key="run.skill",
+            variant_key="default",
+            providers=_build_run_prompt_providers(cfg, skill_content=skill_content),
+        )
+
+    return make_context_builder(
+        template_key="run.skill",
+        body_provider_key="run.context",
+        body_fn=build,
+        prompts_path=prompts_path,
+        variable_name="skill_content",
+    )
+
+
+def make_publish_context_builder(
+    skill_content: str,
+    config: VibeConfig | None = None,
+    prompts_path: Path | None = None,
+) -> PromptContextBuilder:
+    """Create a PromptContextBuilder for publish path (commit_mode) execution.
+
+    Uses run.publish recipe with publish-specific exit contract.
+    The publish path is triggered by state/merge-ready and transitions to state/handoff.
+    """
+    cfg = config or VibeConfig.get_defaults()
+
+    def build() -> str:
+        return PromptManifest.load_default().render_sections(
+            recipe_key="run.publish",
             variant_key="default",
             providers=_build_run_prompt_providers(cfg, skill_content=skill_content),
         )

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -113,6 +113,7 @@ _PROMPT_KEYS: dict[str, set[str]] = {
     "run": {
         "output_format",
         "run_task",
+        "publish_task",
         "coding_task",
         "retry_task",
         "run_prompt",

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -322,6 +322,31 @@ class CodeagentExecutionService:
                     execution_cwd=ctx.execution_cwd,
                 )
 
+            # Publish path safety net: if executor ran in commit_mode and state
+            # is still merge-ready, force transition to handoff.
+            # This runs BEFORE noop gate to catch the case where the agent
+            # prompt didn't execute the exit contract correctly.
+            # IMPORTANT: This must run before noop_gate transitions to blocked.
+            if (
+                command.role == "executor"
+                and command.issue_number is not None
+                and flow_state
+                and flow_state.get("commit_mode")
+                and ctx.before_state_label == "state/merge-ready"
+            ):
+                from vibe3.models import IssueState
+                from vibe3.services.label_service import LabelService
+
+                label_service = LabelService(repo=getattr(self.config, "repo", None))
+                current_state = label_service.get_state(command.issue_number)
+
+                if current_state == IssueState.MERGE_READY:
+                    log.warning(
+                        "Publish path safety net: state still merge-ready "
+                        "after executor, forcing transition to handoff"
+                    )
+                    label_service.set_state(command.issue_number, IssueState.HANDOFF)
+
             # Unified no-op gate: single hard logic check after agent completion.
             # Executes ONLY for L3 worker roles (manager/planner/executor/reviewer).
             # Supervisor (L2) is lightweight: no flow, no state machine, skip gate.
@@ -346,57 +371,6 @@ class CodeagentExecutionService:
                     ctx.store.update_flow_state(
                         ctx.branch, transition_count=flow_state["transition_count"]
                     )
-
-                # Publish path safety net: if executor ran in commit_mode and state
-                # is still merge-ready, force transition to handoff.
-                # This catches cases where the agent prompt didn't execute the
-                # exit contract correctly.
-                if (
-                    command.role == "executor"
-                    and flow_state
-                    and flow_state.get("commit_mode")
-                    and ctx.before_state_label == "state/merge-ready"
-                ):
-                    from vibe3.execution.state_verification import (
-                        StateVerificationService,
-                    )
-
-                    verifier = StateVerificationService(store=ctx.store)
-                    after_label, _ = verifier.get_issue_state_label(
-                        issue_number=command.issue_number,
-                        repo=getattr(self.config, "repo", None),
-                        branch=ctx.branch,
-                        flow_state=flow_state,
-                        tick_id=command.tick_id,
-                    )
-                    if after_label == "state/merge-ready":
-                        log.warning(
-                            "Publish path safety net: state still merge-ready "
-                            "after executor, forcing transition to handoff"
-                        )
-                        import subprocess
-
-                        repo_arg = []
-                        repo_value = getattr(self.config, "repo", None)
-                        if repo_value:
-                            repo_arg = ["--repo", str(repo_value)]
-                        subprocess.run(
-                            [
-                                "gh",
-                                "issue",
-                                "edit",
-                                str(command.issue_number),
-                                "--add-label",
-                                "state/handoff",
-                                "--remove-label",
-                                "state/merge-ready",
-                            ]
-                            + repo_arg,
-                            capture_output=True,
-                            text=True,
-                            timeout=30,
-                            check=False,
-                        )
 
             # Supervisor success: remove state/handoff label to prevent re-dispatch.
             # Agent is expected to close the issue, but we ensure label cleanup.

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -347,6 +347,57 @@ class CodeagentExecutionService:
                         ctx.branch, transition_count=flow_state["transition_count"]
                     )
 
+                # Publish path safety net: if executor ran in commit_mode and state
+                # is still merge-ready, force transition to handoff.
+                # This catches cases where the agent prompt didn't execute the
+                # exit contract correctly.
+                if (
+                    command.role == "executor"
+                    and flow_state
+                    and flow_state.get("commit_mode")
+                    and ctx.before_state_label == "state/merge-ready"
+                ):
+                    from vibe3.execution.state_verification import (
+                        StateVerificationService,
+                    )
+
+                    verifier = StateVerificationService(store=ctx.store)
+                    after_label, _ = verifier.get_issue_state_label(
+                        issue_number=command.issue_number,
+                        repo=getattr(self.config, "repo", None),
+                        branch=ctx.branch,
+                        flow_state=flow_state,
+                        tick_id=command.tick_id,
+                    )
+                    if after_label == "state/merge-ready":
+                        log.warning(
+                            "Publish path safety net: state still merge-ready "
+                            "after executor, forcing transition to handoff"
+                        )
+                        import subprocess
+
+                        repo_arg = []
+                        repo_value = getattr(self.config, "repo", None)
+                        if repo_value:
+                            repo_arg = ["--repo", str(repo_value)]
+                        subprocess.run(
+                            [
+                                "gh",
+                                "issue",
+                                "edit",
+                                str(command.issue_number),
+                                "--add-label",
+                                "state/handoff",
+                                "--remove-label",
+                                "state/merge-ready",
+                            ]
+                            + repo_arg,
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                            check=False,
+                        )
+
             # Supervisor success: remove state/handoff label to prevent re-dispatch.
             # Agent is expected to close the issue, but we ensure label cleanup.
             if command.role == "supervisor" and command.issue_number is not None:

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from types import SimpleNamespace
 
+from loguru import logger
+
 from vibe3.adapters.resource_root import resolve_resource_root
 from vibe3.agents import (
     CodeagentResult,
@@ -159,8 +161,10 @@ def execute_manual_run(
                 flow_state = SQLiteClient().get_flow_state(branch)
                 if flow_state and flow_state.get("commit_mode"):
                     is_publish_path = True
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(
+                    f"Failed to check flow_state for publish path detection: {e}"
+                )
 
         # Use publish-specific context builder for commit_mode execution
         context_builder = (

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -11,6 +11,7 @@ from vibe3.agents import (
     RunPromptMode,
     create_codeagent_command,
     describe_run_plan_sections,
+    make_publish_context_builder,
     make_run_context_builder,
     make_skill_context_builder,
 )
@@ -150,9 +151,27 @@ def execute_manual_run(
                 handoff_metadata={"skill": skill},
             )
             return None
+
+        # Check if this is a publish path execution (commit_mode from flow_state)
+        is_publish_path = False
+        if branch:
+            try:
+                flow_state = SQLiteClient().get_flow_state(branch)
+                if flow_state and flow_state.get("commit_mode"):
+                    is_publish_path = True
+            except Exception:
+                pass
+
+        # Use publish-specific context builder for commit_mode execution
+        context_builder = (
+            make_publish_context_builder(skill_content)
+            if is_publish_path
+            else make_skill_context_builder(skill_content)
+        )
+
         command = create_codeagent_command(
             role="executor",
-            context_builder=make_skill_context_builder(skill_content),
+            context_builder=context_builder,
             task=instructions or f"Execute skill: {skill}",
             dry_run=dry_run,
             handoff_kind="run",

--- a/tests/vibe3/execution/test_noop_gate_publish.py
+++ b/tests/vibe3/execution/test_noop_gate_publish.py
@@ -1,0 +1,311 @@
+"""Test for publish path safety net in codeagent_runner."""
+
+from unittest.mock import MagicMock, patch
+
+from vibe3.agents.models import CodeagentCommand
+from vibe3.execution.codeagent_runner import CodeagentExecutionService
+from vibe3.models import IssueState
+
+
+def _make_mock_store() -> MagicMock:
+    """Create a mock SQLiteClient."""
+    store = MagicMock()
+    store.get_flow_state.return_value = {}
+    return store
+
+
+def _make_github_issue_payload(state_label: str = "state/plan") -> dict:
+    """Build a GitHub issue payload dict with given state label."""
+    labels = [{"name": state_label}] if state_label else []
+    return {"labels": labels, "state": "open"}
+
+
+def _make_mock_agent_result(success: bool = True, stdout: str = "done") -> MagicMock:
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.exit_code = 0 if success else 1
+    result.stdout = stdout
+    result.stderr = ""
+    result.session_id = "test-session"
+    return result
+
+
+class TestPublishPathSafetyNet:
+    """Tests for publish path safety net logic."""
+
+    def test_safety_net_fires_before_noop_gate(self) -> None:
+        """Safety net should run BEFORE noop gate when conditions are met."""
+        agent_result = _make_mock_agent_result()
+        mock_store = _make_mock_store()
+        # Simulate publish path: commit_mode=True
+        mock_store.get_flow_state.return_value = {"commit_mode": "true"}
+
+        command = CodeagentCommand(
+            role="executor",
+            context_builder=lambda: "publish prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store,
+            ),
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:run",
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.apply_unified_noop_gate"
+            ) as mock_gate,
+            patch(
+                "vibe3.services.label_service.LabelService"
+            ) as mock_label_service_cls,
+        ):
+            # Before state: merge-ready
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/merge-ready"
+            )
+            mock_backend.return_value.run.return_value = agent_result
+            mock_opts.return_value = MagicMock()
+
+            # Mock LabelService to simulate state still merge-ready
+            mock_label_service = MagicMock()
+            mock_label_service.get_state.return_value = IssueState.MERGE_READY
+            mock_label_service_cls.return_value = mock_label_service
+
+            service = CodeagentExecutionService()
+            result = service.execute_sync(command)
+
+        assert result.success
+        # Safety net should have fired
+        mock_label_service.get_state.assert_called_once_with(42)
+        mock_label_service.set_state.assert_called_once_with(42, IssueState.HANDOFF)
+        # Noop gate should still run after safety net
+        mock_gate.assert_called_once()
+
+    def test_safety_net_only_for_executor_commit_mode(self) -> None:
+        """Safety net should only fire for executor with commit_mode."""
+        # Test 1: executor without commit_mode - should not fire
+        mock_store_no_commit = _make_mock_store()
+        mock_store_no_commit.get_flow_state.return_value = {}
+
+        command_executor = CodeagentCommand(
+            role="executor",
+            context_builder=lambda: "prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store_no_commit,
+            ),
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:run",
+            ),
+            patch("vibe3.execution.codeagent_runner.apply_unified_noop_gate"),
+            patch(
+                "vibe3.services.label_service.LabelService"
+            ) as mock_label_service_cls,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/merge-ready"
+            )
+            mock_backend.return_value.run.return_value = _make_mock_agent_result()
+            mock_opts.return_value = MagicMock()
+            mock_label_service = MagicMock()
+            mock_label_service_cls.return_value = mock_label_service
+
+            service = CodeagentExecutionService()
+            service.execute_sync(command_executor)
+
+        # Safety net should NOT fire (no commit_mode)
+        mock_label_service.set_state.assert_not_called()
+
+        # Test 2: planner with commit_mode - should not fire
+        mock_store_planner = _make_mock_store()
+        mock_store_planner.get_flow_state.return_value = {"commit_mode": "true"}
+
+        command_planner = CodeagentCommand(
+            role="planner",
+            context_builder=lambda: "prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store_planner,
+            ),
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:plan",
+            ),
+            patch("vibe3.execution.codeagent_runner.apply_unified_noop_gate"),
+            patch(
+                "vibe3.services.label_service.LabelService"
+            ) as mock_label_service_cls,
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/merge-ready"
+            )
+            mock_backend.return_value.run.return_value = _make_mock_agent_result()
+            mock_opts.return_value = MagicMock()
+            mock_label_service = MagicMock()
+            mock_label_service_cls.return_value = mock_label_service
+
+            service = CodeagentExecutionService()
+            service.execute_sync(command_planner)
+
+        # Safety net should NOT fire (wrong role)
+        mock_label_service.set_state.assert_not_called()
+
+    def test_safety_net_skipped_if_state_already_handoff(self) -> None:
+        """Safety net should not transition if state is already handoff."""
+        agent_result = _make_mock_agent_result()
+        mock_store = _make_mock_store()
+        mock_store.get_flow_state.return_value = {"commit_mode": "true"}
+
+        command = CodeagentCommand(
+            role="executor",
+            context_builder=lambda: "publish prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store,
+            ),
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:run",
+            ),
+            patch("vibe3.execution.codeagent_runner.apply_unified_noop_gate"),
+            patch(
+                "vibe3.services.label_service.LabelService"
+            ) as mock_label_service_cls,
+        ):
+            # Before state: merge-ready (captured before agent)
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/merge-ready"
+            )
+            mock_backend.return_value.run.return_value = agent_result
+            mock_opts.return_value = MagicMock()
+
+            # But current state is already handoff (agent succeeded)
+            mock_label_service = MagicMock()
+            mock_label_service.get_state.return_value = IssueState.HANDOFF
+            mock_label_service_cls.return_value = mock_label_service
+
+            service = CodeagentExecutionService()
+            service.execute_sync(command)
+
+        # Safety net should check state, but NOT transition
+        mock_label_service.get_state.assert_called_once_with(42)
+        mock_label_service.set_state.assert_not_called()
+
+    def test_safety_net_uses_label_service_not_subprocess(self) -> None:
+        """Verify safety net uses LabelService instead of raw subprocess."""
+        agent_result = _make_mock_agent_result()
+        mock_store = _make_mock_store()
+        mock_store.get_flow_state.return_value = {"commit_mode": "true"}
+
+        command = CodeagentCommand(
+            role="executor",
+            context_builder=lambda: "publish prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store,
+            ),
+            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:run",
+            ),
+            patch("vibe3.execution.codeagent_runner.apply_unified_noop_gate"),
+            patch(
+                "vibe3.services.label_service.LabelService"
+            ) as mock_label_service_cls,
+            patch("subprocess.run") as mock_subprocess,  # Should NOT be called
+        ):
+            mock_gh.return_value.view_issue.return_value = _make_github_issue_payload(
+                "state/merge-ready"
+            )
+            mock_backend.return_value.run.return_value = agent_result
+            mock_opts.return_value = MagicMock()
+
+            mock_label_service = MagicMock()
+            mock_label_service.get_state.return_value = IssueState.MERGE_READY
+            mock_label_service_cls.return_value = mock_label_service
+
+            service = CodeagentExecutionService()
+            service.execute_sync(command)
+
+        # Verify LabelService is used
+        mock_label_service.set_state.assert_called_once()
+        # Verify subprocess is NOT used for gh issue edit (safety net uses LabelService)
+        # Note: subprocess may be called for other purposes (e.g., git operations)
+        for call in mock_subprocess.call_args_list:
+            args = call[0][0] if call[0] else []
+            # Ensure no 'gh issue edit' calls were made
+            if args and args[0] == "gh" and "issue" in args and "edit" in args:
+                raise AssertionError(
+                    f"Safety net should use LabelService, not subprocess. "
+                    f"Found gh issue edit call: {args}"
+                )


### PR DESCRIPTION
## Summary

Fix executor publish path state transition issue (#1830).

**Problem**: Executor in commit_mode would leave state at `state/merge-ready` after PR creation instead of transitioning to `state/handoff` or `state/done`, requiring unnecessary governance intervention.

**Solution**: Add publish path safety net logic that runs before noop gate to force state transition if executor completed but state is still merge-ready.

## Changes

1. **fix(executor): add publish-specific exit contract for commit_mode execution**
   - Ensure executor properly transitions state after commit_mode execution

2. **fix(execution): move publish path safety net before noop gate**
   - Add safety net logic that checks if executor ran in commit_mode and state is still merge-ready
   - Force transition to handoff state if needed
   - Runs BEFORE noop gate to prevent blocked state

3. **config: increase codeagent_runner.py LOC limit for safety net logic**
   - Increase exception limit from 580 to 610 lines
   - Accommodate +25 lines of safety net logic

## Test Plan

- [x] All pre-push checks passed (type check, tests, LOC checks)
- [x] 41 tests passed in incremental test suite
- [x] Pre-commit checks passed (black, ruff, mypy, shellcheck)

## Related

- Fixes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
