### PR TITLE
feat(commands): add --show-prompt requires --dry-run validation

### DIFF
--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -27,6 +27,23 @@ _SHOW_PROMPT_OPT = Annotated[
         ),
     ),
 ]
+
+
+def validate_show_prompt_dependency(dry_run: bool, show_prompt: bool) -> None:
+    """Validate that --show-prompt is only used with --dry-run.
+
+    Args:
+        dry_run: Whether --dry-run flag is set
+        show_prompt: Whether --show-prompt flag is set
+
+    Raises:
+        typer.Exit: If --show-prompt is used without --dry-run
+    """
+    if show_prompt and not dry_run:
+        typer.echo("Error: --show-prompt requires --dry-run", err=True)
+        raise typer.Exit(1)
+
+
 _ASYNC_OPT = Annotated[
     bool,
     typer.Option(

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -9,6 +9,7 @@ from vibe3.commands.command_options import (
     _ASYNC_OPT,
     _DRY_RUN_OPT,
     _SHOW_PROMPT_OPT,
+    validate_show_prompt_dependency,
 )
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.services.issue_context_loader import load_issue_info
@@ -33,6 +34,9 @@ def internal_manager_dispatch(
     ] = None,
 ) -> None:
     """L3: Dispatch the State Manager agent."""
+    # Validate --show-prompt requires --dry-run
+    validate_show_prompt_dependency(dry_run, show_prompt)
+
     from vibe3.execution.issue_role_sync_runner import (
         run_issue_role_async,
         run_issue_role_sync,

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -16,6 +16,7 @@ from vibe3.commands.command_options import (
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
     build_role_cli_overrides,
+    validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
 from vibe3.config.loader import load_runtime_config
@@ -358,6 +359,9 @@ def default(
         return
 
     target_branch = resolve_branch_arg(branch)
+
+    # Validate --show-prompt requires --dry-run
+    validate_show_prompt_dependency(dry_run, show_prompt)
 
     # --task is alias for --spec (backward compatibility)
     spec_path = spec or task

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -15,6 +15,7 @@ from vibe3.commands.command_options import (
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
     ensure_flow_for_current_branch,
+    validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
 from vibe3.commands.pr_helpers import build_base_resolution_usecase
@@ -135,6 +136,10 @@ def default(
         return
 
     target_branch = resolve_branch_arg(branch)
+
+    # Validate --show-prompt requires --dry-run
+    validate_show_prompt_dependency(dry_run, show_prompt)
+
     _review_branch_impl(
         branch=target_branch,
         trace=trace,
@@ -215,6 +220,9 @@ def base(
     """
     if trace:
         enable_method_trace()
+
+    # Validate --show-prompt requires --dry-run
+    validate_show_prompt_dependency(dry_run, show_prompt)
 
     flow_service, current_branch = ensure_flow_for_current_branch()
     try:

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -16,6 +16,7 @@ from vibe3.commands.command_options import (
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
     build_role_cli_overrides,
+    validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
 from vibe3.config.loader import load_runtime_config
@@ -79,6 +80,9 @@ def run_command(
     """Execute implementation plan or skill."""
     if trace:
         enable_method_trace()
+
+    # Validate --show-prompt requires --dry-run
+    validate_show_prompt_dependency(dry_run, show_prompt)
 
     # Register EDA event handlers for run command (may publish events)
     from vibe3.domain.handlers import register_event_handlers

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -190,7 +190,7 @@ def test_review_base_help_mentions_show_prompt_option():
 
 def test_review_base_show_prompt_forwarded_to_sync():
     """review base --show-prompt should forward the flag to
-    execute_manual_review_sync."""
+    execute_manual_review_sync (requires --dry-run)."""
     with (
         patch("vibe3.commands.review.ensure_flow_for_current_branch") as mock_flow,
         patch("vibe3.commands.review.build_base_resolution_usecase") as mock_base,
@@ -210,7 +210,9 @@ def test_review_base_show_prompt_forwarded_to_sync():
             {"verdict": "MINOR", "handoff_file": None},
         )()
 
-        result = runner.invoke(app, ["base", "main", "--no-async", "--show-prompt"])
+        result = runner.invoke(
+            app, ["base", "main", "--no-async", "--dry-run", "--show-prompt"]
+        )
 
     assert result.exit_code == 0
     assert mock_execute.call_args.kwargs["show_prompt"] is True

--- a/tests/vibe3/commands/test_show_prompt_validation.py
+++ b/tests/vibe3/commands/test_show_prompt_validation.py
@@ -1,0 +1,233 @@
+"""Tests for --show-prompt requires --dry-run validation."""
+
+from unittest.mock import patch
+
+import pytest
+from click.exceptions import Exit
+from typer.testing import CliRunner
+
+from vibe3.cli import app as cli_app
+from vibe3.commands.command_options import validate_show_prompt_dependency
+
+runner = CliRunner(env={"NO_COLOR": "1"})
+
+
+class TestValidateShowPromptDependency:
+    """Unit tests for the validation helper function."""
+
+    def test_rejects_show_prompt_without_dry_run(self):
+        """Should exit with error when --show-prompt is used without --dry-run."""
+        # typer.Exit is click.exceptions.Exit, which is a subclass of SystemExit
+        with pytest.raises(Exit) as exc_info:
+            validate_show_prompt_dependency(dry_run=False, show_prompt=True)
+
+        assert exc_info.value.exit_code == 1
+
+    def test_allows_show_prompt_with_dry_run(self):
+        """Should not raise when --show-prompt is used with --dry-run."""
+        # Should not raise
+        validate_show_prompt_dependency(dry_run=True, show_prompt=True)
+
+    def test_allows_no_show_prompt_without_dry_run(self):
+        """Should not raise when --show-prompt is not used."""
+        # Should not raise
+        validate_show_prompt_dependency(dry_run=False, show_prompt=False)
+
+    def test_allows_no_show_prompt_with_dry_run(self):
+        """Should not raise when only --dry-run is used."""
+        # Should not raise
+        validate_show_prompt_dependency(dry_run=True, show_prompt=False)
+
+
+class TestRunCommandValidation:
+    """Integration tests for run command validation."""
+
+    def test_run_rejects_show_prompt_without_dry_run(self):
+        """run command should reject --show-prompt without --dry-run."""
+        # Patch execute_manual_run to avoid real execution
+        with patch("vibe3.commands.run.execute_manual_run") as mock_execute:
+            result = runner.invoke(cli_app, ["run", "test", "--show-prompt"])
+
+        assert result.exit_code == 1
+        assert "Error: --show-prompt requires --dry-run" in result.output
+        # Mock should NOT be called since validation happens first
+        mock_execute.assert_not_called()
+
+    def test_run_show_prompt_with_dry_run_still_works(self):
+        """run command should accept --show-prompt with --dry-run."""
+        # Patch execute_manual_run to avoid real execution
+        with patch("vibe3.commands.run.execute_manual_run"):
+            result = runner.invoke(
+                cli_app, ["run", "test", "--dry-run", "--show-prompt", "--no-async"]
+            )
+
+        # Validation should pass, but command may fail for other
+        # reasons (missing flow, etc.). The key is that we should
+        # NOT see the validation error
+        assert "Error: --show-prompt requires --dry-run" not in result.output
+
+
+class TestPlanCommandValidation:
+    """Integration tests for plan command validation."""
+
+    def test_plan_rejects_show_prompt_without_dry_run(self):
+        """plan command should reject --show-prompt without --dry-run."""
+        with patch("vibe3.commands.plan._plan_for_branch") as mock_plan:
+            result = runner.invoke(cli_app, ["plan", "--branch", "42", "--show-prompt"])
+
+        assert result.exit_code == 1
+        assert "Error: --show-prompt requires --dry-run" in result.output
+        # Mock should NOT be called since validation happens first
+        mock_plan.assert_not_called()
+
+    def test_plan_show_prompt_with_dry_run_still_works(self):
+        """plan command should accept --show-prompt with --dry-run."""
+        with patch("vibe3.commands.plan.FlowService") as mock_flow_service:
+            # Setup mock to avoid hitting real flow state
+            mock_flow_instance = mock_flow_service.return_value
+            mock_flow_instance.get_flow_status.return_value = None
+
+            result = runner.invoke(
+                cli_app, ["plan", "--branch", "42", "--dry-run", "--show-prompt"]
+            )
+
+        # Should exit with error about missing flow, NOT about --show-prompt
+        assert "Error: --show-prompt requires --dry-run" not in result.output
+
+
+class TestReviewCommandValidation:
+    """Integration tests for review command validation."""
+
+    def test_review_rejects_show_prompt_without_dry_run(self):
+        """review command should reject --show-prompt without --dry-run."""
+        with patch("vibe3.commands.review._review_branch_impl") as mock_review:
+            result = runner.invoke(
+                cli_app, ["review", "--branch", "42", "--show-prompt"]
+            )
+
+        assert result.exit_code == 1
+        assert "Error: --show-prompt requires --dry-run" in result.output
+        # Mock should NOT be called since validation happens first
+        mock_review.assert_not_called()
+
+    def test_review_show_prompt_with_dry_run_still_works(self):
+        """review command should accept --show-prompt with --dry-run."""
+        with patch(
+            "vibe3.commands.review.validate_review_prerequisites"
+        ) as mock_validate:
+            # Setup mock to allow validation to pass
+            mock_validate.return_value = (None, 42)
+
+            with patch("vibe3.execution.issue_role_sync_runner.run_issue_role_sync"):
+                result = runner.invoke(
+                    cli_app,
+                    [
+                        "review",
+                        "--branch",
+                        "42",
+                        "--dry-run",
+                        "--show-prompt",
+                        "--no-async",
+                    ],
+                )
+
+        # Should exit 0, not with validation error
+        assert "Error: --show-prompt requires --dry-run" not in result.output
+
+
+class TestReviewBaseCommandValidation:
+    """Integration tests for review base subcommand validation."""
+
+    def test_review_base_rejects_show_prompt_without_dry_run(self):
+        """review base command should reject --show-prompt without --dry-run."""
+        with patch(
+            "vibe3.commands.review.ensure_flow_for_current_branch"
+        ) as mock_ensure:
+            # Setup mock to avoid needing real flow
+            mock_ensure.return_value = (None, "test-branch")
+
+            result = runner.invoke(cli_app, ["review", "base", "main", "--show-prompt"])
+
+        assert result.exit_code == 1
+        assert "Error: --show-prompt requires --dry-run" in result.output
+
+    def test_review_base_show_prompt_with_dry_run_still_works(self):
+        """review base command should accept --show-prompt with --dry-run."""
+        with patch(
+            "vibe3.commands.review.ensure_flow_for_current_branch"
+        ) as mock_ensure:
+            # Setup mock to avoid needing real flow
+            mock_ensure.return_value = (None, "test-branch")
+
+            with patch(
+                "vibe3.commands.review.build_base_resolution_usecase"
+            ) as mock_base_usecase:
+                resolved = (
+                    mock_base_usecase.return_value.resolve_review_base.return_value
+                )
+                resolved.auto_detected = False
+                resolved.base_branch = "main"
+
+                with patch(
+                    "vibe3.commands.review.build_base_review_request"
+                ) as mock_build:
+                    mock_build.return_value = (None, None, None)
+
+                    with patch(
+                        "vibe3.commands.review.execute_manual_review_sync"
+                    ) as mock_execute:
+                        mock_execute.return_value.verdict = "PASS"
+                        mock_execute.return_value.handoff_file = None
+
+                        result = runner.invoke(
+                            cli_app,
+                            [
+                                "review",
+                                "base",
+                                "main",
+                                "--dry-run",
+                                "--show-prompt",
+                            ],
+                        )
+
+        # Should exit 0, not with validation error
+        assert "Error: --show-prompt requires --dry-run" not in result.output
+
+
+class TestInternalManagerCommandValidation:
+    """Integration tests for internal manager command validation."""
+
+    def test_internal_manager_rejects_show_prompt_without_dry_run(self):
+        """internal manager command should reject --show-prompt without --dry-run."""
+        with patch(
+            "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+        ) as mock_run:
+            result = runner.invoke(
+                cli_app, ["internal", "manager", "123", "--show-prompt", "--no-async"]
+            )
+
+        assert result.exit_code == 1
+        assert "Error: --show-prompt requires --dry-run" in result.output
+        # Mock should NOT be called since validation happens first
+        mock_run.assert_not_called()
+
+    def test_internal_manager_show_prompt_with_dry_run_still_works(self):
+        """internal manager command should accept --show-prompt with --dry-run."""
+        with patch(
+            "vibe3.execution.issue_role_sync_runner.run_issue_role_sync"
+        ) as mock_run:
+            result = runner.invoke(
+                cli_app,
+                [
+                    "internal",
+                    "manager",
+                    "123",
+                    "--dry-run",
+                    "--show-prompt",
+                    "--no-async",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Mock should be called since validation passed
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Summary

Add validation to reject `--show-prompt` flag when used without `--dry-run` across all agent command entry points.

## Implementation

- Added `validate_show_prompt_dependency()` helper in `command_options.py`
- Wired validation into 5 command entry points:
  - `run.py` (run_command)
  - `plan.py` (default callback)
  - `review.py` (default callback and base command)
  - `internal.py` (internal_manager_dispatch)
- Comprehensive test coverage: 14 new tests in `test_show_prompt_validation.py`

## Testing

- All 14 new tests pass
- All 365 regression tests pass
- MyPy type checking: ✅
- Ruff linting: ✅
- Black formatting: ✅
- LOC checks: ✅ (all files under 400 line CI threshold)

## Changes

- **5 files modified**: command_options.py, run.py, plan.py, review.py, internal.py
- **1 test file modified**: test_review.py (added --dry-run to existing --show-prompt tests)
- **1 new test file**: test_show_prompt_validation.py (233 lines)
- **Total**: +274 LOC, -2 LOC

Closes #2037

---

## Contributors

claude/opus
