### PR TITLE
refactor(review): remove unused review.task alias (#2095)

### DIFF
--- a/src/vibe3/agents/review_prompt.py
+++ b/src/vibe3/agents/review_prompt.py
@@ -263,8 +263,6 @@ def _build_review_prompt_providers(
         ),
         "review.retry_task": review_retry_task,
         "review.exit_contract": review_exit_contract,
-        # Backward-compatible alias for local recipe overrides.
-        "review.task": review_exit_contract,
     }
 
 


### PR DESCRIPTION
Closes #2095

## Summary

Remove unused `review.task` alias from `_build_review_prompt_providers` in `review_prompt.py`. The key was defined but never used in any recipe, test, config, or doc.

## Changes

- **src/vibe3/agents/review_prompt.py**: Removed 2 lines
  - Deleted backward-compatibility comment (line 266)
  - Deleted `"review.task": review_exit_contract` dict entry (line 267)

## Verification

✅ **No references in codebase**
- `rg '"review\.task"' src/ tests/ config/ docs/` returns zero matches
- Only definition was in the removed lines

✅ **All tests pass**
- 27 tests in `test_review_prompt.py` and `test_review.py`
- No behavioral changes (canonical key `review.exit_contract` still available)

✅ **Quality checks clean**
- `ruff check`: All checks passed
- `mypy`: No type errors
- `pre-commit`: All hooks passed

✅ **LOC compliance**
- All files under CI block threshold (400 lines)

## Risk Assessment

**Low risk**: The `review.task` alias was never used in any tracked configuration. The canonical key `review.exit_contract` provides identical functionality. Any custom recipes (not in repo) using `review.task` can migrate to `review.exit_contract` with zero behavioral change.

## Related

- Issue: #2095
- Plan: docs/plans/issue-2095-remove-dead-code-alias.md
- Audit: docs/reports/issue-2095-audit-report.md (PASS)

---

## Contributors

claude/opus
