### PR TITLE
refactor(modularity): 为所有模块添加 __all__ 定义

### DIFF
--- a/src/vibe3/__init__.py
+++ b/src/vibe3/__init__.py
@@ -1,1 +1,6 @@
 """Vibe 3.0 package."""
+
+# Top-level package re-exports key symbols for convenience
+# Most users should import from submodules directly
+
+__all__: list[str] = []

--- a/src/vibe3/adapters/__init__.py
+++ b/src/vibe3/adapters/__init__.py
@@ -47,3 +47,11 @@ def list_adapters() -> list[str]:
         List of adapter names
     """
     return list(_ADAPTERS.keys())
+
+
+__all__ = [
+    "AdapterManifest",
+    "register_adapter",
+    "get_adapter",
+    "list_adapters",
+]

--- a/src/vibe3/orchestra/services/__init__.py
+++ b/src/vibe3/orchestra/services/__init__.py
@@ -1,0 +1,3 @@
+"""Orchestra services namespace."""
+
+__all__: list[str] = []

--- a/src/vibe3/services/protocols/__init__.py
+++ b/src/vibe3/services/protocols/__init__.py
@@ -1,0 +1,5 @@
+"""Services protocols namespace."""
+
+from vibe3.services.protocols.flow_protocols import FlowBootstrapProtocol
+
+__all__: list[str] = ["FlowBootstrapProtocol"]

--- a/src/vibe3/ui/__init__.py
+++ b/src/vibe3/ui/__init__.py
@@ -1,1 +1,6 @@
 """UI layer — console output primitives and Rich rendering components."""
+
+# Re-export key UI components for convenience
+# Note: Most UI components are used internally, selective re-exports only
+
+__all__: list[str] = []

--- a/tests/vibe3/test_modularity/test_public_interfaces.py
+++ b/tests/vibe3/test_modularity/test_public_interfaces.py
@@ -16,10 +16,6 @@ if TYPE_CHECKING:
 class TestModuleExports:
     """Test that modules properly define and export public interfaces."""
 
-    @pytest.mark.xfail(
-        reason="Known architectural debt: many modules lack __all__ - "
-        "tracked as follow-up"
-    )
     def test_all_modules_have_all_defined(self, module_registry: list[str]) -> None:
         """Verify all modules have __all__ defined in __init__.py.
 
@@ -39,11 +35,19 @@ class TestModuleExports:
 
                 has_all = False
                 for node in ast.walk(tree):
+                    # Check for regular assignment: __all__ = [...]
                     if isinstance(node, ast.Assign):
                         for target in node.targets:
                             if isinstance(target, ast.Name) and target.id == "__all__":
                                 has_all = True
                                 break
+                    # Check for annotated assignment: __all__: list[str] = [...]
+                    elif isinstance(node, ast.AnnAssign):
+                        if (
+                            isinstance(node.target, ast.Name)
+                            and node.target.id == "__all__"
+                        ):
+                            has_all = True
 
                 if not has_all:
                     modules_without_all.append(module_name)


### PR DESCRIPTION
## 问题

许多模块缺少 `__all__` 定义，导致公共 API 边界不清晰。

## 解决方案

为所有模块添加 `__all__` 定义：

### 修改的模块

1. **adapters** (`src/vibe3/adapters/__init__.py`)
   - 导出 4 个公共符号：AdapterManifest, register_adapter, get_adapter, list_adapters
   
2. **ui** (`src/vibe3/ui/__init__.py`)
   - 空命名空间（UI 组件主要用于内部）
   
3. **顶层 vibe3** (`src/vibe3/__init__.py`)
   - 空命名空间（用户应从子模块导入）
   
4. **orchestra/services** (`src/vibe3/orchestra/services/__init__.py`)
   - 空命名空间
   
5. **services/protocols** (`src/vibe3/services/protocols/__init__.py`)
   - 导出 FlowBootstrapProtocol（公共 API）

### 测试修复

- 移除 `test_all_modules_have_all_defined` 的 xfail 标记
- 修复 AST 检查以支持类型注解的 `__all__: list[str] = []`

## 验证

- ✅ 所有 27 个模块现在都有 `__all__` 定义
- ✅ 测试通过：11 passed, 5 xfailed
- ✅ Pre-commit hooks 通过
- ✅ 类型检查通过 (mypy --strict)
- ✅ LOC 检查通过（所有文件 < 400 行）

## 测试计划

运行命令：
```bash
uv run pytest tests/vibe3/test_modularity/test_public_interfaces.py -v
```

预期结果：所有测试通过或按预期 xfail

Closes #2090

---

## Contributors

Claude Sonnet 4.5
