### PR TITLE
refactor(cli): unify role CLI override argv/config handling

### DIFF
--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -4,10 +4,6 @@ from typing import TYPE_CHECKING, Annotated, Literal, Optional
 
 import typer
 
-from vibe3.config.cli_overrides import (
-    build_role_cli_overrides as _build_role_cli_overrides,
-)
-
 if TYPE_CHECKING:
     from vibe3.services.flow_service import FlowService
 
@@ -131,13 +127,3 @@ def ensure_flow_for_current_branch() -> tuple["FlowService", str]:
         raise typer.Exit(1)
 
     return flow_service, branch
-
-
-def build_role_cli_overrides(
-    role: str,
-    agent: str | None,
-    backend: str | None,
-    model: str | None,
-) -> dict[str, str]:
-    """Build cli_overrides dict for load_runtime_config."""
-    return _build_role_cli_overrides(role, agent, backend, model)

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -15,10 +15,10 @@ from vibe3.commands.command_options import (
     _MODEL_OPT,
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
-    build_role_cli_overrides,
     validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
+from vibe3.config.cli_overrides import RoleCliOverrides, build_role_cli_overrides
 from vibe3.config.loader import load_runtime_config
 from vibe3.exceptions import ConfigError
 from vibe3.execution.codeagent_runner import CodeagentExecutionService
@@ -133,15 +133,10 @@ def _plan_for_branch(
             config=config,
         )
     else:
-        cli_args = ["plan"]
-        if agent:
-            cli_args += ["--agent", agent]
-        if backend:
-            cli_args += ["--backend", backend]
-        if model:
-            cli_args += ["--model", model]
-        if fresh_session:
-            cli_args += ["--fresh-session"]
+        overrides = RoleCliOverrides(
+            agent=agent, backend=backend, model=model, fresh_session=fresh_session
+        )
+        cli_args = ["plan"] + overrides.to_argv()
 
         result = execute_spec_plan_async(
             request=spec_input.request,
@@ -301,17 +296,13 @@ def _plan_spec_impl(
             config=config,
         )
     else:
+        overrides = RoleCliOverrides(
+            agent=agent, backend=backend, model=model, fresh_session=fresh_session
+        )
         cli_args = ["plan"]
         if spec_path:
             cli_args += ["--spec", spec_path]
-        if agent:
-            cli_args += ["--agent", agent]
-        if backend:
-            cli_args += ["--backend", backend]
-        if model:
-            cli_args += ["--model", model]
-        if fresh_session:
-            cli_args += ["--fresh-session"]
+        cli_args += overrides.to_argv()
 
         result = execute_spec_plan_async(
             request=spec_input.request,

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -15,10 +15,10 @@ from vibe3.commands.command_options import (
     _MODEL_OPT,
     _SHOW_PROMPT_OPT,
     _TRACE_OPT,
-    build_role_cli_overrides,
     validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
+from vibe3.config.cli_overrides import build_role_cli_overrides
 from vibe3.config.loader import load_runtime_config
 from vibe3.exceptions import ConfigError, UserError
 from vibe3.roles.run import (

--- a/src/vibe3/config/cli_overrides.py
+++ b/src/vibe3/config/cli_overrides.py
@@ -1,5 +1,42 @@
 """Helpers for building runtime config CLI overrides."""
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoleCliOverrides:
+    """CLI override parameters for role configuration."""
+
+    agent: str | None = None
+    backend: str | None = None
+    model: str | None = None
+    fresh_session: bool = False
+
+    def to_config_overrides(self, role: str) -> dict[str, str]:
+        """Convert to config override dict for load_runtime_config."""
+        overrides: dict[str, str] = {}
+        if self.backend:
+            overrides[f"{role}.agent_config.backend"] = self.backend
+        if self.model:
+            overrides[f"{role}.agent_config.model"] = self.model
+        if self.agent:
+            overrides[f"{role}.agent_config.agent"] = self.agent
+        return overrides
+
+    def to_argv(self) -> list[str]:
+        """Convert to argv list for CLI invocation."""
+        args: list[str] = []
+        if self.agent:
+            args += ["--agent", self.agent]
+        if self.backend:
+            args += ["--backend", self.backend]
+        if self.model:
+            args += ["--model", self.model]
+        if self.fresh_session:
+            args += ["--fresh-session"]
+        return args
+
+
 ROLE_CONFIG_SECTIONS: dict[str, str] = {
     "executor": "run",
     "planner": "plan",
@@ -14,14 +51,9 @@ def build_role_cli_overrides(
     model: str | None,
 ) -> dict[str, str]:
     """Build cli_overrides dict for load_runtime_config."""
-    overrides: dict[str, str] = {}
-    if backend:
-        overrides[f"{role}.agent_config.backend"] = backend
-    if model:
-        overrides[f"{role}.agent_config.model"] = model
-    if agent:
-        overrides[f"{role}.agent_config.agent"] = agent
-    return overrides
+    return RoleCliOverrides(
+        agent=agent, backend=backend, model=model
+    ).to_config_overrides(role)
 
 
 def build_issue_role_cli_overrides(
@@ -34,4 +66,6 @@ def build_issue_role_cli_overrides(
     config_section = ROLE_CONFIG_SECTIONS.get(role_name)
     if config_section is None:
         return {}
-    return build_role_cli_overrides(config_section, agent, backend, model)
+    return RoleCliOverrides(
+        agent=agent, backend=backend, model=model
+    ).to_config_overrides(config_section)

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -7,7 +7,7 @@ import typer
 from vibe3.agents import CodeagentBackend
 from vibe3.clients import GitClient, SQLiteClient
 from vibe3.config import load_orchestra_config
-from vibe3.config.cli_overrides import build_issue_role_cli_overrides
+from vibe3.config.cli_overrides import ROLE_CONFIG_SECTIONS, RoleCliOverrides
 from vibe3.execution.coordinator import ExecutionCoordinator
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
 from vibe3.execution.role_interfaces import IssueRoleSyncSpec
@@ -51,8 +51,12 @@ def run_issue_role_async(
         current_branch = GitClient().get_current_branch()
         branch = spec.resolve_branch(store, issue_number, current_branch)
 
-    cli_overrides = build_issue_role_cli_overrides(
-        spec.role_name, agent, backend, model
+    overrides = RoleCliOverrides(
+        agent=agent, backend=backend, model=model, fresh_session=fresh_session
+    )
+    config_section = ROLE_CONFIG_SECTIONS.get(spec.role_name)
+    cli_overrides = (
+        overrides.to_config_overrides(config_section) if config_section else {}
     )
     options = spec.resolve_options(config, cli_overrides or None)
     actor = format_agent_actor(options)
@@ -75,13 +79,9 @@ def run_issue_role_async(
                 )
             raise typer.Exit(1)
 
-        _append_child_cli_overrides(
-            request,
-            agent=agent,
-            backend=backend,
-            model=model,
-            fresh_session=fresh_session,
-        )
+        cmd = getattr(request, "cmd", None)
+        if isinstance(cmd, list):
+            cmd.extend(overrides.to_argv())
 
         try:
             result = coordinator.dispatch_execution(request)
@@ -167,8 +167,12 @@ def run_issue_role_sync(
         None if fresh_session else load_session_id(spec.role_name, branch=branch)
     )
 
-    cli_overrides = build_issue_role_cli_overrides(
-        spec.role_name, agent, backend, model
+    overrides = RoleCliOverrides(
+        agent=agent, backend=backend, model=model, fresh_session=fresh_session
+    )
+    config_section = ROLE_CONFIG_SECTIONS.get(spec.role_name)
+    cli_overrides = (
+        overrides.to_config_overrides(config_section) if config_section else {}
     )
     options = spec.resolve_options(config, cli_overrides or None)
     actor = format_agent_actor(options)
@@ -214,25 +218,3 @@ def run_issue_role_sync(
                 sync_result.reason or f"{spec.role_name} exited with failure",
             )
         raise typer.Exit(1)
-
-
-def _append_child_cli_overrides(
-    request: object,
-    *,
-    agent: str | None,
-    backend: str | None,
-    model: str | None,
-    fresh_session: bool,
-) -> None:
-    """Append role CLI overrides to an async self-invocation command."""
-    cmd = getattr(request, "cmd", None)
-    if not isinstance(cmd, list):
-        return
-    if agent:
-        cmd.extend(["--agent", agent])
-    if backend:
-        cmd.extend(["--backend", backend])
-    if model:
-        cmd.extend(["--model", model])
-    if fresh_session:
-        cmd.append("--fresh-session")

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -17,6 +17,7 @@ from vibe3.agents import (
     run_inspect_json,
 )
 from vibe3.analysis.inspect_output_adapter import changed_symbols
+from vibe3.config.cli_overrides import RoleCliOverrides
 from vibe3.config.loader import load_runtime_config
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.role_gates import REVIEWER_GATE_CONFIG
@@ -497,19 +498,15 @@ def _build_manual_review_async_cli_args(
     model: str | None = None,
     fresh_session: bool = False,
 ) -> list[str]:
+    overrides = RoleCliOverrides(
+        agent=agent, backend=backend, model=model, fresh_session=fresh_session
+    )
     args = ["review", "base"]
     if request.scope.base_branch:
         args.append(request.scope.base_branch)
     if instructions:
         args.append(instructions)
-    if agent:
-        args += ["--agent", agent]
-    if backend:
-        args += ["--backend", backend]
-    if model:
-        args += ["--model", model]
-    if fresh_session:
-        args += ["--fresh-session"]
+    args += overrides.to_argv()
     return args
 
 

--- a/tests/vibe3/config/test_cli_overrides.py
+++ b/tests/vibe3/config/test_cli_overrides.py
@@ -1,0 +1,83 @@
+"""Tests for CLI overrides module."""
+
+from vibe3.config.cli_overrides import (
+    RoleCliOverrides,
+    build_issue_role_cli_overrides,
+    build_role_cli_overrides,
+)
+
+
+class TestRoleCliOverrides:
+    """Tests for RoleCliOverrides dataclass."""
+
+    def test_to_config_overrides_all_set(self) -> None:
+        """Test config override dict with all fields set."""
+        o = RoleCliOverrides(agent="a", backend="b", model="m", fresh_session=True)
+        assert o.to_config_overrides("plan") == {
+            "plan.agent_config.agent": "a",
+            "plan.agent_config.backend": "b",
+            "plan.agent_config.model": "m",
+        }
+
+    def test_to_config_overrides_defaults(self) -> None:
+        """Test config override dict with defaults (empty)."""
+        o = RoleCliOverrides()
+        assert o.to_config_overrides("run") == {}
+
+    def test_to_config_overrides_partial(self) -> None:
+        """Test config override dict with partial fields."""
+        o = RoleCliOverrides(backend="b")
+        assert o.to_config_overrides("review") == {
+            "review.agent_config.backend": "b",
+        }
+
+    def test_to_argv_all_set(self) -> None:
+        """Test argv list with all fields set."""
+        o = RoleCliOverrides(agent="a", backend="b", model="m", fresh_session=True)
+        assert o.to_argv() == [
+            "--agent",
+            "a",
+            "--backend",
+            "b",
+            "--model",
+            "m",
+            "--fresh-session",
+        ]
+
+    def test_to_argv_defaults(self) -> None:
+        """Test argv list with defaults (empty)."""
+        o = RoleCliOverrides()
+        assert o.to_argv() == []
+
+    def test_to_argv_partial(self) -> None:
+        """Test argv list with partial fields."""
+        o = RoleCliOverrides(agent="a", fresh_session=True)
+        assert o.to_argv() == ["--agent", "a", "--fresh-session"]
+
+    def test_frozen(self) -> None:
+        """Test that dataclass is frozen (immutable)."""
+        o = RoleCliOverrides(agent="a")
+        # Dataclass is frozen, mutation should raise
+        try:
+            o.agent = "b"
+            assert False, "Should have raised FrozenInstanceError"
+        except AttributeError:
+            pass
+
+    def test_build_role_cli_overrides_delegates(self) -> None:
+        """Test that build_role_cli_overrides delegates to RoleCliOverrides."""
+        result = build_role_cli_overrides("plan", "a", "b", "m")
+        assert result == RoleCliOverrides(
+            agent="a", backend="b", model="m"
+        ).to_config_overrides("plan")
+
+    def test_build_issue_role_cli_overrides_delegates(self) -> None:
+        """Test that build_issue_role_cli_overrides delegates to RoleCliOverrides."""
+        result = build_issue_role_cli_overrides("reviewer", "a", "b", "m")
+        assert result == RoleCliOverrides(
+            agent="a", backend="b", model="m"
+        ).to_config_overrides("review")
+
+    def test_build_issue_role_cli_overrides_unknown_role(self) -> None:
+        """Test that unknown role returns empty dict."""
+        assert build_issue_role_cli_overrides("unknown", "a", "b", "m") == {}

--- a/tests/vibe3/config/test_cli_overrides.py
+++ b/tests/vibe3/config/test_cli_overrides.py
@@ -1,5 +1,9 @@
 """Tests for CLI overrides module."""
 
+import dataclasses
+
+import pytest
+
 from vibe3.config.cli_overrides import (
     RoleCliOverrides,
     build_issue_role_cli_overrides,
@@ -57,12 +61,8 @@ class TestRoleCliOverrides:
     def test_frozen(self) -> None:
         """Test that dataclass is frozen (immutable)."""
         o = RoleCliOverrides(agent="a")
-        # Dataclass is frozen, mutation should raise
-        try:
+        with pytest.raises(dataclasses.FrozenInstanceError):
             o.agent = "b"
-            assert False, "Should have raised FrozenInstanceError"
-        except AttributeError:
-            pass
 
     def test_build_role_cli_overrides_delegates(self) -> None:
         """Test that build_role_cli_overrides delegates to RoleCliOverrides."""


### PR DESCRIPTION
## Summary

Introduce `RoleCliOverrides` dataclass to unify CLI override handling across 4 modules, replacing scattered argv concatenation with single source of truth.

## Changes

- **Added `RoleCliOverrides` dataclass** in `cli_overrides.py` with `to_config_overrides()` and `to_argv()` projections
- **Removed confusing re-export** from `command_options.py` for clearer module boundaries
- **Replaced 4 argv concatenation sites** in `plan.py`, `issue_role_sync_runner.py`, and `review.py`
- **Updated `run.py`** to import directly from `cli_overrides`
- **Added comprehensive unit tests** (10 new tests) for `RoleCliOverrides` dataclass

## Benefits

- **Single source of truth** for CLI override handling
- **Eliminates code duplication** across 4 modules
- **Clearer module boundaries**: `command_options` for Typer options, `cli_overrides` for config/argv logic
- **Better test coverage**: `cli_overrides.py` now has direct test coverage (previously untested)

## Test Results

- ✅ 188 tests pass (including 10 new tests)
- ✅ No type errors (mypy clean)
- ✅ No lint errors (ruff clean)
- ✅ All files under LOC limits

## Related Issues

- Closes #2063
- Follow-up: #2117 (run_command.py async path gap)

---

## Contributors

claude/opus
