### PR TITLE
feat(service): add scene_base_ref check to IssueFlowService read guard

### DIFF
--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -4,10 +4,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vibe3.clients import SQLiteClient
+from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import InvalidBranchLinkError
 
 if TYPE_CHECKING:
+    from vibe3.models.orchestra_config import OrchestraConfig
     from vibe3.services.convention_resolver import ConventionResolver
 
 
@@ -21,6 +23,11 @@ def _default_resolver() -> "ConventionResolver":
     from vibe3.services.convention_resolver import ConventionResolver
 
     return ConventionResolver.from_repo()
+
+
+def _default_config() -> "OrchestraConfig":
+    """Default factory for orchestra config."""
+    return load_orchestra_config()
 
 
 @dataclass
@@ -42,6 +49,7 @@ class IssueFlowService:
 
     store: SQLiteClient = field(default_factory=_default_store)
     resolver: "ConventionResolver" = field(default_factory=_default_resolver)
+    config: "OrchestraConfig" = field(default_factory=_default_config)
 
     def canonical_branch_name(self, issue_number: int) -> str:
         """Return canonical task branch name.
@@ -194,11 +202,12 @@ class IssueFlowService:
             return None
 
         # Guard: detect corrupted branch links
-        base_branches = set(VibeConfig.get_defaults().flow.protected_branches)
+        base_branch = self.config.scene_base_ref.replace("origin/", "")
+        protected_branches = set(VibeConfig.get_defaults().flow.protected_branches)
 
         for flow in flows:
             flow_branch = str(flow.get("branch") or "").strip()
-            if flow_branch in base_branches:
+            if flow_branch == base_branch or flow_branch in protected_branches:
                 raise InvalidBranchLinkError(flow_branch, issue_number)
 
         canonical_branch = self.canonical_branch_name(issue_number)

--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -202,6 +202,12 @@ class IssueFlowService:
             return None
 
         # Guard: detect corrupted branch links
+        # Check both sources of protected branches:
+        # - scene_base_ref: OrchestraConfig's configurable base branch for current scene
+        #   (e.g., 'main', 'develop', stripped of 'origin/' prefix to match DB storage)
+        # - protected_branches: VibeConfig's hardcoded list of protected branches
+        #   (e.g., ['main', 'develop', 'release/*'])
+        # This aligns with TaskService.link_issue() write guard for consistency.
         base_branch = self.config.scene_base_ref.replace("origin/", "")
         protected_branches = set(VibeConfig.get_defaults().flow.protected_branches)
 

--- a/tests/vibe3/services/test_issue_flow_service_branch_validation.py
+++ b/tests/vibe3/services/test_issue_flow_service_branch_validation.py
@@ -113,3 +113,62 @@ class TestIssueFlowServiceBranchValidationGuard:
                 service.find_active_flow(999)
 
             assert exc_info.value.branch == "staging"
+
+    def test_find_active_flow_rejects_scene_base_ref(self, monkeypatch) -> None:
+        """find_active_flow rejects branch matching scene_base_ref from config."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+
+        mock_config = MagicMock(spec=OrchestraConfig)
+        mock_config.scene_base_ref = "origin/custom-base"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store, config=mock_config)
+
+            store.update_flow_state(
+                "custom-base", flow_slug="custom-base", flow_status="active"
+            )
+            store.add_issue_link("custom-base", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "custom-base"
+            assert exc_info.value.issue_number == 999
+
+    def test_find_active_flow_strips_origin_prefix_from_scene_base_ref(
+        self, monkeypatch
+    ) -> None:
+        """find_active_flow strips 'origin/' prefix from scene_base_ref.
+
+        Tests comparison after stripping the prefix.
+        """
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+
+        mock_config = MagicMock(spec=OrchestraConfig)
+        mock_config.scene_base_ref = "origin/custom-base"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from vibe3.clients.sqlite_client import SQLiteClient
+
+            db_path = Path(tmpdir) / "test.db"
+            store = SQLiteClient(db_path=str(db_path))
+            service = IssueFlowService(store=store, config=mock_config)
+
+            # Insert branch WITHOUT origin/ prefix (as stored in DB)
+            store.update_flow_state(
+                "custom-base", flow_slug="custom-base", flow_status="active"
+            )
+            store.add_issue_link("custom-base", 999, "task")
+
+            with pytest.raises(InvalidBranchLinkError) as exc_info:
+                service.find_active_flow(999)
+
+            assert exc_info.value.branch == "custom-base"


### PR DESCRIPTION
## Summary

Add `OrchestraConfig`-based `scene_base_ref` check to `IssueFlowService.find_active_flow()` read guard, making it consistent with `TaskService.link_issue()` write guard. Uses lazy-load pattern to maintain backward compatibility with existing call sites.

## Changes

- **src/vibe3/services/issue_flow_service.py**:
  - Added `OrchestraConfig` field with lazy default factory
  - Enhanced read guard to check both `scene_base_ref` and `protected_branches`
  - Maintains backward compatibility (no call-site changes required)

- **tests/vibe3/services/test_issue_flow_service_branch_validation.py**:
  - Added test for `scene_base_ref` rejection
  - Added test for `origin/` prefix stripping logic

## Test Plan

- [x] All existing tests pass (22/22)
- [x] New tests for `scene_base_ref` rejection
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Pre-commit hooks pass
- [x] Pre-push checks pass (compile, type, test, LOC)

Fixes #2021

---

## Contributors

claude/opus
