### PR TITLE
refactor(services): use config flow.protected_branches instead of hardcoded values

### DIFF
--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vibe3.clients import SQLiteClient
+from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import InvalidBranchLinkError
 
 if TYPE_CHECKING:
@@ -193,7 +194,7 @@ class IssueFlowService:
             return None
 
         # Guard: detect corrupted branch links
-        base_branches = {"main", "master", "develop"}
+        base_branches = set(VibeConfig.get_defaults().flow.protected_branches)
 
         for flow in flows:
             flow_branch = str(flow.get("branch") or "").strip()

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -9,6 +9,7 @@ from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models import IssueState
 from vibe3.models.flow import FlowStatusResponse, IssueLink
@@ -107,11 +108,8 @@ class TaskService:
 
         # Guard: prevent base branches from being linked to issues
         base_branch = self._get_orchestra_config().scene_base_ref.replace("origin/", "")
-        if normalized_branch == base_branch or normalized_branch in (
-            "main",
-            "master",
-            "develop",
-        ):
+        protected_branches = set(VibeConfig.get_defaults().flow.protected_branches)
+        if normalized_branch == base_branch or normalized_branch in protected_branches:
             raise InvalidBranchLinkError(normalized_branch, issue_number)
 
         # Now add the new link

--- a/tests/vibe3/services/test_issue_flow_service.py
+++ b/tests/vibe3/services/test_issue_flow_service.py
@@ -4,10 +4,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
-import pytest
-
 from vibe3.config.profile_convention import ProfileConvention
-from vibe3.exceptions import InvalidBranchLinkError
 from vibe3.models.branch_convention import BranchConvention
 from vibe3.services.issue_flow_service import IssueFlowService
 
@@ -298,83 +295,3 @@ class TestIssueFlowServiceResolveTaskIssueNumber:
 
         result = service.resolve_task_issue_number("feature/my-branch")
         assert result is None
-
-
-class TestIssueFlowServiceBranchValidationGuard:
-    """Tests for read guard against corrupted branch links."""
-
-    def test_find_active_flow_rejects_main_branch(self) -> None:
-        """find_active_flow raises InvalidBranchLinkError when 'main' is linked."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            from vibe3.clients.sqlite_client import SQLiteClient
-
-            db_path = Path(tmpdir) / "test.db"
-            store = SQLiteClient(db_path=str(db_path))
-            service = IssueFlowService(store=store)
-
-            # Insert corrupted branch link (directly into DB to bypass write guard)
-            store.update_flow_state("main", flow_slug="main", flow_status="active")
-            store.add_issue_link("main", 999, "task")
-
-            with pytest.raises(InvalidBranchLinkError) as exc_info:
-                service.find_active_flow(999)
-
-            assert exc_info.value.branch == "main"
-            assert exc_info.value.issue_number == 999
-            assert "DELETE FROM flow_issue_links" in str(exc_info.value)
-
-    def test_find_active_flow_rejects_master_branch(self) -> None:
-        """find_active_flow raises InvalidBranchLinkError when 'master' is linked."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            from vibe3.clients.sqlite_client import SQLiteClient
-
-            db_path = Path(tmpdir) / "test.db"
-            store = SQLiteClient(db_path=str(db_path))
-            service = IssueFlowService(store=store)
-
-            store.update_flow_state("master", flow_slug="master", flow_status="active")
-            store.add_issue_link("master", 999, "task")
-
-            with pytest.raises(InvalidBranchLinkError) as exc_info:
-                service.find_active_flow(999)
-
-            assert exc_info.value.branch == "master"
-            assert exc_info.value.issue_number == 999
-
-    def test_find_active_flow_rejects_develop_branch(self) -> None:
-        """find_active_flow raises InvalidBranchLinkError when 'develop' is linked."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            from vibe3.clients.sqlite_client import SQLiteClient
-
-            db_path = Path(tmpdir) / "test.db"
-            store = SQLiteClient(db_path=str(db_path))
-            service = IssueFlowService(store=store)
-
-            store.update_flow_state(
-                "develop", flow_slug="develop", flow_status="active"
-            )
-            store.add_issue_link("develop", 999, "task")
-
-            with pytest.raises(InvalidBranchLinkError) as exc_info:
-                service.find_active_flow(999)
-
-            assert exc_info.value.branch == "develop"
-            assert exc_info.value.issue_number == 999
-
-    def test_find_active_flow_accepts_valid_task_branch(self) -> None:
-        """find_active_flow accepts valid task branch."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            from vibe3.clients.sqlite_client import SQLiteClient
-
-            db_path = Path(tmpdir) / "test.db"
-            store = SQLiteClient(db_path=str(db_path))
-            service = IssueFlowService(store=store)
-
-            store.update_flow_state(
-                "task/issue-999", flow_slug="issue-999", flow_status="active"
-            )
-            store.add_issue_link("task/issue-999", 999, "task")
-
-            result = service.find_active_flow(999)
-            assert result is not None
-            assert result["branch"] == "task/issue-999"

--- a/tests/vibe3/services/test_issue_flow_service_branch_validation.py
+++ b/tests/vibe3/services/test_issue_flow_service_branch_validation.py
@@ -1,0 +1,115 @@
+"""Tests for IssueFlowService branch validation guards."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from vibe3.exceptions import InvalidBranchLinkError
+from vibe3.services.issue_flow_service import IssueFlowService
+
+
+class TestIssueFlowServiceBranchValidationGuard:
+    """Tests for read guard against corrupted branch links."""
+
+    def test_find_active_flow_rejects_main_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'main' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            # Insert corrupted branch link (directly into DB to bypass write guard)
+            store.update_flow_state("main", flow_slug="main", flow_status="active")
+            store.add_issue_link("main", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "main"
+            assert exc_info.value.issue_number == 999
+            assert "DELETE FROM flow_issue_links" in str(exc_info.value)
+
+    def test_find_active_flow_rejects_master_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'master' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state("master", flow_slug="master", flow_status="active")
+            store.add_issue_link("master", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "master"
+            assert exc_info.value.issue_number == 999
+
+    def test_find_active_flow_rejects_develop_branch(self) -> None:
+        """find_active_flow raises InvalidBranchLinkError when 'develop' is linked."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state(
+                "develop", flow_slug="develop", flow_status="active"
+            )
+            store.add_issue_link("develop", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "develop"
+            assert exc_info.value.issue_number == 999
+
+    def test_find_active_flow_accepts_valid_task_branch(self) -> None:
+        """find_active_flow accepts valid task branch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state(
+                "task/issue-999", flow_slug="issue-999", flow_status="active"
+            )
+            store.add_issue_link("task/issue-999", 999, "task")
+
+            result = service.find_active_flow(999)
+            assert result is not None
+            assert result["branch"] == "task/issue-999"
+
+    def test_find_active_flow_rejects_custom_protected_branch(
+        self, monkeypatch
+    ) -> None:
+        """find_active_flow rejects custom protected branch from config."""
+        from vibe3.config.settings import FlowConfig, VibeConfig
+
+        custom_config = VibeConfig(flow=FlowConfig(protected_branches=["staging"]))
+        monkeypatch.setattr(VibeConfig, "get_defaults", lambda: custom_config)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store)
+
+            store.update_flow_state(
+                "staging", flow_slug="staging", flow_status="active"
+            )
+            store.add_issue_link("staging", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "staging"

--- a/tests/vibe3/services/test_task_service_branch_validation.py
+++ b/tests/vibe3/services/test_task_service_branch_validation.py
@@ -89,3 +89,25 @@ def test_link_issue_accepts_valid_branch(tmp_path, monkeypatch):
     assert result.branch == "task/issue-999"
     assert result.issue_number == 999
     assert result.issue_role == "task"
+
+
+def test_link_issue_rejects_custom_protected_branch(tmp_path, monkeypatch):
+    """link_issue raises InvalidBranchLinkError for custom protected branch."""
+    from vibe3.config.settings import FlowConfig, VibeConfig
+
+    custom_config = VibeConfig(
+        flow=FlowConfig(protected_branches=["staging", "production"])
+    )
+    monkeypatch.setattr(VibeConfig, "get_defaults", lambda: custom_config)
+
+    db_path = tmp_path / "fresh.db"
+    store = SQLiteClient(db_path=str(db_path))
+    service = TaskService(
+        store=store,
+        orchestra_config=OrchestraConfig(scene_base_ref="origin/main"),
+    )
+
+    with pytest.raises(InvalidBranchLinkError) as exc_info:
+        service.link_issue("staging", 999, role="task")
+
+    assert exc_info.value.branch == "staging"


### PR DESCRIPTION
## Summary

Refactors hardcoded protected branch names (`"main"`, `"master"`, `"develop"`) to use configuration from `flow.protected_branches` in settings.yaml.

**Changes**:
- `task_service.py`: Replaced hardcoded set with `VibeConfig.get_defaults().flow.protected_branches`
- `issue_flow_service.py`: Same refactor
- Split test file to meet LOC limits:
  - Extracted branch validation tests to `test_issue_flow_service_branch_validation.py`
  - Both files now under 400-line threshold
- Added comprehensive tests for custom protected branches

**Benefits**:
- Eliminates hardcoded values
- Enables custom protected branch configuration
- Follows existing pattern from `check_service.py` and `flow_service.py`

## Test Plan

- [x] All 38 tests pass (task_service + issue_flow_service + branch validation)
- [x] Type checking (mypy) passed
- [x] Linting (ruff) passed
- [x] Custom protected branch tests added and passing
- [x] Default behavior unchanged (defaults to ["main", "master", "develop"])
- [x] LOC limits verified (both test files under 400 lines)

Closes #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
