### PR TITLE
docs(cli_overrides): document fresh_session exclusion and sync docstrings

### DIFF
--- a/src/vibe3/config/cli_overrides.py
+++ b/src/vibe3/config/cli_overrides.py
@@ -13,7 +13,11 @@ class RoleCliOverrides:
     fresh_session: bool = False
 
     def to_config_overrides(self, role: str) -> dict[str, str]:
-        """Convert to config override dict for load_runtime_config."""
+        """Convert to config override dict for load_runtime_config.
+
+        Note: fresh_session is intentionally excluded — it is a runtime control
+        flag passed via argv, not a config-schema key.
+        """
         overrides: dict[str, str] = {}
         if self.backend:
             overrides[f"{role}.agent_config.backend"] = self.backend

--- a/src/vibe3/execution/issue_role_sync_runner.py
+++ b/src/vibe3/execution/issue_role_sync_runner.py
@@ -81,6 +81,8 @@ def run_issue_role_async(
 
         cmd = getattr(request, "cmd", None)
         if isinstance(cmd, list):
+            # Append CLI params to child self-invocation so the sync
+            # child resolves the same runtime configuration.
             cmd.extend(overrides.to_argv())
 
         try:
@@ -149,8 +151,9 @@ def run_issue_role_sync(
     the same lifecycle / handoff / pre-gate / no-op shell is used.
     See docs/standards/vibe3-execution-paths-standard.md.
 
-    CLI override params are passed into role option resolution so command-layer
-    overrides are reflected in the ExecutionRequest options.
+    Agent configuration overrides (agent/backend/model) are passed into role
+    option resolution so command-layer overrides are reflected in the
+    ExecutionRequest options.
     """
     repo = resolve_orchestra_repo_root()
     config = load_orchestra_config(target_repo=repo)


### PR DESCRIPTION
## Summary

Adds documentation clarifications for `RoleCliOverrides` asymmetric handling of `fresh_session`:
- Docstring note in `to_config_overrides()` explaining why `fresh_session` is excluded
- Narrowed `run_issue_role_sync` docstring to accurately reflect override scope
- Inline comment explaining CLI params append in child self-invocation

All changes are documentation-only with no behavioral modifications.

## Changes

- `src/vibe3/config/cli_overrides.py`: Added `Note:` paragraph to `to_config_overrides()` docstring
- `src/vibe3/execution/issue_role_sync_runner.py`: Narrowed docstring and added inline comment

## Testing

- All tests passing (12/12)
- No lint errors (ruff clean)
- No type errors (mypy clean)
- Test evidence confirms documented behavior accuracy

## Related

Closes #2120
Follow-up from #2118
Parent issue: #2063

---

## Contributors

claude/opus
