### PR TITLE
refactor(snapshot): add __add__ method to DiffSummary for operator-based merging

### DIFF
--- a/src/vibe3/analysis/snapshot_diff.py
+++ b/src/vibe3/analysis/snapshot_diff.py
@@ -222,18 +222,7 @@ def compute_diff(
         module_changes, module_summary, warnings = _diff_modules(baseline, current)
         dep_changes, dep_summary = _diff_dependencies(baseline, current)
 
-        summary = DiffSummary(
-            files_added=file_summary.files_added,
-            files_removed=file_summary.files_removed,
-            files_modified=file_summary.files_modified,
-            modules_added=module_summary.modules_added,
-            modules_removed=module_summary.modules_removed,
-            modules_modified=module_summary.modules_modified,
-            dependencies_added=dep_summary.dependencies_added,
-            dependencies_removed=dep_summary.dependencies_removed,
-            total_loc_delta=file_summary.total_loc_delta,
-            total_functions_delta=file_summary.total_functions_delta,
-        )
+        summary = file_summary + module_summary + dep_summary
 
         diff = StructureDiff(
             baseline_id=baseline.snapshot_id,

--- a/src/vibe3/models/snapshot.py
+++ b/src/vibe3/models/snapshot.py
@@ -1,5 +1,7 @@
 """Snapshot models for structure analysis."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Literal, Optional
 
@@ -135,6 +137,21 @@ class DiffSummary(BaseModel):
     dependencies_removed: int = 0
     total_loc_delta: int = 0
     total_functions_delta: int = 0
+
+    def __add__(self, other: DiffSummary) -> DiffSummary:
+        return DiffSummary(
+            files_added=self.files_added + other.files_added,
+            files_removed=self.files_removed + other.files_removed,
+            files_modified=self.files_modified + other.files_modified,
+            modules_added=self.modules_added + other.modules_added,
+            modules_removed=self.modules_removed + other.modules_removed,
+            modules_modified=self.modules_modified + other.modules_modified,
+            dependencies_added=self.dependencies_added + other.dependencies_added,
+            dependencies_removed=self.dependencies_removed + other.dependencies_removed,
+            total_loc_delta=self.total_loc_delta + other.total_loc_delta,
+            total_functions_delta=self.total_functions_delta
+            + other.total_functions_delta,
+        )
 
 
 class DiffWarning(BaseModel):

--- a/tests/vibe3/analysis/test_snapshot_diff.py
+++ b/tests/vibe3/analysis/test_snapshot_diff.py
@@ -1,0 +1,119 @@
+"""Tests for compute_diff function."""
+
+from vibe3.analysis.snapshot_diff import compute_diff
+from vibe3.models.snapshot import (
+    DependencyEdge,
+    FileSnapshot,
+    ModuleSnapshot,
+    StructureMetrics,
+    StructureSnapshot,
+)
+
+
+def test_compute_diff_merges_summaries():
+    """Test that compute_diff correctly merges sub-summaries."""
+    # Create baseline snapshot
+    baseline = StructureSnapshot(
+        snapshot_id="2026-03-20T10-00-00_main_abc1234",
+        branch="main",
+        commit="abc1234567890",
+        commit_short="abc1234",
+        created_at="2026-03-20T10:00:00",
+        root="src/vibe3",
+        files=[
+            FileSnapshot(
+                path="services/old_service.py",
+                language="python",
+                total_loc=100,
+                function_count=5,
+            ),
+        ],
+        modules=[
+            ModuleSnapshot(
+                module="services",
+                file_count=1,
+                total_loc=100,
+                total_functions=5,
+                files=["services/old_service.py"],
+            ),
+        ],
+        dependencies=[
+            DependencyEdge(from_module="services", to_module="utils"),
+        ],
+        metrics=StructureMetrics(
+            total_files=1,
+            total_loc=100,
+            total_functions=5,
+        ),
+    )
+
+    # Create current snapshot with changes
+    current = StructureSnapshot(
+        snapshot_id="2026-03-24T15-30-00_feature_def5678",
+        branch="feature/test",
+        commit="def5678901234",
+        commit_short="def5678",
+        created_at="2026-03-24T15:30:00",
+        root="src/vibe3",
+        files=[
+            FileSnapshot(
+                path="services/old_service.py",
+                language="python",
+                total_loc=150,  # Modified
+                function_count=7,  # Modified
+            ),
+            FileSnapshot(
+                path="services/new_service.py",
+                language="python",
+                total_loc=200,
+                function_count=10,
+            ),
+        ],
+        modules=[
+            ModuleSnapshot(
+                module="services",
+                file_count=2,  # Changed
+                total_loc=350,  # Changed
+                total_functions=17,  # Changed
+                files=["services/old_service.py", "services/new_service.py"],
+            ),
+            ModuleSnapshot(
+                module="commands",
+                file_count=1,
+                total_loc=50,
+                total_functions=2,
+                files=["commands/new_cmd.py"],
+            ),
+        ],
+        dependencies=[
+            DependencyEdge(from_module="services", to_module="utils"),
+            DependencyEdge(from_module="services", to_module="models"),
+        ],
+        metrics=StructureMetrics(
+            total_files=2,
+            total_loc=350,
+            total_functions=17,
+        ),
+    )
+
+    # Compute diff
+    diff = compute_diff(baseline, current)
+
+    # Verify summary has correctly merged counts
+    # File changes: 1 added, 0 removed, 1 modified
+    assert diff.summary.files_added == 1
+    assert diff.summary.files_removed == 0
+    assert diff.summary.files_modified == 1
+
+    # Module changes: 1 added, 0 removed, 1 modified
+    assert diff.summary.modules_added == 1
+    assert diff.summary.modules_removed == 0
+    assert diff.summary.modules_modified == 1
+
+    # Dependency changes: 1 added, 0 removed
+    assert diff.summary.dependencies_added == 1
+    assert diff.summary.dependencies_removed == 0
+
+    # LOC and function deltas
+    assert diff.summary.total_loc_delta == 250  # 350 - 100 = 250
+    assert diff.summary.total_functions_delta == 12  # 17 - 5 = 12

--- a/tests/vibe3/models/test_snapshot.py
+++ b/tests/vibe3/models/test_snapshot.py
@@ -1,0 +1,87 @@
+"""Tests for snapshot models."""
+
+from vibe3.models.snapshot import DiffSummary
+
+
+def test_diff_summary_add():
+    """Test that adding two DiffSummary instances sums all fields."""
+    a = DiffSummary(
+        files_added=1,
+        files_removed=2,
+        files_modified=3,
+        modules_added=4,
+        modules_removed=5,
+        modules_modified=6,
+        dependencies_added=7,
+        dependencies_removed=8,
+        total_loc_delta=100,
+        total_functions_delta=50,
+    )
+    b = DiffSummary(
+        files_added=10,
+        files_removed=20,
+        files_modified=30,
+        modules_added=40,
+        modules_removed=50,
+        modules_modified=60,
+        dependencies_added=70,
+        dependencies_removed=80,
+        total_loc_delta=200,
+        total_functions_delta=150,
+    )
+
+    result = a + b
+
+    assert result.files_added == 11
+    assert result.files_removed == 22
+    assert result.files_modified == 33
+    assert result.modules_added == 44
+    assert result.modules_removed == 55
+    assert result.modules_modified == 66
+    assert result.dependencies_added == 77
+    assert result.dependencies_removed == 88
+    assert result.total_loc_delta == 300
+    assert result.total_functions_delta == 200
+
+
+def test_diff_summary_add_defaults():
+    """Test that adding two default DiffSummary instances returns all zeros."""
+    a = DiffSummary()
+    b = DiffSummary()
+
+    result = a + b
+
+    assert result.files_added == 0
+    assert result.files_removed == 0
+    assert result.files_modified == 0
+    assert result.modules_added == 0
+    assert result.modules_removed == 0
+    assert result.modules_modified == 0
+    assert result.dependencies_added == 0
+    assert result.dependencies_removed == 0
+    assert result.total_loc_delta == 0
+    assert result.total_functions_delta == 0
+
+
+def test_diff_summary_add_commutative():
+    """Test that DiffSummary addition is commutative."""
+    a = DiffSummary(
+        files_added=1,
+        files_removed=2,
+        total_loc_delta=100,
+        total_functions_delta=50,
+    )
+    b = DiffSummary(
+        files_added=10,
+        files_removed=20,
+        total_loc_delta=200,
+        total_functions_delta=150,
+    )
+
+    result_ab = a + b
+    result_ba = b + a
+
+    assert result_ab.files_added == result_ba.files_added
+    assert result_ab.files_removed == result_ba.files_removed
+    assert result_ab.total_loc_delta == result_ba.total_loc_delta
+    assert result_ab.total_functions_delta == result_ba.total_functions_delta


### PR DESCRIPTION
## Summary
Replace manual field mapping in `compute_diff` with operator-based merging using `DiffSummary.__add__`. This eliminates the Filter-Instead-of-Delete anti-pattern and makes the code more maintainable.

## Changes
- Add `__add__` method to `DiffSummary` that sums all fields and returns new instance
- Simplify `compute_diff` to use `file_summary + module_summary + dep_summary`
- Add unit tests for `DiffSummary.__add__` (add, defaults, commutative)
- Add unit test for `compute_diff` to verify merged summary counts

## Implementation Details
**Before** (11 lines of manual mapping):
```python
summary = DiffSummary(
    files_added=file_summary.files_added,
    files_removed=file_summary.files_removed,
    files_modified=file_summary.files_modified,
    modules_added=module_summary.modules_added,
    modules_removed=module_summary.modules_removed,
    modules_modified=module_summary.modules_modified,
    dependencies_added=dep_summary.dependencies_added,
    dependencies_removed=dep_summary.dependencies_removed,
    total_loc_delta=file_summary.total_loc_delta,
    total_functions_delta=file_summary.total_functions_delta,
)
```

**After** (1 line):
```python
summary = file_summary + module_summary + dep_summary
```

## Verification
- ✅ mypy: Success (391 source files → 396 after rebase)
- ✅ ruff: All checks passed
- ✅ pytest: 241 tests passed (analysis + models)
- ✅ No behavior change - operator-based merge produces identical results

## Test Coverage
- **Direct tests**: 4 new tests
  - `tests/vibe3/models/test_snapshot.py`: 3 tests for `DiffSummary.__add__`
  - `tests/vibe3/analysis/test_snapshot_diff.py`: 1 test for `compute_diff`
- **Module tests**: 241 tests passed in `tests/vibe3/analysis/` and `tests/vibe3/models/`

Fixes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
