### PR TITLE
[codex] Stabilize L3 cycle tracking text

### DIFF
--- a/docs/handoff/issue-1992-fix-instructions.md
+++ b/docs/handoff/issue-1992-fix-instructions.md
@@ -15,12 +15,16 @@
 )
 ```
 
-**Problem**: The xfail reason states "10 L3-internal circular deps" but running the DFS algorithm finds **12** cycles within L3 core.
+**Problem**: The xfail reason states "10 L3-internal circular deps", but
+the DFS helper's reported count is traversal-order dependent unless the graph
+is canonicalized. A hard-coded count in the xfail reason can drift from the
+actual test output and mislead later reviews.
 
-**Fix Required**: Update the reason string to reflect the accurate count:
+**Fix Required**: Avoid hard-coding a precise cycle count in the xfail reason,
+and make DFS traversal deterministic for stable failure output:
 ```python
 @pytest.mark.xfail(
-    reason="Known architectural debt: 12 L3-internal circular deps remain in "
+    reason="Known architectural debt: L3-internal circular deps remain in "
     "{domain, execution, orchestra, roles, runtime, services} SCC. "
     "Tracked by epic #1987."
 )
@@ -28,7 +32,8 @@
 
 **Verification**:
 - Run the test and verify it still xfails correctly
-- Count should match actual cycles found by DFS
+- Run the cycle detection under multiple `PYTHONHASHSEED` values and verify the
+  hard gate still reports zero outside-L3 cycles
 
 ### Finding 2: Stale reference to old test name
 

--- a/tests/vibe3/test_modularity/conftest.py
+++ b/tests/vibe3/test_modularity/conftest.py
@@ -31,7 +31,7 @@ MODULE_LAYER_MAP: dict[str, int] = {
     "prompts": 4,
     # Layer 3 - Orchestration core（编排核心层：事件驱动的业务编排与执行控制）
     # 这 6 个模块构成一个强连通分量（SCC），内部存在已知的循环依赖技术债，
-    # 由 test_no_circular_deps_within_l3_core 追踪（Phase 1/2 后仍有 10 个循环依赖）。
+    # 由 test_no_circular_deps_within_l3_core 追踪（Phase 1/2 后仍有内部循环依赖）。
     # 作为同一层，它们对外（L1/L2）保持盲态，不产生向上依赖违规。
     # Epic #1987 追踪中。
     "domain": 3,

--- a/tests/vibe3/test_modularity/test_dependency_direction.py
+++ b/tests/vibe3/test_modularity/test_dependency_direction.py
@@ -167,7 +167,7 @@ def _detect_cycles_dfs(
         rec_stack.add(node)
         path.append(node)
 
-        for neighbor in graph.get(node, []):
+        for neighbor in sorted(graph.get(node, [])):
             if neighbor not in visited:
                 dfs(neighbor, path)
             elif neighbor in rec_stack:
@@ -179,7 +179,7 @@ def _detect_cycles_dfs(
         path.pop()
         rec_stack.remove(node)
 
-    for module in graph:
+    for module in sorted(graph):
         if module not in visited:
             dfs(module, [])
 
@@ -195,7 +195,7 @@ class TestCircularDependencies:
         """Verify no circular dependencies outside L3 orchestration core.
 
         This is a hard gate: any cycle involving at least one non-L3 module
-        will fail immediately. All 10 remaining cycles are within L3 core
+        will fail immediately. Known remaining cycles are within L3 core
         {domain, execution, orchestra, roles, runtime, services}.
 
         L3 modules are derived from MODULE_LAYER_MAP (layer == 3).
@@ -221,7 +221,7 @@ class TestCircularDependencies:
             )
 
     @pytest.mark.xfail(
-        reason="Known architectural debt: 12 L3-internal circular deps remain in "
+        reason="Known architectural debt: L3-internal circular deps remain in "
         "{domain, execution, orchestra, roles, runtime, services} SCC. "
         "Tracked by epic #1987."
     )
@@ -230,7 +230,7 @@ class TestCircularDependencies:
     ) -> None:
         """Verify no circular dependencies within L3 orchestration core.
 
-        This is an xfail test tracking the 10 known cycles within the
+        This is an xfail test tracking known cycles within the
         L3 orchestration core {domain, execution, orchestra, roles, runtime, services}.
 
         L3 modules are derived from MODULE_LAYER_MAP (layer == 3).


### PR DESCRIPTION
## Summary

Follow-up to #2084 after the merge. This fixes the review finding that the L3 circular dependency xfail text still relied on an unstable hard-coded cycle count.

Changes:
- Sort DFS traversal in the modularity cycle helper so failure output is deterministic.
- Remove precise L3 cycle counts from xfail text, docstrings, and conftest comments.
- Update the checked-in follow-up instructions so they no longer recommend changing one hard-coded count to another.

## Validation

- `PYTHONHASHSEED=1..5 PYTHONPATH=src uv run python ...` -> stable `within=13 outside=0`
- `PYTHONPATH=src uv run pytest tests/vibe3/test_modularity/ -q` -> `10 passed, 6 xfailed`
- `PYTHONPATH=src uv run ruff check --fix tests/vibe3/test_modularity/conftest.py tests/vibe3/test_modularity/test_dependency_direction.py`
- Commit hooks passed
- Push hooks passed: incremental tests `3 passed, 2 xfailed`; mypy clean

## Contributors

- GPT-5 Codex
