### PR TITLE
refactor(agents): migrate internal imports to public API paths

### DIFF
--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -72,7 +72,7 @@ from vibe3.agents.run_prompt import (
     make_run_context_builder,
     make_skill_context_builder,
 )
-from vibe3.models.prompt_meta import PromptContextMode
+from vibe3.models import PromptContextMode
 
 __all__ = [
     # Protocols & Models

--- a/src/vibe3/agents/backends/__init__.py
+++ b/src/vibe3/agents/backends/__init__.py
@@ -14,7 +14,7 @@ from vibe3.agents.backends.async_launcher import (
 )
 from vibe3.agents.backends.codeagent import CodeagentBackend
 from vibe3.agents.backends.codeagent_config import sync_models_json
-from vibe3.config.agent_preset import resolve_effective_agent_options
+from vibe3.config import resolve_effective_agent_options
 
 __all__ = [
     "CodeagentBackend",

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -21,13 +21,14 @@ from vibe3.agents.backends.session_manager import (
     extract_session_id,
     should_retry_without_session,
 )
+from vibe3.config import resolve_effective_agent_options
 from vibe3.config.agent_preset import (
     has_agent_env_override,
-    resolve_effective_agent_options,
     resolve_repo_agent_preset_name,
 )
 from vibe3.exceptions import AgentExecutionError
-from vibe3.models.review_runner import AgentOptions, AgentResult
+from vibe3.models import AgentOptions
+from vibe3.models.review_runner import AgentResult
 from vibe3.utils.codeagent_helpers import (
     build_prompt_file_content,
     diagnose_backend_error,

--- a/src/vibe3/agents/backends/codeagent_config.py
+++ b/src/vibe3/agents/backends/codeagent_config.py
@@ -9,12 +9,9 @@ from typing import Any, Final
 
 from loguru import logger
 
-from vibe3.config.agent_preset import (
-    read_models_json,
-    repo_models_json_path,
-    resolve_effective_agent_options,
-)
-from vibe3.models.review_runner import AgentOptions
+from vibe3.config import resolve_effective_agent_options
+from vibe3.config.agent_preset import read_models_json, repo_models_json_path
+from vibe3.models import AgentOptions
 
 # Path to codeagent models config
 MODELS_JSON_PATH: Final[Path] = Path.home() / ".codeagent" / "models.json"

--- a/src/vibe3/agents/base.py
+++ b/src/vibe3/agents/base.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from vibe3.models.review_runner import AgentOptions, AgentResult
+from vibe3.models import AgentOptions
+from vibe3.models.review_runner import AgentResult
 
 
 @runtime_checkable

--- a/src/vibe3/agents/models.py
+++ b/src/vibe3/agents/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 
 ExecutionRole = Literal["planner", "executor", "reviewer", "manager"]
 

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -14,14 +14,17 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.config.convention_resolver import ConventionResolver
-from vibe3.config.settings import VibeConfig
+from vibe3.config import ConventionResolver, VibeConfig
+from vibe3.environment import resolve_runtime_asset
 from vibe3.exceptions import VibeError
+from vibe3.models import PromptContextMode
 from vibe3.models.plan import PlanRequest
-from vibe3.models.prompt_meta import PromptContextMode
-from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
-from vibe3.prompts.manifest import PromptManifest, PromptProvider
-from vibe3.utils.runtime_assets import resolve_runtime_asset
+from vibe3.prompts import (
+    PromptContextBuilder,
+    PromptManifest,
+    PromptProvider,
+    make_context_builder,
+)
 
 PlanPromptMode = Literal["first", "retry"]
 

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -190,6 +190,7 @@ def _build_plan_prompt_providers(
         if plan_config and plan_config.common_rules is not None:
             result: str | None = plan_config.common_rules
             return result
+        # Cast needed: lazy __getattr__ import loses type info
         return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -10,7 +10,7 @@ Section builders (build_plan_policy_section, etc.) remain available for direct u
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from loguru import logger
 
@@ -190,7 +190,7 @@ def _build_plan_prompt_providers(
         if plan_config and plan_config.common_rules is not None:
             result: str | None = plan_config.common_rules
             return result
-        return resolver.get_policy_path("common")
+        return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:
         return build_tools_guide_section(common_rules_path())

--- a/src/vibe3/agents/review_pipeline_helpers.py
+++ b/src/vibe3/agents/review_pipeline_helpers.py
@@ -7,13 +7,13 @@ from typing import Any
 import typer
 from loguru import logger
 
-from vibe3.analysis.snapshot_diff import compute_diff
+from vibe3.analysis import compute_diff
 from vibe3.analysis.snapshot_service import (
     SnapshotError,
     build_snapshot,
     find_snapshot_by_branch,
 )
-from vibe3.models.snapshot import StructureDiff
+from vibe3.models import StructureDiff
 
 
 def run_inspect_json(args: list[str]) -> dict[str, object]:

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -18,14 +18,17 @@ from typing import Literal
 from loguru import logger
 
 from vibe3.analysis.snapshot_diff_section import build_snapshot_diff_section
-from vibe3.config.convention_resolver import ConventionResolver
-from vibe3.config.settings import VibeConfig
+from vibe3.config import ConventionResolver, VibeConfig
+from vibe3.environment import resolve_runtime_asset
 from vibe3.exceptions import VibeError
-from vibe3.models.prompt_meta import PromptContextMode
+from vibe3.models import PromptContextMode
 from vibe3.models.review import ReviewRequest
-from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
-from vibe3.prompts.manifest import PromptManifest, PromptProvider
-from vibe3.utils.runtime_assets import resolve_runtime_asset
+from vibe3.prompts import (
+    PromptContextBuilder,
+    PromptManifest,
+    PromptProvider,
+    make_context_builder,
+)
 
 ReviewPromptMode = Literal["first", "retry"]
 

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from loguru import logger
 
@@ -244,7 +244,7 @@ def _build_review_prompt_providers(
     def common_rules_path() -> str | None:
         if config.review.common_rules is not None:
             return config.review.common_rules
-        return resolver.get_policy_path("common")
+        return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:
         return build_tools_guide_section(common_rules_path())

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -244,6 +244,7 @@ def _build_review_prompt_providers(
     def common_rules_path() -> str | None:
         if config.review.common_rules is not None:
             return config.review.common_rules
+        # Cast needed: lazy __getattr__ import loses type info
         return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -9,7 +9,7 @@ Public API:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from loguru import logger
 
@@ -126,7 +126,7 @@ def _build_run_prompt_providers(
         if run_config and run_config.common_rules is not None:
             result: str | None = run_config.common_rules
             return result
-        return resolver.get_policy_path("common")
+        return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:
         return build_tools_guide_section(common_rules_path())

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -13,12 +13,15 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.config.convention_resolver import ConventionResolver
-from vibe3.config.settings import VibeConfig
-from vibe3.models.prompt_meta import PromptContextMode
-from vibe3.prompts.context_builder import PromptContextBuilder, make_context_builder
-from vibe3.prompts.manifest import PromptManifest, PromptProvider
-from vibe3.utils.runtime_assets import resolve_runtime_asset
+from vibe3.config import ConventionResolver, VibeConfig
+from vibe3.environment import resolve_runtime_asset
+from vibe3.models import PromptContextMode
+from vibe3.prompts import (
+    PromptContextBuilder,
+    PromptManifest,
+    PromptProvider,
+    make_context_builder,
+)
 
 
 def build_run_task_section(task_text: str | None) -> str:

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -126,6 +126,7 @@ def _build_run_prompt_providers(
         if run_config and run_config.common_rules is not None:
             result: str | None = run_config.common_rules
             return result
+        # Cast needed: lazy __getattr__ import loses type info
         return cast(str | None, resolver.get_policy_path("common"))
 
     def common_rules_section() -> str | None:


### PR DESCRIPTION
Closes #1920

## Summary
Migrates all internal imports in \`src/vibe3/agents/\` from sub-module paths to public API paths, following the pattern established in PR #1997.

**Scope**: 10 files, all within agents module
**LOC delta**: +40/-32 (import refactoring only)
**No behavior changes**

## Changes
- Migrated 9 import types to public API paths:
  - \`PromptContextMode\`, \`AgentOptions\`, \`VibeConfig\`
  - \`ConventionResolver\`
  - \`resolve_effective_agent_options\`, \`resolve_runtime_asset\`
  - Prompt builder types: \`PromptContextBuilder\`, \`PromptManifest\`, \`PromptProvider\`, \`make_context_builder\`
  - \`compute_diff\`, \`StructureDiff\`

- Preserved 9 exempted imports (upstream modules don't export):
  - AgentResult, PlanRequest, ReviewRequest, AsyncExecutionHandle
  - snapshot_service symbols, build_snapshot_diff_section
  - codeagent_helpers symbols
  - agent_preset utility functions

## Testing
- 125 tests passed in agents module
- No new mypy errors introduced
- Pre-existing mypy errors documented (not introduced by this change)

## Related
- Original issue: #1629 (PR #1707 closed without merge)
- Follow-up issue: #1920
- System improvement: #2042 (exempted imports for upstream)

---

## Contributors

claude/opus
