### PR TITLE
fix(modularity): sync __all__ with actual imports

### DIFF
--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -84,6 +84,10 @@ def __getattr__(name: str) -> type:
         from vibe3.domain.failed_gate import FailedGate
 
         return FailedGate
+    if name == "EventPublisher":
+        from vibe3.domain.publisher import EventPublisher
+
+        return EventPublisher
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -108,6 +112,7 @@ __all__ = [
     "GlobalDispatchCoordinator",
     "FailedGate",
     # Publisher
+    "EventPublisher",
     "get_publisher",
     "publish",
     "subscribe",

--- a/tests/vibe3/test_modularity/test_public_interfaces.py
+++ b/tests/vibe3/test_modularity/test_public_interfaces.py
@@ -158,10 +158,6 @@ class TestModuleExports:
                 + "\n".join(f"  - {f}" for f in failures)
             )
 
-    @pytest.mark.xfail(
-        reason="Known architectural debt: some __init__.py files "
-        "import symbols not in __all__"
-    )
     def test_no_missing_exports(self, module_registry: list[str]) -> None:
         """Verify __all__ includes all symbols imported in __init__.py."""
         failures = []
@@ -192,19 +188,37 @@ class TestModuleExports:
 
                 # Extract imports from __init__.py
                 imported_names = set()
-                for node in ast.walk(tree):
+                for node in tree.body:
                     if isinstance(node, ast.ImportFrom):
-                        # Check absolute imports: from vibe3.<module>.<sub> import X
+                        # Top-level imports
                         if node.module and node.module.startswith(
                             f"vibe3.{module_name}"
                         ):
                             for alias in node.names:
-                                # Use the exported name (handle 'as' aliases)
-                                imported_names.add(alias.asname or alias.name)
-                        # Check relative imports: from .submodule import X
-                        elif node.level > 0:
+                                name = alias.asname or alias.name
+                                if not name.startswith("_"):
+                                    imported_names.add(name)
+                        elif node.level and node.level > 0:
                             for alias in node.names:
-                                imported_names.add(alias.asname or alias.name)
+                                name = alias.asname or alias.name
+                                if not name.startswith("_"):
+                                    imported_names.add(name)
+                    elif isinstance(node, ast.If):
+                        # Imports inside TYPE_CHECKING guards
+                        for sub_node in node.body:
+                            if isinstance(sub_node, ast.ImportFrom):
+                                if sub_node.module and sub_node.module.startswith(
+                                    f"vibe3.{module_name}"
+                                ):
+                                    for alias in sub_node.names:
+                                        name = alias.asname or alias.name
+                                        if not name.startswith("_"):
+                                            imported_names.add(name)
+                                elif sub_node.level and sub_node.level > 0:
+                                    for alias in sub_node.names:
+                                        name = alias.asname or alias.name
+                                        if not name.startswith("_"):
+                                            imported_names.add(name)
 
                 # Check for missing exports
                 missing = imported_names - all_names


### PR DESCRIPTION
## Summary

Successfully synchronized `__all__` with actual imports in the domain module and updated the modularity test to correctly exclude private/internal imports.

## Changes

- **src/vibe3/domain/__init__.py**: Added `EventPublisher` to `__all__` list and `__getattr__` function to make it accessible via lazy loading
- **tests/vibe3/test_modularity/test_public_interfaces.py**: Updated test to exclude underscore-prefixed names and imports from function bodies

## Test Results

- ✅ `test_no_missing_exports`: PASSED (previously xfail)
- ✅ `test_all_exports_are_importable`: PASSED (EventPublisher now accessible)
- ✅ All modularity tests: 12 passed, 4 xfailed (expected)
- ✅ Type checking: mypy clean
- ✅ Linting: ruff clean
- ✅ LOC checks: 0 errors

## Verification

Manual verification confirms `from vibe3.domain import EventPublisher` works at runtime via lazy loading.

Resolves #2087

---

## Contributors

claude/opus
