### PR TITLE
refactor(prompts): extract build_tools_guide_section to shared module

### DIFF
--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -40,8 +40,11 @@ Backend Config:
   ``~/.codeagent/models.json``
 """
 
-from typing import TYPE_CHECKING, Any
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+# Cross-module imports (not self-references) - kept minimal per modularity rules
 from vibe3.models import PromptContextMode
 
 if TYPE_CHECKING:
@@ -76,99 +79,43 @@ if TYPE_CHECKING:
         make_run_context_builder,
         make_skill_context_builder,
     )
+    from vibe3.prompts.sections import build_tools_guide_section
 
 
-def __getattr__(name: str) -> Any:
-    """Lazy import for all symbols to avoid circular dependencies."""
-    if name == "CodeagentBackend":
-        from vibe3.agents.backends.codeagent import CodeagentBackend
+# Lazy imports for self-references (avoid circular init dependencies)
+_LAZY_IMPORTS = {
+    "CodeagentBackend": "vibe3.agents.backends.codeagent",
+    "sync_models_json": "vibe3.agents.backends.codeagent_config",
+    "AgentBackend": "vibe3.agents.base",
+    "CodeagentCommand": "vibe3.agents.models",
+    "CodeagentResult": "vibe3.agents.models",
+    "ExecutionRole": "vibe3.agents.models",
+    "create_codeagent_command": "vibe3.agents.models",
+    "build_plan_prompt_body": "vibe3.agents.plan_prompt",
+    "describe_plan_sections": "vibe3.agents.plan_prompt",
+    "make_plan_context_builder": "vibe3.agents.plan_prompt",
+    "build_snapshot_diff": "vibe3.agents.review_pipeline_helpers",
+    "run_inspect_json": "vibe3.agents.review_pipeline_helpers",
+    "build_review_prompt_body": "vibe3.agents.review_prompt",
+    "describe_review_sections": "vibe3.agents.review_prompt",
+    "make_review_context_builder": "vibe3.agents.review_prompt",
+    "RunPromptMode": "vibe3.agents.run_prompt",
+    "build_run_prompt_body": "vibe3.agents.run_prompt",
+    "describe_run_plan_sections": "vibe3.agents.run_prompt",
+    "make_publish_context_builder": "vibe3.agents.run_prompt",
+    "make_run_context_builder": "vibe3.agents.run_prompt",
+    "make_skill_context_builder": "vibe3.agents.run_prompt",
+    "build_tools_guide_section": "vibe3.prompts.sections",
+}
 
-        return CodeagentBackend
-    if name == "sync_models_json":
-        from vibe3.agents.backends.codeagent_config import sync_models_json
 
-        return sync_models_json
-    if name == "AgentBackend":
-        from vibe3.agents.base import AgentBackend
+def __getattr__(name: str) -> object:
+    """Lazy import for agents symbols to avoid circular dependencies."""
+    if name in _LAZY_IMPORTS:
+        import importlib
 
-        return AgentBackend
-    if name == "CodeagentCommand":
-        from vibe3.agents.models import CodeagentCommand
-
-        return CodeagentCommand
-    if name == "CodeagentResult":
-        from vibe3.agents.models import CodeagentResult
-
-        return CodeagentResult
-    if name == "ExecutionRole":
-        from vibe3.agents.models import ExecutionRole
-
-        return ExecutionRole
-    if name == "create_codeagent_command":
-        from vibe3.agents.models import create_codeagent_command
-
-        return create_codeagent_command
-    if name == "build_plan_prompt_body":
-        from vibe3.agents.plan_prompt import build_plan_prompt_body
-
-        return build_plan_prompt_body
-    if name == "describe_plan_sections":
-        from vibe3.agents.plan_prompt import describe_plan_sections
-
-        return describe_plan_sections
-    if name == "make_plan_context_builder":
-        from vibe3.agents.plan_prompt import make_plan_context_builder
-
-        return make_plan_context_builder
-    if name == "build_snapshot_diff":
-        from vibe3.agents.review_pipeline_helpers import build_snapshot_diff
-
-        return build_snapshot_diff
-    if name == "run_inspect_json":
-        from vibe3.agents.review_pipeline_helpers import run_inspect_json
-
-        return run_inspect_json
-    if name == "build_review_prompt_body":
-        from vibe3.agents.review_prompt import build_review_prompt_body
-
-        return build_review_prompt_body
-    if name == "describe_review_sections":
-        from vibe3.agents.review_prompt import describe_review_sections
-
-        return describe_review_sections
-    if name == "make_review_context_builder":
-        from vibe3.agents.review_prompt import make_review_context_builder
-
-        return make_review_context_builder
-    if name == "RunPromptMode":
-        from vibe3.agents.run_prompt import RunPromptMode
-
-        return RunPromptMode
-    if name == "build_run_prompt_body":
-        from vibe3.agents.run_prompt import build_run_prompt_body
-
-        return build_run_prompt_body
-    if name == "describe_run_plan_sections":
-        from vibe3.agents.run_prompt import describe_run_plan_sections
-
-        return describe_run_plan_sections
-    if name == "make_publish_context_builder":
-        from vibe3.agents.run_prompt import make_publish_context_builder
-
-        return make_publish_context_builder
-    if name == "make_run_context_builder":
-        from vibe3.agents.run_prompt import make_run_context_builder
-
-        return make_run_context_builder
-    if name == "make_skill_context_builder":
-        from vibe3.agents.run_prompt import make_skill_context_builder
-
-        return make_skill_context_builder
-    if name == "build_tools_guide_section":
-        from vibe3.prompts.sections import build_tools_guide_section
-
-        return build_tools_guide_section
-
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -40,9 +40,7 @@ Backend Config:
   ``~/.codeagent/models.json``
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vibe3.models import PromptContextMode
 
@@ -78,47 +76,99 @@ if TYPE_CHECKING:
         make_run_context_builder,
         make_skill_context_builder,
     )
-    from vibe3.prompts.sections import (
-        build_tools_guide_section,
-        resolve_common_rules_path,
-    )
 
 
-# Lazy imports for all symbols to avoid cross-module side effects
-_LAZY_IMPORTS = {
-    "CodeagentBackend": "vibe3.agents.backends.codeagent",
-    "sync_models_json": "vibe3.agents.backends.codeagent_config",
-    "AgentBackend": "vibe3.agents.base",
-    "CodeagentCommand": "vibe3.agents.models",
-    "CodeagentResult": "vibe3.agents.models",
-    "ExecutionRole": "vibe3.agents.models",
-    "create_codeagent_command": "vibe3.agents.models",
-    "build_plan_prompt_body": "vibe3.agents.plan_prompt",
-    "describe_plan_sections": "vibe3.agents.plan_prompt",
-    "make_plan_context_builder": "vibe3.agents.plan_prompt",
-    "build_snapshot_diff": "vibe3.agents.review_pipeline_helpers",
-    "run_inspect_json": "vibe3.agents.review_pipeline_helpers",
-    "build_review_prompt_body": "vibe3.agents.review_prompt",
-    "describe_review_sections": "vibe3.agents.review_prompt",
-    "make_review_context_builder": "vibe3.agents.review_prompt",
-    "RunPromptMode": "vibe3.agents.run_prompt",
-    "build_run_prompt_body": "vibe3.agents.run_prompt",
-    "describe_run_plan_sections": "vibe3.agents.run_prompt",
-    "make_publish_context_builder": "vibe3.agents.run_prompt",
-    "make_run_context_builder": "vibe3.agents.run_prompt",
-    "make_skill_context_builder": "vibe3.agents.run_prompt",
-    "build_tools_guide_section": "vibe3.prompts.sections",
-    "resolve_common_rules_path": "vibe3.prompts.sections",
-}
+def __getattr__(name: str) -> Any:
+    """Lazy import for all symbols to avoid circular dependencies."""
+    if name == "CodeagentBackend":
+        from vibe3.agents.backends.codeagent import CodeagentBackend
 
+        return CodeagentBackend
+    if name == "sync_models_json":
+        from vibe3.agents.backends.codeagent_config import sync_models_json
 
-def __getattr__(name: str) -> object:
-    """Lazy import for agents symbols to avoid cross-module side effects."""
-    if name in _LAZY_IMPORTS:
-        import importlib
+        return sync_models_json
+    if name == "AgentBackend":
+        from vibe3.agents.base import AgentBackend
 
-        module = importlib.import_module(_LAZY_IMPORTS[name])
-        return getattr(module, name)
+        return AgentBackend
+    if name == "CodeagentCommand":
+        from vibe3.agents.models import CodeagentCommand
+
+        return CodeagentCommand
+    if name == "CodeagentResult":
+        from vibe3.agents.models import CodeagentResult
+
+        return CodeagentResult
+    if name == "ExecutionRole":
+        from vibe3.agents.models import ExecutionRole
+
+        return ExecutionRole
+    if name == "create_codeagent_command":
+        from vibe3.agents.models import create_codeagent_command
+
+        return create_codeagent_command
+    if name == "build_plan_prompt_body":
+        from vibe3.agents.plan_prompt import build_plan_prompt_body
+
+        return build_plan_prompt_body
+    if name == "describe_plan_sections":
+        from vibe3.agents.plan_prompt import describe_plan_sections
+
+        return describe_plan_sections
+    if name == "make_plan_context_builder":
+        from vibe3.agents.plan_prompt import make_plan_context_builder
+
+        return make_plan_context_builder
+    if name == "build_snapshot_diff":
+        from vibe3.agents.review_pipeline_helpers import build_snapshot_diff
+
+        return build_snapshot_diff
+    if name == "run_inspect_json":
+        from vibe3.agents.review_pipeline_helpers import run_inspect_json
+
+        return run_inspect_json
+    if name == "build_review_prompt_body":
+        from vibe3.agents.review_prompt import build_review_prompt_body
+
+        return build_review_prompt_body
+    if name == "describe_review_sections":
+        from vibe3.agents.review_prompt import describe_review_sections
+
+        return describe_review_sections
+    if name == "make_review_context_builder":
+        from vibe3.agents.review_prompt import make_review_context_builder
+
+        return make_review_context_builder
+    if name == "RunPromptMode":
+        from vibe3.agents.run_prompt import RunPromptMode
+
+        return RunPromptMode
+    if name == "build_run_prompt_body":
+        from vibe3.agents.run_prompt import build_run_prompt_body
+
+        return build_run_prompt_body
+    if name == "describe_run_plan_sections":
+        from vibe3.agents.run_prompt import describe_run_plan_sections
+
+        return describe_run_plan_sections
+    if name == "make_publish_context_builder":
+        from vibe3.agents.run_prompt import make_publish_context_builder
+
+        return make_publish_context_builder
+    if name == "make_run_context_builder":
+        from vibe3.agents.run_prompt import make_run_context_builder
+
+        return make_run_context_builder
+    if name == "make_skill_context_builder":
+        from vibe3.agents.run_prompt import make_skill_context_builder
+
+        return make_skill_context_builder
+    if name == "build_tools_guide_section":
+        from vibe3.prompts.sections import build_tools_guide_section
+
+        return build_tools_guide_section
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -141,7 +191,6 @@ __all__ = [
     "build_review_prompt_body",
     "make_review_context_builder",
     "build_tools_guide_section",
-    "resolve_common_rules_path",
     "describe_plan_sections",
     "describe_run_plan_sections",
     "describe_review_sections",

--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -22,7 +22,7 @@ Prompt Builders:
 - ``build_review_prompt_body`` / ``make_review_context_builder`` — review
   agent prompt construction
 - ``build_tools_guide_section`` — shared utility for building tools guide
-  sections
+  sections (re-exported from prompts.sections)
 - ``describe_plan_sections`` / ``describe_run_plan_sections`` /
   ``describe_review_sections`` — section key inspectors for dry-run summaries
 
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-# Cross-module imports (not self-references) - kept minimal per modularity rules
 from vibe3.models import PromptContextMode
 
 if TYPE_CHECKING:
@@ -68,7 +67,6 @@ if TYPE_CHECKING:
     )
     from vibe3.agents.review_prompt import (
         build_review_prompt_body,
-        build_tools_guide_section,
         describe_review_sections,
         make_review_context_builder,
     )
@@ -80,8 +78,13 @@ if TYPE_CHECKING:
         make_run_context_builder,
         make_skill_context_builder,
     )
+    from vibe3.prompts.sections import (
+        build_tools_guide_section,
+        resolve_common_rules_path,
+    )
 
-# Lazy imports for self-references (avoid circular init dependencies)
+
+# Lazy imports for all symbols to avoid cross-module side effects
 _LAZY_IMPORTS = {
     "CodeagentBackend": "vibe3.agents.backends.codeagent",
     "sync_models_json": "vibe3.agents.backends.codeagent_config",
@@ -96,7 +99,6 @@ _LAZY_IMPORTS = {
     "build_snapshot_diff": "vibe3.agents.review_pipeline_helpers",
     "run_inspect_json": "vibe3.agents.review_pipeline_helpers",
     "build_review_prompt_body": "vibe3.agents.review_prompt",
-    "build_tools_guide_section": "vibe3.agents.review_prompt",
     "describe_review_sections": "vibe3.agents.review_prompt",
     "make_review_context_builder": "vibe3.agents.review_prompt",
     "RunPromptMode": "vibe3.agents.run_prompt",
@@ -105,11 +107,13 @@ _LAZY_IMPORTS = {
     "make_publish_context_builder": "vibe3.agents.run_prompt",
     "make_run_context_builder": "vibe3.agents.run_prompt",
     "make_skill_context_builder": "vibe3.agents.run_prompt",
+    "build_tools_guide_section": "vibe3.prompts.sections",
+    "resolve_common_rules_path": "vibe3.prompts.sections",
 }
 
 
 def __getattr__(name: str) -> object:
-    """Lazy import for agents symbols to avoid circular dependencies."""
+    """Lazy import for agents symbols to avoid cross-module side effects."""
     if name in _LAZY_IMPORTS:
         import importlib
 
@@ -137,6 +141,7 @@ __all__ = [
     "build_review_prompt_body",
     "make_review_context_builder",
     "build_tools_guide_section",
+    "resolve_common_rules_path",
     "describe_plan_sections",
     "describe_run_plan_sections",
     "describe_review_sections",

--- a/src/vibe3/agents/plan_prompt.py
+++ b/src/vibe3/agents/plan_prompt.py
@@ -10,7 +10,7 @@ Section builders (build_plan_policy_section, etc.) remain available for direct u
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 from loguru import logger
 
@@ -23,6 +23,10 @@ from vibe3.prompts import (
     PromptManifest,
     PromptProvider,
     make_context_builder,
+)
+from vibe3.prompts.sections import (
+    build_tools_guide_section,
+    resolve_common_rules_path,
 )
 
 PlanPromptMode = Literal["first", "retry"]
@@ -150,8 +154,6 @@ def _build_plan_prompt_providers(
     context_mode: PromptContextMode,
 ) -> dict[str, PromptProvider]:
     """Build providers used by config/prompts/prompt-recipes.yaml plan sections."""
-    from vibe3.agents.review_prompt import build_tools_guide_section
-
     plan_config = getattr(config, "plan", None)
     task_request = (
         request if context_mode == "bootstrap" else PlanRequest(scope=request.scope)
@@ -185,15 +187,12 @@ def _build_plan_prompt_providers(
         )
         return build_plan_task_section(task_request, plan_task_text)
 
-    def common_rules_path() -> str | None:
-        if plan_config and plan_config.common_rules is not None:
-            result: str | None = plan_config.common_rules
-            return result
-        # Cast needed: lazy __getattr__ import loses type info
-        return cast(str | None, resolver.get_policy_path("common"))
-
     def common_rules_section() -> str | None:
-        return build_tools_guide_section(common_rules_path())
+        return build_tools_guide_section(
+            resolve_common_rules_path(
+                plan_config.common_rules if plan_config else None, resolver
+            )
+        )
 
     return {
         "plan.policy": plan_policy,

--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -5,7 +5,7 @@ Public API:
 - ``make_review_context_builder(request, config)`` - PromptContextBuilder
 
 Section builders remain available for direct composition:
-- build_policy_section, build_tools_guide_section, build_ast_analysis_section
+- build_policy_section, build_ast_analysis_section
 - build_review_task_section, build_output_contract_section
 """
 
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 from loguru import logger
 
@@ -27,6 +27,10 @@ from vibe3.prompts import (
     PromptManifest,
     PromptProvider,
     make_context_builder,
+)
+from vibe3.prompts.sections import (
+    build_tools_guide_section,
+    resolve_common_rules_path,
 )
 
 ReviewPromptMode = Literal["first", "retry"]
@@ -60,36 +64,6 @@ def build_policy_section(policy_path: str) -> str:
         return content
     except OSError as e:
         raise ContextBuilderError(f"Cannot read policy: {e}") from e
-
-
-def build_tools_guide_section(tools_guide_path: str | None) -> str | None:
-    """Build tools guide section from file.
-
-    Source: config/v3/settings.yaml (review.common_rules)
-
-    Args:
-        tools_guide_path: Path to tools guide file (optional)
-
-    Returns:
-        Tools guide section or None if not configured/available
-    """
-    if not tools_guide_path:
-        return None
-
-    log = logger.bind(domain="context_builder", action="build_tools_guide_section")
-    path = resolve_runtime_asset(tools_guide_path)
-    if not path.exists():
-        return None
-
-    try:
-        tools_guide = path.read_text(encoding="utf-8")
-        log.success("Tools guide section built")
-        return f"## Available Tools\n\n{tools_guide}"
-    except OSError as e:
-        log.bind(error=str(e), path=str(tools_guide_path)).warning(
-            "Could not read tools guide"
-        )
-        return None
 
 
 def build_ast_analysis_section(
@@ -240,14 +214,10 @@ def _build_review_prompt_providers(
         )
         return build_policy_section(policy_path) if policy_path else ""
 
-    def common_rules_path() -> str | None:
-        if config.review.common_rules is not None:
-            return config.review.common_rules
-        # Cast needed: lazy __getattr__ import loses type info
-        return cast(str | None, resolver.get_policy_path("common"))
-
     def common_rules_section() -> str | None:
-        return build_tools_guide_section(common_rules_path())
+        return build_tools_guide_section(
+            resolve_common_rules_path(config.review.common_rules, resolver)
+        )
 
     return {
         "review.policy": review_policy,

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -9,7 +9,7 @@ Public API:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 from loguru import logger
 
@@ -21,6 +21,10 @@ from vibe3.prompts import (
     PromptManifest,
     PromptProvider,
     make_context_builder,
+)
+from vibe3.prompts.sections import (
+    build_tools_guide_section,
+    resolve_common_rules_path,
 )
 
 
@@ -83,14 +87,7 @@ def _build_run_prompt_providers(
     plan_content: str | None = None,
     skill_content: str | None = None,
 ) -> dict[str, PromptProvider]:
-    """Build providers used by config/prompts/prompt-recipes.yaml run sections.
-
-    Note: Imports review_prompt inline to avoid circular dependency at module level.
-    If review_prompt ever needs to import run_prompt, extract shared helpers
-    (e.g., build_tools_guide_section) to a common module like prompts/sections.py.
-    """
-    from vibe3.agents.review_prompt import build_tools_guide_section
-
+    """Build providers used by config/prompts/prompt-recipes.yaml run sections."""
     run_config = getattr(config, "run", None)
     resolver = ConventionResolver.from_repo()
 
@@ -122,15 +119,12 @@ def _build_run_prompt_providers(
             )
         return getattr(run_config, "coding_task", None)
 
-    def common_rules_path() -> str | None:
-        if run_config and run_config.common_rules is not None:
-            result: str | None = run_config.common_rules
-            return result
-        # Cast needed: lazy __getattr__ import loses type info
-        return cast(str | None, resolver.get_policy_path("common"))
-
     def common_rules_section() -> str | None:
-        return build_tools_guide_section(common_rules_path())
+        return build_tools_guide_section(
+            resolve_common_rules_path(
+                run_config.common_rules if run_config else None, resolver
+            )
+        )
 
     return {
         "run.plan_ref": plan_ref,

--- a/src/vibe3/prompts/__init__.py
+++ b/src/vibe3/prompts/__init__.py
@@ -9,6 +9,7 @@ Public API:
 - ProviderRegistry: provider registration and dispatch
 - Exceptions: PromptAssemblyError, MissingVariableError, etc.
 - Template helpers: DEFAULT_PROMPTS_PATH, resolve_prompt_template
+- Section builders: build_tools_guide_section, resolve_common_rules_path
 """
 
 from __future__ import annotations
@@ -47,6 +48,10 @@ if TYPE_CHECKING:
         VariableSourceKind,
     )
     from vibe3.prompts.provider_registry import ProviderRegistry
+    from vibe3.prompts.sections import (
+        build_tools_guide_section,
+        resolve_common_rules_path,
+    )
     from vibe3.prompts.template_loader import (
         DEFAULT_PROMPTS_PATH,
         resolve_prompt_template,
@@ -87,6 +92,8 @@ _LAZY_IMPORTS = {
     "PromptValidationResult": "vibe3.prompts.validation",
     "PromptValidationService": "vibe3.prompts.validation",
     "ValidationIssue": "vibe3.prompts.validation",
+    "build_tools_guide_section": "vibe3.prompts.sections",
+    "resolve_common_rules_path": "vibe3.prompts.sections",
 }
 
 
@@ -136,4 +143,7 @@ __all__ = [
     # Template helpers
     "DEFAULT_PROMPTS_PATH",
     "resolve_prompt_template",
+    # Section builders
+    "build_tools_guide_section",
+    "resolve_common_rules_path",
 ]

--- a/src/vibe3/prompts/__init__.py
+++ b/src/vibe3/prompts/__init__.py
@@ -12,7 +12,9 @@ Public API:
 - Section builders: build_tools_guide_section, resolve_common_rules_path
 """
 
-from typing import TYPE_CHECKING, Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vibe3.prompts.assembler import PromptAssembler
@@ -61,129 +63,48 @@ if TYPE_CHECKING:
     )
 
 
-def __getattr__(name: str) -> Any:
-    """Lazy import for all symbols to avoid cross-module side effects."""
-    if name == "PromptAssembler":
-        from vibe3.prompts.assembler import PromptAssembler
+# Lazy imports
+_LAZY_IMPORTS = {
+    "PromptAssembler": "vibe3.prompts.assembler",
+    "PromptContextBuilder": "vibe3.prompts.context_builder",
+    "make_context_builder": "vibe3.prompts.context_builder",
+    "MissingVariableError": "vibe3.prompts.exceptions",
+    "PromptAssemblyError": "vibe3.prompts.exceptions",
+    "ProviderNotFoundError": "vibe3.prompts.exceptions",
+    "TemplateNotFoundError": "vibe3.prompts.exceptions",
+    "UnusedVariableError": "vibe3.prompts.exceptions",
+    "PromptManifest": "vibe3.prompts.manifest",
+    "PromptProvider": "vibe3.prompts.manifest",
+    "PromptRecipeDefinition": "vibe3.prompts.manifest",
+    "PromptRecipeVariant": "vibe3.prompts.manifest",
+    "LoadedPromptRecipeDefinition": "vibe3.prompts.models",
+    "PromptMaterialSpec": "vibe3.prompts.models",
+    "PromptRecipe": "vibe3.prompts.models",
+    "PromptRecipeKind": "vibe3.prompts.models",
+    "PromptRecipeVariantSpec": "vibe3.prompts.models",
+    "PromptRenderResult": "vibe3.prompts.models",
+    "PromptSectionSpec": "vibe3.prompts.models",
+    "PromptVariableProvenance": "vibe3.prompts.models",
+    "PromptVariableSource": "vibe3.prompts.models",
+    "VariableSourceKind": "vibe3.prompts.models",
+    "ProviderRegistry": "vibe3.prompts.provider_registry",
+    "build_tools_guide_section": "vibe3.prompts.sections",
+    "resolve_common_rules_path": "vibe3.prompts.sections",
+    "DEFAULT_PROMPTS_PATH": "vibe3.prompts.template_loader",
+    "resolve_prompt_template": "vibe3.prompts.template_loader",
+    "PromptValidationResult": "vibe3.prompts.validation",
+    "PromptValidationService": "vibe3.prompts.validation",
+    "ValidationIssue": "vibe3.prompts.validation",
+}
 
-        return PromptAssembler
-    if name == "PromptContextBuilder":
-        from vibe3.prompts.context_builder import PromptContextBuilder
 
-        return PromptContextBuilder
-    if name == "make_context_builder":
-        from vibe3.prompts.context_builder import make_context_builder
+def __getattr__(name: str) -> object:
+    """Lazy import for prompts symbols to avoid circular dependencies."""
+    if name in _LAZY_IMPORTS:
+        import importlib
 
-        return make_context_builder
-    if name == "PromptManifest":
-        from vibe3.prompts.manifest import PromptManifest
-
-        return PromptManifest
-    if name == "PromptProvider":
-        from vibe3.prompts.manifest import PromptProvider
-
-        return PromptProvider
-    if name == "PromptRecipeDefinition":
-        from vibe3.prompts.manifest import PromptRecipeDefinition
-
-        return PromptRecipeDefinition
-    if name == "PromptRecipeVariant":
-        from vibe3.prompts.manifest import PromptRecipeVariant
-
-        return PromptRecipeVariant
-    if name == "LoadedPromptRecipeDefinition":
-        from vibe3.prompts.models import LoadedPromptRecipeDefinition
-
-        return LoadedPromptRecipeDefinition
-    if name == "PromptMaterialSpec":
-        from vibe3.prompts.models import PromptMaterialSpec
-
-        return PromptMaterialSpec
-    if name == "PromptRecipe":
-        from vibe3.prompts.models import PromptRecipe
-
-        return PromptRecipe
-    if name == "PromptRecipeKind":
-        from vibe3.prompts.models import PromptRecipeKind
-
-        return PromptRecipeKind
-    if name == "PromptRecipeVariantSpec":
-        from vibe3.prompts.models import PromptRecipeVariantSpec
-
-        return PromptRecipeVariantSpec
-    if name == "PromptRenderResult":
-        from vibe3.prompts.models import PromptRenderResult
-
-        return PromptRenderResult
-    if name == "PromptSectionSpec":
-        from vibe3.prompts.models import PromptSectionSpec
-
-        return PromptSectionSpec
-    if name == "PromptVariableProvenance":
-        from vibe3.prompts.models import PromptVariableProvenance
-
-        return PromptVariableProvenance
-    if name == "PromptVariableSource":
-        from vibe3.prompts.models import PromptVariableSource
-
-        return PromptVariableSource
-    if name == "VariableSourceKind":
-        from vibe3.prompts.models import VariableSourceKind
-
-        return VariableSourceKind
-    if name == "ProviderRegistry":
-        from vibe3.prompts.provider_registry import ProviderRegistry
-
-        return ProviderRegistry
-    if name == "MissingVariableError":
-        from vibe3.prompts.exceptions import MissingVariableError
-
-        return MissingVariableError
-    if name == "PromptAssemblyError":
-        from vibe3.prompts.exceptions import PromptAssemblyError
-
-        return PromptAssemblyError
-    if name == "ProviderNotFoundError":
-        from vibe3.prompts.exceptions import ProviderNotFoundError
-
-        return ProviderNotFoundError
-    if name == "TemplateNotFoundError":
-        from vibe3.prompts.exceptions import TemplateNotFoundError
-
-        return TemplateNotFoundError
-    if name == "UnusedVariableError":
-        from vibe3.prompts.exceptions import UnusedVariableError
-
-        return UnusedVariableError
-    if name == "PromptValidationResult":
-        from vibe3.prompts.validation import PromptValidationResult
-
-        return PromptValidationResult
-    if name == "PromptValidationService":
-        from vibe3.prompts.validation import PromptValidationService
-
-        return PromptValidationService
-    if name == "ValidationIssue":
-        from vibe3.prompts.validation import ValidationIssue
-
-        return ValidationIssue
-    if name == "DEFAULT_PROMPTS_PATH":
-        from vibe3.prompts.template_loader import DEFAULT_PROMPTS_PATH
-
-        return DEFAULT_PROMPTS_PATH
-    if name == "resolve_prompt_template":
-        from vibe3.prompts.template_loader import resolve_prompt_template
-
-        return resolve_prompt_template
-    if name == "build_tools_guide_section":
-        from vibe3.prompts.sections import build_tools_guide_section
-
-        return build_tools_guide_section
-    if name == "resolve_common_rules_path":
-        from vibe3.prompts.sections import resolve_common_rules_path
-
-        return resolve_common_rules_path
-
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/vibe3/prompts/__init__.py
+++ b/src/vibe3/prompts/__init__.py
@@ -12,9 +12,7 @@ Public API:
 - Section builders: build_tools_guide_section, resolve_common_rules_path
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vibe3.prompts.assembler import PromptAssembler
@@ -62,48 +60,130 @@ if TYPE_CHECKING:
         ValidationIssue,
     )
 
-# Lazy imports
-_LAZY_IMPORTS = {
-    "PromptAssembler": "vibe3.prompts.assembler",
-    "PromptContextBuilder": "vibe3.prompts.context_builder",
-    "make_context_builder": "vibe3.prompts.context_builder",
-    "MissingVariableError": "vibe3.prompts.exceptions",
-    "PromptAssemblyError": "vibe3.prompts.exceptions",
-    "ProviderNotFoundError": "vibe3.prompts.exceptions",
-    "TemplateNotFoundError": "vibe3.prompts.exceptions",
-    "UnusedVariableError": "vibe3.prompts.exceptions",
-    "PromptManifest": "vibe3.prompts.manifest",
-    "PromptProvider": "vibe3.prompts.manifest",
-    "PromptRecipeDefinition": "vibe3.prompts.manifest",
-    "PromptRecipeVariant": "vibe3.prompts.manifest",
-    "LoadedPromptRecipeDefinition": "vibe3.prompts.models",
-    "PromptMaterialSpec": "vibe3.prompts.models",
-    "PromptRecipe": "vibe3.prompts.models",
-    "PromptRecipeKind": "vibe3.prompts.models",
-    "PromptRecipeVariantSpec": "vibe3.prompts.models",
-    "PromptRenderResult": "vibe3.prompts.models",
-    "PromptSectionSpec": "vibe3.prompts.models",
-    "PromptVariableProvenance": "vibe3.prompts.models",
-    "PromptVariableSource": "vibe3.prompts.models",
-    "VariableSourceKind": "vibe3.prompts.models",
-    "ProviderRegistry": "vibe3.prompts.provider_registry",
-    "DEFAULT_PROMPTS_PATH": "vibe3.prompts.template_loader",
-    "resolve_prompt_template": "vibe3.prompts.template_loader",
-    "PromptValidationResult": "vibe3.prompts.validation",
-    "PromptValidationService": "vibe3.prompts.validation",
-    "ValidationIssue": "vibe3.prompts.validation",
-    "build_tools_guide_section": "vibe3.prompts.sections",
-    "resolve_common_rules_path": "vibe3.prompts.sections",
-}
 
+def __getattr__(name: str) -> Any:
+    """Lazy import for all symbols to avoid cross-module side effects."""
+    if name == "PromptAssembler":
+        from vibe3.prompts.assembler import PromptAssembler
 
-def __getattr__(name: str) -> object:
-    """Lazy import for prompts symbols to avoid circular dependencies."""
-    if name in _LAZY_IMPORTS:
-        import importlib
+        return PromptAssembler
+    if name == "PromptContextBuilder":
+        from vibe3.prompts.context_builder import PromptContextBuilder
 
-        module = importlib.import_module(_LAZY_IMPORTS[name])
-        return getattr(module, name)
+        return PromptContextBuilder
+    if name == "make_context_builder":
+        from vibe3.prompts.context_builder import make_context_builder
+
+        return make_context_builder
+    if name == "PromptManifest":
+        from vibe3.prompts.manifest import PromptManifest
+
+        return PromptManifest
+    if name == "PromptProvider":
+        from vibe3.prompts.manifest import PromptProvider
+
+        return PromptProvider
+    if name == "PromptRecipeDefinition":
+        from vibe3.prompts.manifest import PromptRecipeDefinition
+
+        return PromptRecipeDefinition
+    if name == "PromptRecipeVariant":
+        from vibe3.prompts.manifest import PromptRecipeVariant
+
+        return PromptRecipeVariant
+    if name == "LoadedPromptRecipeDefinition":
+        from vibe3.prompts.models import LoadedPromptRecipeDefinition
+
+        return LoadedPromptRecipeDefinition
+    if name == "PromptMaterialSpec":
+        from vibe3.prompts.models import PromptMaterialSpec
+
+        return PromptMaterialSpec
+    if name == "PromptRecipe":
+        from vibe3.prompts.models import PromptRecipe
+
+        return PromptRecipe
+    if name == "PromptRecipeKind":
+        from vibe3.prompts.models import PromptRecipeKind
+
+        return PromptRecipeKind
+    if name == "PromptRecipeVariantSpec":
+        from vibe3.prompts.models import PromptRecipeVariantSpec
+
+        return PromptRecipeVariantSpec
+    if name == "PromptRenderResult":
+        from vibe3.prompts.models import PromptRenderResult
+
+        return PromptRenderResult
+    if name == "PromptSectionSpec":
+        from vibe3.prompts.models import PromptSectionSpec
+
+        return PromptSectionSpec
+    if name == "PromptVariableProvenance":
+        from vibe3.prompts.models import PromptVariableProvenance
+
+        return PromptVariableProvenance
+    if name == "PromptVariableSource":
+        from vibe3.prompts.models import PromptVariableSource
+
+        return PromptVariableSource
+    if name == "VariableSourceKind":
+        from vibe3.prompts.models import VariableSourceKind
+
+        return VariableSourceKind
+    if name == "ProviderRegistry":
+        from vibe3.prompts.provider_registry import ProviderRegistry
+
+        return ProviderRegistry
+    if name == "MissingVariableError":
+        from vibe3.prompts.exceptions import MissingVariableError
+
+        return MissingVariableError
+    if name == "PromptAssemblyError":
+        from vibe3.prompts.exceptions import PromptAssemblyError
+
+        return PromptAssemblyError
+    if name == "ProviderNotFoundError":
+        from vibe3.prompts.exceptions import ProviderNotFoundError
+
+        return ProviderNotFoundError
+    if name == "TemplateNotFoundError":
+        from vibe3.prompts.exceptions import TemplateNotFoundError
+
+        return TemplateNotFoundError
+    if name == "UnusedVariableError":
+        from vibe3.prompts.exceptions import UnusedVariableError
+
+        return UnusedVariableError
+    if name == "PromptValidationResult":
+        from vibe3.prompts.validation import PromptValidationResult
+
+        return PromptValidationResult
+    if name == "PromptValidationService":
+        from vibe3.prompts.validation import PromptValidationService
+
+        return PromptValidationService
+    if name == "ValidationIssue":
+        from vibe3.prompts.validation import ValidationIssue
+
+        return ValidationIssue
+    if name == "DEFAULT_PROMPTS_PATH":
+        from vibe3.prompts.template_loader import DEFAULT_PROMPTS_PATH
+
+        return DEFAULT_PROMPTS_PATH
+    if name == "resolve_prompt_template":
+        from vibe3.prompts.template_loader import resolve_prompt_template
+
+        return resolve_prompt_template
+    if name == "build_tools_guide_section":
+        from vibe3.prompts.sections import build_tools_guide_section
+
+        return build_tools_guide_section
+    if name == "resolve_common_rules_path":
+        from vibe3.prompts.sections import resolve_common_rules_path
+
+        return resolve_common_rules_path
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/vibe3/prompts/sections.py
+++ b/src/vibe3/prompts/sections.py
@@ -1,0 +1,64 @@
+"""Shared prompt section builders.
+
+Public API:
+- ``build_tools_guide_section`` — build tools guide section from file
+- ``resolve_common_rules_path`` — resolve common rules path from config or resolver
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from loguru import logger
+
+from vibe3.config import ConventionResolver
+from vibe3.environment import resolve_runtime_asset
+
+
+def build_tools_guide_section(tools_guide_path: str | None) -> str | None:
+    """Build tools guide section from file.
+
+    Source: config/v3/settings.yaml (review.common_rules)
+
+    Args:
+        tools_guide_path: Path to tools guide file (optional)
+
+    Returns:
+        Tools guide section or None if not configured/available
+    """
+    if not tools_guide_path:
+        return None
+
+    log = logger.bind(domain="context_builder", action="build_tools_guide_section")
+    path = resolve_runtime_asset(tools_guide_path)
+    if not path.exists():
+        return None
+
+    try:
+        tools_guide = path.read_text(encoding="utf-8")
+        log.success("Tools guide section built")
+        return f"## Available Tools\n\n{tools_guide}"
+    except OSError as e:
+        log.bind(error=str(e), path=str(tools_guide_path)).warning(
+            "Could not read tools guide"
+        )
+        return None
+
+
+def resolve_common_rules_path(
+    agent_common_rules: str | None,
+    resolver: ConventionResolver,
+) -> str | None:
+    """Resolve common rules path from agent config or convention resolver fallback.
+
+    Args:
+        agent_common_rules: Configured common rules path from agent config
+        resolver: Convention resolver for fallback policy path resolution
+
+    Returns:
+        Resolved common rules path or None
+    """
+    if agent_common_rules is not None:
+        return agent_common_rules
+    # Cast needed: lazy __getattr__ import loses type info
+    return cast(str | None, resolver.get_policy_path("common"))

--- a/tests/vibe3/agents/test_review_prompt.py
+++ b/tests/vibe3/agents/test_review_prompt.py
@@ -15,7 +15,6 @@ from vibe3.agents.review_prompt import (
     build_policy_section,
     build_review_prompt_body,
     build_review_task_section,
-    build_tools_guide_section,
 )
 from vibe3.models.review import ReviewRequest, ReviewScope
 
@@ -37,31 +36,6 @@ class TestBuildPolicySection:
         """Should raise ContextBuilderError if file not found."""
         with pytest.raises(ContextBuilderError, match="Cannot read policy"):
             build_policy_section("/nonexistent/policy.md")
-
-
-class TestBuildToolsGuideSection:
-    """Tests for build_tools_guide_section (unit test)."""
-
-    def test_returns_none_if_not_configured(self) -> None:
-        """Should return None if path is None."""
-        result = build_tools_guide_section(None)
-        assert result is None
-
-    def test_returns_none_if_file_not_exists(self, tmp_path: Path) -> None:
-        """Should return None if file does not exist."""
-        result = build_tools_guide_section(str(tmp_path / "nonexistent.md"))
-        assert result is None
-
-    def test_reads_tools_guide(self, tmp_path: Path) -> None:
-        """Should read tools guide from file."""
-        tools_file = tmp_path / "tools.md"
-        tools_file.write_text("Use `vibe3 inspect` for analysis.")
-
-        result = build_tools_guide_section(str(tools_file))
-
-        assert result is not None
-        assert "## Available Tools" in result
-        assert "vibe3 inspect" in result
 
 
 class TestBuildAstAnalysisSection:

--- a/tests/vibe3/prompts/test_sections.py
+++ b/tests/vibe3/prompts/test_sections.py
@@ -1,0 +1,69 @@
+"""Tests for prompt section builders."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from vibe3.config import ConventionResolver
+from vibe3.prompts.sections import (
+    build_tools_guide_section,
+    resolve_common_rules_path,
+)
+
+
+class TestBuildToolsGuideSection:
+    """Tests for build_tools_guide_section (unit test)."""
+
+    def test_returns_none_if_not_configured(self) -> None:
+        """Should return None if path is None."""
+        result = build_tools_guide_section(None)
+        assert result is None
+
+    def test_returns_none_if_file_not_exists(self, tmp_path: Path) -> None:
+        """Should return None if file does not exist."""
+        result = build_tools_guide_section(str(tmp_path / "nonexistent.md"))
+        assert result is None
+
+    def test_reads_tools_guide(self, tmp_path: Path) -> None:
+        """Should read tools guide from file."""
+        tools_file = tmp_path / "tools.md"
+        tools_file.write_text("Use `vibe3 inspect` for analysis.")
+
+        result = build_tools_guide_section(str(tools_file))
+
+        assert result is not None
+        assert "## Available Tools" in result
+        assert "vibe3 inspect" in result
+
+
+class TestResolveCommonRulesPath:
+    """Tests for resolve_common_rules_path helper."""
+
+    def test_returns_configured_path_when_set(self) -> None:
+        """Should return configured path if provided."""
+        resolver = MagicMock(spec=ConventionResolver)
+
+        result = resolve_common_rules_path("config/rules.md", resolver)
+
+        assert result == "config/rules.md"
+        # Should not call resolver if path is provided
+        resolver.get_policy_path.assert_not_called()
+
+    def test_falls_back_to_resolver_when_none(self) -> None:
+        """Should fall back to resolver if agent_common_rules is None."""
+        resolver = MagicMock(spec=ConventionResolver)
+        resolver.get_policy_path.return_value = "default/rules.md"
+
+        result = resolve_common_rules_path(None, resolver)
+
+        assert result == "default/rules.md"
+        resolver.get_policy_path.assert_called_once_with("common")
+
+    def test_returns_none_when_both_sources_none(self) -> None:
+        """Should return None if both configured path and resolver return None."""
+        resolver = MagicMock(spec=ConventionResolver)
+        resolver.get_policy_path.return_value = None
+
+        result = resolve_common_rules_path(None, resolver)
+
+        assert result is None
+        resolver.get_policy_path.assert_called_once_with("common")


### PR DESCRIPTION
## Summary

Extract `build_tools_guide_section` from `review_prompt.py` into a new `src/vibe3/prompts/sections.py` module, and create a shared `resolve_common_rules_path` helper to eliminate duplicated logic across the three agent prompt builders.

## Changes

- **src/vibe3/prompts/sections.py** (NEW): Shared section builders — `build_tools_guide_section` (moved from review_prompt.py) and `resolve_common_rules_path` (extracted from the duplicated pattern in all three agents)
- **src/vibe3/prompts/__init__.py**: Add re-exports for `build_tools_guide_section` and `resolve_common_rules_path`
- **src/vibe3/agents/review_prompt.py**: Remove `build_tools_guide_section` definition, use `resolve_common_rules_path`
- **src/vibe3/agents/run_prompt.py**: Remove inline import, use shared helpers
- **src/vibe3/agents/plan_prompt.py**: Remove inline import, use shared helpers
- **src/vibe3/agents/__init__.py**: Update import source for re-export
- **tests/vibe3/prompts/test_sections.py** (NEW): Move `TestBuildToolsGuideSection` and add `TestResolveCommonRulesPath`
- **tests/vibe3/agents/test_review_prompt.py**: Remove moved test class

## Test Plan

- [x] All tests pass (190 tests in 1.36s)
- [x] Type check clean (mypy: 398 source files, no issues)
- [x] Lint clean (ruff: all checks passed)
- [x] Direct tests: test_sections.py (6 tests), test_review_prompt.py (17 tests)
- [x] No behavioral changes — purely structural refactoring

## Related Issue

Fixes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
