### PR TITLE
refactor(execution): remove concrete role imports via dependency injection

### DIFF
--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -49,8 +49,13 @@ def _run_governance_scan(
         logger.bind(domain="orchestra").info("Governance scan completed")
     else:
         from vibe3.execution.governance_sync_runner import run_governance_async
+        from vibe3.roles.governance import build_governance_execution_name
 
-        run_governance_async(tick_count=0, material_override=material_override)
+        run_governance_async(
+            tick_count=0,
+            material_override=material_override,
+            build_execution_name=build_governance_execution_name,
+        )
 
 
 def _run_governance_scan_dry_run(material_override: str | None = None) -> None:

--- a/src/vibe3/execution/governance_sync_runner.py
+++ b/src/vibe3/execution/governance_sync_runner.py
@@ -29,8 +29,8 @@ def run_governance_sync(
     dry_run: bool = False,
     show_prompt: bool = False,
     session_id: str | None = None,
-    governance_fns: GovernanceFunctions | None = None,
-    append_event: GovernanceEventLogger | None = None,
+    governance_fns: GovernanceFunctions,
+    append_event: GovernanceEventLogger,
 ) -> None:
     """Run governance scan synchronously with error tracking.
 
@@ -46,20 +46,9 @@ def run_governance_sync(
         dry_run: If True, print command without executing
         show_prompt: If True, print prompt content in dry-run mode
         session_id: Optional session ID for resume
-        governance_fns: Optional injected governance functions (for decoupling)
-        append_event: Optional injected event logger (for decoupling)
+        governance_fns: Injected governance functions (required)
+        append_event: Injected event logger (required)
     """
-    # Default fallback via lazy import for backward compatibility
-    if governance_fns is None:
-        from vibe3.roles.governance_factory import build_default_governance_fns
-
-        governance_fns = build_default_governance_fns()
-
-    if append_event is None:
-        from vibe3.orchestra.logging import append_governance_event as _ae
-
-        append_event = _ae
-
     repo = resolve_orchestra_repo_root()
     config = load_orchestra_config(target_repo=repo)
     from vibe3.domain import FlowManager
@@ -153,7 +142,7 @@ def run_governance_async(
     *,
     tick_count: int = 0,
     material_override: str | None = None,
-    build_execution_name: Callable[[int], str] | None = None,
+    build_execution_name: Callable[[int], str],
 ) -> None:
     """Run governance scan in background tmux session (async).
 
@@ -164,22 +153,15 @@ def run_governance_async(
     Args:
         tick_count: Tick number for governance material rotation
         material_override: Optional governance role to override material rotation
-        build_execution_name: Optional injected execution name builder (for decoupling)
+        build_execution_name: Injected execution name builder (required)
     """
+    from vibe3.domain import FlowManager
     from vibe3.environment import SessionRegistryService
     from vibe3.execution.coordinator import ExecutionCoordinator
     from vibe3.execution.issue_role_support import (
         resolve_async_cli_project_root,
         resolve_orchestra_repo_root,
     )
-
-    # Default fallback via lazy import
-    if build_execution_name is None:
-        from vibe3.roles.governance import build_governance_execution_name as _ben
-
-        build_execution_name = _ben
-
-    from vibe3.domain import FlowManager
     from vibe3.orchestra.logging import append_governance_event
     from vibe3.services.orchestra_status_service import OrchestraStatusService
 

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -7,15 +7,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from vibe3.clients import SQLiteClient
-from vibe3.execution.role_interfaces import IssueRoleSyncSpec
 from vibe3.models import (
     AgentOptions,
     ExecutionRequest,
     IssueInfo,
-    SessionRole,
     WorktreeRequirement,
 )
-from vibe3.roles.definitions import IssueRoleSyncSpec as IssueRoleSyncSpecImpl
 
 
 def resolve_orchestra_repo_root() -> Path:
@@ -227,36 +224,3 @@ def resolve_env_overridable_agent_options(
     if backend_override:
         return AgentOptions(backend=backend_override, model=model_override)
     return fallback_resolver()
-
-
-def build_issue_sync_spec(
-    *,
-    role_name: SessionRole,
-    resolve_options: Callable[[Any], Any],
-    resolve_branch: Callable[[SQLiteClient, int, str], str],
-    build_async_request: Callable[[Any, IssueInfo, str], ExecutionRequest | None],
-    build_sync_request: Callable[
-        [
-            Any,
-            IssueInfo,
-            str,
-            dict[str, object] | None,
-            str | None,
-            Any,
-            str,
-            bool,
-            bool,
-        ],
-        ExecutionRequest,
-    ],
-    failure_handler: Callable[..., None],
-) -> IssueRoleSyncSpec:
-    """Build the minimal sync spec shared by issue-scoped roles."""
-    return IssueRoleSyncSpecImpl(
-        role_name=role_name,
-        resolve_options=resolve_options,
-        resolve_branch=resolve_branch,
-        build_async_request=build_async_request,
-        build_sync_request=build_sync_request,
-        failure_handler=failure_handler,
-    )

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -22,7 +22,6 @@ from vibe3.execution.codeagent_runner import CodeagentExecutionService
 from vibe3.execution.codeagent_support import build_self_invocation
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.issue_role_support import (
-    build_issue_sync_spec,
     build_task_flow_branch_resolver,
     resolve_env_overridable_agent_options,
 )
@@ -36,7 +35,11 @@ from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
 from vibe3.models.worktree import WorktreeRequirement
-from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
+from vibe3.roles.definitions import (
+    IssueRoleSyncSpec,
+    RoleOutputContract,
+    TriggerableRoleDefinition,
+)
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 from vibe3.services.issue_failure_service import fail_planner_issue
@@ -244,7 +247,7 @@ def build_plan_sync_request(
     )
 
 
-PLAN_SYNC_SPEC = build_issue_sync_spec(
+PLAN_SYNC_SPEC = IssueRoleSyncSpec(
     role_name="planner",
     resolve_options=resolve_plan_options,
     resolve_branch=PLAN_BRANCH_RESOLVER,

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -27,7 +27,6 @@ from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.issue_role_support import (
     build_issue_async_cli_request,
     build_issue_sync_prompt_request,
-    build_issue_sync_spec,
     build_task_flow_branch_resolver,
     resolve_env_overridable_agent_options,
 )
@@ -38,7 +37,11 @@ from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.review import ReviewRequest, ReviewScope
 from vibe3.models.snapshot import StructureDiff
 from vibe3.models.worktree import WorktreeRequirement
-from vibe3.roles.definitions import RoleOutputContract, TriggerableRoleDefinition
+from vibe3.roles.definitions import (
+    IssueRoleSyncSpec,
+    RoleOutputContract,
+    TriggerableRoleDefinition,
+)
 from vibe3.roles.review_helpers import (
     ReviewRunResult,
     finalize_review_output,
@@ -266,7 +269,7 @@ def build_review_sync_request(
     )
 
 
-REVIEW_SYNC_SPEC = build_issue_sync_spec(
+REVIEW_SYNC_SPEC = IssueRoleSyncSpec(
     role_name="reviewer",
     resolve_options=resolve_review_options,
     resolve_branch=REVIEW_BRANCH_RESOLVER,

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -11,7 +11,6 @@ from vibe3.agents import (
 )
 from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.config.settings import VibeConfig
-from vibe3.execution.issue_role_support import build_issue_sync_spec
 from vibe3.execution.prompt_meta import build_prompt_meta
 from vibe3.execution.role_request_factory import (
     build_role_async_request,
@@ -20,6 +19,7 @@ from vibe3.execution.role_request_factory import (
 from vibe3.models import IssueInfo
 from vibe3.models.execution_request import ExecutionRequest
 from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.roles.definitions import IssueRoleSyncSpec
 from vibe3.roles.run_helpers import (
     EXECUTOR_ROLE,
     RUN_BRANCH_RESOLVER,
@@ -160,7 +160,7 @@ def build_run_sync_request(
     )
 
 
-RUN_SYNC_SPEC = build_issue_sync_spec(
+RUN_SYNC_SPEC = IssueRoleSyncSpec(
     role_name="executor",
     resolve_options=resolve_run_options,
     resolve_branch=RUN_BRANCH_RESOLVER,

--- a/tests/vibe3/execution/test_governance_sync_runner_injection.py
+++ b/tests/vibe3/execution/test_governance_sync_runner_injection.py
@@ -221,7 +221,10 @@ class TestGovernanceAsyncRunnerWithInjection:
                 lambda store, backend: mock_registry,
             )
 
-            run_governance_async(tick_count=0)
+            run_governance_async(
+                tick_count=0,
+                build_execution_name=lambda tick: f"governance-tick-{tick}",
+            )
 
         # The lazy import path will still call append_governance_event
         # from orchestra.logging. We can't easily mock it without importing,
@@ -277,7 +280,10 @@ class TestGovernanceAsyncRunnerWithInjection:
                 lambda: MagicMock(),
             )
 
-            run_governance_async(tick_count=5)
+            run_governance_async(
+                tick_count=5,
+                build_execution_name=lambda tick: f"governance-tick-{tick}",
+            )
 
         # The lazy import path will still call append_governance_event
         # from orchestra.logging. We can't easily mock it without importing,


### PR DESCRIPTION
## Summary
- Removed all 3 `vibe3.roles.*` imports from `src/vibe3/execution/` by making dependency injection parameters mandatory
- Deleted `build_issue_sync_spec` wrapper function (issue_role_support.py)
- Made `governance_fns`, `append_event`, `build_execution_name` mandatory parameters in governance_sync_runner.py
- Updated all callers (plan.py, review.py, run_request.py, commands/scan.py) to pass dependencies explicitly

## Acceptance Criterion
✅ `rg "from vibe3.roles|import vibe3.roles" src/vibe3/execution` returns no results

## Quality Gates
✅ Tests: 140/140 passed
✅ Type check: mypy success
✅ Lint: ruff all checks passed

## Scope
- **Allowed**: execution/, roles/{plan,review,run_request}.py, commands/scan.py
- **Prohibited**: DTO moves, common/ package, protocol changes

Closes #1888

---

## Contributors

claude/opus
