### PR TITLE
refactor(tests): strengthen service conftest mock quality (#1918)

### DIFF
--- a/tests/vibe3/services/conftest.py
+++ b/tests/vibe3/services/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibe3.analysis.coverage_service import CoverageService
+from vibe3.clients.github_client import GitHubClient
 from vibe3.models.orchestration import IssueState
 from vibe3.services.task_resume_operations import TaskResumeOperations
 
@@ -36,6 +37,13 @@ def block_gh_subprocess(request, monkeypatch):
                 f"Test: {test_id}\n"
                 f"If this test needs real gh, mark it with @pytest.mark.integration"
             )
+        if isinstance(cmd, str) and cmd.strip().startswith("gh "):
+            test_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown")
+            raise RuntimeError(
+                f"Blocked gh CLI call in unit test (shell=True): {cmd[:60]}\n"
+                f"Test: {test_id}\n"
+                f"If this test needs real gh, mark it with @pytest.mark.integration"
+            )
         return _real_run(*args, **kwargs)
 
     monkeypatch.setattr(subprocess, "run", _guarded_run)
@@ -50,11 +58,11 @@ def stable_worktree_actor(monkeypatch):
         lambda: "test-actor",
     )
 
-    mock_gh = MagicMock()
+    mock_gh = MagicMock(spec=GitHubClient)
     mock_gh.get_pr.return_value = None
     mock_gh.view_issue.return_value = None
-    mock_gh.list_pr.return_value = []
-    mock_gh.diff_pr.return_value = ""
+    mock_gh.list_prs_for_branch.return_value = []
+    mock_gh.get_pr_diff.return_value = ""
 
     monkeypatch.setattr(
         "vibe3.services.flow_read_mixin.GitHubClient",

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.orchestra_config import OrchestraConfig, SupervisorHandoffConfig
@@ -20,7 +21,7 @@ def stable_flow_actor(monkeypatch):
         lambda store, branch, explicit_actor=None: explicit_actor or "test-actor",
     )
 
-    mock_gh = MagicMock()
+    mock_gh = MagicMock(spec=GitHubClient)
     mock_gh.get_pr.return_value = None
 
     monkeypatch.setattr(


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-1918` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-1918
```


---

## Summary

Fix ghost mock methods in service test fixtures and add `spec=GitHubClient` to prevent future ghost mocks.

## Changes

- **conftest.py**: Fixed ghost mock method names:
  - `list_pr` → `list_prs_for_branch`
  - `diff_pr` → `get_pr_diff`
- **Both fixtures**: Added `spec=GitHubClient` to MagicMock to prevent future ghost method calls
- **conftest.py**: Added `shell=True` guard for string-form gh CLI calls in `block_gh_subprocess`

## Testing

All 708 service tests pass. Changes are test-only, no production code touched.

## Related

Fixes #1918

---

## Contributors

claude/opus
