### PR TITLE
refactor(clients): consolidate scattered GitHub CLI execution logic

### DIFF
--- a/src/vibe3/clients/github_client_base.py
+++ b/src/vibe3/clients/github_client_base.py
@@ -8,6 +8,9 @@ from loguru import logger
 
 from vibe3.exceptions import GitHubError, UserError
 
+# Standard timeout for GitHub CLI API calls (seconds)
+GH_API_TIMEOUT = 30
+
 
 def raise_gh_pr_error(
     error: subprocess.CalledProcessError,
@@ -89,6 +92,43 @@ class GitHubClientBase:
                 operation="check_auth",
             ).error("Failed to check auth")
             return False
+
+    def _run_gh_command(
+        self,
+        cmd: list[str],
+        *,
+        timeout: int | None = None,
+        pager: bool = False,
+    ) -> subprocess.CompletedProcess[str] | None:
+        """Execute a gh CLI command with standard error handling.
+
+        Args:
+            cmd: Full command list (e.g. ["gh", "issue", "list", ...]).
+            timeout: Seconds before timeout. Defaults to GH_API_TIMEOUT.
+            pager: If True, inject GH_PAGER=cat into the subprocess env.
+
+        Returns:
+            CompletedProcess on success.
+            None on TimeoutExpired or FileNotFoundError (gh not installed).
+        """
+        env = {**os.environ, "GH_PAGER": "cat"} if pager else None
+        effective_timeout = timeout if timeout is not None else GH_API_TIMEOUT
+        try:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            logger.bind(external="github", cmd=" ".join(cmd[:3])).warning(
+                f"gh command timed out after {effective_timeout}s"
+            )
+            return None
+        except FileNotFoundError:
+            logger.bind(external="github").warning("gh CLI not found")
+            return None
 
     def get_current_user(self) -> str:
         """Get current authenticated user login name."""

--- a/src/vibe3/clients/github_issue_admin_ops.py
+++ b/src/vibe3/clients/github_issue_admin_ops.py
@@ -3,13 +3,9 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from typing import Any, cast
 
 from loguru import logger
-
-# Standard timeout for GitHub CLI API calls (seconds)
-GH_API_TIMEOUT = 30
 
 
 class IssueAdminMixin:
@@ -39,13 +35,12 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to remove assignees from issue #{issue_number}"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to remove assignees from issue #{issue_number}"
+                )
             return False
         return True
 
@@ -76,13 +71,12 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to add assignee to issue #{issue_number}"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to add assignee to issue #{issue_number}"
+                )
             return False
         return True
 
@@ -122,13 +116,12 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                "Failed to list issues with assignees"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    "Failed to list issues with assignees"
+                )
             return []
         return cast(list[dict[str, Any]], json.loads(result.stdout))
 
@@ -160,13 +153,12 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to close issue #{issue_number}"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to close issue #{issue_number}"
+                )
             return False
         return True
 
@@ -196,13 +188,12 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to add comment on #{issue_number}"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to add comment on #{issue_number}"
+                )
             return False
         return True
 
@@ -311,14 +302,13 @@ class IssueAdminMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-        )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
 
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to create issue: {title}"
-            )
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to create issue: {title}"
+                )
             return None
 
         # Parse issue number from URL

--- a/src/vibe3/clients/github_issue_body_ops.py
+++ b/src/vibe3/clients/github_issue_body_ops.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from typing import Any, cast
 
 from loguru import logger
-
-GH_API_TIMEOUT = 30
 
 
 class IssueBodyMixin:
@@ -38,19 +35,18 @@ class IssueBodyMixin:
             "body",
         ]
 
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-            )
-            if result.returncode != 0:
+        result = self._run_gh_command(cmd)
+        if result is None or result.returncode != 0:
+            if result is not None:
                 logger.bind(external="github", error=result.stderr).error(
                     f"Failed to get issue #{issue_number} body"
                 )
-                return None
+            return None
 
+        try:
             data = json.loads(result.stdout)
             return cast(str | None, data.get("body", ""))
-        except (json.JSONDecodeError, subprocess.TimeoutExpired) as e:
+        except json.JSONDecodeError as e:
             logger.bind(
                 external="github",
                 operation="get_issue_body",
@@ -89,21 +85,11 @@ class IssueBodyMixin:
             body,
         ]
 
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=GH_API_TIMEOUT
-            )
-            if result.returncode != 0:
+        result = self._run_gh_command(cmd)
+        if result is None or result.returncode != 0:
+            if result is not None:
                 logger.bind(external="github", error=result.stderr).error(
                     f"Failed to update issue #{issue_number} body"
                 )
-                return False
-            return True
-        except subprocess.TimeoutExpired as e:
-            logger.bind(
-                external="github",
-                operation="update_issue_body",
-                issue_number=issue_number,
-                error=str(e),
-            ).warning(f"Timeout updating issue body: {e}")
             return False
+        return True

--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -1,14 +1,12 @@
 """GitHub client issues operations."""
 
 import json
-import os
 import re
-import subprocess
 from typing import Any, cast
 
 from loguru import logger
 
-from vibe3.clients.github_issue_admin_ops import GH_API_TIMEOUT, IssueAdminMixin
+from vibe3.clients.github_issue_admin_ops import IssueAdminMixin
 
 # Patterns GitHub uses to auto-close issues via PR body
 _LINKED_ISSUE_RE = re.compile(
@@ -103,11 +101,12 @@ class IssuesMixin(IssueAdminMixin):
             "number,headRefName,body,mergedAt",
         ]
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                "Failed to list merged PRs"
-            )
+        result = self._run_gh_command(cmd)
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    "Failed to list merged PRs"
+                )
             return []
         return cast(list[dict[str, Any]], json.loads(result.stdout))
 
@@ -159,11 +158,12 @@ class IssuesMixin(IssueAdminMixin):
             cmd.extend(["--search", search])
         if repo:
             cmd.extend(["--repo", repo])
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                "Failed to list issues"
-            )
+        result = self._run_gh_command(cmd)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    "Failed to list issues"
+                )
             return []
         return cast(list[dict[str, Any]], json.loads(result.stdout))
 
@@ -244,18 +244,10 @@ class IssuesMixin(IssueAdminMixin):
         ]
         if repo:
             cmd.extend(["--repo", repo])
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=15,
-                env={**os.environ, "GH_PAGER": "cat"},
-            )
-        except subprocess.TimeoutExpired:
-            logger.bind(external="github", issue_number=issue_number).warning(
-                f"Timed out fetching issue #{issue_number}"
-            )
+
+        result = self._run_gh_command(cmd, pager=True)
+        if result is None:
+            # Timeout or gh CLI not found
             return "network_error"
         if result.returncode != 0:
             stderr = result.stderr or ""
@@ -316,24 +308,12 @@ class IssuesMixin(IssueAdminMixin):
         if repo:
             cmd.extend(["--repo", repo])
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_API_TIMEOUT,
-                env={**os.environ, "GH_PAGER": "cat"},
-            )
-        except subprocess.TimeoutExpired:
-            logger.bind(external="github", issue_number=issue_number).warning(
-                f"Timed out fetching comments for issue #{issue_number}"
-            )
-            return []
-
-        if result.returncode != 0:
-            logger.bind(external="github", error=result.stderr).error(
-                f"Failed to list comments on issue #{issue_number}"
-            )
+        result = self._run_gh_command(cmd, pager=True)  # type: ignore[attr-defined]
+        if result is None or result.returncode != 0:
+            if result is not None:
+                logger.bind(external="github", error=result.stderr).error(
+                    f"Failed to list comments on issue #{issue_number}"
+                )
             return []
 
         try:

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -168,27 +168,21 @@ class PRReadMixin:
             )
             target = result.stdout.strip()
 
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "view",
-                    target,
-                    "--json",
-                    "number,title,body,state,headRefName,baseRefName,"
-                    "url,isDraft,createdAt,updatedAt,mergedAt,closedAt,mergeable,statusCheckRollup,"
-                    "closingIssuesReferences",
-                ],
-                capture_output=True,
-                text=True,
-            )
-        except FileNotFoundError:
-            logger.bind(external="github", target=target).warning(
-                "GitHub CLI (gh) not found, skipping PR lookup"
-            )
+        result = self._run_gh_command(
+            [
+                "gh",
+                "pr",
+                "view",
+                target,
+                "--json",
+                "number,title,body,state,headRefName,baseRefName,"
+                "url,isDraft,createdAt,updatedAt,mergedAt,closedAt,mergeable,statusCheckRollup,"
+                "closingIssuesReferences",
+            ]
+        )
+        if result is None:
+            # Timeout or gh CLI not found
             return None
-
         if result.returncode != 0:
             logger.bind(external="github", target=target).warning("PR not found")
             return None
@@ -250,51 +244,36 @@ class PRReadMixin:
 
         # Fetch CI check details via gh pr checks
         ci_checks: list[CICheck] = []
-        try:
-            checks_result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "checks",
-                    target,
-                    "--json",
-                    "name,state,bucket,link,description,workflow",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if checks_result.returncode == 0:
+        checks_result = self._run_gh_command(
+            [
+                "gh",
+                "pr",
+                "checks",
+                target,
+                "--json",
+                "name,state,bucket,link,description,workflow",
+            ]
+        )
+        if checks_result is not None and checks_result.returncode == 0:
+            try:
                 checks_data = json.loads(checks_result.stdout)
                 ci_checks = [
                     _enrich_failed_check(CICheck(**c))
                     for c in checks_data
                     if isinstance(c, dict)
                 ]
-            else:
-                stderr = checks_result.stderr.strip() if checks_result.stderr else None
-                logger.bind(
-                    external="github",
-                    target=target,
-                    returncode=checks_result.returncode,
-                    stderr=stderr,
-                ).debug("gh pr checks returned non-zero exit code")
-        except json.JSONDecodeError as e:
-            logger.bind(external="github", target=target, error=str(e)).debug(
-                "Failed to parse gh pr checks JSON output"
-            )
-        except subprocess.TimeoutExpired:
-            logger.bind(external="github", target=target).debug(
-                "gh pr checks timed out after 30 seconds"
-            )
-        except FileNotFoundError:
-            logger.bind(external="github", target=target).debug(
-                "gh CLI not found when fetching CI checks"
-            )
-        except Exception as e:
-            logger.bind(external="github", target=target, error=str(e)).debug(
-                "Unexpected error fetching CI checks"
-            )
+            except json.JSONDecodeError as e:
+                logger.bind(external="github", target=target, error=str(e)).debug(
+                    "Failed to parse gh pr checks JSON output"
+                )
+        elif checks_result is not None:
+            stderr = checks_result.stderr.strip() if checks_result.stderr else None
+            logger.bind(
+                external="github",
+                target=target,
+                returncode=checks_result.returncode,
+                stderr=stderr,
+            ).debug("gh pr checks returned non-zero exit code")
 
         return PRResponse(
             number=int(data["number"]),
@@ -354,14 +333,10 @@ class PRReadMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
-        except FileNotFoundError:
-            logger.bind(external="github", repo=repo).warning(
-                "GitHub CLI (gh) not found, returning empty PR list"
-            )
+        result = self._run_gh_command(cmd)
+        if result is None:
+            # Timeout or gh CLI not found
             return []
-
         if result.returncode != 0:
             logger.bind(external="github", repo=repo, stderr=result.stderr).warning(
                 "Failed to list PRs, returning empty list"
@@ -448,14 +423,10 @@ class PRReadMixin:
         if repo:
             cmd.extend(["--repo", repo])
 
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
-        except FileNotFoundError:
-            logger.bind(external="github", branch=branch, repo=repo).warning(
-                "GitHub CLI (gh) not found, returning empty PR list"
-            )
+        result = self._run_gh_command(cmd)
+        if result is None:
+            # Timeout or gh CLI not found
             return []
-
         if result.returncode != 0:
             logger.bind(
                 external="github", branch=branch, repo=repo, stderr=result.stderr

--- a/tests/vibe3/clients/test_github_client_base.py
+++ b/tests/vibe3/clients/test_github_client_base.py
@@ -1,0 +1,109 @@
+"""Tests for GitHub client base functionality."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from vibe3.clients.github_client_base import GH_API_TIMEOUT, GitHubClientBase
+
+
+class TestRunGhCommand:
+    """Tests for _run_gh_command helper method."""
+
+    def test_successful_command_execution(self) -> None:
+        """Test successful command execution returns CompletedProcess."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="success output",
+                stderr="",
+            )
+
+            result = client._run_gh_command(["gh", "issue", "list"])
+
+            assert result is not None
+            assert result.returncode == 0
+            assert result.stdout == "success output"
+            mock_run.assert_called_once()
+
+    def test_timeout_returns_none_and_logs_warning(self) -> None:
+        """Test TimeoutExpired returns None and logs warning."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["gh"], timeout=30)
+
+            result = client._run_gh_command(["gh", "issue", "list"])
+
+            assert result is None
+            mock_run.assert_called_once()
+
+    def test_filenotfound_returns_none_and_logs_warning(self) -> None:
+        """Test FileNotFoundError returns None and logs warning."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+
+            result = client._run_gh_command(["gh", "issue", "list"])
+
+            assert result is None
+            mock_run.assert_called_once()
+
+    def test_pager_true_injects_gh_pager_env(self) -> None:
+        """Test pager=True injects GH_PAGER=cat into env."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = client._run_gh_command(["gh", "issue", "view", "123"], pager=True)
+
+            assert result is not None
+            # Verify that env was passed with GH_PAGER=cat
+            call_kwargs = mock_run.call_args[1]
+            assert "env" in call_kwargs
+            assert call_kwargs["env"]["GH_PAGER"] == "cat"
+
+    def test_pager_false_does_not_inject_env(self) -> None:
+        """Test pager=False does not inject env."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = client._run_gh_command(["gh", "issue", "list"], pager=False)
+
+            assert result is not None
+            # Verify that env was not passed
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs.get("env") is None
+
+    def test_timeout_parameter_overrides_default(self) -> None:
+        """Test timeout parameter overrides GH_API_TIMEOUT default."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = client._run_gh_command(["gh", "issue", "list"], timeout=60)
+
+            assert result is not None
+            # Verify that timeout was passed as 60
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs["timeout"] == 60
+
+    def test_default_timeout_uses_gh_api_timeout(self) -> None:
+        """Test default timeout uses GH_API_TIMEOUT."""
+        client = GitHubClientBase()
+
+        with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = client._run_gh_command(["gh", "issue", "list"])
+
+            assert result is not None
+            # Verify that timeout was passed as GH_API_TIMEOUT
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs["timeout"] == GH_API_TIMEOUT

--- a/tests/vibe3/clients/test_github_client_issues.py
+++ b/tests/vibe3/clients/test_github_client_issues.py
@@ -28,7 +28,7 @@ def _client() -> GitHubClient:
 
 def test_list_issues_with_assignees_success():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps(
@@ -51,7 +51,7 @@ def test_list_issues_with_assignees_success():
 
 def test_list_issues_with_assignees_failure_returns_empty():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=1, stderr="Error")
         issues = client.list_issues_with_assignees()
         assert issues == []
@@ -59,7 +59,7 @@ def test_list_issues_with_assignees_failure_returns_empty():
 
 def test_list_issues_with_assignees_passes_repo():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="[]")
         client.list_issues_with_assignees(repo="org/repo")
 
@@ -74,14 +74,14 @@ def test_list_issues_with_assignees_passes_repo():
 
 def test_close_issue_success():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         assert client.close_issue(1) is True
 
 
 def test_remove_assignees_success():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         assert client.remove_assignees(1, ["alice", "bob"]) is True
 
@@ -93,42 +93,42 @@ def test_remove_assignees_success():
 
 def test_remove_assignees_empty_is_noop():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         assert client.remove_assignees(1, []) is True
         mock_run.assert_not_called()
 
 
 def test_close_issue_with_comment():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         assert client.close_issue(1, comment="Fixed it") is True
 
 
 def test_close_issue_failure_returns_false():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=1)
         assert client.close_issue(1) is False
 
 
 def test_add_comment_success():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         assert client.add_comment(1, "Nice") is True
 
 
 def test_add_comment_failure_returns_false():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=1)
         assert client.add_comment(1, "Nice") is False
 
 
 def test_add_comment_passes_repo():
     client = _client()
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         client.add_comment(1, "Nice", repo="org/repo")
 
@@ -184,7 +184,7 @@ def test_close_issue_if_open_returns_failure_when_close_fails(
 
 def test_create_issue_success(github_client: GitHubClient) -> None:
     """create_issue should return issue number on success."""
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         # Mock gh issue create output
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -202,7 +202,7 @@ def test_create_issue_success(github_client: GitHubClient) -> None:
 
 def test_create_issue_with_labels(github_client: GitHubClient) -> None:
     """create_issue should apply labels when provided."""
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout="https://github.com/owner/repo/issues/43\n",
@@ -223,7 +223,7 @@ def test_create_issue_with_labels(github_client: GitHubClient) -> None:
 
 def test_create_issue_with_assignees(github_client: GitHubClient) -> None:
     """create_issue should assign users when assignees provided."""
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout="https://github.com/owner/repo/issues/44\n",
@@ -244,7 +244,7 @@ def test_create_issue_with_assignees(github_client: GitHubClient) -> None:
 
 def test_create_issue_failure_returns_none(github_client: GitHubClient) -> None:
     """create_issue should return None on failure."""
-    with patch("vibe3.clients.github_issue_admin_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stderr="Validation Failed",
@@ -260,7 +260,7 @@ def test_create_issue_failure_returns_none(github_client: GitHubClient) -> None:
 
 def test_list_issue_comments_success(github_client: GitHubClient) -> None:
     """list_issue_comments should return comments on success."""
-    with patch("vibe3.clients.github_issues_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps(
@@ -290,7 +290,7 @@ def test_list_issue_comments_success(github_client: GitHubClient) -> None:
 
 def test_list_issue_comments_empty(github_client: GitHubClient) -> None:
     """list_issue_comments should return empty list when no comments."""
-    with patch("vibe3.clients.github_issues_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"comments": []}),
@@ -303,7 +303,7 @@ def test_list_issue_comments_empty(github_client: GitHubClient) -> None:
 
 def test_list_issue_comments_timeout(github_client: GitHubClient) -> None:
     """list_issue_comments should return empty list on timeout."""
-    with patch("vibe3.clients.github_issues_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=30)
 
         result = github_client.list_issue_comments(issue_number=123)
@@ -313,7 +313,7 @@ def test_list_issue_comments_timeout(github_client: GitHubClient) -> None:
 
 def test_list_issue_comments_failure(github_client: GitHubClient) -> None:
     """list_issue_comments should return empty list on failure."""
-    with patch("vibe3.clients.github_issues_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stderr="Not found",

--- a/tests/vibe3/clients/test_github_client_prs.py
+++ b/tests/vibe3/clients/test_github_client_prs.py
@@ -139,7 +139,7 @@ def test_create_pr_maps_recoverable_error_to_user_error(
         draft=True,
     )
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "create"],
@@ -167,7 +167,7 @@ def test_create_pr_maps_non_recoverable_error_to_github_error(
         draft=True,
     )
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "create"],
@@ -259,7 +259,7 @@ def test_get_pr_enriches_failed_checks_with_category_and_command() -> None:
         ]
     }
 
-    with patch("vibe3.clients.github_pr_read_ops.subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout=json.dumps(pr_data), stderr=""),
             MagicMock(returncode=0, stdout=json.dumps(checks_data), stderr=""),
@@ -293,7 +293,7 @@ def test_mark_ready_success(
 def test_mark_ready_maps_recoverable_error_to_user_error(
     github_client: GitHubClient,
 ) -> None:
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "ready", "123"],
@@ -309,7 +309,7 @@ def test_mark_ready_maps_recoverable_error_to_user_error(
 def test_merge_pr_maps_non_recoverable_error_to_github_error(
     github_client: GitHubClient,
 ) -> None:
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "merge", "123"],
@@ -326,7 +326,7 @@ def test_merge_pr_maps_non_recoverable_error_to_github_error(
 def test_update_pr_maps_error_to_user_error(github_client: GitHubClient) -> None:
     request = UpdatePRRequest(number=123, title="new title")
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "edit", "123"],
@@ -415,7 +415,7 @@ def review_mixin():
 
 def test_get_pr_diff_file_limit_error(review_mixin):
     """Test that PR diff with >300 files raises UserError."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         # Mock subprocess error with file limit message
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
@@ -440,7 +440,7 @@ def test_get_pr_diff_file_limit_error(review_mixin):
 
 def test_get_pr_diff_other_error(review_mixin):
     """Test that other PR diff errors raise GitHubError."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "diff", "200"],
@@ -456,7 +456,7 @@ def test_get_pr_diff_other_error(review_mixin):
 
 def test_get_pr_files_file_limit_error(review_mixin):
     """Test that PR files with >300 files raises UserError."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         # Mock subprocess error with file limit message
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
@@ -478,7 +478,7 @@ def test_get_pr_files_file_limit_error(review_mixin):
 
 def test_get_pr_files_success(review_mixin):
     """Test successful get_pr_files."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_result = MagicMock()
         mock_result.stdout = "file1.py\nfile2.py\nfile3.py\n"
         mock_result.returncode = 0
@@ -491,7 +491,7 @@ def test_get_pr_files_success(review_mixin):
 
 def test_get_pr_files_other_error(review_mixin):
     """Test that other PR files errors raise GitHubError."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "diff", "200", "--name-only"],
@@ -507,7 +507,7 @@ def test_get_pr_files_other_error(review_mixin):
 
 def test_error_message_suggests_alternatives(review_mixin):
     """Test that error message suggests alternative approaches."""
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=["gh", "pr", "diff", "200"],

--- a/tests/vibe3/clients/test_github_issue_body_ops.py
+++ b/tests/vibe3/clients/test_github_issue_body_ops.py
@@ -3,10 +3,11 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from vibe3.clients.github_client_base import GitHubClientBase
 from vibe3.clients.github_issue_body_ops import IssueBodyMixin
 
 
-class _TestIssueBodyOps(IssueBodyMixin):
+class _TestIssueBodyOps(GitHubClientBase, IssueBodyMixin):
     """Test class for mixin."""
 
 
@@ -14,7 +15,7 @@ def test_get_issue_body_success() -> None:
     """Test successful body retrieval."""
     ops = _TestIssueBodyOps()
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"body": "Test issue body"}),
@@ -27,7 +28,7 @@ def test_get_issue_body_not_found() -> None:
     """Test body retrieval failure."""
     ops = _TestIssueBodyOps()
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stderr="issue not found",
@@ -40,7 +41,7 @@ def test_update_issue_body_success() -> None:
     """Test successful body update."""
     ops = _TestIssueBodyOps()
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
         result = ops.update_issue_body(123, "New body")
         assert result is True
@@ -50,7 +51,7 @@ def test_update_issue_body_failure() -> None:
     """Test body update failure."""
     ops = _TestIssueBodyOps()
 
-    with patch("subprocess.run") as mock_run:
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stderr="permission denied",


### PR DESCRIPTION
Closes #2130

## Summary

Add unified `_run_gh_command` helper method to `GitHubClientBase` and refactor 4 mixin files to use it instead of inline `subprocess.run` calls.

**Changes**:
- Add `GH_API_TIMEOUT = 30` constant and `_run_gh_command` method to `GitHubClientBase`
- Refactor 4 mixin files (15 `subprocess.run` calls consolidated)
- Update test mock patches to target `github_client_base.subprocess.run`
- Add unit tests for `_run_gh_command` helper

**Benefits**:
- Eliminates duplicated timeout constants across modules
- Standardizes error handling for TimeoutExpired and FileNotFoundError
- Fixes timeout inconsistency (view_issue: 15s → 30s)
- Adds missing timeouts to previously unbounded calls

**Behavioral Changes**:
- `view_issue` timeout: 15s → 30s (consistent with other operations)
- Previously unbounded calls now have 30s timeout: `list_merged_prs`, `list_issues`, `list_all_prs`, `list_prs_for_branch`, `get_pr`

## Test Plan

- All 194 client tests pass
- Type checking clean (mypy)
- Lint clean (ruff)
- New unit tests for `_run_gh_command` helper added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
