### PR TITLE
feat(commands): add --branch/--dry-run/--show-prompt to internal manager

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -140,6 +140,9 @@ code_limits:
         reason: "配置加载核心模块，包含配置文件查找、YAML 加载、环境变量覆盖、keys.env fallback（repo root 相对路径解析）、变量展开等紧密耦合的配置加载逻辑；新增 load_runtime_config() 统一入口（issue #1925）、target_repo 参数支持、lazy import 注释和 repo root 检测逻辑后略微超标"
 
       # 基础设施核心模块
+      - path: "src/vibe3/agents/backends/async_launcher.py"
+        limit: 410
+        reason: "Async launcher 聚合，包含 tmux session 管理、log path 分配、env passthrough 等紧密耦合逻辑；新增 VIBE3_ASYNC_CHILD 到 CRITICAL_ENV_PASSTHROUGH 修复 pre-push hook 测试失败"
       - path: "src/vibe3/environment/worktree_lifecycle.py"
         limit: 500
         reason: "Worktree creation, validation, and find-or-create core logic extracted from worktree.py for size management; contains creation methods, validation helpers, recorded path lookup, and unified worktree resolution logic"

--- a/src/vibe3/agents/backends/async_launcher.py
+++ b/src/vibe3/agents/backends/async_launcher.py
@@ -22,6 +22,7 @@ CRITICAL_ENV_PASSTHROUGH = {
     "SHELL",
     "TMPDIR",
     "USER",
+    "VIBE3_ASYNC_CHILD",
 }
 
 

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -5,7 +5,13 @@ from typing import Annotated
 
 import typer
 
+from vibe3.commands.command_options import (
+    _ASYNC_OPT,
+    _DRY_RUN_OPT,
+    _SHOW_PROMPT_OPT,
+)
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.services.branch_arg import resolve_branch_arg
 from vibe3.services.issue_context_loader import load_issue_info
 
 app = typer.Typer(
@@ -19,13 +25,13 @@ app = typer.Typer(
 @app.command("manager")
 def internal_manager_dispatch(
     issue: Annotated[int, typer.Argument(help="Issue number to manage")],
-    no_async: Annotated[
-        bool,
-        typer.Option(
-            "--no-async",
-            help="Run synchronously (blocking) instead of async tmux session",
-        ),
-    ] = False,
+    no_async: _ASYNC_OPT = False,
+    dry_run: _DRY_RUN_OPT = False,
+    show_prompt: _SHOW_PROMPT_OPT = False,
+    branch: Annotated[
+        str | None,
+        typer.Option("--branch", help="Branch name or issue number"),
+    ] = None,
 ) -> None:
     """L3: Dispatch the State Manager agent."""
     from vibe3.execution.issue_role_sync_runner import (
@@ -34,19 +40,23 @@ def internal_manager_dispatch(
     )
     from vibe3.roles.manager import MANAGER_SYNC_SPEC
 
+    resolved_branch = resolve_branch_arg(branch) if branch is not None else None
+
     if no_async:
         run_issue_role_sync(
             issue_number=issue,
-            dry_run=False,  # Execution-only, no dry-run
+            dry_run=dry_run,
             fresh_session=False,
-            show_prompt=False,
+            show_prompt=show_prompt,
             spec=MANAGER_SYNC_SPEC,
+            branch=resolved_branch,
         )
     else:
         run_issue_role_async(
             issue_number=issue,
-            dry_run=False,  # Execution-only, no dry-run
+            dry_run=dry_run,
             spec=MANAGER_SYNC_SPEC,
+            branch=resolved_branch,
         )
 
 

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -11,7 +11,6 @@ from vibe3.commands.command_options import (
     _SHOW_PROMPT_OPT,
 )
 from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.services.branch_arg import resolve_branch_arg
 from vibe3.services.issue_context_loader import load_issue_info
 
 app = typer.Typer(
@@ -40,8 +39,6 @@ def internal_manager_dispatch(
     )
     from vibe3.roles.manager import MANAGER_SYNC_SPEC
 
-    resolved_branch = resolve_branch_arg(branch) if branch is not None else None
-
     if no_async:
         run_issue_role_sync(
             issue_number=issue,
@@ -49,14 +46,14 @@ def internal_manager_dispatch(
             fresh_session=False,
             show_prompt=show_prompt,
             spec=MANAGER_SYNC_SPEC,
-            branch=resolved_branch,
+            branch=branch,
         )
     else:
         run_issue_role_async(
             issue_number=issue,
             dry_run=dry_run,
             spec=MANAGER_SYNC_SPEC,
-            branch=resolved_branch,
+            branch=branch,
         )
 
 

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -16,6 +16,7 @@ from vibe3.services import (
     load_issue_info,
     record_dispatch_failure_if_unexpected,
 )
+from vibe3.services.branch_arg import resolve_branch_arg
 
 
 def run_issue_role_async(
@@ -36,7 +37,9 @@ def run_issue_role_async(
     issue = load_issue_info(issue_number, config=config)
 
     store = SQLiteClient()
-    if branch is None:
+    if branch is not None:
+        branch = resolve_branch_arg(branch)
+    else:
         current_branch = GitClient().get_current_branch()
         branch = spec.resolve_branch(store, issue_number, current_branch)
 
@@ -129,7 +132,9 @@ def run_issue_role_sync(
     issue = load_issue_info(issue_number, config=config)
 
     store = SQLiteClient()
-    if branch is None:
+    if branch is not None:
+        branch = resolve_branch_arg(branch)
+    else:
         current_branch = GitClient().get_current_branch()
         branch = spec.resolve_branch(store, issue_number, current_branch)
     flow_state = store.get_flow_state(branch) if branch else None

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -23,6 +23,7 @@ def run_issue_role_async(
     issue_number: int,
     dry_run: bool,
     spec: IssueRoleSyncSpec,
+    branch: str | None = None,
 ) -> None:
     """Run a role asynchronously via tmux wrapper.
 
@@ -35,8 +36,9 @@ def run_issue_role_async(
     issue = load_issue_info(issue_number, config=config)
 
     store = SQLiteClient()
-    current_branch = GitClient().get_current_branch()
-    branch = spec.resolve_branch(store, issue_number, current_branch)
+    if branch is None:
+        current_branch = GitClient().get_current_branch()
+        branch = spec.resolve_branch(store, issue_number, current_branch)
 
     options = spec.resolve_options(config)
     actor = format_agent_actor(options)
@@ -102,6 +104,8 @@ def run_issue_role_async(
             raise typer.Exit(1) from exc
 
     typer.echo(f"-> {spec.role_name} run: issue #{issue_number} (async dry-run)")
+    typer.echo(f"   branch: {branch}")
+    typer.echo(f"   actor:  {actor}")
 
 
 def run_issue_role_sync(
@@ -111,6 +115,7 @@ def run_issue_role_sync(
     fresh_session: bool,
     show_prompt: bool,
     spec: IssueRoleSyncSpec,
+    branch: str | None = None,
 ) -> None:
     """Run a role synchronously (direct execution without tmux wrapper).
 
@@ -124,8 +129,9 @@ def run_issue_role_sync(
     issue = load_issue_info(issue_number, config=config)
 
     store = SQLiteClient()
-    current_branch = GitClient().get_current_branch()
-    branch = spec.resolve_branch(store, issue_number, current_branch)
+    if branch is None:
+        current_branch = GitClient().get_current_branch()
+        branch = spec.resolve_branch(store, issue_number, current_branch)
     flow_state = store.get_flow_state(branch) if branch else None
     session_id = (
         None if fresh_session else load_session_id(spec.role_name, branch=branch)
@@ -157,6 +163,8 @@ def run_issue_role_sync(
 
     if dry_run:
         typer.echo(f"-> {spec.role_name} run: issue #{issue_number} (dry-run)")
+        typer.echo(f"   branch: {branch}")
+        typer.echo(f"   actor:  {actor}")
         return
 
     if not sync_result.launched:

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -57,7 +57,7 @@ def test_internal_manager_show_prompt():
 
 
 def test_internal_manager_branch_override():
-    """测试 internal manager --branch 参数透传."""
+    """测试 internal manager --branch 参数透传 (sync path)."""
     with patch(
         "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
     ) as mock_run:
@@ -79,22 +79,34 @@ def test_internal_manager_branch_override():
         assert mock_run.call_args.kwargs["branch"] == "task/issue-1905"
 
 
-def test_internal_manager_dry_run_summary_output():
-    """测试 internal manager --dry-run 输出包含 branch 和 actor 信息."""
+def test_internal_manager_branch_override_async():
+    """测试 internal manager --branch 参数透传 (async path)."""
     with patch(
-        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_async"
     ) as mock_run:
-        # Mock the actual dry-run output
-        mock_run.return_value = None
         result = runner.invoke(
-            cli_app, ["internal", "manager", "1905", "--no-async", "--dry-run"]
+            cli_app,
+            ["internal", "manager", "123", "--branch", "task/issue-1905"],
         )
 
         assert result.exit_code == 0
-        # Verify dry_run=True is passed
-        assert mock_run.call_args.kwargs["dry_run"] is True
-        # The actual output verification would require running the real function
-        # which is tested in test_issue_role_sync_runner.py
+        assert mock_run.call_args.kwargs["issue_number"] == 123
+        assert mock_run.call_args.kwargs["branch"] == "task/issue-1905"
+        assert mock_run.call_args.kwargs["dry_run"] is False
+
+
+def test_internal_manager_branch_numeric():
+    """测试 --branch 接受 issue number，CLI 层透传原始值由 runner 解析."""
+    with patch(
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+    ) as mock_run:
+        result = runner.invoke(
+            cli_app,
+            ["internal", "manager", "123", "--no-async", "--branch", "1905"],
+        )
+
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["branch"] == "1905"
 
 
 def test_internal_apply_dispatch():

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -20,8 +20,81 @@ def test_internal_manager_dispatch():
         assert result.exit_code == 0
         assert mock_run.call_args.kwargs["issue_number"] == 123
         assert mock_run.call_args.kwargs["dry_run"] is False
+        assert mock_run.call_args.kwargs["show_prompt"] is False
         assert mock_run.call_args.kwargs["fresh_session"] is False
         assert mock_run.call_args.kwargs["spec"].role_name == "manager"
+
+
+def test_internal_manager_dry_run():
+    """测试 internal manager --dry-run 参数透传."""
+    with patch(
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+    ) as mock_run:
+        result = runner.invoke(
+            cli_app, ["internal", "manager", "123", "--no-async", "--dry-run"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["issue_number"] == 123
+        assert mock_run.call_args.kwargs["dry_run"] is True
+        assert mock_run.call_args.kwargs["show_prompt"] is False
+
+
+def test_internal_manager_show_prompt():
+    """测试 internal manager --show-prompt 参数透传."""
+    with patch(
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+    ) as mock_run:
+        result = runner.invoke(
+            cli_app,
+            ["internal", "manager", "123", "--no-async", "--dry-run", "--show-prompt"],
+        )
+
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["issue_number"] == 123
+        assert mock_run.call_args.kwargs["dry_run"] is True
+        assert mock_run.call_args.kwargs["show_prompt"] is True
+
+
+def test_internal_manager_branch_override():
+    """测试 internal manager --branch 参数透传."""
+    with patch(
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+    ) as mock_run:
+        result = runner.invoke(
+            cli_app,
+            [
+                "internal",
+                "manager",
+                "123",
+                "--no-async",
+                "--dry-run",
+                "--branch",
+                "task/issue-1905",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["issue_number"] == 123
+        assert mock_run.call_args.kwargs["branch"] == "task/issue-1905"
+
+
+def test_internal_manager_dry_run_summary_output():
+    """测试 internal manager --dry-run 输出包含 branch 和 actor 信息."""
+    with patch(
+        "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+    ) as mock_run:
+        # Mock the actual dry-run output
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli_app, ["internal", "manager", "1905", "--no-async", "--dry-run"]
+        )
+
+        assert result.exit_code == 0
+        # Verify dry_run=True is passed
+        assert mock_run.call_args.kwargs["dry_run"] is True
+        # The actual output verification would require running the real function
+        # which is tested in test_issue_role_sync_runner.py
 
 
 def test_internal_apply_dispatch():


### PR DESCRIPTION
## Summary
- Add `--branch` parameter to override branch resolution (accepts branch name or issue number)
- Add `--dry-run` parameter to print command summary without executing
- Add `--show-prompt` parameter to print full rendered prompt with `--dry-run`
- Fix pre-push hook test failures by adding `VIBE3_ASYNC_CHILD` to critical env passthrough

## Changes
- Modified `src/vibe3/commands/internal.py` to add CLI parameters
- Modified `src/vibe3/execution/issue_role_sync_runner.py` to support `branch` parameter (backward-compatible)
- Added comprehensive tests in `tests/vibe3/commands/test_internal.py`
- Fixed `src/vibe3/agents/backends/async_launcher.py` to ensure `VIBE3_ASYNC_CHILD` is always passed through
- Added LOC exception for `async_launcher.py` (was already at 400-line limit)

## Test Plan
- [x] All existing tests pass (9/9 direct, 127/127 incremental)
- [x] New tests for `--branch`, `--dry-run`, and `--show-prompt` parameters
- [x] Pre-push hook passes (including previously failing async tests)
- [x] Type checking passes (mypy)
- [x] LOC checks pass

Closes #1905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
