### PR TITLE
fix(governance): 防止 auto-cleanup 和 Epic 收口检查的重复评论（#865 遗留问题）

### DIFF
--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -159,6 +159,8 @@ Forbidden:
 
 **验证失败处理**：
 
+**防重复（强制）**：在执行 cleanup comment 前，检查该 issue 最新评论。如果最新评论已是相同的 `[governance auto-cleanup]` 内容（相同清理原因），跳过评论，仅在 stdout 记录。
+
 ```bash
 gh issue edit <issue-number> --remove-label "orchestra-governed"
 gh issue comment <issue-number> --body "[governance auto-cleanup] 移除 orchestra-governed：issue 不再满足持有条件（无 assignee / assignee 非 manager / 已关闭），允许重新进入评估"
@@ -412,6 +414,9 @@ Steps:
      f. **所有 sub-issues 已完成**：
         - 这是高置信度终局条件：all sub-issues completed → 直接关闭 epic
         - 关闭前执行未完成工作检查；如有剩余工作，创建 follow-up issue 并在关闭评论中引用
+        - **防重复（强制）**：
+          - 所有 sub-issues 已完成 → 直接关闭 epic，写 `[governance close]` 评论（不要写 suggest）
+          - 写评论前检查最新评论：如果最新评论已是 `[governance close]` 或 `[governance suggest] 建议关闭此 Epic`，跳过评论
         - 写 `[governance close]` 评论说明 sub-issues 状态和关闭理由
         - 关闭原 epic；不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
      g. **部分 sub-issues 未完成**：
@@ -564,10 +569,12 @@ Exit:
 - **去重检查**：若已存在相同类型的 `[governance decide]` 或 `[governance suggest]` 评论（关键字匹配），跳过该评论
 - **类型匹配规则**：
   - `[governance suggest] 建议关闭此 Issue` → 检查是否已有"建议关闭"
+  - `[governance suggest] 建议关闭此 Epic` → 检查最新评论是否已建议关闭此 Epic
   - `[governance suggest] 建议恢复此 Issue` → 检查是否已有"建议恢复"
   - `[governance suggest] 入池评估` → 检查是否已有"入池评估"
   - `[governance suggest] 关注` → 检查是否已有"关注"且关注原因相同
   - `[governance decide]` 恢复 → 检查是否已有相同恢复动作
+  - `[governance auto-cleanup] 移除 orchestra-governed` → 检查最新评论是否已是相同的 auto-cleanup 动作（比对清理原因）
   - `[governance close] 已关闭此 Epic` → 关闭前检查 issue 是否已经 CLOSED，避免重复 close
 - **跳过时的输出**：在 governance 输出中记录"已建议（跳过重复评论）"，说明原因
 - **目的**：避免重复刷屏，保持 issue 讨论清洁


### PR DESCRIPTION
## Summary

- 扩展 governance 去重规则，防止 `[governance auto-cleanup]` 和 `[governance suggest] 建议关闭此 Epic` 的重复评论
- 在 Step 0 (标签验证与清理) 添加防重复指令，检查最新评论后再发布 cleanup 评论
- 在 Step 6 (Epic 收口检查) 添加防重复指令，确保已完成 Epic 只关闭一次，不重复建议

## 问题背景

Issue #865 实现了 `vibe-task` 标签过滤，防止入池评估的重复评论。但遗留了两个问题：

1. `[governance auto-cleanup]` 评论重复（Issue #1844 有 5 条重复）
2. Epic 收口建议评论重复（Issue #1844 有 2 条重复）

根本原因：这两类评论绕过了 `orchestra-governed` 标签过滤，每次 scan 都会执行。

## Changes

- `supervisor/governance/assignee-pool.md`: 扩展去重规则 section，添加两种评论类型的去重匹配规则
- 在 Step 0 和 Step 6 添加明确的防重复指令，检查最新评论是否已存在相同内容

## Test Plan

- ✅ Prompt-only 修改，无需自动化测试
- ✅ 手动审查：所有 4 个 plan requirements 已实现（line 572, 577, 162, 417-419）
- 🔄 实际验证：等待下次 governance scan 确认不再产生重复评论

Fixes #2018

## Contributors

claude/sonnet-4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)