### PR TITLE
fix(governance): material rotation tick 冲突导致 roadmap intake 从未执行

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -99,6 +99,9 @@ code_limits:
         reason: "终端 flow 清理 + detached worktree 清理聚合，包含 done/aborted 处理、live session 过滤、issue resume、detached worktree 安全清理（worktree root 比较、flow-managed scope 检查）等紧密耦合逻辑；Task #9 重构后新增 TaskResumeOperations 集成，略微超标"
 
       # Roles 层 —— 允许 480-600
+      - path: "src/vibe3/roles/governance.py"
+        limit: 450
+        reason: "Core governance aggregation file with tightly coupled responsibilities (material rotation via execution_count, snapshot context building, prompt rendering, request building) - splitting would harm cohesion and readability"
       - path: "src/vibe3/roles/review.py"
         limit: 600
         reason: "Reviewer 角色聚合，包含 request builder、sync/async dispatch、parser 集成"

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -79,6 +79,10 @@ def internal_governance_dispatch(
     tick: Annotated[
         int, typer.Argument(help="Tick count for governance material rotation")
     ],
+    execution_count: Annotated[
+        int,
+        typer.Argument(help="Independent execution count for material rotation"),
+    ] = 0,
     material: Annotated[
         str | None,
         typer.Option(
@@ -98,7 +102,9 @@ def internal_governance_dispatch(
     """
     from vibe3.services.scan_service import dispatch_governance_execution
 
-    dispatch_governance_execution(tick_count=tick, material_override=material)
+    dispatch_governance_execution(
+        tick_count=tick, execution_count=execution_count, material_override=material
+    )
 
 
 @app.command("bootstrap")

--- a/src/vibe3/domain/events/governance.py
+++ b/src/vibe3/domain/events/governance.py
@@ -16,6 +16,7 @@ class GovernanceScanStarted(DomainEvent):
     """
 
     tick_count: int
+    execution_count: int = 0  # Independent counter for material rotation
     actor: str = "system:governance"
     timestamp: str | None = None
 

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -122,7 +122,7 @@ def handle_governance_scan_started(
     execution_name = build_governance_execution_name(event.tick_count)
 
     # Build CLI self-invocation request (cmd field, no prompt)
-    # This ensures the tmux wrapper calls 'internal governance <tick>'
+    # This ensures the tmux wrapper calls 'internal governance <tick> <execution_count>'
     # which enters governance_sync_runner with ErrorTrackingService
     command_root = resolve_async_cli_project_root(root)
     cmd = [
@@ -136,6 +136,7 @@ def handle_governance_scan_started(
         "internal",
         "governance",
         str(event.tick_count),
+        str(event.execution_count),
     ]
 
     env = dict(os.environ)

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -78,6 +78,9 @@ class OrchestrationFacade(ServiceBase):
                 creating a new one on each tick.
         """
         self._tick_count = tick_count
+        self._governance_execution_count = (
+            0  # Independent counter for material rotation
+        )
         self._config = config or load_orchestra_config()
         self._created_at = time.monotonic()
         self._last_governance_started_at: float | None = None
@@ -258,10 +261,16 @@ class OrchestrationFacade(ServiceBase):
         # Update timestamp when actually emitting event
         self._last_governance_started_at = time.monotonic()
 
-        event = GovernanceScanStarted(tick_count=tick_count)
+        # Increment governance execution count for material rotation
+        self._governance_execution_count += 1
+
+        event = GovernanceScanStarted(
+            tick_count=tick_count, execution_count=self._governance_execution_count
+        )
         logger.bind(
             domain="orchestration_facade",
             tick_count=tick_count,
+            execution_count=self._governance_execution_count,
         ).info("Emitting GovernanceScanStarted event")
         publish(event)
 

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -24,6 +24,7 @@ from vibe3.services import record_dispatch_failure_if_unexpected
 def run_governance_sync(
     *,
     tick_count: int,
+    execution_count: int = 0,
     material_override: str | None = None,
     dry_run: bool = False,
     show_prompt: bool = False,
@@ -39,6 +40,8 @@ def run_governance_sync(
 
     Args:
         tick_count: Tick number for governance material rotation
+        execution_count: Independent counter for material rotation
+            (resolves tick conflict)
         material_override: Optional governance role to override material rotation
         dry_run: If True, print command without executing
         show_prompt: If True, print prompt content in dry-run mode
@@ -74,12 +77,14 @@ def run_governance_sync(
         snapshot,
         config=config,
         tick_count=tick_count,
+        execution_count=execution_count,
         material_override=material_override,
     )
     render_result = governance_fns.render_prompt(
         config,
         snapshot_context,
         tick_count=tick_count,
+        execution_count=execution_count,
         material_override=material_override,
     )
     prompt_content = render_result.rendered_text

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -77,11 +77,11 @@ _GOVERNANCE_RUNTIME_VARS = (
 
 def _resolve_governance_material(
     config: OrchestraConfig,
-    tick_count: int,
+    execution_count: int,
 ) -> str:
     _ = config
     catalog = load_governance_material_catalog()
-    return catalog[tick_count % len(catalog)].name
+    return catalog[execution_count % len(catalog)].name
 
 
 def _load_governance_recipe_definition() -> PromptRecipeDefinition:
@@ -108,6 +108,7 @@ def build_governance_snapshot_context(
     *,
     config: OrchestraConfig | None = None,
     tick_count: int = 0,
+    execution_count: int = 0,
     material_override: str | None = None,
     github: GitHubClient | None = None,
 ) -> dict[str, Any]:
@@ -122,7 +123,7 @@ def build_governance_snapshot_context(
             )
         current_material = selected.name
     else:
-        current_material = _resolve_governance_material(config, tick_count)
+        current_material = _resolve_governance_material(config, execution_count)
     material_name = Path(current_material).name
 
     if material_name == "roadmap-intake.md":
@@ -217,7 +218,10 @@ def _build_runtime_registry(context: dict[str, Any]) -> ProviderRegistry:
 
 
 def build_governance_recipe(
-    config: OrchestraConfig, tick_count: int = 0, material_override: str | None = None
+    config: OrchestraConfig,
+    tick_count: int = 0,
+    execution_count: int = 0,
+    material_override: str | None = None,
 ) -> PromptRecipe:
     """Build the PromptRecipe for governance dispatch."""
     recipe_def = _load_governance_recipe_definition()
@@ -244,8 +248,8 @@ def build_governance_recipe(
             )
         current_material = current.name
     else:
-        # Normal tick-based rotation
-        current = catalog[tick_count % len(catalog)]
+        # Use execution_count for material rotation (independent of tick_count)
+        current = catalog[execution_count % len(catalog)]
         current_material = current.name
 
     supervisor_content_source = current.source
@@ -283,12 +287,16 @@ def render_governance_prompt(
     snapshot_context: dict[str, Any],
     prompts_path: Path | None = None,
     tick_count: int = 0,
+    execution_count: int = 0,
     material_override: str | None = None,
 ) -> PromptRenderResult:
     """Render governance plan from snapshot context via PromptAssembler."""
     prompts_path = prompts_path or DEFAULT_PROMPTS_PATH
     recipe = build_governance_recipe(
-        config, tick_count=tick_count, material_override=material_override
+        config,
+        tick_count=tick_count,
+        execution_count=execution_count,
+        material_override=material_override,
     )
     registry = _build_runtime_registry(snapshot_context)
     assembler = PromptAssembler(prompts_path=prompts_path, registry=registry)
@@ -314,6 +322,7 @@ def build_governance_request(
     snapshot: Any,
     repo_path: Path | None = None,
     prompts_path: Path | None = None,
+    execution_count: int = 0,
 ) -> ExecutionRequest | None:
     """Build governance execution request.
 
@@ -331,12 +340,17 @@ def build_governance_request(
         snapshot,
         config=config,
         tick_count=tick_count,
+        execution_count=execution_count,
     )
     render_result = render_governance_prompt(
-        config, snapshot_context, prompts_path, tick_count=tick_count
+        config,
+        snapshot_context,
+        prompts_path,
+        tick_count=tick_count,
+        execution_count=execution_count,
     )
     plan_content = render_result.rendered_text
-    current_material = _resolve_governance_material(config, tick_count)
+    current_material = _resolve_governance_material(config, execution_count)
 
     if config.governance.dry_run:
         root = repo_path or resolve_orchestra_repo_root()

--- a/src/vibe3/roles/governance_factory.py
+++ b/src/vibe3/roles/governance_factory.py
@@ -31,6 +31,7 @@ def build_default_governance_fns() -> GovernanceFunctions:
             *,
             config: Any = None,
             tick_count: int = 0,
+            execution_count: int = 0,
             material_override: str | None = None,
             **kwargs: Any,
         ) -> dict[str, Any]:
@@ -38,6 +39,7 @@ def build_default_governance_fns() -> GovernanceFunctions:
                 snapshot,
                 config=config,
                 tick_count=tick_count,
+                execution_count=execution_count,
                 material_override=material_override,
                 **kwargs,
             )
@@ -48,6 +50,7 @@ def build_default_governance_fns() -> GovernanceFunctions:
             snapshot_context: dict[str, Any],
             *,
             tick_count: int = 0,
+            execution_count: int = 0,
             material_override: str | None = None,
             **kwargs: Any,
         ) -> Any:
@@ -55,6 +58,7 @@ def build_default_governance_fns() -> GovernanceFunctions:
                 config,
                 snapshot_context,
                 tick_count=tick_count,
+                execution_count=execution_count,
                 material_override=material_override,
                 **kwargs,
             )

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -40,7 +40,9 @@ def extract_material_description(material_path: str) -> str:
 
 
 def dispatch_governance_execution(
-    tick_count: int = 0, material_override: str | None = None
+    tick_count: int = 0,
+    execution_count: int = 0,
+    material_override: str | None = None,
 ) -> None:
     """Execute governance scan (execution-only entry point).
 
@@ -48,6 +50,8 @@ def dispatch_governance_execution(
 
     Args:
         tick_count: Tick number for governance material rotation
+        execution_count: Independent counter for material rotation
+            (resolves tick conflict)
         material_override: Optional governance role to override material rotation
     """
     from vibe3.execution.governance_sync_runner import run_governance_sync
@@ -56,6 +60,7 @@ def dispatch_governance_execution(
 
     run_governance_sync(
         tick_count=tick_count,
+        execution_count=execution_count,
         material_override=material_override,
         dry_run=False,  # Execution-only, no dry-run
         show_prompt=False,

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -133,12 +133,14 @@ def test_internal_governance_dispatch_forwards_tick_and_material():
     ) as mock_dispatch:
         result = runner.invoke(
             cli_app,
-            ["internal", "governance", "8", "--material", "roadmap-intake"],
+            ["internal", "governance", "8", "0", "--material", "roadmap-intake"],
         )
 
         assert result.exit_code == 0
         mock_dispatch.assert_called_once_with(
-            tick_count=8, material_override="roadmap-intake"
+            tick_count=8,
+            execution_count=0,
+            material_override="roadmap-intake",
         )
 
 

--- a/tests/vibe3/domain/handlers/test_governance_scan.py
+++ b/tests/vibe3/domain/handlers/test_governance_scan.py
@@ -90,7 +90,9 @@ class TestGovernanceScanHandler:
         mock_status.snapshot.return_value = mock_snapshot
         mock_status_cls.return_value = mock_status
 
-        handle_governance_scan_started(GovernanceScanStarted(tick_count=5))
+        handle_governance_scan_started(
+            GovernanceScanStarted(tick_count=5, execution_count=3)
+        )
 
         mock_coordinator.dispatch_execution.assert_called_once()
         # Verify CLI self-invocation command structure
@@ -98,9 +100,9 @@ class TestGovernanceScanHandler:
         assert call_args.role == "governance"
         assert call_args.mode == "async"
         assert call_args.cmd is not None
-        assert "internal" in call_args.cmd
-        assert "governance" in call_args.cmd
-        assert "5" in call_args.cmd  # tick_count
+        # Verify command ends with expected args
+        # Full: ["uv", "run", ..., "internal", "governance", "5", "3"]
+        assert call_args.cmd[-4:] == ["internal", "governance", "5", "3"]
 
     @patch("vibe3.environment.session_registry.SessionRegistryService")
     @patch("vibe3.clients.sqlite_client.SQLiteClient")

--- a/tests/vibe3/domain/test_orchestration_facade.py
+++ b/tests/vibe3/domain/test_orchestration_facade.py
@@ -51,6 +51,7 @@ class TestOrchestrationFacade:
         event = mock_publish.call_args.args[0]
         assert isinstance(event, GovernanceScanStarted)
         assert event.tick_count == 1
+        assert event.execution_count == 1  # First execution
 
         mock_publish.reset_mock()
         facade.on_heartbeat_tick()
@@ -58,6 +59,7 @@ class TestOrchestrationFacade:
         event2 = mock_publish.call_args.args[0]
         assert isinstance(event2, GovernanceScanStarted)
         assert event2.tick_count == 2
+        assert event2.execution_count == 2  # Second execution
 
     @patch("vibe3.domain.orchestration_facade.publish")
     @patch("vibe3.domain.orchestration_facade.time.monotonic")

--- a/tests/vibe3/roles/test_governance_context_comment.py
+++ b/tests/vibe3/roles/test_governance_context_comment.py
@@ -169,7 +169,9 @@ class TestBuildSnapshotContext:
         ]
         mock_github_cls.return_value = mock_github
 
-        ctx = build_governance_snapshot_context(snapshot, config=config, tick_count=1)
+        ctx = build_governance_snapshot_context(
+            snapshot, config=config, tick_count=0, execution_count=1
+        )
 
         assert ctx["issue_scope_name"] == "broader repo issue pool"
         assert ctx["active_count"] == 1
@@ -179,7 +181,7 @@ class TestBuildSnapshotContext:
     @patch("vibe3.roles.governance_utils.GitHubClient")
     def test_cron_supervisor_filters_to_docs_candidates(self, mock_github_cls):
         snapshot = _make_snapshot()
-        # tick_count=2 selects cron-supervisor from recipe catalog
+        # execution_count=2 selects cron-supervisor from recipe catalog
         config = _make_config()
         mock_github = MagicMock()
         mock_github.list_issues.return_value = [
@@ -202,7 +204,9 @@ class TestBuildSnapshotContext:
         ]
         mock_github_cls.return_value = mock_github
 
-        ctx = build_governance_snapshot_context(snapshot, config=config, tick_count=2)
+        ctx = build_governance_snapshot_context(
+            snapshot, config=config, tick_count=0, execution_count=2
+        )
 
         # After migration, scope and filtering work based on recipe catalog material
         assert ctx["issue_scope_name"] == "broader repo docs scope"
@@ -344,8 +348,10 @@ class TestBuildSnapshotContext:
         ]
         mock_github_cls.return_value = mock_github
 
-        # Use roadmap-intake material
-        ctx = build_governance_snapshot_context(snapshot, config=config, tick_count=1)
+        # Use roadmap-intake material (execution_count=1)
+        ctx = build_governance_snapshot_context(
+            snapshot, config=config, tick_count=0, execution_count=1
+        )
 
         assert ctx["issue_scope_name"] == "broader repo issue pool"
         assert ctx["active_count"] == 1

--- a/tests/vibe3/roles/test_governance_recipe_render.py
+++ b/tests/vibe3/roles/test_governance_recipe_render.py
@@ -152,7 +152,8 @@ class TestRenderGovernancePrompt:
             config,
             ctx,
             prompts_path,
-            tick_count=1,
+            tick_count=0,
+            execution_count=1,
         )
 
         assert (

--- a/tests/vibe3/roles/test_governance_request_materials.py
+++ b/tests/vibe3/roles/test_governance_request_materials.py
@@ -134,37 +134,53 @@ class TestRoundRobinMaterialSelection:
     """Tests that build_governance_recipe selects material from recipe catalog."""
 
     def test_tick_0_selects_first(self):
-        """tick_count=0 selects first material from recipe catalog."""
-        recipe = build_governance_recipe(_make_config(), tick_count=0)
+        """execution_count=0 selects first material from recipe catalog."""
+        recipe = build_governance_recipe(
+            _make_config(), tick_count=0, execution_count=0
+        )
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/assignee-pool.md"
 
     def test_tick_1_selects_second(self):
-        """tick_count=1 selects second material from recipe catalog."""
-        recipe = build_governance_recipe(_make_config(), tick_count=1)
+        """execution_count=1 selects second material from recipe catalog."""
+        recipe = build_governance_recipe(
+            _make_config(), tick_count=0, execution_count=1
+        )
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/roadmap-intake.md"
 
     def test_tick_2_selects_third(self):
-        """tick_count=2 selects third material from recipe catalog."""
-        recipe = build_governance_recipe(_make_config(), tick_count=2)
+        """execution_count=2 selects third material from recipe catalog."""
+        recipe = build_governance_recipe(
+            _make_config(), tick_count=0, execution_count=2
+        )
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/cron-supervisor.md"
 
     def test_tick_wraps_around(self):
-        """tick_count wraps around material catalog (4 materials, tick 4 -> index 0)."""
-        recipe = build_governance_recipe(_make_config(), tick_count=4)
+        """execution_count wraps around material catalog.
+
+        (4 materials, count 4 -> index 0).
+        """
+        recipe = build_governance_recipe(
+            _make_config(), tick_count=0, execution_count=4
+        )
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/assignee-pool.md"
 
     def test_large_tick_uses_modulo(self):
-        """tick_count=9 wraps around 4 materials to index 1 (9 % 4 = 1)."""
-        recipe = build_governance_recipe(_make_config(), tick_count=9)
+        """execution_count=9 wraps around 4 materials to index 1 (9 % 4 = 1)."""
+        recipe = build_governance_recipe(
+            _make_config(), tick_count=0, execution_count=9
+        )
         val = recipe.variables["supervisor_name"].value
         assert val == "supervisor/governance/roadmap-intake.md"
 
     def test_build_governance_request_uses_round_robin(self):
-        """build_governance_request picks material per tick from recipe catalog."""
+        """build_governance_request picks material per execution_count.
+
+        from recipe catalog.
+        """
         config = _make_config()
         snapshot = _make_snapshot()
         with (
@@ -175,14 +191,14 @@ class TestRoundRobinMaterialSelection:
             mock_github = MagicMock()
             mock_github.list_issues.return_value = []
             mock_github_cls.return_value = mock_github
-            req_tick0 = build_governance_request(config, 0, snapshot)
-            req_tick1 = build_governance_request(config, 1, snapshot)
+            req_tick0 = build_governance_request(config, 0, snapshot, execution_count=0)
+            req_tick1 = build_governance_request(config, 0, snapshot, execution_count=1)
         # Both should produce valid requests (circuit breaker closed, dry_run=False)
         assert req_tick0 is not None
         assert req_tick1 is not None
         # Execution names reflect different ticks
         assert req_tick0.execution_name.endswith("-t0")
-        assert req_tick1.execution_name.endswith("-t1")
+        assert req_tick1.execution_name.endswith("-t0")
 
 
 class TestGovernanceRoleDefinition:


### PR DESCRIPTION
## 问题描述

Governance material rotation 逻辑与 `interval_ticks` 配置冲突，导致 `roadmap-intake.md` 等 materials 从未被执行。

## 根本原因

**Tick 冲突 bug**：

```
Heartbeat tick: 1→2→3→4→5→6→7→8...
                ↓
Interval gating (interval_ticks=4):
                ↓ 只在 tick % 4 == 0 时触发
Governance scan: tick 4, 8, 12, 16, 20...
                ↓
Material rotation: catalog[tick % 4]
                ↓
Material index:  0, 0, 0, 0, 0...  ← 永远是 assignee-pool！
```

**数学原因**：
- `interval_ticks = 4`（governance 每 4 个 heartbeat tick 执行一次）
- `len(material_catalog) = 4`（有 4 个 materials）
- 所有触发的 tick（4, 8, 12, ...）都满足 `tick % 4 == 0`
- Material index 永远是 0，永远选择 `assignee-pool.md`

## 修复方案

使用独立的 governance 执行计数器 (`execution_count`) 进行 material rotation，与 heartbeat tick 计数器 (`tick_count`) 解耦。

## 变更

1. `GovernanceScanStarted` 事件添加 `execution_count` 字段
2. `OrchestrationFacade` 添加 `_governance_execution_count` 计数器
3. 所有相关函数签名和调用链更新
4. 更新相关测试

## 影响范围

- ✅ `roadmap-intake.md` 等 materials 现在可以正常轮转执行
- ✅ 新 issue 可以被正常 intake
- ✅ 不改变 `interval_ticks` 语义
- ✅ Material rotation 独立于 heartbeat tick

## 测试

- ✅ 类型检查通过（mypy）
- ✅ 代码格式检查通过（black, ruff）
- ✅ 所有相关测试通过

Closes: #2043