### PR TITLE
refactor(server): unify public API and eliminate deep imports

### DIFF
--- a/src/vibe3/server/__init__.py
+++ b/src/vibe3/server/__init__.py
@@ -9,10 +9,10 @@ if TYPE_CHECKING:
     from vibe3.domain import FailedGate, FlowManager
 
     # Runtime layer re-exports
-    from vibe3.runtime import CircuitBreaker, HeartbeatServer
-
     # Orchestra instance utilities (now in runtime)
-    from vibe3.runtime.orchestra_instance import (
+    from vibe3.runtime import (
+        CircuitBreaker,
+        HeartbeatServer,
         OrchestraInstanceInfo,
         read_instance_info,
         validate_instance,
@@ -21,25 +21,8 @@ if TYPE_CHECKING:
 
     # MCP server
     from vibe3.server.mcp import (
-        _serialize_snapshot,
         create_mcp_server,
         format_snapshot_for_mcp,
-    )
-
-    # Registry
-    from vibe3.server.registry import (
-        ORCHESTRA_TMUX_SESSION,
-        _build_async_serve_command,
-        _build_server,
-        _build_server_with_launch_cwd,
-        _kill_orchestra_tmux_session,
-        _orchestra_tmux_session_exists,
-        _resolve_async_cli_override_root,
-        _resolve_dispatcher_models_root,
-        _resolve_orchestra_log_dir,
-        _setup_tailscale_webhook,
-        _start_async_serve,
-        _validate_pid_file,
     )
 
     # Server utilities
@@ -54,27 +37,13 @@ _LAZY_IMPORTS = {
     "CircuitBreaker": "vibe3.runtime",
     "HeartbeatServer": "vibe3.runtime",
     # Orchestra instance utilities
-    "OrchestraInstanceInfo": "vibe3.runtime.orchestra_instance",
-    "read_instance_info": "vibe3.runtime.orchestra_instance",
-    "validate_instance": "vibe3.runtime.orchestra_instance",
-    "write_instance_info": "vibe3.runtime.orchestra_instance",
+    "OrchestraInstanceInfo": "vibe3.runtime",
+    "read_instance_info": "vibe3.runtime",
+    "validate_instance": "vibe3.runtime",
+    "write_instance_info": "vibe3.runtime",
     # MCP server
     "create_mcp_server": "vibe3.server.mcp",
     "format_snapshot_for_mcp": "vibe3.server.mcp",
-    "_serialize_snapshot": "vibe3.server.mcp",
-    # Registry
-    "ORCHESTRA_TMUX_SESSION": "vibe3.server.registry",
-    "_build_server": "vibe3.server.registry",
-    "_build_server_with_launch_cwd": "vibe3.server.registry",
-    "_build_async_serve_command": "vibe3.server.registry",
-    "_start_async_serve": "vibe3.server.registry",
-    "_setup_tailscale_webhook": "vibe3.server.registry",
-    "_orchestra_tmux_session_exists": "vibe3.server.registry",
-    "_kill_orchestra_tmux_session": "vibe3.server.registry",
-    "_resolve_dispatcher_models_root": "vibe3.server.registry",
-    "_resolve_orchestra_log_dir": "vibe3.server.registry",
-    "_resolve_async_cli_override_root": "vibe3.server.registry",
-    "_validate_pid_file": "vibe3.server.registry",
     # Server utilities
     "find_available_port": "vibe3.server.server_utils",
 }
@@ -107,18 +76,4 @@ __all__ = [
     # mcp
     "create_mcp_server",
     "format_snapshot_for_mcp",
-    "_serialize_snapshot",
-    # registry
-    "_validate_pid_file",
-    "_build_server",
-    "_build_server_with_launch_cwd",
-    "_build_async_serve_command",
-    "_start_async_serve",
-    "_setup_tailscale_webhook",
-    "_orchestra_tmux_session_exists",
-    "_kill_orchestra_tmux_session",
-    "_resolve_dispatcher_models_root",
-    "_resolve_orchestra_log_dir",
-    "_resolve_async_cli_override_root",
-    "ORCHESTRA_TMUX_SESSION",
 ]

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -12,16 +12,12 @@ from typing import Annotated
 import typer
 import uvicorn
 
-from vibe3.clients.git_client import GitClient
-from vibe3.config.agent_preset import find_missing_backend_commands
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.observability.logger import setup_logging
-from vibe3.orchestra.logging import orchestra_events_log_path, orchestra_log_dir
-from vibe3.runtime.orchestra_instance import (
-    OrchestraInstanceInfo,
-    write_instance_info,
-)
+from vibe3.clients import GitClient
+from vibe3.config import find_missing_backend_commands, load_orchestra_config
+from vibe3.models import OrchestraConfig
+from vibe3.observability import setup_logging
+from vibe3.orchestra import orchestra_events_log_path, orchestra_log_dir
+from vibe3.runtime import OrchestraInstanceInfo, write_instance_info
 
 from .registry import (
     _build_server_with_launch_cwd,
@@ -160,7 +156,7 @@ def start(
     setup_logging(verbose=verbose)
 
     # Register EDA event handlers for orchestra event processing
-    from vibe3.domain.handlers import register_event_handlers
+    from vibe3.domain import register_event_handlers
 
     register_event_handlers()
 
@@ -218,7 +214,7 @@ def start(
         config = config.model_copy(update={"port": effective_port})
 
     # Phase 1: FailedGate Preflight
-    from vibe3.orchestra.failed_gate import FailedGate
+    from vibe3.domain import FailedGate
 
     gate = FailedGate()
     result = gate.check()
@@ -346,7 +342,7 @@ def status() -> None:
     """Show Orchestra server status, FailedGate state, and recent activity."""
     from rich.console import Console
 
-    from vibe3.services.orchestra_helpers import get_manager_usernames
+    from vibe3.services import get_manager_usernames
     from vibe3.services.serve_status_service import ServeStatusService
 
     console = Console()
@@ -453,7 +449,7 @@ def resume(
     """
     from rich.console import Console
 
-    from vibe3.orchestra.failed_gate import FailedGate
+    from vibe3.domain import FailedGate
 
     console = Console()
     failed_gate = FailedGate()

--- a/src/vibe3/server/mcp.py
+++ b/src/vibe3/server/mcp.py
@@ -8,10 +8,8 @@ from loguru import logger
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
-    from vibe3.services.orchestra_status_service import (
-        OrchestraSnapshot,
-        OrchestraStatusService,
-    )
+    from vibe3.services import OrchestraStatusService
+    from vibe3.services.orchestra_status_service import OrchestraSnapshot
 
 
 def _serialize_snapshot(snapshot: "OrchestraSnapshot") -> dict:

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -14,29 +14,27 @@ from fastapi.responses import HTMLResponse
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.domain import FailedGate, FlowManager
 from vibe3.domain.orchestration_facade import OrchestrationFacade
-from vibe3.environment.session_registry import SessionRegistryService
-from vibe3.execution.capacity_service import CapacityService
+from vibe3.environment import SessionRegistryService
+from vibe3.execution import CapacityService
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models import OrchestraConfig
+from vibe3.orchestra import orchestra_events_log_path, orchestra_log_dir
 from vibe3.orchestra.dispatch_coordinator_factory import (
     create_global_dispatch_coordinator,
 )
-from vibe3.orchestra.logging import orchestra_events_log_path, orchestra_log_dir
-from vibe3.runtime import CircuitBreaker, HeartbeatServer
-from vibe3.runtime.heartbeat import FailedGateProtocol
-from vibe3.runtime.orchestra_instance import (
+from vibe3.runtime import (
+    CircuitBreaker,
+    HeartbeatServer,
     OrchestraInstanceInfo,
     read_instance_info,
     validate_instance,
 )
-from vibe3.services.orchestra_status_service import (
-    OrchestraSnapshot,
-    OrchestraStatusService,
-)
+from vibe3.runtime.heartbeat import FailedGateProtocol
+from vibe3.services import OrchestraStatusService
+from vibe3.services.orchestra_status_service import OrchestraSnapshot
 
 ORCHESTRA_TMUX_SESSION = "vibe3-orchestra-serve"
 
@@ -91,7 +89,7 @@ def _build_server_with_launch_cwd(
     launch_cwd: Path | None = None,
 ) -> tuple[HeartbeatServer, FastAPI]:
     """Instantiate heartbeat + FastAPI app with explicit launch cwd context."""
-    from vibe3.agents.backends.codeagent import CodeagentBackend
+    from vibe3.agents import CodeagentBackend
 
     shared_github = GitHubClient()
     shared_store = SQLiteClient()

--- a/tests/vibe3/orchestra/test_mcp_server.py
+++ b/tests/vibe3/orchestra/test_mcp_server.py
@@ -74,7 +74,7 @@ class TestMCPResources:
 
     def test_status_resource_returns_json(self):
         """Status resource should return JSON snapshot."""
-        from vibe3.server import _serialize_snapshot
+        from vibe3.server.mcp import _serialize_snapshot
 
         mock_state = MockIssueState("in-progress")
         mock_entry = MockIssueStatusEntry(
@@ -207,7 +207,7 @@ class TestMCPTools:
     def test_orchestra_issue_detail_tool(self):
         """orchestra_issue_detail tool should return issue details."""
         # This is tested indirectly via _serialize_snapshot
-        from vibe3.server import _serialize_snapshot
+        from vibe3.server.mcp import _serialize_snapshot
 
         mock_state = MockIssueState("review")
         mock_entry = MockIssueStatusEntry(
@@ -298,7 +298,7 @@ class TestMCPServerIntegration:
     def test_mcp_server_graceful_degradation_on_import_error(self):
         """Should continue without MCP if import fails."""
         from vibe3.models.orchestra_config import OrchestraConfig
-        from vibe3.server import _build_server
+        from vibe3.server.registry import _build_server
 
         config = OrchestraConfig()
 
@@ -313,7 +313,7 @@ class TestMCPServerIntegration:
     def test_build_server_creates_fastapi_app(self):
         """_build_server should create FastAPI app with status endpoint."""
         from vibe3.models.orchestra_config import OrchestraConfig
-        from vibe3.server import _build_server
+        from vibe3.server.registry import _build_server
 
         config = OrchestraConfig()
         heartbeat, fastapi_app = _build_server(config)
@@ -326,7 +326,7 @@ class TestMCPServerIntegration:
 
     def test_serialize_snapshot_includes_queue_metadata(self):
         """MCP serialization includes queue metadata for ready issues."""
-        from vibe3.server import _serialize_snapshot
+        from vibe3.server.mcp import _serialize_snapshot
 
         # Create a ready issue with queue metadata
         ready_issue = MockIssueStatusEntry(

--- a/tests/vibe3/orchestra/test_serve.py
+++ b/tests/vibe3/orchestra/test_serve.py
@@ -12,8 +12,8 @@ from vibe3.cli import app
 from vibe3.config.settings import VibeConfig
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.orchestra.failed_gate import GateResult
-from vibe3.server import _build_async_serve_command
 from vibe3.server import app as serve_module
+from vibe3.server.registry import _build_async_serve_command
 
 
 @pytest.fixture(autouse=True)
@@ -452,8 +452,8 @@ def test_resume_clears_errors_even_when_gate_is_open(monkeypatch) -> None:
         blocked_ticks=0,
     )
 
-    # Patch where FailedGate is defined, not where it's imported
-    with patch("vibe3.orchestra.failed_gate.FailedGate", return_value=mock_gate):
+    # Patch where FailedGate is imported (from domain in app.py)
+    with patch("vibe3.domain.FailedGate", return_value=mock_gate):
         runner = CliRunner()
         result = runner.invoke(app, ["serve", "resume", "--reason", "test"])
 
@@ -486,8 +486,8 @@ def test_resume_clears_gate_when_active(monkeypatch) -> None:
         blocked_ticks=3,
     )
 
-    # Patch where FailedGate is defined
-    with patch("vibe3.orchestra.failed_gate.FailedGate", return_value=mock_gate):
+    # Patch where FailedGate is imported (from domain in app.py)
+    with patch("vibe3.domain.FailedGate", return_value=mock_gate):
         runner = CliRunner()
         result = runner.invoke(app, ["serve", "resume", "--reason", "fixed"])
 


### PR DESCRIPTION
## Summary

Refactored server module to use public API imports from other modules and cleaned up `__init__.py` to expose only genuinely public symbols.

Fixes #2137

## Changes

- **app.py**: Replaced 7 deep imports with public API imports
  - Clients, config, models, observability, orchestra, runtime imports
  - Fixed inline imports: register_event_handlers, FailedGate, get_manager_usernames
  - Kept 2 exceptions: _resolve_manager_token (private), ServeStatusService (not exported)

- **registry.py**: Replaced 9 deep imports with public API imports
  - Clients, domain, environment, execution, models, orchestra, runtime, services imports
  - Fixed inline import: CodeagentBackend
  - Kept 5 exceptions (not exported by target modules)

- **mcp.py**: Replaced 1 deep import with public API import
  - OrchestraStatusService updated
  - Kept 1 exception: OrchestraSnapshot (not exported)

- **__init__.py**: Cleaned up exports
  - Removed 13 private symbols from __all__ (24→11)
  - Updated TYPE_CHECKING imports to use public API

- **Tests**: Updated 2 test files to import private symbols from actual modules

## Verification

- ✅ 60 targeted tests pass
- ✅ mypy: no issues in 5 source files
- ✅ ruff: all checks passed
- ✅ 24 violations fixed, 7 documented exceptions remain

## Remaining Deep Imports

7 deep imports remain as documented exceptions (symbols not exported by target modules - out of scope):
1. `_resolve_manager_token` (private symbol)
2. `ServeStatusService` (not exported from services)
3. `OrchestrationFacade` (not exported from domain)
4. `resolve_orchestra_repo_root` (not exported from execution)
5. `create_global_dispatch_coordinator` (not exported from orchestra)
6. `FailedGateProtocol` (not exported from runtime)
7. `OrchestraSnapshot` (not exported from services)

These will be addressed when their respective modules are refactored under Epic #1626.

## Test Plan

- Direct tests: `tests/vibe3/server/`, `tests/vibe3/orchestra/test_mcp_server.py`, `tests/vibe3/orchestra/test_serve.py`
- Affected tests: `tests/vibe3/services/test_serve_status*.py`
- All tests pass, type checks pass, lint checks pass

🤖 Generated with Claude Code

---

## Contributors

claude/opus
