### PR TITLE
refactor(services): move inline import to top-level

### DIFF
--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vibe3.clients import SQLiteClient
+from vibe3.exceptions import InvalidBranchLinkError
 
 if TYPE_CHECKING:
     from vibe3.services.convention_resolver import ConventionResolver
@@ -193,7 +194,6 @@ class IssueFlowService:
 
         # Guard: detect corrupted branch links
         base_branches = {"main", "master", "develop"}
-        from vibe3.exceptions import InvalidBranchLinkError
 
         for flow in flows:
             flow_branch = str(flow.get("branch") or "").strip()


### PR DESCRIPTION
## Summary
- Move `InvalidBranchLinkError` import from inline (line 196) to top-level import section in `issue_flow_service.py`
- Resolves style inconsistency identified in issue #2010 audit
- No functional changes - pure code style improvement

## Changes
- **File**: `src/vibe3/services/issue_flow_service.py`
- **LOC delta**: +1, -1 (net zero)
- **Scope**: Single file, single import relocation

## Verification
- ✅ 19 tests passed (incremental test suite)
- ✅ Type check passed (mypy)
- ✅ Lint passed (ruff)
- ✅ No circular dependencies introduced
- ✅ Pre-push checks passed

## Test Plan
- [x] Run incremental test suite (19 tests passed)
- [x] Verify no import errors or circular dependencies
- [x] Confirm type checking passes
- [x] Verify lint compliance

Closes #2031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
