### PR TITLE
refactor(test): update stale comment about append_governance_event import

### DIFF
--- a/tests/vibe3/execution/test_governance_sync_runner_injection.py
+++ b/tests/vibe3/execution/test_governance_sync_runner_injection.py
@@ -226,9 +226,9 @@ class TestGovernanceAsyncRunnerWithInjection:
                 build_execution_name=lambda tick: f"governance-tick-{tick}",
             )
 
-        # The lazy import path will still call append_governance_event
-        # from orchestra.logging. We can't easily mock it without importing,
-        # so we skip the assertion (verification is done via integration tests)
+        # append_governance_event is a local import inside run_governance_async
+        # and not injected, so we can't mock it via setattr. We skip the
+        # assertion (verification is done via integration tests)
 
     def test_skip_when_circuit_breaker_open(self) -> None:
         """Async dispatch should be skipped when circuit breaker is open."""
@@ -285,6 +285,6 @@ class TestGovernanceAsyncRunnerWithInjection:
                 build_execution_name=lambda tick: f"governance-tick-{tick}",
             )
 
-        # The lazy import path will still call append_governance_event
-        # from orchestra.logging. We can't easily mock it without importing,
-        # so we skip the assertion (verification is done via integration tests)
+        # append_governance_event is a local import inside run_governance_async
+        # and not injected, so we can't mock it via setattr. We skip the
+        # assertion (verification is done via integration tests)


### PR DESCRIPTION
Closes #2056

## Summary

Update stale comment in `test_governance_sync_runner_injection.py` to accurately reflect the current implementation after PR #2053's dependency injection refactor.

## Changes

- Updated 2 instances of stale comment (lines 229-231 and 288-290)
- Old comment referenced "lazy import path" pattern removed by DI refactor
- New comment correctly describes that `append_governance_event` is a local import inside `run_governance_async` and not injected as a dependency

## Verification

- ✅ All 5 tests pass: `uv run pytest tests/vibe3/execution/test_governance_sync_runner_injection.py -q`
- ✅ Pre-commit hooks passed (Ruff, Black, MyPy)
- ✅ LOC check passed (no files exceed CI block threshold)

## Related

- Issue: #2056
- Related PR: #2053 (dependency injection refactor)

---

## Contributors

claude/opus
