### PR TITLE
fix(analysis): exclude __init__.py from test selection in pre-push hook

### DIFF
--- a/docs/directives/issue-2022-merge-directive.md
+++ b/docs/directives/issue-2022-merge-directive.md
@@ -1,0 +1,31 @@
+# Merge Directive: Issue #2022
+
+## Task
+Prepare commit message and create PR for the test selector fix.
+
+## Commit Guidelines
+- Title: `fix(analysis): exclude __init__.py from test selection in pre-push hook`
+- Body should explain:
+  - Problem: test selector incorrectly included __init__.py files
+  - Solution: Added exclusion in both code paths (is_v3_test_file + source-to-test mapping)
+  - Impact: Eliminates misleading "no tests ran" warning
+- Reference: Closes #2022
+
+## PR Requirements
+- Base branch: main
+- Title: Same as commit title
+- Body should include:
+  - Summary of the fix
+  - Test results (129 analysis tests pass)
+  - Reference to issue #2022
+
+## Quality Checks
+- All tests already pass (verified in execution phase)
+- Type checking clean (mypy)
+- Linting clean (ruff)
+- No additional changes needed
+
+## Scope
+- Single focused fix
+- Low risk
+- No breaking changes

--- a/src/vibe3/analysis/change_scope_service.py
+++ b/src/vibe3/analysis/change_scope_service.py
@@ -44,7 +44,11 @@ def is_v3_source_file(filepath: str) -> bool:
 
 def is_v3_test_file(filepath: str) -> bool:
     """Return True for Python tests under tests/vibe3."""
-    return filepath.startswith("tests/vibe3/") and filepath.endswith(".py")
+    return (
+        filepath.startswith("tests/vibe3/")
+        and filepath.endswith(".py")
+        and Path(filepath).name != "__init__.py"
+    )
 
 
 def is_hook_file(filepath: str) -> bool:

--- a/src/vibe3/analysis/change_scope_service.py
+++ b/src/vibe3/analysis/change_scope_service.py
@@ -43,7 +43,11 @@ def is_v3_source_file(filepath: str) -> bool:
 
 
 def is_v3_test_file(filepath: str) -> bool:
-    """Return True for Python tests under tests/vibe3."""
+    """Return True for Python tests under tests/vibe3.
+
+    __init__.py files are excluded because they contain no tests,
+    preventing misleading "no tests ran" warnings in pre-push hooks.
+    """
     return (
         filepath.startswith("tests/vibe3/")
         and filepath.endswith(".py")

--- a/src/vibe3/analysis/pre_push_test_selector.py
+++ b/src/vibe3/analysis/pre_push_test_selector.py
@@ -204,6 +204,8 @@ def _map_source_to_tests(source_path: str, root: Path) -> list[str]:
     resolved: list[str] = []
     seen: set[str] = set()
     for candidate in candidates:
+        if candidate.name == "__init__.py":
+            continue
         if candidate.exists():
             rel_path = candidate.relative_to(root).as_posix()
             if rel_path not in seen:

--- a/src/vibe3/analysis/pre_push_test_selector.py
+++ b/src/vibe3/analysis/pre_push_test_selector.py
@@ -204,6 +204,7 @@ def _map_source_to_tests(source_path: str, root: Path) -> list[str]:
     resolved: list[str] = []
     seen: set[str] = set()
     for candidate in candidates:
+        # __init__.py files contain no tests; skip to avoid "no tests ran" warnings
         if candidate.name == "__init__.py":
             continue
         if candidate.exists():

--- a/tests/vibe3/analysis/test_change_scope_service.py
+++ b/tests/vibe3/analysis/test_change_scope_service.py
@@ -4,6 +4,7 @@ from vibe3.analysis.change_scope_service import (
     classify_changed_files,
     count_changed_lines,
     is_test_file,
+    is_v3_test_file,
 )
 
 
@@ -64,3 +65,10 @@ def test_count_changed_lines_supports_optional_path_filter() -> None:
 
     assert count_changed_lines(diff_text) == 3
     assert count_changed_lines(diff_text, code_paths=["src/"]) == 2
+
+
+def test_is_v3_test_file_excludes_init_py() -> None:
+    assert not is_v3_test_file("tests/vibe3/agents/__init__.py")
+    assert not is_v3_test_file("tests/vibe3/__init__.py")
+    assert is_v3_test_file("tests/vibe3/agents/test_agent.py")
+    assert is_v3_test_file("tests/vibe3/services/test_check_service.py")

--- a/tests/vibe3/analysis/test_pre_push_test_selector.py
+++ b/tests/vibe3/analysis/test_pre_push_test_selector.py
@@ -92,3 +92,19 @@ def test_top_level_unmapped_source_skips_full_suite() -> None:
     assert selection.tests == []
     assert selection.unmapped_sources == ["src/vibe3/__init__.py"]
     assert "tests/vibe3" not in selection.tests
+
+
+def test_excludes_init_py_from_v3_test_files() -> None:
+    """__init__.py under tests/vibe3/ must not be selected as a test target."""
+    selection = select_pre_push_tests(["tests/vibe3/agents/__init__.py"])
+
+    assert "tests/vibe3/agents/__init__.py" not in selection.tests
+
+
+def test_excludes_init_py_from_source_to_test_mapping() -> None:
+    """Changing src/vibe3/.../__init__.py must not map to tests/.../__init__.py."""
+    selection = select_pre_push_tests(
+        ["src/vibe3/agents/__init__.py"],
+    )
+
+    assert "tests/vibe3/agents/__init__.py" not in selection.tests


### PR DESCRIPTION
## Summary

Fixed two code paths that incorrectly selected __init__.py as test targets in the pre-push hook:

1. **is_v3_test_file()** in change_scope_service.py:
   - Added exclusion for __init__.py files
   - Prevents __init__.py from being classified as a test file

2. **_map_source_to_tests()** in pre_push_test_selector.py:
   - Filter out __init__.py from glob results
   - Prevents src/vibe3/.../__init__.py from mapping to tests/.../__init__.py

## Problem

The test selector was incorrectly including __init__.py files as test targets, which led to misleading "no tests ran" warnings during pre-push checks.

## Solution

Added explicit exclusions in both code paths:
- Direct test file detection (is_v3_test_file)
- Source-to-test file mapping (_map_source_to_tests)

## Test Results

All analysis tests pass (129 tests):
- test_is_v3_test_file_excludes_init_py
- test_excludes_init_py_from_v3_test_files
- test_excludes_init_py_from_source_to_test_mapping

## Impact

- Low risk change (only adds exclusion conditions)
- No breaking changes
- Eliminates misleading "no tests ran" warning

Closes #2022

---

## Contributors

claude/opus
