### PR TITLE
refactor(clients): split protocols.py into subpackage

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -194,6 +194,7 @@ AI Agent → AGENTS.md → SOUL.md (宪法和原则)
 - `agents/` - AI Agent 调用层（plan/review/run pipeline + backends）
 - `analysis/` - 代码智能（symbol 分析、结构快照、变更范围）
 - `clients/` - 外部系统客户端（Git, GitHub, AI, Serena, SQLite）
+  - `clients/protocols/` - Protocol 定义层（依赖注入接口，支持 mock 测试和解耦）
 - `commands/` - CLI 子命令实现（flow, handoff, pr, task, status, inspect 等）
 - `config/` - 配置加载、Profile 管理与 Pydantic schema 验证
 - `environment/` - 环境资源管理（Session 和 Worktree 统一抽象层）
@@ -225,6 +226,41 @@ vibe3 inspect symbols <file>:<symbol>     # 符号引用分析
 vibe3 inspect files <file>                # 文件结构 + 依赖关系
 vibe3 inspect commit <sha>                # 改动影响范围
 ```
+
+#### `clients/protocols/` - Protocol 定义层
+
+**职责**：依赖注入接口定义，支持 mock 测试和架构解耦
+
+**设计原因**：
+- **依赖注入**：通过 Protocol 定义接口，允许 services 层依赖抽象而非具体实现
+- **可测试性**：方便在测试中注入 mock 对象，隔离外部依赖
+- **架构清晰**：明确区分接口契约（clients/protocols/）和具体实现（clients/）
+- **向后兼容**：通过 `__init__.py` 重导出，保持所有现有导入路径有效
+
+**模块组成**：
+- `backend.py` - Backend 协议（tmux, 执行控制）
+- `github.py` - GitHub 客户端协议（PR, Issue, 认证）
+- `flow.py` - Flow 读取协议
+- `git.py` - Git 路径操作协议
+- `pr.py` - PR 创建协议
+
+**导入示例**：
+```python
+# 推荐：从子模块导入（明确来源）
+from vibe3.clients.protocols.github import GitHubClientProtocol
+
+# 兼容：从包根导入（向后兼容）
+from vibe3.clients.protocols import GitHubClientProtocol
+
+# 兼容：从旧位置导入（shim 重导出）
+from vibe3.services.flow_reader import FlowReader
+```
+
+**规则**：
+- 只包含 Protocol 定义（`typing.Protocol`）
+- 不包含具体实现
+- 通过 `__init__.py` 重导出所有公共符号
+- 各模块添加 `py.typed` 标记支持类型检查器
 
 ### `lib/` - V2 Shell 核心逻辑
 

--- a/src/vibe3/clients/protocols/__init__.py
+++ b/src/vibe3/clients/protocols/__init__.py
@@ -1,0 +1,35 @@
+"""Protocol definitions for clients.
+
+This package consolidates all Protocol definitions under clients.protocols.
+All symbols are re-exported for backward compatibility.
+"""
+
+from vibe3.clients.protocols.backend import BackendProtocol
+from vibe3.clients.protocols.flow import FlowReader
+from vibe3.clients.protocols.git import GitPathProtocol
+from vibe3.clients.protocols.github import (
+    GitHubAuthPort,
+    GitHubClientProtocol,
+    IssueReadPort,
+    IssueWritePort,
+    PRCommentPort,
+    PRDiffPort,
+    PRReadPort,
+    PRWritePort,
+)
+from vibe3.clients.protocols.pr import BaseResolver
+
+__all__ = [
+    "BackendProtocol",
+    "FlowReader",
+    "GitPathProtocol",
+    "GitHubAuthPort",
+    "GitHubClientProtocol",
+    "IssueReadPort",
+    "IssueWritePort",
+    "PRCommentPort",
+    "PRDiffPort",
+    "PRReadPort",
+    "PRWritePort",
+    "BaseResolver",
+]

--- a/src/vibe3/clients/protocols/__init__.py
+++ b/src/vibe3/clients/protocols/__init__.py
@@ -2,6 +2,14 @@
 
 This package consolidates all Protocol definitions under clients.protocols.
 All symbols are re-exported for backward compatibility.
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.github import GitHubClientProtocol
+    from vibe3.clients.protocols.backend import BackendProtocol
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import GitHubClientProtocol, BackendProtocol
 """
 
 from vibe3.clients.protocols.backend import BackendProtocol

--- a/src/vibe3/clients/protocols/backend.py
+++ b/src/vibe3/clients/protocols/backend.py
@@ -1,4 +1,12 @@
-"""BackendProtocol — Protocol for backend operations (tmux, execution)."""
+"""BackendProtocol — Protocol for backend operations (tmux, execution).
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.backend import BackendProtocol
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import BackendProtocol
+"""
 
 from pathlib import Path
 from typing import Protocol

--- a/src/vibe3/clients/protocols/backend.py
+++ b/src/vibe3/clients/protocols/backend.py
@@ -1,0 +1,83 @@
+"""BackendProtocol — Protocol for backend operations (tmux, execution)."""
+
+from pathlib import Path
+from typing import Protocol
+
+from vibe3.models.execution_handle import AsyncExecutionHandle
+from vibe3.models.review_runner import AgentOptions, AgentResult
+
+
+class BackendProtocol(Protocol):
+    """Protocol for backend operations (tmux, execution).
+
+    Used for dependency injection to avoid architecture layer violations.
+    Services layer depends on this protocol, concrete implementation
+    (CodeagentBackend) is injected at handler/orchestration layer.
+    """
+
+    def has_tmux_session(self, session_name: str) -> bool:
+        """Check if tmux session exists.
+
+        Args:
+            session_name: Exact tmux session name to check
+
+        Returns:
+            True if session exists, False otherwise
+        """
+        ...
+
+    def run(
+        self,
+        prompt: str,
+        options: AgentOptions,
+        task: str | None = None,
+        dry_run: bool = False,
+        session_id: str | None = None,
+        cwd: Path | None = None,
+    ) -> AgentResult:
+        """Run agent synchronously.
+
+        Args:
+            prompt: Prompt content
+            options: Agent execution options
+            task: Optional task description
+            dry_run: If True, print command without executing
+            session_id: Optional session ID to resume
+            cwd: Working directory
+
+        Returns:
+            Agent execution result
+        """
+        ...
+
+    def start_async(
+        self,
+        prompt: str,
+        options: AgentOptions,
+        *,
+        task: str | None = None,
+        session_id: str | None = None,
+        execution_name: str,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        keep_alive_seconds: int = 0,
+    ) -> AsyncExecutionHandle:
+        """Start agent asynchronously in tmux.
+
+        Args:
+            prompt: Prompt content
+            options: Agent execution options
+            task: Optional task description
+            session_id: Optional session ID to resume
+            execution_name: Unique execution name for session and logs
+            cwd: Working directory
+            env: Optional environment variable overrides
+            keep_alive_seconds: Seconds to keep tmux session alive after completion
+
+        Returns:
+            Async execution handle with session and log info
+        """
+        ...
+
+
+__all__ = ["BackendProtocol"]

--- a/src/vibe3/clients/protocols/flow.py
+++ b/src/vibe3/clients/protocols/flow.py
@@ -2,6 +2,16 @@
 
 Defines the minimal read interface that OrchestraStatusService needs,
 decoupling orchestra from the manager implementation layer.
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.flow import FlowReader
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import FlowReader
+
+    # Legacy (services shim re-export)
+    from vibe3.services.flow_reader import FlowReader
 """
 
 from __future__ import annotations

--- a/src/vibe3/clients/protocols/flow.py
+++ b/src/vibe3/clients/protocols/flow.py
@@ -1,0 +1,28 @@
+"""FlowReader Protocol — read-only interface for flow state queries.
+
+Defines the minimal read interface that OrchestraStatusService needs,
+decoupling orchestra from the manager implementation layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class FlowReader(Protocol):
+    """Read-only protocol for flow state queries used by orchestra services."""
+
+    def get_flow_for_issue(self, issue_number: int) -> dict[str, Any] | None:
+        """Return the active flow record for the given issue, or None."""
+        ...
+
+    def get_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return the PR number associated with the issue's flow, or None."""
+        ...
+
+    def get_active_flow_count(self) -> int:
+        """Return the number of currently active flows."""
+        ...
+
+
+__all__ = ["FlowReader"]

--- a/src/vibe3/clients/protocols/git.py
+++ b/src/vibe3/clients/protocols/git.py
@@ -1,0 +1,16 @@
+"""GitPathProtocol — Protocol for Git path-related operations."""
+
+from pathlib import Path
+from typing import Protocol
+
+
+class GitPathProtocol(Protocol):
+    """Protocol for Git path-related operations."""
+
+    def get_git_common_dir(self) -> str: ...
+    def get_worktree_root(self) -> str: ...
+    def find_worktree_path_for_branch(self, branch: str) -> Path | None: ...
+    def get_current_branch(self) -> str: ...
+
+
+__all__ = ["GitPathProtocol"]

--- a/src/vibe3/clients/protocols/git.py
+++ b/src/vibe3/clients/protocols/git.py
@@ -1,4 +1,15 @@
-"""GitPathProtocol — Protocol for Git path-related operations."""
+"""GitPathProtocol — Protocol for Git path-related operations.
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.git import GitPathProtocol
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import GitPathProtocol
+
+    # Legacy (services shim re-export)
+    from vibe3.services.git_path_client import GitPathProtocol
+"""
 
 from pathlib import Path
 from typing import Protocol

--- a/src/vibe3/clients/protocols/github.py
+++ b/src/vibe3/clients/protocols/github.py
@@ -1,87 +1,8 @@
-"""Protocol definitions for clients."""
+"""GitHub client protocols — narrow port protocols for GitHub operations."""
 
-from pathlib import Path
 from typing import Any, Protocol
 
-from vibe3.models.execution_handle import AsyncExecutionHandle
 from vibe3.models.pr import CreatePRRequest, PRResponse, UpdatePRRequest
-from vibe3.models.review_runner import AgentOptions, AgentResult
-
-
-class BackendProtocol(Protocol):
-    """Protocol for backend operations (tmux, execution).
-
-    Used for dependency injection to avoid architecture layer violations.
-    Services layer depends on this protocol, concrete implementation
-    (CodeagentBackend) is injected at handler/orchestration layer.
-    """
-
-    def has_tmux_session(self, session_name: str) -> bool:
-        """Check if tmux session exists.
-
-        Args:
-            session_name: Exact tmux session name to check
-
-        Returns:
-            True if session exists, False otherwise
-        """
-        ...
-
-    def run(
-        self,
-        prompt: str,
-        options: AgentOptions,
-        task: str | None = None,
-        dry_run: bool = False,
-        session_id: str | None = None,
-        cwd: Path | None = None,
-    ) -> AgentResult:
-        """Run agent synchronously.
-
-        Args:
-            prompt: Prompt content
-            options: Agent execution options
-            task: Optional task description
-            dry_run: If True, print command without executing
-            session_id: Optional session ID to resume
-            cwd: Working directory
-
-        Returns:
-            Agent execution result
-        """
-        ...
-
-    def start_async(
-        self,
-        prompt: str,
-        options: AgentOptions,
-        *,
-        task: str | None = None,
-        session_id: str | None = None,
-        execution_name: str,
-        cwd: Path | None = None,
-        env: dict[str, str] | None = None,
-        keep_alive_seconds: int = 0,
-    ) -> AsyncExecutionHandle:
-        """Start agent asynchronously in tmux.
-
-        Args:
-            prompt: Prompt content
-            options: Agent execution options
-            task: Optional task description
-            session_id: Optional session ID to resume
-            execution_name: Unique execution name for session and logs
-            cwd: Working directory
-            env: Optional environment variable overrides
-            keep_alive_seconds: Seconds to keep tmux session alive after completion
-
-        Returns:
-            Async execution handle with session and log info
-        """
-        ...
-
-
-# Narrow port protocols for GitHub client
 
 
 class GitHubAuthPort(Protocol):
@@ -321,3 +242,15 @@ class GitHubClientProtocol(
     """
 
     pass
+
+
+__all__ = [
+    "GitHubAuthPort",
+    "PRReadPort",
+    "PRWritePort",
+    "PRDiffPort",
+    "PRCommentPort",
+    "IssueReadPort",
+    "IssueWritePort",
+    "GitHubClientProtocol",
+]

--- a/src/vibe3/clients/protocols/github.py
+++ b/src/vibe3/clients/protocols/github.py
@@ -1,4 +1,12 @@
-"""GitHub client protocols — narrow port protocols for GitHub operations."""
+"""GitHub client protocols — narrow port protocols for GitHub operations.
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.github import GitHubClientProtocol, PRReadPort
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import GitHubClientProtocol, PRReadPort
+"""
 
 from typing import Any, Protocol
 

--- a/src/vibe3/clients/protocols/pr.py
+++ b/src/vibe3/clients/protocols/pr.py
@@ -1,0 +1,13 @@
+"""BaseResolver — Protocol for base branch resolution."""
+
+from typing import Protocol
+
+
+class BaseResolver(Protocol):
+    """Protocol for base branch resolution."""
+
+    def resolve_pr_create_base(self, requested_base: str | None) -> str: ...
+    def collect_branch_material(self, base_branch: str, branch: str) -> object: ...
+
+
+__all__ = ["BaseResolver"]

--- a/src/vibe3/clients/protocols/pr.py
+++ b/src/vibe3/clients/protocols/pr.py
@@ -1,4 +1,15 @@
-"""BaseResolver — Protocol for base branch resolution."""
+"""BaseResolver — Protocol for base branch resolution.
+
+Import paths:
+    # Recommended (explicit source)
+    from vibe3.clients.protocols.pr import BaseResolver
+
+    # Backward compatible (package re-export)
+    from vibe3.clients.protocols import BaseResolver
+
+    # Legacy (services shim re-export)
+    from vibe3.services.pr_create_usecase import BaseResolver
+"""
 
 from typing import Protocol
 

--- a/src/vibe3/clients/protocols/py.typed
+++ b/src/vibe3/clients/protocols/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker file - package supports type hints

--- a/src/vibe3/services/flow_reader.py
+++ b/src/vibe3/services/flow_reader.py
@@ -1,25 +1,5 @@
-"""FlowReader Protocol — read-only interface for flow state queries.
+"""Re-export shim — FlowReader has moved to clients.protocols.flow."""
 
-Defines the minimal read interface that OrchestraStatusService needs,
-decoupling orchestra from the manager implementation layer.
-"""
+from vibe3.clients.protocols.flow import FlowReader
 
-from __future__ import annotations
-
-from typing import Any, Protocol
-
-
-class FlowReader(Protocol):
-    """Read-only protocol for flow state queries used by orchestra services."""
-
-    def get_flow_for_issue(self, issue_number: int) -> dict[str, Any] | None:
-        """Return the active flow record for the given issue, or None."""
-        ...
-
-    def get_pr_for_issue(self, issue_number: int) -> int | None:
-        """Return the PR number associated with the issue's flow, or None."""
-        ...
-
-    def get_active_flow_count(self) -> int:
-        """Return the number of currently active flows."""
-        ...
+__all__ = ["FlowReader"]

--- a/src/vibe3/services/git_path_client.py
+++ b/src/vibe3/services/git_path_client.py
@@ -1,16 +1,8 @@
 """Git path operations protocol and wrappers."""
 
 from pathlib import Path
-from typing import Protocol
 
-
-class GitPathProtocol(Protocol):
-    """Protocol for Git path-related operations."""
-
-    def get_git_common_dir(self) -> str: ...
-    def get_worktree_root(self) -> str: ...
-    def find_worktree_path_for_branch(self, branch: str) -> Path | None: ...
-    def get_current_branch(self) -> str: ...
+from vibe3.clients.protocols.git import GitPathProtocol
 
 
 def _get_git_client(git_client: GitPathProtocol | None = None) -> GitPathProtocol:

--- a/src/vibe3/services/pr_create_usecase.py
+++ b/src/vibe3/services/pr_create_usecase.py
@@ -2,7 +2,6 @@
 
 import os
 from dataclasses import dataclass
-from typing import Protocol
 
 from loguru import logger
 from rich.console import Console
@@ -10,6 +9,7 @@ from rich.prompt import Prompt
 
 from vibe3.clients.ai_client import AIClient
 from vibe3.clients.ai_suggestion_client import AISuggestionClient
+from vibe3.clients.protocols.pr import BaseResolver
 from vibe3.config.settings import VibeConfig
 from vibe3.prompts.template_loader import resolve_prompts_path
 from vibe3.services.base_resolution_usecase import BaseResolutionUsecase
@@ -25,13 +25,6 @@ class PRCreateResult:
     body: str
     base_branch: str
     actor: str
-
-
-class BaseResolver(Protocol):
-    """Protocol for base branch resolution."""
-
-    def resolve_pr_create_base(self, requested_base: str | None) -> str: ...
-    def collect_branch_material(self, base_branch: str, branch: str) -> object: ...
 
 
 class PRCreateUsecase:


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `dev/issue-2110` is behind `main` by **9 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin dev/issue-2110
```


---

## Summary

Split the monolithic `clients/protocols.py` into a `clients/protocols/` subpackage, migrate `FlowReader` from `services/flow_reader.py`, extract `GitPathProtocol` from `services/git_path_client.py`, and extract `BaseResolver` from `services/pr_create_usecase.py`. Maintain full backward compatibility via re-exports.

## Changes

### New Files
- `clients/protocols/__init__.py`: Re-export all public symbols
- `clients/protocols/backend.py`: `BackendProtocol`
- `clients/protocols/github.py`: GitHub port protocols
- `clients/protocols/flow.py`: `FlowReader` (migrated)
- `clients/protocols/git.py`: `GitPathProtocol` (extracted)
- `clients/protocols/pr.py`: `BaseResolver` (extracted)

### Modified Files
- `clients/protocols.py`: Deleted (replaced by subpackage)
- `services/flow_reader.py`: Re-export shim
- `services/git_path_client.py`: Removed Protocol, kept utilities
- `services/pr_create_usecase.py`: Removed BaseResolver

## Tests

All tests passed: **2768 passed, 1 skipped, 5 xfailed** (expected)

## Verification

- ✅ All symbols importable from package root
- ✅ Backward compatibility maintained
- ✅ No circular imports
- ✅ Type checks clean (mypy: 395 source files)
- ✅ Lint checks clean (ruff)

Closes #2110

---

## Contributors

claude/opus
