### PR TITLE
fix(execution): backfill backend_session_id on terminal lifecycle events

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -176,8 +176,8 @@ code_limits:
         limit: 500
         reason: "Codeagent async 执行测试集，覆盖异步启动、日志收集、错误处理等场景，共享 fixture"
       - path: "tests/vibe3/execution/test_execution_lifecycle.py"
-        limit: 550
-        reason: "Execution lifecycle 测试集，5 个测试类围绕同一服务契约，共享 fixture"
+        limit: 570
+        reason: "Execution lifecycle 测试集，5 个测试类围绕同一服务契约，共享 fixture；新增 test_empty_session_id_does_not_backfill 边缘情况测试（38 行）验证空字符串 session_id 处理逻辑"
       - path: "tests/vibe3/execution/test_coordinator.py"
         limit: 600
         reason: "Coordinator 核心测试，12 个测试函数围绕调度逻辑（async/sync dispatch、capacity、error handling），共享 mock_dependencies fixture，拆分收益低"

--- a/src/vibe3/execution/execution_lifecycle.py
+++ b/src/vibe3/execution/execution_lifecycle.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from loguru import logger
 
@@ -189,11 +189,13 @@ def _sync_registry_from_lifecycle_event(
     live_sessions = store.list_live_runtime_sessions(role=role)
     for session in live_sessions:
         if session.get("branch") == branch:
-            store.update_runtime_session(
-                session["id"],
-                status=terminal_status,
-                ended_at=datetime.now().isoformat(),
-            )
+            updates: dict[str, Any] = {
+                "status": terminal_status,
+                "ended_at": datetime.now().isoformat(),
+            }
+            if session_id and not session.get("backend_session_id"):
+                updates["backend_session_id"] = session_id
+            store.update_runtime_session(session["id"], **updates)
 
 
 def persist_execution_lifecycle_event(

--- a/src/vibe3/execution/execution_lifecycle.py
+++ b/src/vibe3/execution/execution_lifecycle.py
@@ -140,7 +140,15 @@ def _sync_registry_from_lifecycle_event(
     session_id: str | None,
     refs: dict[str, str] | None = None,
 ) -> None:
-    """Sync runtime_session registry based on lifecycle event."""
+    """Sync runtime_session registry based on lifecycle event.
+
+    For terminal events (completed/aborted/failed), backfills backend_session_id
+    if the session doesn't already have one. This ensures data completeness for
+    sessions that completed before the caller had a chance to set backend_session_id
+    during live session.
+
+    Idempotency: Only writes backend_session_id if currently NULL/empty.
+    """
     if lifecycle == "started":
         tmux_session = None
         if refs:
@@ -195,6 +203,11 @@ def _sync_registry_from_lifecycle_event(
             }
             if session_id and not session.get("backend_session_id"):
                 updates["backend_session_id"] = session_id
+                logger.bind(
+                    domain="execution_lifecycle",
+                    branch=branch,
+                    role=role,
+                ).debug(f"Backfilling backend_session_id for session {session['id']}")
             store.update_runtime_session(session["id"], **updates)
 
 

--- a/tests/vibe3/execution/test_execution_lifecycle.py
+++ b/tests/vibe3/execution/test_execution_lifecycle.py
@@ -348,6 +348,44 @@ class TestRegistrySync:
         assert session["backend_session_id"] == "abort-session-456"
         assert session["status"] == "aborted"
 
+    def test_empty_session_id_does_not_backfill(self, tmp_path: Path) -> None:
+        """Empty string session_id should be treated as invalid and skip backfill."""
+        import sqlite3
+
+        store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+
+        # Start session
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-60",
+            role="executor",
+            lifecycle="started",
+            actor="agent:test",
+            detail="Run started",
+        )
+
+        # Complete with empty session_id
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-60",
+            role="executor",
+            lifecycle="completed",
+            actor="agent:test",
+            detail="Run completed",
+            session_id="",  # Empty string should be skipped
+        )
+
+        # Verify backend_session_id remains NULL
+        conn = store._get_connection()
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM runtime_session WHERE branch = ?", ("task/issue-60",)
+        )
+        session = dict(cursor.fetchone())
+        assert session["backend_session_id"] is None
+        assert session["status"] == "done"
+
 
 class TestExtendedRoles:
     """Tests for extended execution roles (manager, supervisor, governance)."""

--- a/tests/vibe3/execution/test_execution_lifecycle.py
+++ b/tests/vibe3/execution/test_execution_lifecycle.py
@@ -248,6 +248,106 @@ class TestRegistrySync:
         assert sessions[0]["target_id"] == "123"
         assert sessions[0]["target_type"] == "issue"
 
+    def test_completed_event_backfills_backend_session_id(self, tmp_path: Path) -> None:
+        """completed event should backfill backend_session_id on terminal."""
+        import sqlite3
+
+        store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-42",
+            role="executor",
+            lifecycle="started",
+            actor="agent:test",
+            detail="Run started",
+        )
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-42",
+            role="executor",
+            lifecycle="completed",
+            actor="agent:test",
+            detail="Run completed",
+            session_id="real-backend-session-123",
+        )
+
+        # Find the session (no longer live, so query all)
+        conn = store._get_connection()
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM runtime_session WHERE branch = ?", ("task/issue-42",)
+        )
+        session = dict(cursor.fetchone())
+        assert session["backend_session_id"] == "real-backend-session-123"
+        assert session["status"] == "done"
+
+    def test_completed_event_does_not_overwrite_existing_backend_session_id(
+        self, tmp_path: Path
+    ) -> None:
+        """completed event should NOT overwrite an already-set backend_session_id."""
+        store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+
+        # Create session with backend_session_id already set
+        sid = store.create_runtime_session(
+            role="executor",
+            target_type="issue",
+            target_id="42",
+            branch="task/issue-42",
+            session_name="vibe3-executor-issue-42",
+            status="running",
+            backend_session_id="original-session-id",
+        )
+
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-42",
+            role="executor",
+            lifecycle="completed",
+            actor="agent:test",
+            detail="Run completed",
+            session_id="new-session-id",
+        )
+
+        session = store.get_runtime_session(sid)
+        assert session is not None
+        assert session["backend_session_id"] == "original-session-id"
+
+    def test_aborted_event_backfills_backend_session_id(self, tmp_path: Path) -> None:
+        """aborted event should also backfill backend_session_id."""
+        import sqlite3
+
+        store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-55",
+            role="reviewer",
+            lifecycle="started",
+            actor="agent:test",
+            detail="Review started",
+        )
+        persist_execution_lifecycle_event(
+            store=store,
+            branch="task/issue-55",
+            role="reviewer",
+            lifecycle="aborted",
+            actor="agent:test",
+            detail="Review aborted",
+            session_id="abort-session-456",
+        )
+
+        conn = store._get_connection()
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM runtime_session WHERE branch = ?", ("task/issue-55",)
+        )
+        session = dict(cursor.fetchone())
+        assert session["backend_session_id"] == "abort-session-456"
+        assert session["status"] == "aborted"
+
 
 class TestExtendedRoles:
     """Tests for extended execution roles (manager, supervisor, governance)."""


### PR DESCRIPTION
Closes #2025

## Summary
Fix backend_session_id always NULL in terminal lifecycle events (completed/aborted/failed).

## Root Cause
Terminal events discarded the session_id parameter instead of writing it to backend_session_id.

## Changes
- Modified `_sync_registry_from_lifecycle_event()` terminal branch to backfill backend_session_id
- Added idempotency guard: only write if backend_session_id is NULL
- Added 3 tests covering completed/aborted events and idempotency

## Test Results
- All 21 tests pass ✅
- Type checking passes (mypy) ✅
- Lint checking passes (ruff) ✅

## Important Notes
⚠️ **This is a prerequisite fix, not the complete solution**

The fix ensures data correctness but doesn't enable session reuse because:
- Fix writes backend_session_id to terminal sessions (done/aborted/failed)
- But load_session_id() only queries live sessions (starting/running)
- Session reuse requires writing during live session (tracked in #2060)

## Related
- Follow-up: #2060 (enable actual session reuse)
- Related: #2023 (--fresh-session parameter support)

---

## Contributors

claude/opus
