### PR TITLE
refactor(clients): 公共接口统一 + 消除内部导入 (194 violations)

### DIFF
--- a/src/vibe3/adapters/github_flow.py
+++ b/src/vibe3/adapters/github_flow.py
@@ -1,7 +1,7 @@
 """GitHub Flow adapter — lightweight skill distribution from global runtime."""
 
 from vibe3.adapters import register_adapter
-from vibe3.clients.runtime_assets import runtime_assets_root
+from vibe3.clients import runtime_assets_root
 from vibe3.models.adapter_manifest import AdapterManifest, AdapterResource
 
 

--- a/src/vibe3/adapters/resource_root.py
+++ b/src/vibe3/adapters/resource_root.py
@@ -36,7 +36,7 @@ def resolve_resource_root(
         candidates.append(Path(git_common_dir).parent)
     else:
         try:
-            from vibe3.clients.git_client import GitClient
+            from vibe3.clients import GitClient
 
             detected_common_dir = GitClient().get_git_common_dir()
             if detected_common_dir:

--- a/src/vibe3/adapters/vibe_center.py
+++ b/src/vibe3/adapters/vibe_center.py
@@ -19,7 +19,7 @@ def _build_vibe_center_manifest() -> AdapterManifest:
     Uses GitClient to find repo root, ensuring correct resource discovery
     regardless of current working directory.
     """
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     git_common_dir = None
     try:
@@ -82,7 +82,7 @@ def _build_vibe_center_manifest() -> AdapterManifest:
     )
 
     # Skills (scan directory)
-    from vibe3.clients.runtime_assets import runtime_assets_root
+    from vibe3.clients import runtime_assets_root
 
     skills_dirs = [repo_root / "skills"]
     global_skills = runtime_assets_root() / "skills"

--- a/src/vibe3/analysis/inspect_query_service.py
+++ b/src/vibe3/analysis/inspect_query_service.py
@@ -32,8 +32,7 @@ from . import dag_service as dag_service_module
 
 def build_change_analysis(source_type: str, identifier: str) -> dict[str, object]:
     """Run change analysis pipeline and return impact/dag/score."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     log = logger.bind(
         domain="inspect", action="change_analysis", source_type=source_type

--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -1,8 +1,35 @@
 """Vibe3 clients layer."""
 
+# Core clients
+# AI clients
+from vibe3.clients.ai_client import AIClient
+from vibe3.clients.ai_suggestion_client import AISuggestionClient
 from vibe3.clients.git_client import GitClient, find_repo_root
+
+# Worktree operations
+from vibe3.clients.git_worktree_ops import prune_worktrees, remove_worktree
 from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import BackendProtocol
+
+# Issue parsing utilities
+from vibe3.clients.github_issues_ops import parse_blocked_by, parse_linked_issues
+
+# Labels
+from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
+
+# Caches
+from vibe3.clients.merged_pr_cache import MergedPRCache
+
+# Protocols
+from vibe3.clients.protocols import BackendProtocol, GitHubClientProtocol
+from vibe3.clients.recent_pr_cache import RecentPRCache
+
+# Runtime assets
+from vibe3.clients.runtime_assets import (
+    check_runtime_asset,
+    resolve_prompt_config,
+    resolve_runtime_asset,
+    runtime_assets_root,
+)
 from vibe3.clients.serena_client import (
     SerenaClient,
     count_references,
@@ -12,11 +39,35 @@ from vibe3.clients.sqlite_client import SQLiteClient
 from vibe3.clients.store_context import get_store
 
 __all__ = [
+    # Protocols
     "BackendProtocol",
+    "GitHubClientProtocol",
+    # Core clients
     "GitClient",
     "GitHubClient",
-    "SerenaClient",
     "SQLiteClient",
+    "SerenaClient",
+    # Labels
+    "GhIssueLabelPort",
+    "IssueLabelPort",
+    # Runtime assets
+    "runtime_assets_root",
+    "resolve_runtime_asset",
+    "check_runtime_asset",
+    "resolve_prompt_config",
+    # Issue parsing
+    "parse_blocked_by",
+    "parse_linked_issues",
+    # Worktree operations
+    "remove_worktree",
+    "prune_worktrees",
+    # Caches
+    "MergedPRCache",
+    "RecentPRCache",
+    # AI clients
+    "AIClient",
+    "AISuggestionClient",
+    # Utilities
     "count_references",
     "extract_function_names",
     "find_repo_root",

--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -4,7 +4,7 @@
 # AI clients
 from vibe3.clients.ai_client import AIClient
 from vibe3.clients.ai_suggestion_client import AISuggestionClient
-from vibe3.clients.git_client import GitClient, find_repo_root
+from vibe3.clients.git_client import GitClient, GitClientProtocol, find_repo_root
 
 # Worktree operations
 from vibe3.clients.git_worktree_ops import prune_worktrees, remove_worktree
@@ -21,6 +21,18 @@ from vibe3.clients.merged_pr_cache import MergedPRCache
 
 # Protocols
 from vibe3.clients.protocols import BackendProtocol, GitHubClientProtocol
+from vibe3.clients.protocols.flow import FlowReader
+from vibe3.clients.protocols.git import GitPathProtocol
+from vibe3.clients.protocols.github import (
+    GitHubAuthPort,
+    IssueReadPort,
+    IssueWritePort,
+    PRCommentPort,
+    PRDiffPort,
+    PRReadPort,
+    PRWritePort,
+)
+from vibe3.clients.protocols.pr import BaseResolver
 from vibe3.clients.recent_pr_cache import RecentPRCache
 
 # Runtime assets
@@ -42,8 +54,19 @@ __all__ = [
     # Protocols
     "BackendProtocol",
     "GitHubClientProtocol",
+    "GitPathProtocol",
+    "FlowReader",
+    "BaseResolver",
+    "GitHubAuthPort",
+    "PRReadPort",
+    "PRWritePort",
+    "PRDiffPort",
+    "PRCommentPort",
+    "IssueReadPort",
+    "IssueWritePort",
     # Core clients
     "GitClient",
+    "GitClientProtocol",
     "GitHubClient",
     "SQLiteClient",
     "SerenaClient",

--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -177,7 +177,7 @@ def rebuild(
         )
         return
 
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
 
     config = load_orchestra_config()
     issue = load_issue_info(issue_number, config=config, github=GitHubClient())

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -171,7 +171,7 @@ def update(
             err=True,
         )
         output_format = "json"
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.services.branch_arg import resolve_branch_arg
     from vibe3.utils.issue_ref import try_parse_issue_number

--- a/src/vibe3/commands/flow_status_helpers.py
+++ b/src/vibe3/commands/flow_status_helpers.py
@@ -113,7 +113,7 @@ def _fetch_worktree_map() -> dict[str, str]:
     """Fetch worktree mapping from git worktree list."""
     worktree_map: dict[str, str] = {}
     try:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         git = GitClient()
         worktree_output = git._run(["worktree", "list", "--porcelain"])

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.commands.command_options import FormatOption, VerboseOption
 from vibe3.commands.common import enable_method_trace
 from vibe3.commands.handoff_render import (

--- a/src/vibe3/commands/inspect_base.py
+++ b/src/vibe3/commands/inspect_base.py
@@ -56,8 +56,7 @@ def register(app: typer.Typer) -> None:
             vibe inspect base origin/develop # Compare current branch vs origin/develop
             vibe inspect base main           # Compare current branch vs origin/main
         """
-        from vibe3.clients.git_client import GitClient
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitClient, GitHubClient
         from vibe3.config.loader import get_config
         from vibe3.models.change_source import BranchSource
         from vibe3.utils.git_helpers import get_current_branch

--- a/src/vibe3/commands/inspect_base_helpers.py
+++ b/src/vibe3/commands/inspect_base_helpers.py
@@ -10,7 +10,7 @@ from vibe3.analysis.change_scope_service import (
     count_changed_lines,
 )
 from vibe3.analysis.serena_service import SerenaService
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.config.loader import get_config
 from vibe3.exceptions import GitError, UserError
 from vibe3.models.change_source import BranchSource

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -146,9 +146,7 @@ def internal_bootstrap(
     ] = False,
 ) -> None:
     """Bootstrap a standardized flow scene through the shared service path."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
 
     config = load_orchestra_config()
@@ -174,8 +172,7 @@ def internal_bootstrap(
 @app.command("backfill-worktree-paths")
 def backfill_worktree_paths() -> None:
     """Backfill worktree_path for existing active task/ flows."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, SQLiteClient
     from vibe3.services.status_query_service import is_auto_task_branch
 
     git = GitClient()

--- a/src/vibe3/commands/mcp.py
+++ b/src/vibe3/commands/mcp.py
@@ -35,9 +35,7 @@ def run() -> None:
       - orchestra://issues: List of managed issues
       - orchestra://circuit-breaker: Circuit breaker state
     """
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.domain import FlowManager
     from vibe3.services.orchestra_status_service import OrchestraStatusService

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.commands.command_options import _ASYNC_OPT
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.observability import setup_logging
@@ -120,7 +120,7 @@ def _run_supervisor_scan_dry_run() -> None:
     """
     from rich.console import Console
 
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.services.scan_service import fetch_supervisor_candidates
     from vibe3.ui.scan_display import display_supervisor_dry_run

--- a/src/vibe3/commands/snapshot.py
+++ b/src/vibe3/commands/snapshot.py
@@ -107,7 +107,7 @@ def save(
         vibe3 snapshot save --as-baseline
         vibe3 snapshot save --json
     """
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     if trace:
         enable_method_trace()
@@ -275,7 +275,7 @@ def diff(
         vibe3 snapshot diff <snapshot-id>    # Compare with specific snapshot
         vibe3 snapshot diff latest           # Compare with latest snapshot
     """
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     if trace:
         enable_method_trace()

--- a/src/vibe3/config/convention_resolver.py
+++ b/src/vibe3/config/convention_resolver.py
@@ -15,7 +15,7 @@ from loguru import logger
 from vibe3.config.profile_convention import ProfileConvention
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
     from vibe3.config.profile_config import ProfileConfig
 
 
@@ -61,7 +61,7 @@ class ConventionResolver:
             GitClient instance (injected or lazy-loaded)
         """
         if self._git_client is None:
-            from vibe3.clients.git_client import GitClient
+            from vibe3.clients import GitClient
 
             self._git_client = GitClient()
         return self._git_client

--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -422,7 +422,7 @@ def load_keys_env_fallback() -> None:
     # (git_client imports from config module)
     repo_root: Path | None = None
     try:
-        from vibe3.clients.git_client import find_repo_root
+        from vibe3.clients import find_repo_root
 
         repo_root = find_repo_root()
     except SystemError:

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Callable, cast
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.domain.protocols.dispatch_protocols import (
     CapacityServiceProtocol,
     CheckServiceProtocol,
@@ -49,7 +49,7 @@ from vibe3.services.label_utils import (
 from vibe3.services.orchestra_helpers import get_manager_usernames
 
 if TYPE_CHECKING:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.roles.definitions import TriggerableRoleDefinition
 

--- a/src/vibe3/domain/flow_manager.py
+++ b/src/vibe3/domain/flow_manager.py
@@ -9,10 +9,7 @@ from typing import cast
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models import IssueInfo, IssueState
 from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -11,7 +11,7 @@ from typing import Callable
 
 from loguru import logger
 
-from vibe3.clients.store_context import get_store
+from vibe3.clients import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events import (
     ExecutorDispatchIntent,

--- a/src/vibe3/domain/handlers/governance_scan.py
+++ b/src/vibe3/domain/handlers/governance_scan.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.store_context import get_store
+from vibe3.clients import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.domain.events.governance import GovernanceScanStarted
@@ -22,7 +22,7 @@ from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionReque
 from vibe3.services.error_helpers import record_dispatch_failure_if_unexpected
 
 if TYPE_CHECKING:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
     from vibe3.config.orchestra_config import OrchestraConfig
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.services.orchestra_status_service import OrchestraStatusService

--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.store_context import get_store
+from vibe3.clients import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.flow_lifecycle import ManagerDispatchIntent
 from vibe3.domain.handler_registry import register_handler
@@ -19,8 +19,7 @@ from vibe3.services.issue_failure_service import block_manager_noop_issue
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.codeagent import CodeagentBackend
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.config.orchestra_settings import OrchestraConfig
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.execution.capacity_service import CapacityService
@@ -61,7 +60,7 @@ def build_dispatch_context(
 
 
 def _lazy_github_client() -> "GitHubClient":
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
 
     return GitHubClient()
 

--- a/src/vibe3/domain/handlers/supervisor_scan.py
+++ b/src/vibe3/domain/handlers/supervisor_scan.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.store_context import get_store
+from vibe3.clients import get_store
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.domain.handler_registry import register_handler

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain import publish
 from vibe3.domain.events.governance import GovernanceScanStarted

--- a/src/vibe3/domain/protocols/dispatch_protocols.py
+++ b/src/vibe3/domain/protocols/dispatch_protocols.py
@@ -3,8 +3,7 @@
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.domain.qualify_gate import QualifyGateService
     from vibe3.models import IssueInfo, IssueState
     from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/domain/protocols/flow_protocols.py
+++ b/src/vibe3/domain/protocols/flow_protocols.py
@@ -6,7 +6,7 @@ Migrated from orchestra/protocols.py to establish domain-first architecture.
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
     from vibe3.models import IssueInfo
 
 

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitClient, GitHubClient
 from vibe3.models import IssueInfo, IssueState
 from vibe3.models.coordination_truth import CoordinationTruth
 from vibe3.models.flow import FlowStatusResponse
@@ -26,7 +25,7 @@ from vibe3.services.label_service import LabelService
 from vibe3.services.task_resume_operations import TaskResumeOperations
 
 if TYPE_CHECKING:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
     from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
 
 

--- a/src/vibe3/environment/__init__.py
+++ b/src/vibe3/environment/__init__.py
@@ -1,6 +1,6 @@
 """Environment isolation modules (worktree, session, runtime assets)."""
 
-from vibe3.clients.runtime_assets import (
+from vibe3.clients import (
     resolve_prompt_config,
     resolve_runtime_asset,
     runtime_assets_root,

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -78,7 +78,7 @@ class CodeagentExecutionService:
         (success or failure), we remove the handoff trigger label so
         the next tick does not re-dispatch the same issue.
         """
-        from vibe3.clients.github_labels import GhIssueLabelPort
+        from vibe3.clients import GhIssueLabelPort
         from vibe3.config.orchestra_settings import load_orchestra_config
         from vibe3.services.orchestra_helpers import get_handoff_state_label
 
@@ -232,7 +232,7 @@ class CodeagentExecutionService:
         before_issue_is_closed = False
         if command.issue_number is not None:
             try:
-                from vibe3.clients.github_client import GitHubClient
+                from vibe3.clients import GitHubClient
 
                 issue_payload = GitHubClient().view_issue(
                     command.issue_number,

--- a/src/vibe3/execution/coordinator.py
+++ b/src/vibe3/execution/coordinator.py
@@ -157,7 +157,7 @@ class ExecutionCoordinator:
 
         Delegates to the single-source-of-truth function in git_client.
         """
-        from vibe3.clients.git_client import find_repo_root
+        from vibe3.clients import find_repo_root
 
         return find_repo_root()
 

--- a/src/vibe3/execution/issue_role_support.py
+++ b/src/vibe3/execution/issue_role_support.py
@@ -20,7 +20,7 @@ def resolve_orchestra_repo_root() -> Path:
 
     Delegates to find_repo_root() — the single source of truth in git_client.
     """
-    from vibe3.clients.git_client import find_repo_root
+    from vibe3.clients import find_repo_root
 
     return find_repo_root()
 

--- a/src/vibe3/execution/state_verification.py
+++ b/src/vibe3/execution/state_verification.py
@@ -61,7 +61,7 @@ class StateVerificationService:
         Raises:
             GitHubAPIError: If GitHub API fails after max retries
         """
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
 
         try:
             issue_payload = GitHubClient().view_issue(issue_number, repo=repo)

--- a/src/vibe3/observability/orchestra_log.py
+++ b/src/vibe3/observability/orchestra_log.py
@@ -14,7 +14,7 @@ def orchestra_log_dir(repo_root: Path | None = None) -> Path:
     if override_dir:
         path = Path(override_dir).expanduser().resolve() / "orchestra"
     else:
-        from vibe3.clients.git_client import find_repo_root
+        from vibe3.clients import find_repo_root
 
         root = repo_root or find_repo_root()
         path = root / "temp" / "logs" / "orchestra"

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -11,7 +11,7 @@ Import from vibe3.orchestra instead of submodules to ensure clean dependencies.
 from typing import TYPE_CHECKING
 
 # Module-level re-exports from clients/ (safe, no cycle risk)
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 
 # Module-level re-exports from models/ (safe, no cycle risk)
 from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/orchestra/dispatch_coordinator_factory.py
+++ b/src/vibe3/orchestra/dispatch_coordinator_factory.py
@@ -13,8 +13,7 @@ from vibe3.services.check_service import CheckService
 from vibe3.services.flow_service import FlowService
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.execution.capacity_service import CapacityService

--- a/src/vibe3/orchestra/dispatch_health_check.py
+++ b/src/vibe3/orchestra/dispatch_health_check.py
@@ -24,7 +24,7 @@ from vibe3.orchestra.protocols import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
 
 class DispatchHealthCheckService:

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -9,8 +9,7 @@ from loguru import logger
 from vibe3.models.orchestra_config import OrchestraConfig
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.models import IssueInfo
     from vibe3.orchestra.protocols import FlowManagerProtocol
 

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -10,7 +10,7 @@ The definitions below are maintained for backward compatibility during migration
 
 from typing import Protocol
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 
 # Re-export protocols from domain for backward compatibility
 from vibe3.domain.protocols.dispatch_protocols import (

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -20,8 +20,7 @@ from vibe3.services.label_utils import should_skip_from_queue
 from vibe3.services.orchestra_helpers import get_manager_usernames
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.orchestra.protocols import FlowManagerProtocol
 

--- a/src/vibe3/orchestra/queue_persistence_service.py
+++ b/src/vibe3/orchestra/queue_persistence_service.py
@@ -17,8 +17,7 @@ from vibe3.services.label_utils import should_skip_from_queue
 from vibe3.services.orchestra_helpers import get_manager_usernames
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.models.orchestra_config import OrchestraConfig
 

--- a/src/vibe3/prompts/builtin_providers.py
+++ b/src/vibe3/prompts/builtin_providers.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.runtime_assets import resolve_runtime_asset
+from vibe3.clients import resolve_runtime_asset
 from vibe3.prompts.exceptions import ProviderNotFoundError
 from vibe3.prompts.models import PromptVariableSource, VariableSourceKind
 from vibe3.prompts.provider_registry import ProviderRegistry
@@ -37,7 +37,7 @@ def resolve_skill_content(
         return None
 
     # Resolve relative path against repo root for CWD-independent access
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     try:
         git_client = GitClient()

--- a/src/vibe3/prompts/manifest.py
+++ b/src/vibe3/prompts/manifest.py
@@ -10,7 +10,7 @@ from typing import Any
 import yaml
 from loguru import logger
 
-from vibe3.clients.runtime_assets import resolve_prompt_config
+from vibe3.clients import resolve_prompt_config
 from vibe3.config.convention_resolver import diagnose_profile
 from vibe3.exceptions import DiagnosticContext, MissingResourceError
 from vibe3.prompts.models import (

--- a/src/vibe3/prompts/template_loader.py
+++ b/src/vibe3/prompts/template_loader.py
@@ -8,7 +8,7 @@ from typing import Any
 import yaml
 from loguru import logger
 
-from vibe3.clients.runtime_assets import resolve_prompt_config
+from vibe3.clients import resolve_prompt_config
 
 DEFAULT_PROMPTS_PATH = Path("config/prompts/prompts.yaml")
 

--- a/src/vibe3/roles/definitions.py
+++ b/src/vibe3/roles/definitions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal
 
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient
 from vibe3.config.role_policy import RoleOutputContract
 from vibe3.models import IssueInfo, IssueState
 from vibe3.models.execution_request import ExecutionRequest

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.role_gates import GOVERNANCE_GATE_CONFIG
 from vibe3.execution.execution_role_policy import ExecutionRolePolicyService

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.services.label_utils import normalize_assignees, normalize_labels
 from vibe3.services.orchestra_helpers import get_manager_usernames

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -9,7 +9,7 @@ from typing import Any
 import yaml
 from loguru import logger
 
-from vibe3.clients.runtime_assets import check_runtime_asset, runtime_assets_root
+from vibe3.clients import check_runtime_asset, runtime_assets_root
 from vibe3.config.convention_resolver import diagnose_profile
 from vibe3.config.role_gates import MANAGER_GATE_CONFIG
 from vibe3.domain import FlowManager

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -13,7 +13,7 @@ from vibe3.agents import (
     describe_plan_sections,
     make_plan_context_builder,
 )
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.config.loader import load_runtime_config
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.role_gates import PLANNER_GATE_CONFIG
@@ -216,7 +216,7 @@ def build_plan_sync_request(
     tick_id: int = 0,
 ) -> ExecutionRequest:
     """Build the planner sync execution request."""
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     flow_state = SQLiteClient().get_flow_state(branch) if branch else None
     (
@@ -375,7 +375,7 @@ def execute_spec_plan_async(
     because they should already be included in ``cli_args`` by the caller.
     """
     _ = request, config, agent, backend, model, fresh_session
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     # Resolve repo path from git common dir (main repo root)
     from vibe3.execution.issue_role_support import resolve_orchestra_repo_root

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -256,7 +256,7 @@ def build_review_sync_request(
     dry_run: bool,
     show_prompt: bool,
 ) -> ExecutionRequest:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     flow_state = SQLiteClient().get_flow_state(branch) if branch else None
     return build_issue_review_request(
@@ -455,7 +455,7 @@ def _dispatch_async_manual_review(
         if issue_number is not None
         else f"vibe3-reviewer-{request.scope.kind}-{target_id or 'adhoc'}"
     )
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
     from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
 
     repo_root = resolve_orchestra_repo_root()

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -16,8 +16,7 @@ from vibe3.agents import (
     make_run_context_builder,
     make_skill_context_builder,
 )
-from vibe3.clients.runtime_assets import resolve_runtime_asset
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient, resolve_runtime_asset
 from vibe3.config.convention_resolver import ConventionResolver
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.settings import VibeConfig

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -9,7 +9,7 @@ from vibe3.agents import (
     describe_run_plan_sections,
     make_run_context_builder,
 )
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient
 from vibe3.config.settings import VibeConfig
 from vibe3.execution.prompt_meta import build_prompt_meta
 from vibe3.execution.role_request_factory import (

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -20,9 +20,7 @@ async def execute_expired_resource_cleanup(
         tick_number: Current tick number (for logging)
     """
     # Delay imports to avoid circular dependencies
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.services.expired_resource_cleanup_service import (
         ExpiredResourceCleanupService,
     )

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -12,7 +12,7 @@ from typing import Annotated
 import typer
 import uvicorn
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.config.agent_preset import find_missing_backend_commands
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -14,8 +14,7 @@ from fastapi.responses import HTMLResponse
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.domain import FailedGate, FlowManager
 from vibe3.domain.orchestration_facade import OrchestrationFacade
 from vibe3.environment.session_registry import SessionRegistryService

--- a/src/vibe3/services/abandon_flow_service.py
+++ b/src/vibe3/services/abandon_flow_service.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueState
 
 if TYPE_CHECKING:

--- a/src/vibe3/services/base_resolution_usecase.py
+++ b/src/vibe3/services/base_resolution_usecase.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Callable, Literal
 
-from vibe3.clients.git_client import GitClient, GitClientProtocol
+from vibe3.clients import GitClient, GitClientProtocol
 from vibe3.exceptions import UserError
 from vibe3.models.change_source import BranchSource
 from vibe3.utils.branch_utils import find_parent_branch

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueState
 from vibe3.models.issue_body import FlowStateProjection
 from vibe3.services.blocked_state_types import BlockedState

--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueState
 from vibe3.services.blocked_state_io import BlockedStateIO
 from vibe3.services.blocked_state_types import (

--- a/src/vibe3/services/check_cleanup_service.py
+++ b/src/vibe3/services/check_cleanup_service.py
@@ -12,14 +12,12 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from vibe3.clients.protocols import BackendProtocol
+from vibe3.clients import BackendProtocol
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.services.task_resume_operations import TaskResumeOperations
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.services.flow_cleanup_service import FlowCleanupService
 
 
@@ -345,7 +343,7 @@ class CheckCleanupService:
                 )
                 return
 
-            from vibe3.clients.github_client import GitHubClient
+            from vibe3.clients import GitHubClient
             from vibe3.services.flow_service import FlowService
             from vibe3.services.issue_flow_service import IssueFlowService
             from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/check_lock.py
+++ b/src/vibe3/services/check_lock.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Generator
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
 
 @contextmanager

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -15,9 +15,7 @@ from vibe3.models.pr import PRState
 from vibe3.services.label_utils import normalize_labels
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.models.pr import PRResponse
     from vibe3.services.flow_status_service import FlowStatusService
 

--- a/src/vibe3/services/check_remote.py
+++ b/src/vibe3/services/check_remote.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients.github_issues_ops import parse_linked_issues
+from vibe3.clients import parse_linked_issues
 from vibe3.models import IssueState
 from vibe3.models.flow import IssueLink
 
@@ -119,7 +119,7 @@ class CheckRemote:
         ).info("Remote index build done (Path A)")
 
         # Path B: rebuild merged PR cache
-        from vibe3.clients.merged_pr_cache import MergedPRCache
+        from vibe3.clients import MergedPRCache
 
         # Resolve repo path from git common dir
         git_common_dir = this.git_client.get_git_common_dir()

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -8,10 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.config.settings import VibeConfig
 from vibe3.models import IssueState
 from vibe3.models.pr import PRState

--- a/src/vibe3/services/coordination_resolver.py
+++ b/src/vibe3/services/coordination_resolver.py
@@ -171,7 +171,7 @@ class CoordinationResolver:
             Dict with projection_state/blocked_reason/blocked_by_issue/dependencies
             from body, or None if read failed
         """
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
         from vibe3.services.issue_body_service import parse_projection
 
         client = GitHubClient()

--- a/src/vibe3/services/error_helpers.py
+++ b/src/vibe3/services/error_helpers.py
@@ -34,7 +34,7 @@ def has_recent_specific_error(
     """
     import sqlite3
 
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     if store is None:
         store = SQLiteClient()
@@ -121,7 +121,7 @@ def record_dispatch_failure_if_unexpected(
 
     # Handle exception-level failures
     if exception is not None:
-        from vibe3.clients.sqlite_client import SQLiteClient
+        from vibe3.clients import SQLiteClient
         from vibe3.exceptions.error_classification import classify_error_hybrid
 
         # Detect test mock leaks - skip recording entirely
@@ -173,7 +173,7 @@ def record_dispatch_failure_if_unexpected(
     # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
     # If no, record E_DISPATCH_FAILURE for infrastructure visibility
     if reason_code == "launch_failed":
-        from vibe3.clients.sqlite_client import SQLiteClient
+        from vibe3.clients import SQLiteClient
 
         _store = SQLiteClient()
         if has_recent_specific_error(
@@ -186,7 +186,7 @@ def record_dispatch_failure_if_unexpected(
             return
         # else: fall through to record E_DISPATCH_FAILURE
 
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     # Include dispatch_source marker and reason_code for disambiguation
     reason_detail = result.reason or "(no detail)"

--- a/src/vibe3/services/expired_resource_cleanup_service.py
+++ b/src/vibe3/services/expired_resource_cleanup_service.py
@@ -14,8 +14,7 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients.git_worktree_ops import remove_worktree
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol, remove_worktree
 
 
 def _is_protected_worktree(
@@ -38,10 +37,7 @@ def _is_protected_worktree(
 
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.protocols import BackendProtocol
+    from vibe3.clients import BackendProtocol, GitClient, GitHubClient, SQLiteClient
     from vibe3.services.pr_service import PRService
 
 

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -19,8 +19,7 @@ from loguru import logger
 from vibe3.clients import BackendProtocol
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient, SQLiteClient
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService
     from vibe3.services.pr_service import PRService
@@ -63,8 +62,7 @@ class FlowCleanupService:
             issue_flow_service: Service for issue-flow mapping
             backend: Backend protocol for tmux session checks
         """
-        from vibe3.clients import SQLiteClient
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient, SQLiteClient
 
         self.git_client = git_client or GitClient()
         self.store = store or SQLiteClient()
@@ -191,7 +189,7 @@ class FlowCleanupService:
                     logger.bind(domain="cleanup", branch=branch).warning(
                         f"Failed to remove worktree, trying prune: {exc}"
                     )
-                    from vibe3.clients.git_worktree_ops import prune_worktrees
+                    from vibe3.clients import prune_worktrees
 
                     prune_worktrees()
                     # Mark as failed even after prune - prune is just cleanup

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -8,10 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.environment.worktree import WorktreeManager
 from vibe3.models.pr import PRState
 from vibe3.services.flow_cleanup_service import FlowCleanupService

--- a/src/vibe3/services/flow_projection_service.py
+++ b/src/vibe3/services/flow_projection_service.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.pr_service import PRService

--- a/src/vibe3/services/flow_read_mixin.py
+++ b/src/vibe3/services/flow_read_mixin.py
@@ -5,9 +5,7 @@ from typing import Literal, Self, cast
 from loguru import logger
 from pydantic import ValidationError
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models.flow import FlowEvent, FlowState, FlowStatusResponse, IssueLink
 from vibe3.services.git_path_client import GitPathProtocol, get_git_common_dir
 

--- a/src/vibe3/services/flow_reader.py
+++ b/src/vibe3/services/flow_reader.py
@@ -1,5 +1,5 @@
 """Re-export shim — FlowReader has moved to clients.protocols.flow."""
 
-from vibe3.clients.protocols.flow import FlowReader
+from vibe3.clients import FlowReader
 
 __all__ = ["FlowReader"]

--- a/src/vibe3/services/flow_rebuild_usecase.py
+++ b/src/vibe3/services/flow_rebuild_usecase.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitClient, GitHubClient, SQLiteClient
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.models import IssueInfo
 from vibe3.services.flow_cleanup_service import FlowCleanupService

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -27,9 +27,7 @@ from vibe3.services.flow_consistency_check import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
 
 
 class RecoveryAction(StrEnum):

--- a/src/vibe3/services/flow_service.py
+++ b/src/vibe3/services/flow_service.py
@@ -1,7 +1,6 @@
 """Flow service implementation."""
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient, SQLiteClient
 from vibe3.config.settings import VibeConfig
 from vibe3.services.flow_block_mixin import FlowLifecycleMixin
 from vibe3.services.flow_transition import FlowTransitionMixin

--- a/src/vibe3/services/flow_status_resolver.py
+++ b/src/vibe3/services/flow_status_resolver.py
@@ -121,7 +121,7 @@ class FlowStatusResolver:
         if issue_number is None:
             raise ValueError("issue_number required for remote source")
 
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
         from vibe3.services.timeline_parser import parse_timeline_from_comments
 
         github_client = GitHubClient()

--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitClient, GitHubClient, SQLiteClient
 from vibe3.models import IssueState
 
 

--- a/src/vibe3/services/flow_timeline_service.py
+++ b/src/vibe3/services/flow_timeline_service.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient, SQLiteClient
     from vibe3.config.timeline_comment_policy import TimelineCommentPolicy
 
 
@@ -47,8 +46,7 @@ class FlowTimelineService:
         github_client: GitHubClient | None = None,
     ) -> None:
         """Initialize timeline service."""
-        from vibe3.clients import SQLiteClient
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient, SQLiteClient
 
         self.store = SQLiteClient() if store is None else store
         self.github_client = GitHubClient() if github_client is None else github_client

--- a/src/vibe3/services/flow_transition.py
+++ b/src/vibe3/services/flow_transition.py
@@ -11,8 +11,7 @@ from typing import Self, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.models.flow import FlowStatusResponse, MainBranchProtectedError

--- a/src/vibe3/services/git_path_client.py
+++ b/src/vibe3/services/git_path_client.py
@@ -2,13 +2,13 @@
 
 from pathlib import Path
 
-from vibe3.clients.protocols.git import GitPathProtocol
+from vibe3.clients import GitPathProtocol
 
 
 def _get_git_client(git_client: GitPathProtocol | None = None) -> GitPathProtocol:
     """Get or create a GitClient instance."""
     if git_client is None:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         return GitClient()
     return git_client

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient, SQLiteClient
 from vibe3.exceptions import UserError
 from vibe3.models.flow import FlowEvent
 from vibe3.models.verdict import VerdictRecord
@@ -23,7 +22,7 @@ from vibe3.services.path_helpers import _SHARED_HANDOFF_PREFIX
 from vibe3.services.signature_service import SignatureService
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
 
 
 class HandoffService:
@@ -102,7 +101,7 @@ class HandoffService:
             git_client: Git client for branch/worktree operations
             github_client: GitHub client for API operations (optional)
         """
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
 
         self.store = store or SQLiteClient()
         self.git_client = git_client or GitClient()

--- a/src/vibe3/services/handoff_status_service.py
+++ b/src/vibe3/services/handoff_status_service.py
@@ -4,8 +4,7 @@ import threading
 from dataclasses import dataclass
 from typing import Any
 
-from vibe3.clients import BackendProtocol, SQLiteClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import BackendProtocol, GitClient, SQLiteClient
 from vibe3.environment.session_registry import SessionRegistryService
 from vibe3.models.flow import FlowEvent, FlowState
 from vibe3.models.verdict import VerdictRecord

--- a/src/vibe3/services/handoff_storage.py
+++ b/src/vibe3/services/handoff_storage.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.services.git_path_client import GitPathProtocol
 from vibe3.services.path_helpers import get_git_common_dir, normalize_ref_path
 from vibe3.utils.git_helpers import get_branch_handoff_dir

--- a/src/vibe3/services/issue_collection_service.py
+++ b/src/vibe3/services/issue_collection_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueInfo
 
 

--- a/src/vibe3/services/issue_context_loader.py
+++ b/src/vibe3/services/issue_context_loader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.exceptions import UserError
 from vibe3.models import IssueInfo
 from vibe3.models.orchestra_config import OrchestraConfig

--- a/src/vibe3/services/issue_title_cache_service.py
+++ b/src/vibe3/services/issue_title_cache_service.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient, SQLiteClient
 
 
 class IssueTitleCacheService:
@@ -48,7 +47,7 @@ class IssueTitleCacheService:
     def github_client(self) -> GitHubClient:
         """Lazy-initialized GitHub client."""
         if self._github_client is None:
-            from vibe3.clients.github_client import GitHubClient
+            from vibe3.clients import GitHubClient
 
             self._github_client = GitHubClient()
         return self._github_client

--- a/src/vibe3/services/label_service.py
+++ b/src/vibe3/services/label_service.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
+from vibe3.clients import GhIssueLabelPort, IssueLabelPort
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.domain.state_machine import (
     STATE_LABEL_META,

--- a/src/vibe3/services/label_utils.py
+++ b/src/vibe3/services/label_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_labels import GhIssueLabelPort
+from vibe3.clients import GhIssueLabelPort
 from vibe3.models.orchestra_config import OrchestraConfig
 
 if TYPE_CHECKING:

--- a/src/vibe3/services/loc_service.py
+++ b/src/vibe3/services/loc_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.config.settings import VibeConfig
 from vibe3.models.change_source import BranchSource, ChangeSource, PRSource
 

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.github_issues_ops import parse_blocked_by
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import (
+    GitClient,
+    GitHubClient,
+    GitHubClientProtocol,
+    parse_blocked_by,
+)
 from vibe3.models import IssueState
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.logging import orchestra_events_log_path

--- a/src/vibe3/services/pr_analysis_service.py
+++ b/src/vibe3/services/pr_analysis_service.py
@@ -38,8 +38,7 @@ def build_pr_analysis(pr_number: int, verbose: bool = False) -> PRCriticalAnalys
     """
     log = logger.bind(domain="pr_analysis", action="analyze", pr_number=pr_number)
     log.info("Analyzing PR")
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
 
@@ -88,8 +87,7 @@ def build_pr_analysis(pr_number: int, verbose: bool = False) -> PRCriticalAnalys
 
 def _get_pr_changed_files(pr_number: int) -> list[str]:
     """Return changed file paths for a PR, including deleted files."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
     all_changed_files = git.get_changed_files(PRSource(pr_number=pr_number))
@@ -138,8 +136,7 @@ def _analyze_critical_files(
     pr_number: int,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Extract changed symbols and DAG impact for critical Python files."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
     svc = SerenaService(git_client=git)

--- a/src/vibe3/services/pr_branch_resolver.py
+++ b/src/vibe3/services/pr_branch_resolver.py
@@ -4,7 +4,7 @@ import shutil
 
 import typer
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.exceptions import UserError
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/services/pr_create_usecase.py
+++ b/src/vibe3/services/pr_create_usecase.py
@@ -7,9 +7,7 @@ from loguru import logger
 from rich.console import Console
 from rich.prompt import Prompt
 
-from vibe3.clients.ai_client import AIClient
-from vibe3.clients.ai_suggestion_client import AISuggestionClient
-from vibe3.clients.protocols.pr import BaseResolver
+from vibe3.clients import AIClient, AISuggestionClient, BaseResolver
 from vibe3.config.settings import VibeConfig
 from vibe3.prompts.template_loader import resolve_prompts_path
 from vibe3.services.base_resolution_usecase import BaseResolutionUsecase

--- a/src/vibe3/services/pr_loc_comment_service.py
+++ b/src/vibe3/services/pr_loc_comment_service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol
 from vibe3.services.loc_service import LocService, LOCStats
 
 LOC_SENTINEL = "<!-- vibe3:pr-loc-summary -->"

--- a/src/vibe3/services/pr_review_briefing_service.py
+++ b/src/vibe3/services/pr_review_briefing_service.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol
 
 SENTINEL = "<!-- vibe3:pr-review-briefing -->"
 

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -7,11 +7,13 @@ from typing import cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.clients.recent_pr_cache import RecentPRCache
+from vibe3.clients import (
+    GitClient,
+    GitHubClient,
+    GitHubClientProtocol,
+    RecentPRCache,
+    SQLiteClient,
+)
 from vibe3.exceptions import GitError, PRNotFoundError, UserError
 from vibe3.models.pr import (
     CreatePRRequest,

--- a/src/vibe3/services/pr_status_checker.py
+++ b/src/vibe3/services/pr_status_checker.py
@@ -13,8 +13,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.merged_pr_cache import MergedPRCache
+from vibe3.clients import GitHubClient, MergedPRCache
 from vibe3.services.git_path_client import get_git_common_dir
 
 

--- a/src/vibe3/services/pr_utils.py
+++ b/src/vibe3/services/pr_utils.py
@@ -2,9 +2,7 @@
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_issues_ops import parse_linked_issues
+from vibe3.clients import GitClient, SQLiteClient, parse_linked_issues
 from vibe3.exceptions import GitError, UserError
 from vibe3.models.flow import IssueLink
 from vibe3.models.pr import PRMetadata

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -227,7 +227,7 @@ def validate_governance_material_consistency(
             )
             return issues
     if repo_root is None:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         git_client = GitClient()
         git_common_dir = git_client.get_git_common_dir()

--- a/src/vibe3/services/signature_service.py
+++ b/src/vibe3/services/signature_service.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.utils.actor_utils import normalize_actor as _normalize_actor_for_display
 
 WORKFLOW_ACTOR = "workflow"

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -10,10 +10,7 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models import IssueInfo, IssueState
 from vibe3.orchestra.queue_ordering import (
     resolve_priority,

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -13,8 +13,7 @@ from vibe3.exceptions import UserError
 from vibe3.models import IssueState
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
     from vibe3.models.flow import FlowStatusResponse
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitClient, GitHubClient
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_flow_service import IssueFlowService
 from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -4,10 +4,13 @@ from typing import Any, Literal, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import (
+    GhIssueLabelPort,
+    GitHubClient,
+    GitHubClientProtocol,
+    IssueLabelPort,
+    SQLiteClient,
+)
 from vibe3.config.orchestra_settings import load_orchestra_config
 from vibe3.config.settings import VibeConfig
 from vibe3.exceptions import InvalidBranchLinkError
@@ -160,7 +163,7 @@ class TaskService:
         # Auto-mirror vibe-task label for task role
         # Only add label if the branch actually exists (true local flow)
         if role == "task":
-            from vibe3.clients.git_client import GitClient
+            from vibe3.clients import GitClient
 
             git = GitClient()
             if git.branch_exists(normalized_branch):

--- a/src/vibe3/services/task_show_service.py
+++ b/src/vibe3/services/task_show_service.py
@@ -8,9 +8,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models.flow import FlowStatusResponse
 from vibe3.models.pr import PRResponse
 from vibe3.services.artifact_parser import ArtifactParser

--- a/src/vibe3/services/verdict_service.py
+++ b/src/vibe3/services/verdict_service.py
@@ -11,8 +11,7 @@ from datetime import UTC, datetime
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient, SQLiteClient
 from vibe3.models.verdict import VerdictRecord
 from vibe3.models.verdict_types import VerdictValue
 from vibe3.services.actor_support import extract_role_from_actor

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -47,7 +47,7 @@ def display_actor(actor: str | None) -> tuple[str, bool]:
 
     # Fallback: worktree git user.name
     try:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         name = GitClient().get_config("user.name") or "unknown"
     except Exception:

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility modules for Vibe3."""
 
-from vibe3.clients.runtime_assets import (
+from vibe3.clients import (
     resolve_prompt_config,
     resolve_runtime_asset,
     runtime_assets_root,

--- a/tests/vibe3/adapters/test_vibe_center_adapter.py
+++ b/tests/vibe3/adapters/test_vibe_center_adapter.py
@@ -54,9 +54,7 @@ def test_vibe_center_adapter_global_skills_fallback():
         # Simulate external repo without skills/ marker
         mock_resolve_root.return_value = Path("/tmp/external-repo")
 
-        with patch(
-            "vibe3.clients.runtime_assets.runtime_assets_root"
-        ) as mock_runtime_root:
+        with patch("vibe3.clients.runtime_assets_root") as mock_runtime_root:
             # Mock global runtime root
             import tempfile
 

--- a/tests/vibe3/commands/test_inspect_base.py
+++ b/tests/vibe3/commands/test_inspect_base.py
@@ -18,7 +18,7 @@ def test_inspect_base_default_parent():
     mock_git = MagicMock()
     mock_git.get_changed_files.return_value = ["tests/test_foo.py", "docs/README.md"]
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git_client:
+    with patch("vibe3.clients.GitClient") as mock_git_client:
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
@@ -41,7 +41,7 @@ def test_inspect_base_custom_base_branch():
     mock_git = MagicMock()
     mock_git.get_changed_files.return_value = ["tests/test_foo.py", "docs/README.md"]
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git_client:
+    with patch("vibe3.clients.GitClient") as mock_git_client:
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
@@ -68,7 +68,7 @@ def test_inspect_base_with_core_files():
     mock_dag = MagicMock()
     mock_dag.impacted_modules = ["vibe3.core", "vibe3.api", "vibe3.utils"]
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git_client:
+    with patch("vibe3.clients.GitClient") as mock_git_client:
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
@@ -100,7 +100,7 @@ def test_inspect_base_json_output():
     mock_dag = MagicMock()
     mock_dag.impacted_modules = ["vibe3.core"]
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git_client:
+    with patch("vibe3.clients.GitClient") as mock_git_client:
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
@@ -146,7 +146,7 @@ def test_inspect_base_json_custom_branch():
     mock_dag = MagicMock()
     mock_dag.impacted_modules = ["vibe3.core"]
 
-    with patch("vibe3.clients.git_client.GitClient") as mock_git_client:
+    with patch("vibe3.clients.GitClient") as mock_git_client:
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
@@ -188,7 +188,7 @@ def test_inspect_base_uses_shared_base_resolver():
     mock_git = MagicMock()
     mock_git.get_changed_files.return_value = []
 
-    with patch("vibe3.clients.git_client.GitClient", return_value=mock_git):
+    with patch("vibe3.clients.GitClient", return_value=mock_git):
         with patch(
             "vibe3.utils.git_helpers.get_current_branch", return_value="feature/test"
         ):

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -164,9 +164,9 @@ def test_internal_bootstrap_dispatch() -> None:
 
     with patch("vibe3.commands.internal.load_orchestra_config") as load_config:
         load_config.return_value = MagicMock(repo="owner/repo")
-        with patch("vibe3.clients.sqlite_client.SQLiteClient"):
-            with patch("vibe3.clients.git_client.GitClient"):
-                with patch("vibe3.clients.github_client.GitHubClient") as github_cls:
+        with patch("vibe3.clients.SQLiteClient"):
+            with patch("vibe3.clients.GitClient"):
+                with patch("vibe3.clients.GitHubClient") as github_cls:
                     with patch(
                         "vibe3.services.flow_orchestrator_service.FlowOrchestratorService"
                     ) as service_cls:

--- a/tests/vibe3/commands/test_snapshot_commands.py
+++ b/tests/vibe3/commands/test_snapshot_commands.py
@@ -40,7 +40,7 @@ def test_snapshot_save_as_baseline_json_outputs_saved_baseline(monkeypatch):
 
     fake_git = MagicMock()
     fake_git.get_current_branch.return_value = "feature/test"
-    monkeypatch.setattr("vibe3.clients.git_client.GitClient", lambda: fake_git)
+    monkeypatch.setattr("vibe3.clients.GitClient", lambda: fake_git)
     monkeypatch.setattr(
         snapshot_command.snapshot_service,
         "save_branch_baseline",

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -168,7 +168,7 @@ class TestIssueStateDispatchHandler:
     @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.roles.manager.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
-    @patch("vibe3.clients.github_client.GitHubClient")
+    @patch("vibe3.clients.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
     def test_records_failed_on_github_none(
         self,
@@ -203,7 +203,7 @@ class TestIssueStateDispatchHandler:
     @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.roles.manager.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
-    @patch("vibe3.clients.github_client.GitHubClient")
+    @patch("vibe3.clients.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
     def test_records_failed_on_network_error(
         self,
@@ -236,7 +236,7 @@ class TestIssueStateDispatchHandler:
     @patch("vibe3.execution.capacity_service.CapacityService")
     @patch("vibe3.roles.manager.build_manager_request")
     @patch("vibe3.domain.handlers.issue_state_dispatch.block_manager_noop_issue")
-    @patch("vibe3.clients.github_client.GitHubClient")
+    @patch("vibe3.clients.GitHubClient")
     @patch("vibe3.domain.handlers.issue_state_dispatch.load_orchestra_config")
     def test_records_failed_on_invalid_issue_data(
         self,

--- a/tests/vibe3/execution/test_codeagent_runner_gate.py
+++ b/tests/vibe3/execution/test_codeagent_runner_gate.py
@@ -51,7 +51,7 @@ class TestExecuteSyncGateIntegration:
                 "vibe3.execution.codeagent_runner.SQLiteClient",
                 return_value=mock_store,
             ),
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
@@ -146,7 +146,7 @@ class TestExecuteSyncGateIntegration:
                 return_value=mock_store,
             ),
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
                 return_value=None,
@@ -197,7 +197,7 @@ class TestExecuteSyncGateIntegration:
                 return_value=mock_store,
             ),
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
                 return_value=None,
@@ -260,7 +260,7 @@ class TestExecuteSyncGateIntegration:
                 return_value=mock_store,
             ),
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
                 return_value=None,
@@ -313,7 +313,7 @@ class TestTransitionCountFlow:
                 return_value=mock_store,
             ),
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
                 return_value=None,
@@ -361,7 +361,7 @@ class TestTransitionCountFlow:
                 return_value=mock_store,
             ),
             patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.execution.codeagent_runner.load_session_id",
                 return_value=None,

--- a/tests/vibe3/execution/test_error_block_decoupling.py
+++ b/tests/vibe3/execution/test_error_block_decoupling.py
@@ -45,7 +45,7 @@ class TestDatabaseErrorDoesNotTriggerBlock:
         temp_db.update_flow_state(branch, flow_slug="test")
         flow_state = temp_db.get_flow_state(branch)
 
-        with patch("vibe3.clients.github_client.GitHubClient") as mock_gh:
+        with patch("vibe3.clients.GitHubClient") as mock_gh:
             mock_gh.return_value.view_issue.return_value = {
                 "labels": [{"name": "state/running"}]
             }
@@ -100,7 +100,7 @@ class TestAgentNoopTriggersBlock:
         flow_state = temp_db.get_flow_state(branch)
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_executor_noop_issue"
             ) as mock_block,
@@ -138,7 +138,7 @@ class TestGitHubAPIFailureNoBlock:
         flow_state = temp_db.get_flow_state(branch)
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_executor_noop_issue"
             ) as mock_block,
@@ -169,7 +169,7 @@ class TestGitHubAPIFailureNoBlock:
         )
         flow_state = temp_db.get_flow_state(branch)
 
-        with patch("vibe3.clients.github_client.GitHubClient") as mock_gh:
+        with patch("vibe3.clients.GitHubClient") as mock_gh:
             mock_gh.return_value.view_issue.side_effect = Exception("GitHub timeout")
 
             with pytest.raises(GitHubAPIError):

--- a/tests/vibe3/integration/conftest.py
+++ b/tests/vibe3/integration/conftest.py
@@ -37,7 +37,7 @@ def mock_all_dependencies():
         patch("vibe3.services.pr_analysis_service._get_recent_commits") as mock_commits,
         patch("vibe3.services.pr_analysis_service._get_pr_commit_count") as mock_count,
         patch("vibe3.services.pr_analysis_service.dag_service") as mock_dag,
-        patch("vibe3.clients.git_client.GitClient") as mock_git_client_class,
+        patch("vibe3.clients.GitClient") as mock_git_client_class,
     ):
         # Setup default returns
         mock_files.return_value = [

--- a/tests/vibe3/integration/test_inspect_pr_integration.py
+++ b/tests/vibe3/integration/test_inspect_pr_integration.py
@@ -207,7 +207,7 @@ def test_build_pr_analysis_commit_count_error():
             "vibe3.services.pr_analysis_service._calculate_risk_score",
             return_value={"score": 1},
         ),
-        patch("vibe3.clients.git_client.GitClient") as mock_git_client_class,
+        patch("vibe3.clients.GitClient") as mock_git_client_class,
         # Mock _fetch_pr_commit_shas to raise (called inside real _get_pr_commit_count)
         patch(
             "vibe3.services.pr_analysis_service._fetch_pr_commit_shas",
@@ -254,7 +254,7 @@ def test_build_pr_analysis_dataclass_fields():
         patch(
             "vibe3.services.pr_analysis_service._get_pr_commit_count", return_value=1
         ),
-        patch("vibe3.clients.git_client.GitClient") as mock_git_client_class,
+        patch("vibe3.clients.GitClient") as mock_git_client_class,
     ):
         mock_dag_result = MagicMock()
         mock_dag_result.impacted_modules = []

--- a/tests/vibe3/roles/test_plan.py
+++ b/tests/vibe3/roles/test_plan.py
@@ -30,7 +30,7 @@ class TestPlannerNoOpGate:
         mock_store = MagicMock()
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_planner_noop_issue"
             ) as mock_block,
@@ -61,7 +61,7 @@ class TestPlannerNoOpGate:
         mock_store = MagicMock()
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_planner_noop_issue"
             ) as mock_block,
@@ -270,7 +270,7 @@ class TestExecuteSpecPlanAsyncWorktreeRequirement:
                 return_value=Path("/fake/repo"),
             ),
             patch("vibe3.roles.plan.load_orchestra_config"),
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.clients.SQLiteClient"),
             patch("vibe3.roles.plan.ExecutionCoordinator") as mock_coord_cls,
         ):
             mock_coord = MagicMock()
@@ -307,7 +307,7 @@ class TestExecuteSpecPlanAsyncWorktreeRequirement:
                 return_value=Path("/fake/repo"),
             ),
             patch("vibe3.roles.plan.load_orchestra_config"),
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.clients.SQLiteClient"),
             patch("vibe3.roles.plan.ExecutionCoordinator") as mock_coord_cls,
         ):
             mock_coord = MagicMock()

--- a/tests/vibe3/roles/test_review.py
+++ b/tests/vibe3/roles/test_review.py
@@ -19,7 +19,7 @@ class TestReviewerNoOpGate:
         mock_store = MagicMock()
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_reviewer_noop_issue"
             ) as mock_block,
@@ -63,7 +63,7 @@ class TestReviewerNoOpGate:
         }
 
         with (
-            patch("vibe3.clients.github_client.GitHubClient") as mock_gh,
+            patch("vibe3.clients.GitHubClient") as mock_gh,
             patch(
                 "vibe3.services.role_policy_helpers.block_reviewer_noop_issue"
             ) as mock_block,
@@ -207,7 +207,7 @@ class TestDispatchAsyncManualReviewWorktreeRequirement:
                 return_value=Path("/fake/repo"),
             ),
             patch("vibe3.roles.review.load_orchestra_config"),
-            patch("vibe3.clients.sqlite_client.SQLiteClient"),
+            patch("vibe3.clients.SQLiteClient"),
             patch("vibe3.roles.review.ExecutionCoordinator") as mock_coord_cls,
         ):
             mock_coord = MagicMock()

--- a/tests/vibe3/services/test_error_helpers.py
+++ b/tests/vibe3/services/test_error_helpers.py
@@ -83,7 +83,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -120,7 +120,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -156,7 +156,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -193,7 +193,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -215,7 +215,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -235,7 +235,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -264,7 +264,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -301,7 +301,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -340,7 +340,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -365,7 +365,7 @@ class TestRecordDispatchFailureIfUnexpected:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):

--- a/tests/vibe3/services/test_error_helpers_exception.py
+++ b/tests/vibe3/services/test_error_helpers_exception.py
@@ -16,7 +16,7 @@ class TestRecordDispatchFailureException:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -36,7 +36,7 @@ class TestRecordDispatchFailureException:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -65,7 +65,7 @@ class TestRecordDispatchFailureException:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):
@@ -102,7 +102,7 @@ class TestRecordDispatchFailureException:
         with (
             patch("vibe3.services.error_helpers.record_error") as mock_record_error,
             patch(
-                "vibe3.clients.sqlite_client.SQLiteClient",
+                "vibe3.clients.SQLiteClient",
                 return_value=mock_store,
             ),
         ):

--- a/tests/vibe3/services/test_flow_cleanup_service.py
+++ b/tests/vibe3/services/test_flow_cleanup_service.py
@@ -116,7 +116,7 @@ def test_remove_worktree_falls_back_to_prune_on_failure() -> None:
         "worktree remove", "fatal: validation failed"
     )
 
-    with patch("vibe3.clients.git_worktree_ops.prune_worktrees") as mock_prune:
+    with patch("vibe3.clients.prune_worktrees") as mock_prune:
         results: dict[str, bool] = {"worktree": True}
         service._remove_worktree("task/issue-123", results)
 

--- a/tests/vibe3/services/test_flow_status.py
+++ b/tests/vibe3/services/test_flow_status.py
@@ -167,9 +167,7 @@ class TestFlowStatusResolver:
             resolver = FlowStatusResolver(store=store)
 
             # No flow in SQLite (deleted or remote machine)
-            with patch(
-                "vibe3.clients.github_client.GitHubClient"
-            ) as mock_github_client_class:
+            with patch("vibe3.clients.GitHubClient") as mock_github_client_class:
                 mock_github_client = MagicMock()
                 mock_github_client_class.return_value = mock_github_client
 

--- a/tests/vibe3/services/test_task_service_fresh_db.py
+++ b/tests/vibe3/services/test_task_service_fresh_db.py
@@ -92,7 +92,7 @@ def test_link_task_demotes_previous_task_flow_on_fresh_db(tmp_path, monkeypatch)
 
     # Mock GitClient to return True for branch_exists (for vibe-task label auto-mirror)
     monkeypatch.setattr(
-        "vibe3.clients.git_client.GitClient",
+        "vibe3.clients.GitClient",
         lambda: type(
             "MockGitClient", (), {"branch_exists": lambda self, branch: True}
         )(),

--- a/tests/vibe3/services/test_vibe_task_label.py
+++ b/tests/vibe3/services/test_vibe_task_label.py
@@ -30,7 +30,7 @@ def test_link_issue_as_task_adds_vibe_task_label(tmp_path, monkeypatch):
 
     # Mock GitClient to return True for branch_exists
     monkeypatch.setattr(
-        "vibe3.clients.git_client.GitClient",
+        "vibe3.clients.GitClient",
         lambda: Mock(branch_exists=lambda branch: True),
     )
 


### PR DESCRIPTION
## Summary

- Supplement clients module public API with 25+ missing symbols
- Refactor all 194 external violations to use public API
- Zero violations remaining
- Type checking passes (mypy clean)
- All tests pass (2753 passed)

## Changes

### Public API (`clients/__init__.py`)
Added 25+ symbols organized by category:
- **Protocols**: GitHubClientProtocol, GitClientProtocol, GitPathProtocol, FlowReader, BaseResolver, GitHub ports
- **Labels**: GhIssueLabelPort, IssueLabelPort
- **Runtime assets**: runtime_assets_root, resolve_runtime_asset, check_runtime_asset, resolve_prompt_config
- **Issue parsing**: parse_blocked_by, parse_linked_issues
- **Worktree operations**: remove_worktree, prune_worktrees
- **Caches**: MergedPRCache, RecentPRCache
- **AI clients**: AIClient, AISuggestionClient

### Import Refactoring
- Refactored **107 files** across services/, ui/, roles/, domain/, execution/, config/, analysis/
- Replaced `from vibe3.clients.xxx import` with `from vibe3.clients import`
- **Zero external violations remaining** ✅

### Test Mock Updates
- Updated **17 test files** with mock path fixes
- All mocks now use `vibe3.clients` public API paths

## Verification

✅ **Zero violations:**
```bash
grep -r "from vibe3\\.clients\\." src/vibe3 --include="*.py" | grep -v "/clients/" | wc -l
# Output: 0
```

✅ **Type checking passes:**
```bash
uv run mypy src/vibe3
# Success: no issues found in 397 source files
```

✅ **All tests pass:**
```bash
uv run pytest tests/vibe3
# 2753 passed, 1 skipped, 5 xfailed
```

## Test Plan

- [x] Type checking passes (`uv run mypy src/vibe3`)
- [x] Linting passes (`uv run ruff check src/vibe3`)  
- [x] Zero violations verified
- [x] All public symbols importable from `vibe3.clients`
- [x] All tests pass (2753 passed)

Closes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)