### PR TITLE
refactor(modularity): eliminate module-level cross-module side-effect imports

### DIFF
--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -40,39 +40,138 @@ Backend Config:
   ``~/.codeagent/models.json``
 """
 
-from vibe3.agents.backends.codeagent import CodeagentBackend
-from vibe3.agents.backends.codeagent_config import sync_models_json
-from vibe3.agents.base import AgentBackend
-from vibe3.agents.models import (
-    CodeagentCommand,
-    CodeagentResult,
-    ExecutionRole,
-    create_codeagent_command,
-)
-from vibe3.agents.plan_prompt import (
-    build_plan_prompt_body,
-    describe_plan_sections,
-    make_plan_context_builder,
-)
-from vibe3.agents.review_pipeline_helpers import (
-    build_snapshot_diff,
-    run_inspect_json,
-)
-from vibe3.agents.review_prompt import (
-    build_review_prompt_body,
-    build_tools_guide_section,
-    describe_review_sections,
-    make_review_context_builder,
-)
-from vibe3.agents.run_prompt import (
-    RunPromptMode,
-    build_run_prompt_body,
-    describe_run_plan_sections,
-    make_publish_context_builder,
-    make_run_context_builder,
-    make_skill_context_builder,
-)
+from typing import TYPE_CHECKING, Any
+
 from vibe3.models import PromptContextMode
+
+if TYPE_CHECKING:
+    from vibe3.agents.backends.codeagent import CodeagentBackend
+    from vibe3.agents.backends.codeagent_config import sync_models_json
+    from vibe3.agents.base import AgentBackend
+    from vibe3.agents.models import (
+        CodeagentCommand,
+        CodeagentResult,
+        ExecutionRole,
+        create_codeagent_command,
+    )
+    from vibe3.agents.plan_prompt import (
+        build_plan_prompt_body,
+        describe_plan_sections,
+        make_plan_context_builder,
+    )
+    from vibe3.agents.review_pipeline_helpers import (
+        build_snapshot_diff,
+        run_inspect_json,
+    )
+    from vibe3.agents.review_prompt import (
+        build_review_prompt_body,
+        build_tools_guide_section,
+        describe_review_sections,
+        make_review_context_builder,
+    )
+    from vibe3.agents.run_prompt import (
+        RunPromptMode,
+        build_run_prompt_body,
+        describe_run_plan_sections,
+        make_publish_context_builder,
+        make_run_context_builder,
+        make_skill_context_builder,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for all symbols to avoid circular dependencies."""
+    if name == "CodeagentBackend":
+        from vibe3.agents.backends.codeagent import CodeagentBackend
+
+        return CodeagentBackend
+    if name == "sync_models_json":
+        from vibe3.agents.backends.codeagent_config import sync_models_json
+
+        return sync_models_json
+    if name == "AgentBackend":
+        from vibe3.agents.base import AgentBackend
+
+        return AgentBackend
+    if name == "CodeagentCommand":
+        from vibe3.agents.models import CodeagentCommand
+
+        return CodeagentCommand
+    if name == "CodeagentResult":
+        from vibe3.agents.models import CodeagentResult
+
+        return CodeagentResult
+    if name == "ExecutionRole":
+        from vibe3.agents.models import ExecutionRole
+
+        return ExecutionRole
+    if name == "create_codeagent_command":
+        from vibe3.agents.models import create_codeagent_command
+
+        return create_codeagent_command
+    if name == "build_plan_prompt_body":
+        from vibe3.agents.plan_prompt import build_plan_prompt_body
+
+        return build_plan_prompt_body
+    if name == "describe_plan_sections":
+        from vibe3.agents.plan_prompt import describe_plan_sections
+
+        return describe_plan_sections
+    if name == "make_plan_context_builder":
+        from vibe3.agents.plan_prompt import make_plan_context_builder
+
+        return make_plan_context_builder
+    if name == "build_snapshot_diff":
+        from vibe3.agents.review_pipeline_helpers import build_snapshot_diff
+
+        return build_snapshot_diff
+    if name == "run_inspect_json":
+        from vibe3.agents.review_pipeline_helpers import run_inspect_json
+
+        return run_inspect_json
+    if name == "build_review_prompt_body":
+        from vibe3.agents.review_prompt import build_review_prompt_body
+
+        return build_review_prompt_body
+    if name == "build_tools_guide_section":
+        from vibe3.agents.review_prompt import build_tools_guide_section
+
+        return build_tools_guide_section
+    if name == "describe_review_sections":
+        from vibe3.agents.review_prompt import describe_review_sections
+
+        return describe_review_sections
+    if name == "make_review_context_builder":
+        from vibe3.agents.review_prompt import make_review_context_builder
+
+        return make_review_context_builder
+    if name == "RunPromptMode":
+        from vibe3.agents.run_prompt import RunPromptMode
+
+        return RunPromptMode
+    if name == "build_run_prompt_body":
+        from vibe3.agents.run_prompt import build_run_prompt_body
+
+        return build_run_prompt_body
+    if name == "describe_run_plan_sections":
+        from vibe3.agents.run_prompt import describe_run_plan_sections
+
+        return describe_run_plan_sections
+    if name == "make_publish_context_builder":
+        from vibe3.agents.run_prompt import make_publish_context_builder
+
+        return make_publish_context_builder
+    if name == "make_run_context_builder":
+        from vibe3.agents.run_prompt import make_run_context_builder
+
+        return make_run_context_builder
+    if name == "make_skill_context_builder":
+        from vibe3.agents.run_prompt import make_skill_context_builder
+
+        return make_skill_context_builder
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Protocols & Models

--- a/src/vibe3/commands/__init__.py
+++ b/src/vibe3/commands/__init__.py
@@ -1,19 +1,23 @@
 """Commands package."""
 
-# Re-export from server for commands-internal use
-from vibe3.server import _validate_pid_file
+from __future__ import annotations
 
-from . import (
-    check,
-    flow,
-    handoff,
-    inspect,
-    plan,
-    pr,
-    review,
-    run,
-    snapshot,
-)
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vibe3.server.registry import _validate_pid_file
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for symbols to avoid cross-module import cascades."""
+    if name == "_validate_pid_file":
+        from vibe3.server.registry import _validate_pid_file
+
+        globals()["_validate_pid_file"] = _validate_pid_file
+        return _validate_pid_file
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "check",

--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -1,15 +1,56 @@
 """Execution control plane public interface."""
 
-from vibe3.execution.capacity_service import CapacityService
-from vibe3.execution.codeagent_runner import CodeagentExecutionService
-from vibe3.execution.coordinator import ExecutionCoordinator
-from vibe3.execution.execution_lifecycle import (
-    execution_prefix,
-    persist_execution_lifecycle_event,
-)
-from vibe3.execution.noop_gate import apply_unified_noop_gate
-from vibe3.execution.session_service import load_session_id
+from typing import TYPE_CHECKING, Any
+
 from vibe3.models import ExecutionLaunchResult, ExecutionRequest
+
+if TYPE_CHECKING:
+    from vibe3.execution.capacity_service import CapacityService
+    from vibe3.execution.codeagent_runner import CodeagentExecutionService
+    from vibe3.execution.coordinator import ExecutionCoordinator
+    from vibe3.execution.execution_lifecycle import (
+        execution_prefix,
+        persist_execution_lifecycle_event,
+    )
+    from vibe3.execution.noop_gate import apply_unified_noop_gate
+    from vibe3.execution.session_service import load_session_id
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for all symbols to avoid circular dependencies."""
+    if name == "CapacityService":
+        from vibe3.execution.capacity_service import CapacityService
+
+        return CapacityService
+    if name == "CodeagentExecutionService":
+        from vibe3.execution.codeagent_runner import CodeagentExecutionService
+
+        return CodeagentExecutionService
+    if name == "ExecutionCoordinator":
+        from vibe3.execution.coordinator import ExecutionCoordinator
+
+        return ExecutionCoordinator
+    if name == "execution_prefix":
+        from vibe3.execution.execution_lifecycle import execution_prefix
+
+        return execution_prefix
+    if name == "persist_execution_lifecycle_event":
+        from vibe3.execution.execution_lifecycle import (
+            persist_execution_lifecycle_event,
+        )
+
+        return persist_execution_lifecycle_event
+    if name == "apply_unified_noop_gate":
+        from vibe3.execution.noop_gate import apply_unified_noop_gate
+
+        return apply_unified_noop_gate
+    if name == "load_session_id":
+        from vibe3.execution.session_service import load_session_id
+
+        return load_session_id
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Core services

--- a/src/vibe3/server/__init__.py
+++ b/src/vibe3/server/__init__.py
@@ -1,44 +1,161 @@
 """vibe3 server module."""
 
-# Domain layer re-exports
-from vibe3.domain import FailedGate, FlowManager
+from typing import TYPE_CHECKING, Any
 
-# Runtime layer re-exports
-from vibe3.runtime import CircuitBreaker, HeartbeatServer
+if TYPE_CHECKING:
+    # Domain layer re-exports
+    from vibe3.domain import FailedGate, FlowManager
 
-# Orchestra instance utilities (now in runtime)
-from vibe3.runtime.orchestra_instance import (
-    OrchestraInstanceInfo,
-    read_instance_info,
-    validate_instance,
-    write_instance_info,
-)
+    # Runtime layer re-exports
+    from vibe3.runtime import CircuitBreaker, HeartbeatServer
 
-# MCP server
-from vibe3.server.mcp import (
-    _serialize_snapshot,
-    create_mcp_server,
-    format_snapshot_for_mcp,
-)
+    # Orchestra instance utilities (now in runtime)
+    from vibe3.runtime.orchestra_instance import (
+        OrchestraInstanceInfo,
+        read_instance_info,
+        validate_instance,
+        write_instance_info,
+    )
 
-# Registry
-from vibe3.server.registry import (
-    ORCHESTRA_TMUX_SESSION,
-    _build_async_serve_command,
-    _build_server,
-    _build_server_with_launch_cwd,
-    _kill_orchestra_tmux_session,
-    _orchestra_tmux_session_exists,
-    _resolve_async_cli_override_root,
-    _resolve_dispatcher_models_root,
-    _resolve_orchestra_log_dir,
-    _setup_tailscale_webhook,
-    _start_async_serve,
-    _validate_pid_file,
-)
+    # MCP server
+    from vibe3.server.mcp import (
+        _serialize_snapshot,
+        create_mcp_server,
+        format_snapshot_for_mcp,
+    )
 
-# Server utilities
-from vibe3.server.server_utils import find_available_port
+    # Registry
+    from vibe3.server.registry import (
+        ORCHESTRA_TMUX_SESSION,
+        _build_async_serve_command,
+        _build_server,
+        _build_server_with_launch_cwd,
+        _kill_orchestra_tmux_session,
+        _orchestra_tmux_session_exists,
+        _resolve_async_cli_override_root,
+        _resolve_dispatcher_models_root,
+        _resolve_orchestra_log_dir,
+        _setup_tailscale_webhook,
+        _start_async_serve,
+        _validate_pid_file,
+    )
+
+    # Server utilities
+    from vibe3.server.server_utils import find_available_port
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for all symbols to avoid circular dependencies."""
+    # Domain layer re-exports
+    if name == "FailedGate":
+        from vibe3.domain import FailedGate
+
+        return FailedGate
+    if name == "FlowManager":
+        from vibe3.domain import FlowManager
+
+        return FlowManager
+
+    # Runtime layer re-exports
+    if name == "CircuitBreaker":
+        from vibe3.runtime import CircuitBreaker
+
+        return CircuitBreaker
+    if name == "HeartbeatServer":
+        from vibe3.runtime import HeartbeatServer
+
+        return HeartbeatServer
+
+    # Orchestra instance utilities
+    if name == "OrchestraInstanceInfo":
+        from vibe3.runtime.orchestra_instance import OrchestraInstanceInfo
+
+        return OrchestraInstanceInfo
+    if name == "read_instance_info":
+        from vibe3.runtime.orchestra_instance import read_instance_info
+
+        return read_instance_info
+    if name == "validate_instance":
+        from vibe3.runtime.orchestra_instance import validate_instance
+
+        return validate_instance
+    if name == "write_instance_info":
+        from vibe3.runtime.orchestra_instance import write_instance_info
+
+        return write_instance_info
+
+    # MCP server
+    if name == "_serialize_snapshot":
+        from vibe3.server.mcp import _serialize_snapshot
+
+        return _serialize_snapshot
+    if name == "create_mcp_server":
+        from vibe3.server.mcp import create_mcp_server
+
+        return create_mcp_server
+    if name == "format_snapshot_for_mcp":
+        from vibe3.server.mcp import format_snapshot_for_mcp
+
+        return format_snapshot_for_mcp
+
+    # Registry
+    if name == "ORCHESTRA_TMUX_SESSION":
+        from vibe3.server.registry import ORCHESTRA_TMUX_SESSION
+
+        return ORCHESTRA_TMUX_SESSION
+    if name == "_build_async_serve_command":
+        from vibe3.server.registry import _build_async_serve_command
+
+        return _build_async_serve_command
+    if name == "_build_server":
+        from vibe3.server.registry import _build_server
+
+        return _build_server
+    if name == "_build_server_with_launch_cwd":
+        from vibe3.server.registry import _build_server_with_launch_cwd
+
+        return _build_server_with_launch_cwd
+    if name == "_kill_orchestra_tmux_session":
+        from vibe3.server.registry import _kill_orchestra_tmux_session
+
+        return _kill_orchestra_tmux_session
+    if name == "_orchestra_tmux_session_exists":
+        from vibe3.server.registry import _orchestra_tmux_session_exists
+
+        return _orchestra_tmux_session_exists
+    if name == "_resolve_async_cli_override_root":
+        from vibe3.server.registry import _resolve_async_cli_override_root
+
+        return _resolve_async_cli_override_root
+    if name == "_resolve_dispatcher_models_root":
+        from vibe3.server.registry import _resolve_dispatcher_models_root
+
+        return _resolve_dispatcher_models_root
+    if name == "_resolve_orchestra_log_dir":
+        from vibe3.server.registry import _resolve_orchestra_log_dir
+
+        return _resolve_orchestra_log_dir
+    if name == "_setup_tailscale_webhook":
+        from vibe3.server.registry import _setup_tailscale_webhook
+
+        return _setup_tailscale_webhook
+    if name == "_start_async_serve":
+        from vibe3.server.registry import _start_async_serve
+
+        return _start_async_serve
+    if name == "_validate_pid_file":
+        from vibe3.server.registry import _validate_pid_file
+
+        return _validate_pid_file
+
+    # Server utilities
+    if name == "find_available_port":
+        from vibe3.server.server_utils import find_available_port
+
+        return find_available_port
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # domain

--- a/tests/vibe3/test_modularity/test_module_independence.py
+++ b/tests/vibe3/test_modularity/test_module_independence.py
@@ -55,10 +55,6 @@ class TestIndependentImport:
             )
 
     @pytest.mark.slow
-    @pytest.mark.xfail(
-        reason="Known architectural debt: 5 modules trigger unexpected cross-module "
-        "imports (agents, commands, execution, prompts, server)"
-    )
     def test_no_cross_module_side_effects(self, module_registry: list[str]) -> None:
         """Verify modules don't trigger unexpected cross-module imports.
 


### PR DESCRIPTION
## Summary

Convert 4 violating `__init__.py` files to use the established `__getattr__` + `TYPE_CHECKING` lazy-import pattern, eliminating cross-module import cascades at `import vibe3.{module}` time.

## Changes

- **agents/__init__.py**: Replace 8 eager submodule imports with lazy loading
- **commands/__init__.py**: Remove eager imports, add lazy `_validate_pid_file`
- **execution/__init__.py**: Replace 6 eager submodule imports with lazy loading  
- **server/__init__.py**: Move ALL eager imports to lazy loading
- **tests**: Remove xfail marker from `test_no_cross_module_side_effects`

## Verification

✅ `test_no_cross_module_side_effects` now **PASSES** (was XFAIL)
✅ All modularity tests pass (3 passed)
✅ mypy: Success (no issues in 396 files)
✅ ruff: All checks passed
✅ Targeted tests: 682 passed, 4 xfailed

## Test Plan

- Run `pytest tests/vibe3/test_modularity/test_module_independence.py` - all tests pass
- Run `mypy src/vibe3` - no new errors
- Run `ruff check` on modified files - all checks pass

Closes #2089

---

## Contributors

claude/opus
