### PR TITLE
fix(governance): 修复 intake/pool 边界和 keys.env 加载问题

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -191,8 +191,8 @@ code_limits:
         limit: 600
         reason: "Coordinator 核心测试，12 个测试函数围绕调度逻辑（async/sync dispatch、capacity、error handling），共享 mock_dependencies fixture，拆分收益低"
       - path: "tests/vibe3/roles/test_governance_context_comment.py"
-        limit: 520
-        reason: "Governance snapshot context and comment format contract tests, covering 11 test methods across TestBuildSnapshotContext and TestCommentFormatContract classes; includes PR #1783 comment format regression tests; split from original test_governance.py (#1803)"
+        limit: 630
+        reason: "Governance snapshot context and comment format contract tests, covering 11 test methods across TestBuildSnapshotContext and TestCommentFormatContract classes; includes PR #1783 comment format regression tests; split from original test_governance.py (#1803); Issue #1925 adds keys.env partial loading, layered markers, and local manager boundary tests (3 new test methods)"
       - path: "tests/vibe3/execution/test_codeagent_runner_gate.py"
         limit: 480
         reason: "Gate 集成测试，包含完整的 mock 设置和断言场景，拆分会破坏测试逻辑完整性"

--- a/docs/governance/governance-roadmap-closed-loop.md
+++ b/docs/governance/governance-roadmap-closed-loop.md
@@ -25,7 +25,9 @@ Issue 创建（无 assignee，无标签）
 [intake 扫描]
   |- 有 orchestra-scanned? -> 跳过
   |- 有 assignee? -> 跳过（已在 pool）
-  |- 无标签、无 assignee -> 三级审查
+  |- 有 roadmap/rfc 或 roadmap/epic? -> 跳过（已路由）
+  |- 无 assignee、无 orchestra-scanned、无 roadmap/rfc/epic -> 三级审查
+       |- 即使带 orchestra-governed，也按当前无 assignee 事实重新评估
        |- 接受 -> 分配 assignee --> 流入 pool（无 scanned 标签）
        |- 跳过 -> 打 orchestra-scanned --> 不再看
               |
@@ -58,8 +60,8 @@ Issue 创建（无 assignee，无标签）
 
 | | roadmap-intake | assignee-pool |
 |---|---|---|
-| **扫描范围** | broader repo（无 assignee） | assignee pool（有 assignee） |
-| **跳过条件** | 有 assignee / 有 `orchestra-scanned` / 有 `orchestra-governed`（防御） | 无 assignee 或 有 `orchestra-governed` |
+| **扫描范围** | broader repo（无 assignee） | 本机 manager 的 assignee pool |
+| **跳过条件** | 有 assignee / 有 `orchestra-scanned` / 有 `roadmap/rfc` / 有 `roadmap/epic` | 无 assignee / assignee 非本机 manager / 有 `orchestra-governed` |
 | **打标签** | 只对跳过的打 `orchestra-scanned` | 对所有决策完的打 `orchestra-governed` |
 | **不打的含义** | 接受 -> assignee 是信号 -> 流入 pool | 无——所有决策完都打 |
 | **过滤例外** | 无 | `roadmap/epic` 收口检查独立扫描所有 epic，不受 governed 过滤 |

--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -5,13 +5,13 @@ description: Use when the user wants project-level roadmap planning, version goa
 
 # /vibe-roadmap - 版本规划与治理审查
 
-维护版本路线图，同时作为三层治理架构的 Layer 3 审查者，消化 pool 层的 `[governance suggest]` 并形成最终 `[roadmap decision]`。
+维护版本路线图，同时作为三层治理架构的 Layer 3 审查者，消化 governance 层的 `[governance suggest][roadmap-intake]` / `[governance suggest][assignee-pool]` 并形成最终 `[roadmap decision]`。
 
 三层架构、标签语义（orchestra-scanned / orchestra-governed / roadmap-reviewed）和三级审查框架（Level 1/2/3）见 @vibe/supervisor/roadmap-common.md（使用 `vibe3 handoff show @vibe/supervisor/roadmap-common.md` 命令读取）。
 
 ## 核心原则
 
-- **审查纠正 governance 决策**：消化 assignee-pool 的 `[governance suggest]`，写 `[roadmap decision]`，打 `roadmap-reviewed`
+- **审查纠正 governance 决策**：消化 roadmap-intake / assignee-pool 的分层 `[governance suggest]`，写 `[roadmap decision]`，打 `roadmap-reviewed`
 - **GitHub-as-truth**：所有操作通过 GitHub labels
 - **不做执行**：不处理单个 flow 执行
 - **manager assignee**：分配 assignee 时使用 `vibe3 task intake <number>`（shell），**禁止手动指定人类用户名**
@@ -19,7 +19,7 @@ description: Use when the user wants project-level roadmap planning, version goa
 ## Scope
 
 **做**：
-- 消化 pool 层的 `[governance suggest]`（Step 0）
+- 消化 governance 层的 `[governance suggest][roadmap-intake]` / `[governance suggest][assignee-pool]`（Step 0）
 - 治理漏网检查（Step 0.5）
 - 版本目标定义与 milestone 分配
 - Issue 分类与 roadmap/priority labels 设置
@@ -44,7 +44,7 @@ description: Use when the user wants project-level roadmap planning, version goa
    ```
    若无历史 `[roadmap decision]` 评论（首次运行），锚点设为 7 天前。
 
-2. **列出未消化的 `[governance suggest]`**（过滤已决策的 issue）：
+2. **列出未消化的分层 `[governance suggest]`**（过滤已决策的 issue）：
    ```bash
    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
    gh search issues "repo:$REPO [governance suggest]" --match comments --limit 50 \
@@ -67,7 +67,7 @@ description: Use when the user wants project-level roadmap planning, version goa
 
 5. **推翻 intake skip 时的三步处理**：
 
-   当被审查的 `[governance suggest]` 来自 intake 层 skip 决策（issue 带 `orchestra-scanned` 且无 assignee），如果你决定纳入该 issue，**必须显式执行三步**（标签语义见 roadmap-common.md）：
+   当被审查的 `[governance suggest][roadmap-intake]` 来自 intake 层 skip 决策（issue 带 `orchestra-scanned` 且无 assignee），如果你决定纳入该 issue，**必须显式执行三步**（标签语义见 roadmap-common.md）：
 
    ```bash
    # 1. 移除 intake 跳过标记
@@ -88,7 +88,9 @@ Step 0 处理完后，检查两类"漏网" issue：
 **类型 A：有 assignee 但缺 state 标签**（通过了 intake 但 pool 还没处理，卡在两层之间）
 
 ```bash
-gh issue list --assignee vibe-manager-agent --limit 50 --json number,title,labels \
+vibe3 status
+# 从 Manager agents 读取本机 manager，再替换下面的 <manager>
+gh issue list --assignee <manager> --limit 50 --json number,title,labels,state \
   --jq '.[] | select(.state == "OPEN")
             | select([.labels[].name] | map(select(startswith("state/"))) | length == 0)
             | {number, title}'

--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -404,13 +404,10 @@ def load_keys_env_fallback() -> None:
     Only loads if environment variables aren't already set.
     Logs warning on failure (non-blocking, allows graceful degradation).
     """
-    # Skip if any vibe env vars are already set (indicates shell wrapper loaded)
-    if any(
-        os.environ.get(key)
-        for key in ["VIBE_MANAGER_GITHUB_TOKEN", "MANAGER_USERNAMES"]
-    ):
+    loadable_keys = {"VIBE_MANAGER_GITHUB_TOKEN", "MANAGER_USERNAMES"}
+    if all(os.environ.get(key) for key in loadable_keys):
         logger.bind(domain="config").debug(
-            "keys.env fallback skipped: environment variables already present"
+            "keys.env fallback skipped: managed environment variables already present"
         )
         return
 
@@ -454,7 +451,8 @@ def load_keys_env_fallback() -> None:
                     key = key.strip()
                     value = value.strip().strip("\"'")
 
-                    # Only set if not already in environment
+                    # Only set if not already in environment. A manually exported
+                    # token must not prevent keys.env from supplying managers.
                     if key and not os.environ.get(key):
                         os.environ[key] = value
 

--- a/src/vibe3/roles/governance.py
+++ b/src/vibe3/roles/governance.py
@@ -175,10 +175,15 @@ def build_governance_snapshot_context(
     github = github or GitHubClient()
     governed_numbers = get_governed_issue_numbers(github, config)
 
-    # Filter out orchestra-governed issues from the active issues
+    manager_usernames = set(OrchestraStatusService.get_manager_usernames(config))
+
+    # Filter out issues that are not owned by this machine's manager pool, plus
+    # issues already decided by assignee-pool.
     active_entries = tuple(snapshot.active_issues)
     filtered_entries = tuple(
-        entry for entry in active_entries if entry.number not in governed_numbers
+        entry
+        for entry in active_entries
+        if entry.assignee in manager_usernames and entry.number not in governed_numbers
     )
 
     skipped_count = len(active_entries) - len(filtered_entries)

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -105,14 +105,19 @@ def build_broader_repo_entries(
             continue
 
         labels = normalize_labels(item.get("labels"))
-        # Three-layer governance filter + legacy compat:
-        # - orchestra-scanned: intake skipped (self-closure)
-        # - orchestra-governed: pool decided (defensive filter, e.g. close/rfc
-        #   after assignee removed)
-        # - orchestra (legacy umbrella): kept as compatibility alias because
-        #   sync-labels.sh is non-destructive and historical issues may still
-        #   carry it
-        if (
+        # Three-layer governance filter + legacy compat. Roadmap intake must not
+        # trust stale orchestra-governed labels on unassigned issues; it owns the
+        # broader unassigned pool and should re-evaluate those candidates.
+        if material_name == "roadmap-intake.md":
+            if (
+                "supervisor" in labels
+                or "orchestra-scanned" in labels
+                or "roadmap/rfc" in labels
+                or "roadmap/epic" in labels
+                or "orchestra" in labels
+            ):
+                continue
+        elif (
             "supervisor" in labels
             or "orchestra-scanned" in labels
             or "orchestra-governed" in labels

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -18,7 +18,7 @@
 - 被 orchestra/governance 视为运行池或 ready queue 候选
 - **不是** repo 全量 open issues，**不是** supervisor issue 池
 
-**当前 governance 的观察范围只限于 assignee issue pool**。它不对 broader repo backlog 做 triage，也不决定哪些 issue 应该进入 assignee issue pool。后者属于 `governance/roadmap-intake` 的职责。
+**当前 governance 的观察范围只限于本机 manager 的 assignee issue pool**。它不对 broader repo backlog 做 triage，也不决定哪些 issue 应该进入 assignee issue pool。后者属于 `governance/roadmap-intake` 的职责。
 
 **supervisor issues 由 roadmap-intake 层处理**，不在 assignee-pool 观察范围内。
 
@@ -47,8 +47,8 @@
 - **Level 3 (Roadmap)**: 终审决策，结果产出后打 `roadmap-reviewed`。
 
 **核心逻辑**：
-- **decide（高置信度）** → 直接执行动作并写 `[governance decide]` comment，说明决策依据和执行结果
-- **suggest（低置信度）** → 写 `[governance suggest]` comment，供人类或 roadmap 层审查
+- **decide（高置信度）** → 直接执行动作并写 `[governance decide][assignee-pool]` comment，说明决策依据和执行结果
+- **suggest（低置信度）** → 写 `[governance suggest][assignee-pool]` comment，供人类或 roadmap 层审查
 - **不确定** → 打 `roadmap/rfc`，说明需要人类判断的具体问题，然后停止；不要反复写 close/split 建议
 
 **decide vs suggest 判定标准**：
@@ -68,7 +68,7 @@
 - 不要把”已有历史 assignee / 历史上进过 pool”当成充分结论；必须以当前 task / flow / ready queue 现场为准
 - 如果 ready queue 很浅，而 broader intake 最近持续没有新增 issue，需在结论中明确指出是”入口收缩”还是”池内真实无候选”
 - 不要输出只有静态归档价值、但对下一步 dispatch 没帮助的 `already in assignee pool` 列表
-- 每个决策产出 `[governance suggest]`，供 vibe-roadmap 审查纠正
+- 每个低置信度决策产出 `[governance suggest][assignee-pool]`，供 vibe-roadmap 审查纠正
 
 **Intake 原则**：
 - **实质判断优先**：不只看标签类型，要实质检查 issue 范围和代码缺口
@@ -85,13 +85,14 @@ Allowed:
 - `labels.read`: 读取所有 labels
 - `labels.write`: 非 state labels（`milestone`、`roadmap/*`、`priority/[0-9]`、`orchestra-governed`）
   - **设置**：决策后打标签（如 `roadmap/rfc`、`roadmap/epic`、`priority/*`、`orchestra-governed`）
-  - **移除**：仅限 `orchestra-governed` 的验证清理（见「标签验证与清理」）
+  - **禁止删除 `orchestra-scanned`**：这是 roadmap-intake 层闭环标签，assignee-pool 不得清理
+  - **不清理 `orchestra-governed`**：已有 governed 的 issue 直接过滤；需要重判时由人类或上层先移除标签并提供证据
   - **不移除 `roadmap/rfc`**：rfc 的清理是人类/vibe-roadmap 职责，不在 pool
 - `flow`: read（读取 flow/worktree 现场信息）
 - `task`: read（读取 task 状态）
 - `handoff`: read（读取交接上下文）
 - `scene`: read（读取现场信息）
-- `comment.write`: 写治理建议评论（格式为 `[governance suggest]` 或 `[governance close]`）
+- `comment.write`: 写治理建议评论（格式为 `[governance suggest][assignee-pool]` 或 `[governance decide][assignee-pool]`）
 - `state/labels.write`: 两项动作，性质不同：
 
   1. **入池评估与标签补齐**（本职工作）：
@@ -101,8 +102,8 @@ Allowed:
      - 检查并补齐 `priority/*` 标签（如缺失）
      - 最后才设置 `state/ready`
      - **禁止**在 priority 评估完成前设置 `state/ready`
-     - 设置后必须写 `[governance suggest]` comment 说明评估依据
-     - 如果认为前一个 agent 判断错误或不值得执行，写 `[governance suggest]` 建议而非直接拒绝
+     - 设置后必须写 `[governance suggest][assignee-pool]` comment 说明评估依据
+     - 如果认为前一个 agent 判断错误或不值得执行，写 `[governance suggest][assignee-pool]` 建议而非直接拒绝
      - **关键要求**：优先级 label 是 assignee pool 评估的证据。有 priority = 已经过 assignee pool 评估，只是漏改 state；无 priority = 还没经过 assignee pool，应走完整评估流程
 
   2. **漏改 blocked 恢复**（唯一补偿动作）：
@@ -110,7 +111,7 @@ Allowed:
      - `blocked_reason` 明确为 `state unchanged`
      - `flow show` 能确认 authoritative ref 已存在
      - 使用 `vibe3 task resume <number> --label auto --yes` 自动恢复到正确状态
-     - 恢复后必须写 `[governance decide]` comment 说明决策依据和执行结果
+     - 恢复后必须写 `[governance decide][assignee-pool]` comment 说明决策依据和执行结果
 
 Forbidden:
 
@@ -127,7 +128,7 @@ Forbidden:
 规则：
 
 - 如果某个动作没有被明确允许，视为 forbidden
-- 治理建议以 `[governance suggest]` 署名写入 issue comment
+- 治理建议以 `[governance suggest][assignee-pool]` 署名写入 issue comment
 - 上述两项动作之外，state/labels 的修改只能由 manager 或人类执行
 
 ## What It Reads
@@ -146,27 +147,31 @@ Forbidden:
 - epic issues（有 `roadmap/epic` 标签的 open issue，用于收口检查）
 - epic sub-issues 状态（通过 `gh issue view <number> --json state,stateReason,labels` 查询）
 
-## 标签验证与清理（强制执行）
+## 候选边界验证（强制执行）
 
-**每次 scan 时，在 Step 1 过滤前，必须先验证 `orchestra-governed` 标签的正确性**，防止标签永久残留导致 issue 被过滤后无法被重新处理。
+**每次 scan 时，在 Step 1 过滤前，必须先确认本机 manager 边界**，防止 assignee-pool 处理 roadmap-intake 或其他机器负责的 issue。
 
-### `orchestra-governed` 标签验证
+### 候选边界验证
 
-**验证条件**（必须全部满足，否则标签过时）：
-- Issue 有 assignee
-- Assignee 在 `manager_usernames` 配置列表中
-- Issue 是 open 状态
-
-**验证失败处理**：
-
-**防重复（强制）**：在执行 cleanup comment 前，检查该 issue 最新评论。如果最新评论已是相同的 `[governance auto-cleanup]` 内容（相同清理原因），跳过评论，仅在 stdout 记录。
+先运行：
 
 ```bash
-gh issue edit <issue-number> --remove-label "orchestra-governed"
-gh issue comment <issue-number> --body "[governance auto-cleanup] 移除 orchestra-governed：issue 不再满足持有条件（无 assignee / assignee 非 manager / 已关闭），允许重新进入评估"
+vibe3 status
 ```
 
-记录到 Actions：`Cleanup: #XXX removed orchestra-governed (no manager assignee)`
+从 `Manager agents` 读取本机 manager 列表。assignee-pool 只处理同时满足以下条件的 issue：
+
+- Issue 是 open 状态
+- Issue 有 assignee
+- Assignee 在本机 `Manager agents` 列表中
+- Issue 没有 `orchestra-governed`
+- Issue 没有 `roadmap-reviewed`
+
+**验证失败处理**：
+- 未分配 assignee 的 issue 属于 roadmap-intake；不得处理或评论未分配给本机 manager 的 issue。
+- 分配给其他 manager / 人类的 issue 只在 stdout 记录，不写 comment、不改 label。
+- 已有 `orchestra-governed` 的 issue 直接过滤；不要删除 `orchestra-governed`，也不要删除 `orchestra-scanned`。
+- 如果要修改上一条 `[governance suggest][assignee-pool]`，必须提交新的证据；如果不修改上一条 suggest，不得 comment。
 
 ### pool 不清理 `roadmap/rfc`
 
@@ -180,13 +185,16 @@ pool **不**验证或移除 `roadmap/rfc`。原因：
 在 Execution Pattern 的 Step 1（标签过滤）**之前**先跑本验证：
 
 ```
-for issue in all_open_issues_with_orchestra_governed:
-    if not (has_assignee and assignee in manager_usernames and is_open):
-        remove orchestra-governed + write [governance auto-cleanup] comment
+manager_usernames = parse(vibe3 status Manager agents)
+for issue in active_issue_snapshot:
+    if issue.assignee not in manager_usernames:
+        skip + stdout only
+    if issue has orchestra-governed:
+        skip + stdout only
 # 然后才进入 Step 1 的正常过滤
 ```
 
-**目的**：防止标签永久残留导致过滤失效；让 assignee 漂移/决策半完成的 issue 能被重新处理。
+**目的**：防止 assignee-pool 绕过 roadmap-intake 或跨机器处理不属于本机 manager 的 issue。
 
 ## Issue Intake 策略
 
@@ -202,7 +210,7 @@ for issue in all_open_issues_with_orchestra_governed:
 ### 灵活处理
 
 **范围过大 → 拆分**
-- 若 issue 范围过大（如涉及多个独立模块），写 `[governance suggest]` 建议 manager 拆分为多个小 issue
+- 若 issue 范围过大（如涉及多个独立模块），写 `[governance suggest][assignee-pool]` 建议 manager 拆分为多个小 issue
 - 不要直接拒绝大范围 issue
 
 **范围明确 → 可处理重构**
@@ -216,10 +224,10 @@ for issue in all_open_issues_with_orchestra_governed:
 
 **不确定 → 优先交给 manager 或标记 RFC**
 - 若 issue 目标明确，只是 scope 偏大或拆分选择未定：
-  - 写 `[governance suggest]` 建议 manager 拆分或继续单 issue
+  - 写 `[governance suggest][assignee-pool]` 建议 manager 拆分或继续单 issue
   - 不把普通拆分选择升级为人类阻塞
 - 若目标、架构方向或拆分形态都无法判断：
-  - 设置 `roadmap/rfc`，写 `[governance suggest]` 说明需要人类决定的问题
+  - 设置 `roadmap/rfc`，写 `[governance suggest][assignee-pool]` 说明需要人类决定的问题
   - 命令：`gh issue edit <issue-number> --add-label "roadmap/rfc"`
   - `roadmap/rfc` 是低置信度终点，不再继续建议 close/split/ready
 
@@ -265,17 +273,17 @@ pool 扫描有 assignee 的 issue →
 - #503: chore: src/vibe3 总行数超过35000行限制
   - 范围过大：涉及整个 src/vibe3
   - 建议：拆分为多个模块级别的清理任务
-  - **结论**：写 `[governance suggest]` 建议 manager / roadmap decider 拆分；拆分后主 issue 继续作为治理容器
+  - **结论**：写 `[governance suggest][assignee-pool]` 建议 manager / roadmap decider 拆分；拆分后主 issue 继续作为治理容器
 
 **应关闭的 issue**
 - #556: tech-debt: 清理事件系统向后兼容别名
   - 若确认事件系统已完全移除旧别名
-  - **结论**：写 `[governance suggest]` 建议关闭（附：旧别名已在 #XYZ 移除）
+  - **结论**：写 `[governance suggest][assignee-pool]` 建议关闭（附：旧别名已在 #XYZ 移除）
 
 **不确定的 issue**
 - #539: 讨论：统一 vibe3 plan/review/run 命令参数和行为
   - 范围不明确，需要架构讨论
-  - **结论**：写 `[governance suggest]` 建议补 scope 或标记 `roadmap/rfc`
+  - **结论**：写 `[governance suggest][assignee-pool]` 建议补 scope 或标记 `roadmap/rfc`
 
 **可自动恢复的 blocked issue**
 - #123: state/blocked (blocked_reason: state unchanged)
@@ -283,14 +291,14 @@ pool 扫描有 assignee 的 issue →
   - 调用 `vibe3 flow show --branch task/issue-123` → plan_ref = "docs/plans/xxx.md"
   - authoritative ref 存在，说明 agent 已完成工作但漏改 state
   - 调用 `vibe3 task resume 123 --label auto --yes`
-  - 写 `[governance decide]` comment 说明决策依据和恢复结果
+  - 写 `[governance decide][assignee-pool]` comment 说明决策依据和恢复结果
   - **结论**：自动恢复成功
 
 **不可自动恢复的 blocked issue**
 - #456: state/blocked (blocked_reason: external dependency)
   - 调用 `gh issue view 456 --json body` → blocked_reason = "external dependency"
   - blocked_reason 不是 "state unchanged"，说明需要真实的人类介入
-  - 写 `[governance suggest]` comment 建议人类检查外部依赖状态
+  - 写 `[governance suggest][assignee-pool]` comment 建议人类检查外部依赖状态
   - **结论**：不自动恢复，建议人类处理
 
 ## What It Produces
@@ -304,10 +312,10 @@ pool 扫描有 assignee 的 issue →
   - resume：明确可恢复的 blocked issue
   - split 建议：分界清晰时
 - ready queue 排序建议
-- `[governance decide]` 和 `[governance suggest]` 格式的决策评论（见 decide/suggest 判定标准）
+- `[governance decide][assignee-pool]` 和 `[governance suggest][assignee-pool]` 格式的决策评论（见 decide/suggest 判定标准）
 - 入池评估与标签补齐：有 assignee 但无 state label → 评 priority → 补 roadmap/priority → 设 `state/ready`
 - **所有决策完成后打 `orchestra-governed` 标签**
-- 漏改恢复补偿：`state unchanged` 恢复（`vibe3 task resume <number> --label auto --yes`，使用 `[governance decide]` 标签）
+- 漏改恢复补偿：`state unchanged` 恢复（`vibe3 task resume <number> --label auto --yes`，使用 `[governance decide][assignee-pool]` 标签）
 
 ## Hard Boundary
 
@@ -331,7 +339,7 @@ pool 扫描有 assignee 的 issue →
   - Epic 检查不受 Step 1 的 `orchestra-governed` 过滤限制
   - 每次 scan 都会检查所有 `roadmap/epic` issues 的进度
   - 对于未完成的 Epic，只记录进度；如果 epic 不是 manager assignee，不添加 `orchestra-governed`，避免下一轮标签验证把它清掉后再次循环
-  - 对于已完成的 Epic，直接关闭，不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
+  - 对于已完成的 Epic，直接关闭，不要写 `[governance suggest][assignee-pool] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
   - **关键**：assignee-pool 是 Epic 进度的最后守门员；高置信度完成就终局，低置信度就 `roadmap/rfc`，不要循环
 
 ### `.claude/` 和 `.codex/` 目录阻塞规则
@@ -341,7 +349,7 @@ pool 扫描有 assignee 的 issue →
 - **原因**：这些目录涉及 agent 权限配置，自动化流程无法修改
 - **触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
 - **处理动作**：
-  - 写 `[governance suggest]` comment 说明：涉及 agent 权限配置目录，无法自动化执行
+  - 写 `[governance suggest][assignee-pool]` comment 说明：涉及 agent 权限配置目录，无法自动化执行
   - 添加 `roadmap/rfc` 标签
   - **禁止**设置 `state/ready` 或纳入 assignee pool
 
@@ -351,14 +359,15 @@ pool 扫描有 assignee 的 issue →
 
 Steps:
 
-0. **标签验证（强制，先于过滤）**：先执行「标签验证与清理」段——校验所有带 `orchestra-governed` 的 open issue 是否仍满足持有条件，不满足则移除并写 cleanup comment。然后才进入下面的标签过滤。
-1. **标签过滤（强制）**：只处理有 manager assignee，且无 `orchestra-governed` 且无 `roadmap-reviewed` 标签的 issue：
+0. **候选边界验证（强制，先于过滤）**：先执行「候选边界验证」段——用 `vibe3 status` 确认本机 Manager agents，只保留分配给本机 manager 的 issue；不得处理或评论未分配给本机 manager 的 issue。
+1. **标签过滤（强制）**：只处理有本机 manager assignee，且无 `orchestra-governed` 且无 `roadmap-reviewed` 标签的 issue：
    - 无 assignee → 跳过（不在 pool 中，由 roadmap-intake 负责）
+   - assignee 不在本机 `Manager agents` 列表中 → 跳过（非本机 pool）
    - 有 `orchestra-governed` 标签 → 跳过（pool 已决策过，不重复检查）
    - 有 `roadmap-reviewed` 标签 → 跳过（roadmap 已终审，pool 不再干预）
 2. 运行全局现场观察命令，读取当前 running issues、ready queue、blocked issues、remote tasks 与 flow 现场：
    ```bash
-   uv run python src/vibe3/cli.py task status
+   vibe3 task status
    ```
    这是 assignee pool 的主观察入口；单个 issue 的评论、refs 与去重细节再用 `vibe3 task show <issue-number>`。
 2. **依赖过滤**：从候选中排除不可进入 ready queue 的 issue：
@@ -378,7 +387,7 @@ Steps:
      d. 检查并补齐 `roadmap/*` 标签（如缺失）
      e. 检查并补齐 `priority/*` 标签（如缺失）
      f. 设置 `state/ready`
-     g. 写 `[governance suggest]` comment 说明评估依据
+     g. 写 `[governance suggest][assignee-pool]` comment 说明评估依据
    - **禁止**在 priority 评估完成前设置 `state/ready`
 5. **Blocked Issues 抽查恢复**：
    - 随机抽取 1-2 个处于 `state/blocked` 的 issues 进行检查
@@ -390,11 +399,11 @@ Steps:
         - 检查 `plan_ref`、`report_ref` 或 `audit_ref` 是否存在
         - 如果存在任意一个 authoritative ref（**高置信度 → decide**）：
           - 调用 `uv run python src/vibe3/cli.py task resume <number> --label auto --yes`
-          - 写 `[governance decide]` comment 说明恢复原因、依据和执行结果
+          - 写 `[governance decide][assignee-pool]` comment 说明恢复原因、依据和执行结果
         - 如果没有任何 authoritative ref（**低置信度 → suggest**）：
-          - 写 `[governance suggest]` comment 建议人类处理
+          - 写 `[governance suggest][assignee-pool]` comment 建议人类处理
      d. 如果是其他 blocked_reason（如外部依赖、手动阻塞等）：
-        - 不执行自动恢复，只写 `[governance suggest]` comment 建议人类处理
+        - 不执行自动恢复，只写 `[governance suggest][assignee-pool]` comment 建议人类处理
 6. **Epic 收口检查**（独立于 Step 1 过滤）：
    - **注意**：此步骤独立于 Step 1 的 `orchestra-governed` 过滤，每次 scan 都会执行
    - 独立查询所有 `roadmap/epic` 标签的 open issues（不受 assignee/governed 过滤限制）：
@@ -415,10 +424,10 @@ Steps:
         - 这是高置信度终局条件：all sub-issues completed → 直接关闭 epic
         - 关闭前执行未完成工作检查；如有剩余工作，创建 follow-up issue 并在关闭评论中引用
         - **防重复（强制）**：
-          - 所有 sub-issues 已完成 → 直接关闭 epic，写 `[governance close]` 评论（不要写 suggest）
-          - 写评论前检查最新评论：如果最新评论已是 `[governance close]` 或 `[governance suggest] 建议关闭此 Epic`，跳过评论
-        - 写 `[governance close]` 评论说明 sub-issues 状态和关闭理由
-        - 关闭原 epic；不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
+          - 所有 sub-issues 已完成 → 直接关闭 epic，写 `[governance decide][assignee-pool]` 评论（不要写 suggest）
+          - 写评论前检查最新评论：如果最新评论已是 `[governance decide][assignee-pool] 已关闭此 Epic` 或 `[governance suggest][assignee-pool] 建议关闭此 Epic`，跳过评论
+        - 写 `[governance decide][assignee-pool]` 评论说明 sub-issues 状态和关闭理由
+        - 关闭原 epic；不要写 `[governance suggest][assignee-pool] 建议关闭此 Epic` 后再只添加 `orchestra-governed`
      g. **部分 sub-issues 未完成**：
         - 不写评论，避免刷屏
         - 如果 epic 有 manager assignee，可添加 `orchestra-governed` 标记本轮已检查
@@ -442,9 +451,9 @@ Decision sketch:
   - 无标签的 issue 放在最后
 - **需要关注的 issue**：
   - 已在 `state/ready` 但有未解除依赖的 issue：标记为 concern，建议 manager 检查
-  - 已在 `state/blocked` 但依赖已解除的 issue：写 `[governance suggest]` 评论建议人类 resume
-  - 已过时的 issue（高置信度）：写 `[governance close]` 直接关闭
-  - 已过时的 issue（低置信度）：添加 `roadmap/rfc`，写 `[governance suggest]` 说明需要人类判断的具体问题
+  - 已在 `state/blocked` 但依赖已解除的 issue：写 `[governance suggest][assignee-pool]` 评论建议人类 resume
+  - 已过时的 issue（高置信度）：写 `[governance decide][assignee-pool]` 并直接关闭
+  - 已过时的 issue（低置信度）：添加 `roadmap/rfc`，写 `[governance suggest][assignee-pool]` 说明需要人类判断的具体问题
 - **入池评估与标签补齐（本职工作）**：
   - 每次 scan 检查所有有 manager assignee 但缺少 `state/*` label 的 issue
   - 先评 priority → 补 roadmap → 补 priority → 最后设 `state/ready`
@@ -467,14 +476,14 @@ Decision sketch:
 
 	  **恢复动作**：
 		  - 调用 `uv run python src/vibe3/cli.py task resume <number> --label auto --yes`
-		  - 写 `[governance decide]` comment 说明恢复原因、依据和执行结果
+		  - 写 `[governance decide][assignee-pool]` comment 说明恢复原因、依据和执行结果
 	  - **注意**：只做最小 state 纠偏，不推进后续阶段
 
   **禁止场景**（不自动恢复）：
   - blocked_reason 不是 "state unchanged"（如外部依赖、手动阻塞、测试失败等）
   - 没有任何 authoritative ref（说明 agent 确实未完成工作）
   - 存在多种不一致信号（无法唯一判断）
-  - 以上场景一律写 `[governance suggest]` 评论建议人类处理
+  - 以上场景一律写 `[governance suggest][assignee-pool]` 评论建议人类处理
 - **label 调整（仅非 state labels）**：
   - milestone 调整
   - roadmap 调整
@@ -558,7 +567,7 @@ Exit:
 
 ## Comment Contract
 
-治理建议以 `[governance decide]` 或 `[governance suggest]` 署名写入 issue comment。
+治理建议以 `[governance decide][assignee-pool]` 或 `[governance suggest][assignee-pool]` 署名写入 issue comment。
 
 **去重规则（强制）**：
 
@@ -566,16 +575,15 @@ Exit:
   - **普通 issue**：如果已有 `orchestra-governed` 标签，直接跳过（已决策过）
   - **Epic issue（例外）**：不受此规则限制，每次 scan 都检查（见 Step 6 Epic 收口检查）
 - **写评论前必须检查**：读取该 issue 的现有 comments
-- **去重检查**：若已存在相同类型的 `[governance decide]` 或 `[governance suggest]` 评论（关键字匹配），跳过该评论
+- **去重检查**：若已存在相同类型的 `[governance decide][assignee-pool]` 或 `[governance suggest][assignee-pool]` 评论（关键字匹配），跳过该评论；如果要修改上一条 suggest，必须在新评论中提交证据；如果不修改上一条 suggest，不得 comment
 - **类型匹配规则**：
-  - `[governance suggest] 建议关闭此 Issue` → 检查是否已有"建议关闭"
-  - `[governance suggest] 建议关闭此 Epic` → 检查最新评论是否已建议关闭此 Epic
-  - `[governance suggest] 建议恢复此 Issue` → 检查是否已有"建议恢复"
-  - `[governance suggest] 入池评估` → 检查是否已有"入池评估"
-  - `[governance suggest] 关注` → 检查是否已有"关注"且关注原因相同
-  - `[governance decide]` 恢复 → 检查是否已有相同恢复动作
-  - `[governance auto-cleanup] 移除 orchestra-governed` → 检查最新评论是否已是相同的 auto-cleanup 动作（比对清理原因）
-  - `[governance close] 已关闭此 Epic` → 关闭前检查 issue 是否已经 CLOSED，避免重复 close
+  - `[governance suggest][assignee-pool] 建议关闭此 Issue` → 检查是否已有"建议关闭"
+  - `[governance suggest][assignee-pool] 建议关闭此 Epic` → 检查最新评论是否已建议关闭此 Epic
+  - `[governance suggest][assignee-pool] 建议恢复此 Issue` → 检查是否已有"建议恢复"
+  - `[governance suggest][assignee-pool] 入池评估` → 检查是否已有"入池评估"
+  - `[governance suggest][assignee-pool] 关注` → 检查是否已有"关注"且关注原因相同
+  - `[governance decide][assignee-pool]` 恢复 → 检查是否已有相同恢复动作
+  - `[governance decide][assignee-pool] 已关闭此 Epic` → 关闭前检查 issue 是否已经 CLOSED，避免重复 close
 - **跳过时的输出**：在 governance 输出中记录"已建议（跳过重复评论）"，说明原因
 - **目的**：避免重复刷屏，保持 issue 讨论清洁
 
@@ -596,11 +604,11 @@ Exit:
 1. 执行未完成工作检查（见下方）
 2. 若发现未完成工作：创建 follow-up issue
 3. 直接关闭原 issue（无需等待 manager）
-4. 写 `[governance close]` 评论说明关闭理由和后续处理
+4. 写 `[governance decide][assignee-pool]` 评论说明关闭理由和后续处理
 
 **执行格式**：
 ```
-[governance close] 已关闭此 Issue
+[governance decide][assignee-pool] 已关闭此 Issue
 
 关闭理由：<具体理由>
 <若为重复，引用重复 Issue 编号>
@@ -622,12 +630,12 @@ Exit:
 **处理流程**：
 1. 执行未完成工作检查
 2. 添加 `roadmap/rfc`
-3. 写 `[governance suggest]` 说明为什么需要人类判断
+3. 写 `[governance suggest][assignee-pool]` 说明为什么需要人类判断
 4. 添加 `orchestra-governed` 后停止；不要反复建议 manager 关闭
 
 **建议格式**：
 ```
-[governance suggest] 低置信度：转 roadmap/rfc
+[governance suggest][assignee-pool] 低置信度：转 roadmap/rfc
 
 关闭理由：<具体理由>
 <若为重复，引用重复 Issue 编号>
@@ -669,7 +677,7 @@ Exit:
 当 blocked issue 满足高置信度恢复条件时（如上游阻塞已关闭 + 无其他阻塞），governance 作为 decider 直接执行恢复：
 
 ```
-[governance decide] 恢复此 Issue
+[governance decide][assignee-pool] 恢复此 Issue
 
 恢复理由：<上游阻塞已关闭的具体说明>
 执行命令：vibe3 task resume <issue-number> --label auto --yes
@@ -678,7 +686,7 @@ Exit:
 
 **执行动作**：
 1. 执行 `vibe3 task resume <issue-number> --label auto --yes`
-2. 写 `[governance decide]` comment 说明决策依据和执行结果
+2. 写 `[governance decide][assignee-pool]` comment 说明决策依据和执行结果
 3. 添加 `orchestra-governed` 标签
 
 **正确的恢复命令**（强制格式）：
@@ -696,7 +704,7 @@ vibe3 task resume <issue-number> --label auto --yes
 当 blocked issue 的依赖状态不明确，或存在多种不确定信号时：
 
 ```
-[governance suggest] 建议恢复此 Issue
+[governance suggest][assignee-pool] 建议恢复此 Issue
 
 恢复理由：<依赖可能已解除的具体说明>
 建议命令：vibe3 task resume <issue-number> --label auto --yes
@@ -715,7 +723,7 @@ vibe3 task resume <issue-number> --label auto --yes
 当 issue 有 manager assignee 但缺少 state label，governance 完成入池评估与标签补齐后：
 
 ```
-[governance suggest] 入池评估
+[governance suggest][assignee-pool] 入池评估
 
 评估依据：<priority 选择的理由>
 已执行动作：
@@ -737,7 +745,7 @@ vibe3 task resume <issue-number> --label auto --yes
 执行格式：
 
 ```
-[governance decide] 已自动恢复 state
+[governance decide][assignee-pool] 已自动恢复 state
 
 恢复原因：检测到 blocked 原因是 state unchanged，但 authoritative ref 已存在，判定为 agent 漏改 state。
 恢复命令：vibe3 task resume <number> --label auto --yes
@@ -756,7 +764,7 @@ vibe3 task resume <issue-number> --label auto --yes
 当发现需要关注但不需立即行动的 issue 时：
 
 ```
-[governance suggest] 关注
+[governance suggest][assignee-pool] 关注
 
 关注原因：<具体说明>
 建议后续动作：<manager 应检查什么>
@@ -767,7 +775,7 @@ vibe3 task resume <issue-number> --label auto --yes
 当 `roadmap/epic` issue 的所有 sub-issues 已完成时：
 
 ```
-[governance close] 已关闭此 Epic
+[governance decide][assignee-pool] 已关闭此 Epic
 
 Epic 编号：#<epic-number>
 Sub-issues 状态：
@@ -818,7 +826,7 @@ Sub-issues 状态：
 **Stop Point Checklist（强制）**：
 
 完成以下动作后才能停止：
-- [ ] 写完 `[governance decide]` 或 `[governance suggest]` 评论
+- [ ] 写完 `[governance decide][assignee-pool]` 或 `[governance suggest][assignee-pool]` 评论
 - [ ] 普通 pool 决策打上 `orchestra-governed` 标签；非 manager assignee 的 partial epic 只记录 stdout
 - [ ] 确认标签已添加（可选：`gh issue view <number> --json labels` 验证）
 - [ ] **Epic 检查**：完成所有 `roadmap/epic` issues 的检查（Step 6）

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -41,7 +41,7 @@
 **触发条件**：改动范围包含 `.claude/` 或 `.codex/` 目录下的任何文件
 
 **处理动作**：
-- 写 `[governance suggest]` comment：涉及 agent 权限配置目录，无法自动化执行
+- 写 `[governance suggest][roadmap-intake]` comment：涉及 agent 权限配置目录，无法自动化执行
 - 添加 `roadmap/rfc` 标签
 - **禁止**纳入 assignee issue pool
 - 记录到 `Skipped`，原因为 `blocked: .claude/.codex directory permission issue`
@@ -57,7 +57,7 @@
 - 每条特征需有具体证据
 
 **命中反模式的处理**：
-- 写 `[governance suggest]` comment：注明反模式原因及评分项（如："反模式：满足 #2 高复杂度低 ROI、#5 边缘场景驱动"）
+- 写 `[governance suggest][roadmap-intake]` comment：注明反模式原因及评分项（如："反模式：满足 #2 高复杂度低 ROI、#5 边缘场景驱动"）
 - 打 `orchestra-scanned` 标签
 - **禁止**纳入 assignee issue pool
 - 记录到 `Skipped`，原因为 `anti-pattern: <评分项>`
@@ -111,7 +111,7 @@
 
 intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 scanned）**。
 
-对于不适合纳入的 issue，intake 在 `[governance suggest]` 评论中说明原因，由后续层（assignee-pool 或 vibe-roadmap）做进一步决策：
+对于不适合纳入的 issue，intake 在 `[governance suggest][roadmap-intake]` 评论中说明原因，由后续层（assignee-pool 或 vibe-roadmap）做进一步决策：
 
 - 范围过大、需拆分 → suggest 中建议拆分，交给 assignee-pool 或 roadmap 处理
 - 目标不明确、需人类讨论 → suggest 中说明不确定，但不设 `roadmap/rfc`（属于 pool 决策范围）
@@ -238,7 +238,7 @@ Why: ...
 
 **正确示例**：
 ```
-[governance suggest] Intake completed (scope=bugfix).
+[governance suggest][roadmap-intake] Intake completed (scope=bugfix).
 ```
 
 ## Permission Contract
@@ -287,31 +287,37 @@ Forbidden:
 ## Execution Pattern
 
 1. 先看 broader repo issue pool 中当前 open issues
-2. **标签过滤（强制）**：扫描前先过滤，只处理无 assignee、无 `orchestra-scanned` 且无 `orchestra-governed` 的 issue：
+2. **标签过滤（强制）**：扫描前先过滤，只处理无 assignee、无 `orchestra-scanned`、无 `roadmap/rfc`、无 `roadmap/epic` 的 issue：
    - 有 assignee → 跳过（已在 pool 中，由 assignee-pool 负责）
    - 有 `orchestra-scanned` 标签 → 跳过（intake 已审查过，不重复扫描）
-   - 有 `orchestra-governed` 标签 → 跳过（pool 已决策过，不该回到 intake；如 `suggest_close`/`rfc` 后 assignee 被移除的情况）
-3. 先运行全局现场观察命令，确认当前 assignee pool / ready queue / blocked / remote tasks 事实：
+   - 有 `roadmap/rfc` 或 `roadmap/epic` 标签 → 跳过（已路由到 roadmap/task 可见层）
+   - 有 `orchestra-governed` 但无 assignee → 不要把 `orchestra-governed` 当作可信跳过条件；按当前 issue 事实重新做 intake 判断
+3. 先运行全局现场观察命令，确认当前机器 manager 与 assignee pool / ready queue / blocked / remote tasks 事实：
    ```bash
-   uv run python src/vibe3/cli.py task status
+   vibe3 status
+   ```
+   `vibe3 status` 中的 Manager agents 是 `vibe3 task intake` 分配对象的真源。
+4. 再运行 task 现场观察命令：
+   ```bash
+   vibe3 task status
    ```
    `task status` 用于理解池子深浅、已有 flow、ready queue 与 blocked 现场；单个 issue 的最近评论与细节仍用 `vibe3 task show <issue-number>`。
-3. 先过滤掉 discussion、明确的大 feature、以及真正需要人类先定方向的 issue
-4. 重点识别以下可纳入对象：
+5. 先过滤掉 discussion、明确的大 feature、以及真正需要人类先定方向的 issue
+6. 重点识别以下可纳入对象：
    - bug fix
    - 方案明确的 small feature
    - **边界明确的 refactor / cleanup**
-5. **事实确认（强制）**：在决定对某个 issue 写 `[governance suggest]` comment 前，必须先运行：
+7. **事实确认（强制）**：在决定对某个 issue 写 `[governance suggest][roadmap-intake]` comment 前，必须先运行：
    ```bash
    vibe3 task show <issue-number>
    ```
-   查看该 issue 最近的 2-3 条评论。如果最近已有 `[governance suggest]` 或 `[governance]` 开头的评论（无论是你自己还是其他 agent 写的），**一律跳过，不再重复写 comment**。靠事实判断，不靠猜测。
-6. 检查这些 issue 是否已在 assignee issue pool，避免重复纳入
-7. 对可纳入对象执行最小动作：
+   查看该 issue 最近的 2-3 条评论。如果最近已有 `[governance suggest][roadmap-intake]` 或其他 `[governance]` 开头的评论，默认跳过，不重复写 comment；只有在你要修改上一条 roadmap-intake suggest 且能提交新的证据时，才允许写更新评论。如果不修改上一条 suggest，不得 comment。
+8. 检查这些 issue 是否已在 assignee issue pool，避免重复纳入
+9. 对可纳入对象执行最小动作：
    - 使用 `vibe3 task intake <issue-number>` 分配 manager assignee（命令自动从配置解析，禁止手动指定人类用户名）
    - 如有必要补最小 routing labels
-8. 对不适合纳入的对象记录简短原因
-9. **扫描 `supervisor + state/ready` issues**，对每个执行：
+10. 对不适合纳入的对象记录简短原因
+11. **扫描 `supervisor + state/ready` issues**，对每个执行：
    - 先运行 `vibe3 task show <issue-number>` 确认最近没有重复 governance comment
    - 三级审查（基础条件 + 架构一致性 + 生命周期）
    - 通过：移除 `state/ready`，补 `state/handoff`，记录到 Actions
@@ -324,24 +330,24 @@ Forbidden:
      gh issue close <issue-number> --comment "关闭理由：<具体理由>"
      ```
    - 不确定：写 suggest 说明不确定，记录到 Actions
-10. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
+12. 如果本轮 `Accepted` 为空，必须在 `Why` 中明确说明：
    - 是因为候选确实都不满足三级审查
    - 还是因为当前材料把”实现选择”误当成了”人类拍板”
    - 若 ready queue 偏浅，优先重新检查是否存在被误判可纳入的 bounded refactor / bugfix
-11. 输出结论后停止
+13. 输出结论后停止
 
 ## Comment Contract
 
 任何 intake 类 routing 评论必须遵循 marker 规则：
 
-- 第一行行首必须是 `[governance]` 或更具体的 `[governance suggest]`（前面只允许空白字符）
-- intake 决策建议用 `[governance suggest]`，因为本材料只产出 routing 信号、不做强制结论
+- 第一行行首必须是 `[governance suggest][roadmap-intake]`（前面只允许空白字符）
+- intake 决策建议用 `[governance suggest][roadmap-intake]`，因为本材料只产出 routing 信号、不做强制结论
 - 不要把 intake 说明嵌入到自由文本中而不带 marker；缺失 marker 会被人类指令解析器误读为人类指令
 
 合规示例：
 ```
-[governance suggest] Intake completed (scope=bugfix).
-[governance suggest] Skipped: scope unclear, needs pool or roadmap review before automation.
+[governance suggest][roadmap-intake] Intake completed (scope=bugfix).
+[governance suggest][roadmap-intake] Skipped: scope unclear, needs pool or roadmap review before automation.
 ```
 
 ## Output Contract
@@ -413,11 +419,11 @@ gh issue edit <issue-number> --add-label "orchestra-scanned"
 
 **Stop Point Checklist（强制）**：
 
-- **接受（分配 assignee）**：写完 `[governance suggest]` 评论即可，不打 scanned 标签
+- **接受（分配 assignee）**：写完 `[governance suggest][roadmap-intake]` 评论即可，不打 scanned 标签
 - **跳过（不接受）**：写完评论后必须打 `orchestra-scanned` 标签
 
 完成以下动作后才能停止：
-- [ ] 写完 `[governance suggest]` 评论
+- [ ] 写完 `[governance suggest][roadmap-intake]` 评论
 - [ ] 如果是跳过：打上 `orchestra-scanned` 标签
 - [ ] 确认标签已添加（可选：`gh issue view <number> --json labels` 验证）
 

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -31,13 +31,14 @@ Governance 分为两层，加上上层的 roadmap 审查，共三层。每层有
 broader repo --> Layer 1: roadmap-intake (入口层)
                     扫描范围: 无 assignee 的 issue
                     过滤: 无 orchestra-scanned（自闭环）
-                          + 无 orchestra-governed（防御：pool 已决策的不该回头）
+                          + 无 roadmap/rfc / roadmap/epic
+                    注意: no-assignee + orchestra-governed 不能被当作可信跳过条件
                     接受 -> 分配 assignee -> 流入 Layer 2
                     跳过 -> 打 orchestra-scanned -> 不再看
                           |
                           v
                  Layer 2: assignee-pool (入池前/池内准入决策层)
-                    扫描范围: 有 assignee 的 issue
+                    扫描范围: 分配给本机 manager 的 issue
                     过滤: 无 orchestra-governed
                     例外: roadmap/epic 收口检查每次独立扫描，不受 governed 过滤
                     高置信度决策(close/split/rfc/epic/ready/resume) -> 直接执行/打闭环标签
@@ -45,7 +46,7 @@ broader repo --> Layer 1: roadmap-intake (入口层)
                           |
                           v
                  Layer 3: vibe-roadmap (上层审查/纠偏层)
-                    扫描范围: 所有 [governance suggest] 评论
+                    扫描范围: 所有 [governance suggest][roadmap-intake] / [governance suggest][assignee-pool] 评论
                     过滤: 无 roadmap-reviewed 且无 roadmap/rfc
                     审查 -> 打 roadmap-reviewed -> 写入 memory.md
 ```
@@ -54,8 +55,8 @@ broader repo --> Layer 1: roadmap-intake (入口层)
 
 | 角色 | 文件 | Marker | 职责 | 标签 |
 |------|------|--------|------|------|
-| **roadmap-intake** | supervisor/governance/roadmap-intake.md | `[governance suggest]` | 入口观察者：扫描 broader repo，决定是否纳入 pool | 跳过时打 `orchestra-scanned` |
-| **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest]` / `[governance close]` | 入池前/池内准入 decider：对 pool 中 issue 做 rfc/epic/ready/close 决策 | 决策后打 `orchestra-governed`，高置信度 close 直接终局 |
+| **roadmap-intake** | supervisor/governance/roadmap-intake.md | `[governance suggest][roadmap-intake]` | 入口观察者：扫描 broader repo，决定是否纳入 pool | 跳过时打 `orchestra-scanned` |
+| **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest][assignee-pool]` / `[governance decide][assignee-pool]` | 入池前/池内准入 decider：对本机 manager pool 中 issue 做 rfc/epic/ready/close 决策 | 决策后打 `orchestra-governed`，高置信度 close 直接终局 |
 | **vibe-roadmap** | skills/vibe-roadmap/SKILL.md | `[roadmap decision]` | 上层审查者：审查 governance 决策，纠正和补全 | 审查后打 `roadmap-reviewed` |
 
 ---
@@ -100,14 +101,13 @@ gh issue edit <issue-number> --add-label "orchestra-scanned"
 **过滤逻辑**：
 ```
 intake 扫描 -> 跳过有 orchestra-scanned 的 issue（自闭环）
-intake 扫描 -> 跳过有 orchestra-governed 的 issue（防御性过滤）
+intake 扫描 -> 跳过有 roadmap/rfc 或 roadmap/epic 的 issue（已路由）
 intake 扫描 -> 跳过有 assignee 的 issue（已在 pool 中）
+intake 扫描 -> 不信任 no-assignee + orchestra-governed，重新评估
 ```
 
-**防御性过滤说明**：
-代码 `build_broader_repo_entries` 同时过滤 `orchestra-scanned` 和 `orchestra-governed`。
-原因：broader repo 默认查询无 assignee 的 issue，但如果一个 issue 曾被 pool 决策（带 `orchestra-governed`）后 assignee 被移除，或 pool 决策 `close`/`rfc` 后 issue 仍 OPEN 但无 assignee，
-不该让 intake 再次评估它——它已经过更上层的决策了。
+**stale governed 说明**：
+`orchestra-governed` 是 assignee-pool 层闭环标签。若 issue 当前无 assignee，它不再证明 issue 仍在 pool 中；roadmap-intake 不把它当作可信跳过条件。
 
 ---
 
@@ -239,7 +239,7 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 
 | 角色 | Marker | 性质 |
 |---|---|---|
-| roadmap-intake / assignee-pool（observer） | `[governance suggest]` | 观察者意见，无强制力 |
+| roadmap-intake / assignee-pool（observer） | `[governance suggest][roadmap-intake]` / `[governance suggest][assignee-pool]` | 观察者意见，无强制力 |
 | **vibe-roadmap（decider）** | `[roadmap decision]` | 决策者结论，覆盖 governance 建议 |
 
 ### 强制规则
@@ -276,7 +276,7 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 
 **决策范围**：**只决定 accept（分配 assignee）或 skip（打 scanned）**
 **检查**：生命周期、依赖、API、模块（含 Level 0：`.claude/`/`.codex/` 目录机械检查）
-**输出**：`[governance suggest]` 建议纳入或跳过，附带原因
+**输出**：`[governance suggest][roadmap-intake]` 建议纳入或跳过，附带原因
 **标签**：不设 `roadmap/*`、`priority/*` 标签。**唯一例外**——Level 0 机械阻塞 skip 时直接打 `roadmap/rfc`：这是路由一个确定性硬阻塞（diff 是否碰 `.claude/`/`.codex/`，yes/no 机械可判），不是 intake 自称 decider。理由：Level 0 issue 无 assignee，pool 永远扫不到；只有 intake 打 `roadmap/rfc` 才能命中 task-status Rule 1 被 `/vibe-task` surface（否则落入 Rule 4 永久隐藏）。
 **边界**：intake 不自称 decider；除 Level 0 机械例外外，跳过原因写在 suggest 中，由 pool 或 roadmap 做进一步决策
 

--- a/tests/vibe3/commands/test_status_config_display.py
+++ b/tests/vibe3/commands/test_status_config_display.py
@@ -1,6 +1,7 @@
 """Tests for status command configuration display enhancements."""
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -157,6 +158,47 @@ class TestRenderConfigurationOutput:
         assert result.exit_code == 0
         assert "Orchestra Status" in result.output
         assert "Vibe3 Configuration" in result.output
+
+    @patch(
+        "vibe3.services.orchestra_status_service.OrchestraStatusService.fetch_live_snapshot"
+    )
+    def test_status_uses_keys_env_manager_when_token_already_exists(
+        self,
+        mock_fetch_live_snapshot: MagicMock,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """keys.env should still fill MANAGER_USERNAMES when another key is set."""
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "keys.env").write_text(
+            "VIBE_MANAGER_GITHUB_TOKEN=from-file\n" "MANAGER_USERNAMES=keys-manager\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "config" / "v3").mkdir(parents=True)
+        (tmp_path / "config" / "v3" / "settings.yaml").write_text(
+            "orchestra:\n"
+            "  repo: test/repo\n"
+            "  manager_usernames:\n"
+            "    - config-manager\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE_MANAGER_GITHUB_TOKEN", "existing-token")
+        monkeypatch.delenv("MANAGER_USERNAMES", raising=False)
+
+        mock_fetch_live_snapshot.return_value = OrchestraSnapshot(
+            timestamp=1234567890.0,
+            server_running=True,
+            active_issues=tuple(),
+            active_flows=0,
+            active_worktrees=0,
+        )
+
+        with patch("vibe3.clients.git_client.find_repo_root", return_value=tmp_path):
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        assert "Manager agents:    keys-manager (env override)" in result.output
 
 
 class TestTaskStatusExcludesSystemStatus:

--- a/tests/vibe3/config/test_env_override.py
+++ b/tests/vibe3/config/test_env_override.py
@@ -159,21 +159,28 @@ class TestGetEnvOverride:
 class TestLoadKeysEnvFallback:
     """Test load_keys_env_fallback function."""
 
-    def test_skip_if_env_already_set(self) -> None:
-        """Test that fallback is skipped if vibe env vars already present."""
-        from loguru import logger
+    def test_loads_missing_manager_usernames_when_token_already_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing token env must not prevent keys.env from supplying managers."""
+        keys_file = tmp_path / "config" / "keys.env"
+        keys_file.parent.mkdir(parents=True, exist_ok=True)
+        keys_file.write_text(
+            "VIBE_MANAGER_GITHUB_TOKEN=from-file\n" "MANAGER_USERNAMES=keys-manager\n"
+        )
 
-        debug_msgs: list[str] = []
-        handler_id = logger.add(lambda msg: debug_msgs.append(str(msg)), level="DEBUG")
-        try:
-            with patch.dict(
-                os.environ, {"VIBE_MANAGER_GITHUB_TOKEN": "existing-token"}
-            ):
-                load_keys_env_fallback()
-        finally:
-            logger.remove(handler_id)
+        monkeypatch.setattr(
+            "vibe3.clients.git_client.find_repo_root",
+            lambda: tmp_path,
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("VIBE_MANAGER_GITHUB_TOKEN", "existing-token")
+        monkeypatch.delenv("MANAGER_USERNAMES", raising=False)
 
-        assert any("keys.env fallback skipped" in m for m in debug_msgs)
+        load_keys_env_fallback()
+
+        assert os.environ.get("VIBE_MANAGER_GITHUB_TOKEN") == "existing-token"
+        assert os.environ.get("MANAGER_USERNAMES") == "keys-manager"
 
     def test_load_from_project_keys(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/vibe3/roles/test_governance_context_comment.py
+++ b/tests/vibe3/roles/test_governance_context_comment.py
@@ -128,7 +128,7 @@ class TestBuildSnapshotContext:
                 number=i,
                 title=f"Issue {i}",
                 state=None,
-                assignee="a",
+                assignee="vibe-manager-agent",
                 has_flow=False,
                 flow_branch=None,
                 has_worktree=False,
@@ -299,16 +299,9 @@ class TestBuildSnapshotContext:
         assert "#100" not in ctx["suggested_issue_details"]
 
     @patch("vibe3.roles.governance_utils.GitHubClient")
-    def test_broader_repo_filters_orchestra_labeled(self, mock_github_cls):
-        """Broader repo candidates should filter all governance-labeled issues.
-
-        Covers the three-layer filter + legacy compat alias:
-        - orchestra-scanned: intake self-closure
-        - orchestra-governed: pool defensive filter (close/rfc with assignee
-          removed)
-        - orchestra: legacy umbrella alias (historical issues; sync-labels.sh
-          is non-destructive)
-        """
+    def test_roadmap_intake_keeps_governed_unassigned_candidates(self, mock_github_cls):
+        """Roadmap intake should not trust stale orchestra-governed
+        on unassigned issues."""
         snapshot = _make_snapshot()
         config = _make_config()
         mock_github = MagicMock()
@@ -331,10 +324,10 @@ class TestBuildSnapshotContext:
             },
             {
                 "number": 203,
-                "title": "Already governed",
-                "body": "Pool decided",
+                "title": "Stale governed",
+                "body": "No assignee; intake should re-evaluate",
                 "assignees": [],
-                "labels": [{"name": "orchestra-governed"}],  # Should be filtered
+                "labels": [{"name": "orchestra-governed"}],  # Should pass through
                 "milestone": None,
             },
             {
@@ -343,6 +336,22 @@ class TestBuildSnapshotContext:
                 "body": "Historical issue",
                 "assignees": [],
                 "labels": [{"name": "orchestra"}],  # Legacy alias — should be filtered
+                "milestone": None,
+            },
+            {
+                "number": 205,
+                "title": "RFC",
+                "body": "Needs human decision",
+                "assignees": [],
+                "labels": [{"name": "roadmap/rfc"}],  # Should be filtered
+                "milestone": None,
+            },
+            {
+                "number": 206,
+                "title": "Epic",
+                "body": "Umbrella issue",
+                "assignees": [],
+                "labels": [{"name": "roadmap/epic"}],  # Should be filtered
                 "milestone": None,
             },
         ]
@@ -354,11 +363,96 @@ class TestBuildSnapshotContext:
         )
 
         assert ctx["issue_scope_name"] == "broader repo issue pool"
-        assert ctx["active_count"] == 1
+        assert ctx["active_count"] == 2
         assert "#202" in ctx["suggested_issue_details"]
+        assert "#203" in ctx["suggested_issue_details"]
         assert "#201" not in ctx["suggested_issue_details"]
-        assert "#203" not in ctx["suggested_issue_details"]
         assert "#204" not in ctx["suggested_issue_details"]
+        assert "#205" not in ctx["suggested_issue_details"]
+        assert "#206" not in ctx["suggested_issue_details"]
+
+    @patch("vibe3.roles.governance.GitHubClient")
+    def test_assignee_pool_filters_nonlocal_and_governed_snapshot_entries(
+        self, mock_github_cls
+    ):
+        """Assignee-pool context should only expose local manager ungoverned issues."""
+        mock_github = MagicMock()
+        mock_github.list_issues.return_value = [
+            {"number": 402, "labels": [{"name": "orchestra-governed"}]},
+        ]
+        mock_github_cls.return_value = mock_github
+
+        local_candidate = IssueStatusEntry(
+            number=401,
+            title="Local candidate",
+            state=None,
+            assignee="local-manager",
+            has_flow=False,
+            flow_branch=None,
+            has_worktree=False,
+            worktree_path=None,
+            has_pr=False,
+            pr_number=None,
+            blocked_by=(),
+        )
+        governed_candidate = IssueStatusEntry(
+            number=402,
+            title="Already governed",
+            state=None,
+            assignee="local-manager",
+            has_flow=False,
+            flow_branch=None,
+            has_worktree=False,
+            worktree_path=None,
+            has_pr=False,
+            pr_number=None,
+            blocked_by=(),
+        )
+        unassigned = IssueStatusEntry(
+            number=403,
+            title="Unassigned",
+            state=None,
+            assignee=None,
+            has_flow=False,
+            flow_branch=None,
+            has_worktree=False,
+            worktree_path=None,
+            has_pr=False,
+            pr_number=None,
+            blocked_by=(),
+        )
+        remote_assignee = IssueStatusEntry(
+            number=404,
+            title="Other assignee",
+            state=None,
+            assignee="other-manager",
+            has_flow=False,
+            flow_branch=None,
+            has_worktree=False,
+            worktree_path=None,
+            has_pr=False,
+            pr_number=None,
+            blocked_by=(),
+        )
+        snapshot = _make_snapshot(
+            active_issues=(
+                local_candidate,
+                governed_candidate,
+                unassigned,
+                remote_assignee,
+            )
+        )
+
+        ctx = build_governance_snapshot_context(
+            snapshot,
+            config=_make_config(manager_usernames=("local-manager",)),
+        )
+
+        assert ctx["active_count"] == 1
+        assert "#401" in ctx["suggested_issue_details"]
+        assert "#402" not in ctx["suggested_issue_details"]
+        assert "#403" not in ctx["suggested_issue_details"]
+        assert "#404" not in ctx["suggested_issue_details"]
 
     def test_no_orchestra_labeled_issues_no_filtering(self):
         """When no orchestra-labeled issues exist, all candidates pass through."""
@@ -413,14 +507,12 @@ class TestCommentFormatContract:
 
         content = Path("supervisor/governance/roadmap-intake.md").read_text()
 
-        # After PR #1801, format is: [governance suggest] Intake completed (scope=...)
-        # More concise, no "assigned to manager-agent (manager-pool)" part
         correct_example_pattern = re.compile(
-            r"\[governance suggest\]\s+Intake completed.*scope="
+            r"\[governance suggest\]\[roadmap-intake\]\s+" r"Intake completed.*scope="
         )
         assert correct_example_pattern.search(
             content
-        ), "Correct example should use new format: Intake completed (scope=...)"
+        ), "Correct example should use layered marker and scope"
 
         # Should NOT use @alice or other human usernames in correct examples
         # Line 236 is marked as "错误示例"
@@ -434,6 +526,28 @@ class TestCommentFormatContract:
             assert (
                 "错误示例" in content
             ), "If @alice appears, it should be marked as wrong example"
+
+    def test_roadmap_intake_material_documents_current_boundaries(self):
+        """Roadmap intake should document the re-intake boundary for stale governed."""
+        content = Path("supervisor/governance/roadmap-intake.md").read_text()
+
+        assert "[governance suggest][roadmap-intake]" in content
+        assert "vibe3 status" in content
+        assert "vibe3 task intake <issue-number>" in content
+        assert "无 `roadmap/rfc`、无 `roadmap/epic`" in content
+        assert "不要把 `orchestra-governed` 当作可信跳过条件" in content
+        assert "如果不修改上一条 suggest，不得 comment" in content
+
+    def test_assignee_pool_material_documents_local_manager_boundary(self):
+        """Assignee pool should document local-manager-only processing."""
+        content = Path("supervisor/governance/assignee-pool.md").read_text()
+
+        assert "[governance suggest][assignee-pool]" in content
+        assert "[governance decide][assignee-pool]" in content
+        assert "vibe3 status" in content
+        assert "禁止删除 `orchestra-scanned`" in content
+        assert "不得处理或评论未分配给本机 manager 的 issue" in content
+        assert "如果不修改上一条 suggest，不得 comment" in content
 
     def test_roadmap_skill_comment_format_matches_intake(self):
         """Verify vibe-roadmap SKILL.md mentions roadmap decision marker."""

--- a/tests/vibe3/roles/test_governance_request_materials.py
+++ b/tests/vibe3/roles/test_governance_request_materials.py
@@ -115,7 +115,7 @@ class TestGovernanceMaterials:
         content = Path("supervisor/governance/assignee-pool.md").read_text()
         assert "all sub-issues completed → 直接关闭 epic" in content
         assert (
-            "不要写 `[governance suggest] 建议关闭此 Epic` 后再只添加 "
+            "不要写 `[governance suggest][assignee-pool] 建议关闭此 Epic` 后再只添加 "
             "`orchestra-governed`" in content
         )
 


### PR DESCRIPTION
## Summary

修复三个核心问题：

1. **keys.env 部分加载**：`any()` → `all()`
   - 避免已有部分环境变量时跳过加载
   - 支持增量加载缺失的配置项

2. **分层治理标记**：引入 role-specific secondary markers
   - `[governance suggest][roadmap-intake]`
   - `[governance suggest][assignee-pool]` / `[governance decide][assignee-pool]`

3. **本地 manager 边界**：assignee-pool 只处理本地 manager 拥有的 issues
   - 通过 `vibe3 status` 获取本地 manager 列表
   - 严格执行 assignee 过滤

## Changes

### Core Fixes

- **src/vibe3/config/loader.py**:
  - 修复 `load_keys_env_fallback()` 使用 `all()` 检查
  - 支持部分环境变量已设置时的增量加载

- **src/vibe3/roles/governance.py**:
  - 添加 `entry.assignee in manager_usernames` 过滤
  - 确保只处理本地 manager 的 issues

- **src/vibe3/roles/governance_utils.py**:
  - 更新 `broader_repo` 过滤逻辑
  - roadmap-intake 重新评估 stale `orchestra-governed` 标签
  - assignee-pool 严格遵守本地 manager 边界

### Documentation Updates

- **supervisor/governance/roadmap-intake.md**:
  - 分层标记格式和搜索方法
  - stale governed 处理流程
  - vibe3 status 命令集成

- **supervisor/governance/assignee-pool.md**:
  - 分层标记格式和搜索方法
  - 本地 manager 边界规则
  - 移除 auto-cleanup 机制

- **supervisor/roadmap-common.md**:
  - 架构流程图更新
  - 角色职责表（分层标记）

- **docs/governance/governance-roadmap-closed-loop.md**:
  - 过滤逻辑对比表
  - 三层架构说明

- **skills/vibe-roadmap/SKILL.md**:
  - 分层标记搜索方法
  - 动态 manager 查找

### Test Updates

- **tests/vibe3/config/test_env_override.py**:
  - keys.env 部分加载测试
  - `find_repo_root` mock

- **tests/vibe3/commands/test_status_config_display.py**:
  - status 命令测试增强

- **tests/vibe3/roles/test_governance_context_comment.py**:
  - roadmap-intake 边界测试
  - assignee-pool 边界测试
  - 分层标记验证

- **tests/vibe3/roles/test_governance_request_materials.py**:
  - 分层标记格式验证

### Configuration

- **config/v3/loc_limits.yaml**:
  - 更新 LOC exception: 520 → 630 行
  - 理由：新增 3 个边界测试方法

## Test Plan

- [x] 所有测试通过（48 tests）
- [x] Pre-commit hooks 检查通过
- [x] LOC 检查通过（无 CI blockers）
- [x] Pre-push hooks 检查通过
- [ ] CI 检查待确认

## Related Issues

治理层架构问题：
- roadmap-intake 信任 stale orchestra-governed 标签
- assignee-pool 越界处理非本地 manager issues
- keys.env 加载在部分环境变量已设置时失败

## Notes

- 移除了 auto-cleanup 机制，简化治理模型
- 分层标记提供精确的职责溯源
- 本地 manager 边界防止跨 manager 操作