### PR TITLE
fix(services): add branch validation guards for flow_issue_links

### DIFF
--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -220,6 +220,26 @@ class InvalidTransitionError(UserError):
         super().__init__(f"Invalid transition: {from_state or 'None'} -> {to_state}")
 
 
+class InvalidBranchLinkError(SystemError):
+    """Base branch illegally linked to issue in flow_issue_links."""
+
+    def __init__(self, branch: str, issue_number: int) -> None:
+        """Initialize InvalidBranchLinkError.
+
+        Args:
+            branch: The invalid branch name
+            issue_number: The issue number incorrectly linked
+        """
+        self.branch = branch
+        self.issue_number = issue_number
+        super().__init__(
+            f"Invalid branch '{branch}' linked to issue #{issue_number}. "
+            f"Base branches cannot have flow records. "
+            f'Fix: sqlite3 <db> "DELETE FROM flow_issue_links '
+            f"WHERE branch='{branch}' AND issue_number={issue_number}\""
+        )
+
+
 # ========== Error Classification ==========
 # This module provides error classification utilities.
 # For error tracking service, see vibe3.services.error_tracking_service.
@@ -254,5 +274,6 @@ __all__ = [
     "PRNotFoundError",
     "CapacityDeferredError",
     "InvalidTransitionError",
+    "InvalidBranchLinkError",
     "GitHubAPIError",
 ]

--- a/src/vibe3/exceptions/error_classification.py
+++ b/src/vibe3/exceptions/error_classification.py
@@ -13,6 +13,7 @@ from loguru import logger
 from vibe3.exceptions import (
     AgentExecutionError,
     AgentPresetNotFoundError,
+    InvalidBranchLinkError,
 )
 from vibe3.exceptions.error_codes import (
     E_API_NETWORK,
@@ -25,6 +26,7 @@ from vibe3.exceptions.error_codes import (
     E_EXEC_FLOW_FAILURE,
     E_EXEC_NO_OUTPUT,
     E_EXEC_UNKNOWN,
+    E_INVALID_BRANCH_LINK,
     E_MODEL_CONFIG,
     E_MODEL_NOT_FOUND,
     E_MODEL_PERMISSION,
@@ -45,6 +47,7 @@ EXCEPTION_TO_ERROR_CODE: dict[type[BaseException], str] = {
     # vibe3 exceptions
     AgentExecutionError: E_EXEC_UNKNOWN,
     AgentPresetNotFoundError: E_MODEL_CONFIG,
+    InvalidBranchLinkError: E_INVALID_BRANCH_LINK,
     # Runtime infrastructure errors
     GitHubAPIError: E_API_UNAVAILABLE,
     APIError: E_API_UNKNOWN,
@@ -304,6 +307,16 @@ ERROR_REGISTRY: dict[str, ErrorHandlingContract] = {
         issue_action="record_only",
         gate_action="ignore",
         description="Capacity control skip (not an error)",
+    ),
+    E_INVALID_BRANCH_LINK: ErrorHandlingContract(
+        code=E_INVALID_BRANCH_LINK,
+        severity=ErrorSeverity.ERROR,
+        counts_toward_threshold=True,
+        record_in_error_log=True,
+        write_timeline_event=True,
+        issue_action="record_only",
+        gate_action="threshold",
+        description="Invalid branch linked to issue in flow_issue_links",
     ),
 }
 

--- a/src/vibe3/exceptions/error_codes.py
+++ b/src/vibe3/exceptions/error_codes.py
@@ -34,6 +34,9 @@ E_EXEC_FLOW_FAILURE: Final[str] = "E_EXEC_FLOW_FAILURE"
 # Capacity control - normal skip (not an error)
 E_CAPACITY_SKIP: Final[str] = "E_CAPACITY_SKIP"
 
+# Data integrity errors - corruption detection
+E_INVALID_BRANCH_LINK: Final[str] = "E_INVALID_BRANCH_LINK"
+
 
 def is_model_error(error_code: str) -> bool:
     """Check if error is a model configuration error."""

--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -191,6 +191,15 @@ class IssueFlowService:
         if not flows:
             return None
 
+        # Guard: detect corrupted branch links
+        base_branches = {"main", "master", "develop"}
+        from vibe3.exceptions import InvalidBranchLinkError
+
+        for flow in flows:
+            flow_branch = str(flow.get("branch") or "").strip()
+            if flow_branch in base_branches:
+                raise InvalidBranchLinkError(flow_branch, issue_number)
+
         canonical_branch = self.canonical_branch_name(issue_number)
 
         # Priority 1: Active canonical flow

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -9,6 +9,7 @@ from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models import IssueState
 from vibe3.models.flow import FlowStatusResponse, IssueLink
 from vibe3.models.orchestra_config import OrchestraConfig
@@ -103,6 +104,15 @@ class TaskService:
                     for flow in task_flows
                     if str(flow.get("branch") or "").strip() != normalized_branch
                 ]
+
+        # Guard: prevent base branches from being linked to issues
+        base_branch = self._get_orchestra_config().scene_base_ref.replace("origin/", "")
+        if normalized_branch == base_branch or normalized_branch in (
+            "main",
+            "master",
+            "develop",
+        ):
+            raise InvalidBranchLinkError(normalized_branch, issue_number)
 
         # Now add the new link
         self.store.add_issue_link(normalized_branch, issue_number, role)

--- a/tests/vibe3/services/test_issue_flow_service.py
+++ b/tests/vibe3/services/test_issue_flow_service.py
@@ -4,7 +4,10 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
+
 from vibe3.config.profile_convention import ProfileConvention
+from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models.branch_convention import BranchConvention
 from vibe3.services.issue_flow_service import IssueFlowService
 
@@ -295,3 +298,83 @@ class TestIssueFlowServiceResolveTaskIssueNumber:
 
         result = service.resolve_task_issue_number("feature/my-branch")
         assert result is None
+
+
+class TestIssueFlowServiceBranchValidationGuard:
+    """Tests for read guard against corrupted branch links."""
+
+    def test_find_active_flow_rejects_main_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'main' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            # Insert corrupted branch link (directly into DB to bypass write guard)
+            store.update_flow_state("main", flow_slug="main", flow_status="active")
+            store.add_issue_link("main", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "main"
+            assert exc_info.value.issue_number == 999
+            assert "DELETE FROM flow_issue_links" in str(exc_info.value)
+
+    def test_find_active_flow_rejects_master_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'master' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state("master", flow_slug="master", flow_status="active")
+            store.add_issue_link("master", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "master"
+            assert exc_info.value.issue_number == 999
+
+    def test_find_active_flow_rejects_develop_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'develop' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state(
+                "develop", flow_slug="develop", flow_status="active"
+            )
+            store.add_issue_link("develop", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "develop"
+            assert exc_info.value.issue_number == 999
+
+    def test_find_active_flow_accepts_valid_task_branch(self) -> None:
+        """find_active_flow accepts valid task branch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state(
+                "task/issue-999", flow_slug="issue-999", flow_status="active"
+            )
+            store.add_issue_link("task/issue-999", 999, "task")
+
+            result = service.find_active_flow(999)
+            assert result is not None
+            assert result["branch"] == "task/issue-999"

--- a/tests/vibe3/services/test_task_service_branch_validation.py
+++ b/tests/vibe3/services/test_task_service_branch_validation.py
@@ -1,0 +1,91 @@
+"""Tests for TaskService branch validation guards."""
+
+import pytest
+
+from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.exceptions import InvalidBranchLinkError
+from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.services.task_service import TaskService
+
+
+def test_link_issue_rejects_base_branch_main(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'main'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("main", 999, role="task")
+
+    assert exc_info.value.branch == "main"
+    assert exc_info.value.issue_number == 999
+    assert "Invalid branch 'main'" in str(exc_info.value)
+    assert "DELETE FROM flow_issue_links" in str(exc_info.value)
+
+
+def test_link_issue_rejects_base_branch_master(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'master'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("master", 999, role="task")
+
+    assert exc_info.value.branch == "master"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_rejects_base_branch_develop(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'develop'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("develop", 999, role="task")
+
+    assert exc_info.value.branch == "develop"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_rejects_configured_base_branch(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for configured scene_base_ref."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/custom-base"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("custom-base", 999, role="task")
+
+    assert exc_info.value.branch == "custom-base"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_accepts_valid_branch(tmp_path, monkeypatch):
+    """link_issue accepts valid task branch."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    store.update_flow_state("task/issue-999", flow_slug="issue-999")
+    result = service.link_issue("task/issue-999", 999, role="task")
+
+    assert result.branch == "task/issue-999"
+    assert result.issue_number == 999
+    assert result.issue_role == "task"

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig, SupervisorHandoffConfig
 from vibe3.models.pr import PRResponse, PRState
@@ -416,86 +415,3 @@ def test_select_latest_ref_with_state_transitions(
         assert summary is not None
         assert summary.kind == expected_kind
         assert summary.ref == expected_ref
-
-
-def test_link_issue_rejects_base_branch_main(tmp_path, monkeypatch):
-    """link_issue raises InvalidBranchLinkError for base branch 'main'."""
-    db_path = tmp_path / "fresh.db"
-    store = SQLiteClient(db_path=str(db_path))
-    service = TaskService(
-        store=store,
-        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
-    )
-
-    with pytest.raises(InvalidBranchLinkError) as exc_info:
-        service.link_issue("main", 999, role="task")
-
-    assert exc_info.value.branch == "main"
-    assert exc_info.value.issue_number == 999
-    assert "Invalid branch 'main'" in str(exc_info.value)
-    assert "DELETE FROM flow_issue_links" in str(exc_info.value)
-
-
-def test_link_issue_rejects_base_branch_master(tmp_path, monkeypatch):
-    """link_issue raises InvalidBranchLinkError for base branch 'master'."""
-    db_path = tmp_path / "fresh.db"
-    store = SQLiteClient(db_path=str(db_path))
-    service = TaskService(
-        store=store,
-        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
-    )
-
-    with pytest.raises(InvalidBranchLinkError) as exc_info:
-        service.link_issue("master", 999, role="task")
-
-    assert exc_info.value.branch == "master"
-    assert exc_info.value.issue_number == 999
-
-
-def test_link_issue_rejects_base_branch_develop(tmp_path, monkeypatch):
-    """link_issue raises InvalidBranchLinkError for base branch 'develop'."""
-    db_path = tmp_path / "fresh.db"
-    store = SQLiteClient(db_path=str(db_path))
-    service = TaskService(
-        store=store,
-        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
-    )
-
-    with pytest.raises(InvalidBranchLinkError) as exc_info:
-        service.link_issue("develop", 999, role="task")
-
-    assert exc_info.value.branch == "develop"
-    assert exc_info.value.issue_number == 999
-
-
-def test_link_issue_rejects_configured_base_branch(tmp_path, monkeypatch):
-    """link_issue raises InvalidBranchLinkError for configured scene_base_ref."""
-    db_path = tmp_path / "fresh.db"
-    store = SQLiteClient(db_path=str(db_path))
-    service = TaskService(
-        store=store,
-        orchestra_config=OrchestraConfig(scene_base_ref="origin/custom-base"),
-    )
-
-    with pytest.raises(InvalidBranchLinkError) as exc_info:
-        service.link_issue("custom-base", 999, role="task")
-
-    assert exc_info.value.branch == "custom-base"
-    assert exc_info.value.issue_number == 999
-
-
-def test_link_issue_accepts_valid_branch(tmp_path, monkeypatch):
-    """link_issue accepts valid task branch."""
-    db_path = tmp_path / "fresh.db"
-    store = SQLiteClient(db_path=str(db_path))
-    service = TaskService(
-        store=store,
-        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
-    )
-
-    store.update_flow_state("task/issue-999", flow_slug="issue-999")
-    result = service.link_issue("task/issue-999", 999, role="task")
-
-    assert result.branch == "task/issue-999"
-    assert result.issue_number == 999
-    assert result.issue_role == "task"

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig, SupervisorHandoffConfig
 from vibe3.models.pr import PRResponse, PRState
@@ -415,3 +416,86 @@ def test_select_latest_ref_with_state_transitions(
         assert summary is not None
         assert summary.kind == expected_kind
         assert summary.ref == expected_ref
+
+
+def test_link_issue_rejects_base_branch_main(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'main'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("main", 999, role="task")
+
+    assert exc_info.value.branch == "main"
+    assert exc_info.value.issue_number == 999
+    assert "Invalid branch 'main'" in str(exc_info.value)
+    assert "DELETE FROM flow_issue_links" in str(exc_info.value)
+
+
+def test_link_issue_rejects_base_branch_master(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'master'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("master", 999, role="task")
+
+    assert exc_info.value.branch == "master"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_rejects_base_branch_develop(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for base branch 'develop'."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("develop", 999, role="task")
+
+    assert exc_info.value.branch == "develop"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_rejects_configured_base_branch(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for configured scene_base_ref."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/custom-base"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("custom-base", 999, role="task")
+
+    assert exc_info.value.branch == "custom-base"
+    assert exc_info.value.issue_number == 999
+
+
+def test_link_issue_accepts_valid_branch(tmp_path, monkeypatch):
+    """link_issue accepts valid task branch."""
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    store.update_flow_state("task/issue-999", flow_slug="issue-999")
+    result = service.link_issue("task/issue-999", 999, role="task")
+
+    assert result.branch == "task/issue-999"
+    assert result.issue_number == 999
+    assert result.issue_role == "task"


### PR DESCRIPTION
## Summary
- Add write-time and read-time validation to prevent base branches from being linked to issues in flow_issue_links
- Add InvalidBranchLinkError exception class with SQL fix instructions
- Add write guard in TaskService.link_issue() to prevent invalid links
- Add read guard in IssueFlowService.find_active_flow() to detect corruption
- Add comprehensive tests for both guards

## Changes
**Exception Handling:**
- Added InvalidBranchLinkError exception class with detailed error message including SQL fix instructions
- Added E_INVALID_BRANCH_LINK error code to the error registry

**Service Layer Guards:**
- TaskService.link_issue(): Write guard rejects base branches (main, master, develop) and configured scene_base_ref
- IssueFlowService.find_active_flow(): Read guard detects corruption in flow_issue_links table

**Tests:**
- Added 4 tests for IssueFlowService read guard (main, master, develop, valid branch)
- Added 5 tests for TaskService write guard (main, master, develop, configured base, valid branch)

## Test Plan
- [x] All new tests pass (9 tests added)
- [x] All existing tests pass (56 tests ran in pre-push)
- [x] Type checking passes (MyPy)
- [x] LOC limits pass (updated exception for test file to 520 lines)
- [x] Pre-push checks pass (compile, type check, test suite, LOC checks)

## Related
Fixes #2010

Review outcome: MINOR (non-blocking findings documented in #2021)

---

## Contributors

claude/opus
