### PR TITLE
refactor(ui): 公共接口统一 + 消除内部导入

### DIFF
--- a/src/vibe3/ui/__init__.py
+++ b/src/vibe3/ui/__init__.py
@@ -1,6 +1,109 @@
 """UI layer — console output primitives and Rich rendering components."""
 
-# Re-export key UI components for convenience
-# Note: Most UI components are used internally, selective re-exports only
+from __future__ import annotations
 
-__all__: list[str] = []
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vibe3.ui.console import console
+    from vibe3.ui.flow_ui import (
+        render_error,
+        render_flow_created,
+        render_flow_status,
+        render_flows_status_dashboard,
+    )
+    from vibe3.ui.flow_ui_primitives import (
+        display_actor,
+        kv,
+        resolve_ref_path,
+        status_text,
+    )
+    from vibe3.ui.flow_ui_timeline import render_flow_timeline
+    from vibe3.ui.handoff_ui import render_handoff_detail
+    from vibe3.ui.pr_ui import (
+        render_local_review_summary,
+        render_pr_confirmed,
+        render_pr_created,
+        render_pr_details,
+        render_pr_ready,
+    )
+    from vibe3.ui.scan_display import (
+        display_governance_dry_run,
+        display_material_list,
+        display_supervisor_dry_run,
+    )
+    from vibe3.ui.task_ui import (
+        build_task_show_payload,
+        render_task_comments,
+        render_task_show,
+    )
+
+# Lazy imports
+_LAZY_IMPORTS = {
+    "console": "vibe3.ui.console",
+    "render_flow_status": "vibe3.ui.flow_ui",
+    "render_flow_created": "vibe3.ui.flow_ui",
+    "render_flows_status_dashboard": "vibe3.ui.flow_ui",
+    "render_error": "vibe3.ui.flow_ui",
+    "status_text": "vibe3.ui.flow_ui_primitives",
+    "kv": "vibe3.ui.flow_ui_primitives",
+    "display_actor": "vibe3.ui.flow_ui_primitives",
+    "resolve_ref_path": "vibe3.ui.flow_ui_primitives",
+    "render_flow_timeline": "vibe3.ui.flow_ui_timeline",
+    "render_handoff_detail": "vibe3.ui.handoff_ui",
+    "render_pr_created": "vibe3.ui.pr_ui",
+    "render_pr_confirmed": "vibe3.ui.pr_ui",
+    "render_pr_ready": "vibe3.ui.pr_ui",
+    "render_local_review_summary": "vibe3.ui.pr_ui",
+    "render_pr_details": "vibe3.ui.pr_ui",
+    "display_supervisor_dry_run": "vibe3.ui.scan_display",
+    "display_material_list": "vibe3.ui.scan_display",
+    "display_governance_dry_run": "vibe3.ui.scan_display",
+    "build_task_show_payload": "vibe3.ui.task_ui",
+    "render_task_show": "vibe3.ui.task_ui",
+    "render_task_comments": "vibe3.ui.task_ui",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Lazy import for ui symbols to avoid circular dependencies."""
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    # Console
+    "console",
+    # Flow UI
+    "render_flow_status",
+    "render_flow_created",
+    "render_flows_status_dashboard",
+    "render_error",
+    # Flow UI primitives
+    "status_text",
+    "kv",
+    "display_actor",
+    "resolve_ref_path",
+    # Flow UI timeline
+    "render_flow_timeline",
+    # Handoff UI
+    "render_handoff_detail",
+    # PR UI
+    "render_pr_created",
+    "render_pr_confirmed",
+    "render_pr_ready",
+    "render_local_review_summary",
+    "render_pr_details",
+    # Scan display
+    "display_supervisor_dry_run",
+    "display_material_list",
+    "display_governance_dry_run",
+    # Task UI
+    "build_task_show_payload",
+    "render_task_show",
+    "render_task_comments",
+]

--- a/src/vibe3/ui/flow_ui.py
+++ b/src/vibe3/ui/flow_ui.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from vibe3.models.flow import FlowStatusResponse
-from vibe3.services.path_helpers import ref_to_handoff_cmd
+from vibe3.services import ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import display_actor, kv, resolve_ref_path, status_text
 from vibe3.ui.flow_ui_timeline import render_flow_timeline  # noqa: F401

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -47,7 +47,7 @@ def display_actor(actor: str | None) -> tuple[str, bool]:
 
     # Fallback: worktree git user.name
     try:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         name = GitClient().get_config("user.name") or "unknown"
     except Exception:

--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -1,7 +1,7 @@
 """Flow UI timeline rendering components."""
 
 from vibe3.models.flow import FlowEvent, FlowStatusResponse
-from vibe3.services.path_helpers import check_ref_exists, ref_to_handoff_cmd
+from vibe3.services import check_ref_exists, ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import display_actor, kv, status_text
 

--- a/src/vibe3/ui/scan_display.py
+++ b/src/vibe3/ui/scan_display.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from vibe3.prompts.models import PromptMaterialSpec
+from vibe3.prompts import PromptMaterialSpec
 
 
 def display_governance_dry_run(

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -6,10 +6,10 @@ from dataclasses import asdict
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from vibe3.services.path_helpers import ref_to_handoff_cmd
+from vibe3.services import ref_to_handoff_cmd
 from vibe3.ui.console import console
 from vibe3.ui.flow_ui_primitives import resolve_ref_path
-from vibe3.utils.constants import AUTOMATED_MARKERS
+from vibe3.utils import AUTOMATED_MARKERS
 
 if TYPE_CHECKING:
     from vibe3.services.task_service import TaskShowResult


### PR DESCRIPTION
Closes #2139

## Summary

- Fix 6 cross-module internal imports to use public API paths
- Establish ui/__init__.py public interface with lazy import pattern
- Export 22 public symbols from ui submodules

## Changes

### Fixed 6 Cross-Module Internal Imports

1. **task_ui.py**:
   - `from vibe3.services.path_helpers import ...` → `from vibe3.services import ...`
   - `from vibe3.utils.constants import ...` → `from vibe3.utils import ...`

2. **flow_ui_timeline.py**:
   - `from vibe3.services.path_helpers import ...` → `from vibe3.services import ...`

3. **flow_ui.py**:
   - `from vibe3.services.path_helpers import ...` → `from vibe3.services import ...`

4. **flow_ui_primitives.py**:
   - `from vibe3.clients.git_client import ...` → `from vibe3.clients import ...`

5. **scan_display.py**:
   - `from vibe3.prompts.models import ...` → `from vibe3.prompts import ...`

### Established UI Module Public Interface

**src/vibe3/ui/__init__.py**:
- Added lazy import pattern using `TYPE_CHECKING` + `__getattr__` (following #1936 pattern)
- Exported 22 public symbols:
  - From console.py: `console`
  - From flow_ui.py: `render_flow_status`, `render_flow_created`, `render_flows_status_dashboard`, `render_error`
  - From flow_ui_primitives.py: `status_text`, `kv`, `display_actor`, `resolve_ref_path`
  - From flow_ui_timeline.py: `render_flow_timeline`
  - From handoff_ui.py: `render_handoff_detail`
  - From pr_ui.py: `render_pr_created`, `render_pr_confirmed`, `render_pr_ready`, `render_local_review_summary`, `render_pr_details`
  - From scan_display.py: `display_supervisor_dry_run`, `display_material_list`, `display_governance_dry_run`
  - From task_ui.py: `build_task_show_payload`, `render_task_show`, `render_task_comments`

## Remaining Work

9 cross-module internal imports remain unfixed due to missing exports in target modules:

1. `pr_ui.py:5` — `from vibe3.models.pr import PRResponse` (needs models module export)
2. `pr_ui.py:7` — `from vibe3.utils.time_format import format_age_aware_time` (needs utils module export)
3. `pr_ui.py:10` — `from vibe3.analysis.local_review_report import LocalReviewReport` (needs analysis module export)
4. `flow_ui_timeline.py:3` — `from vibe3.models.flow import FlowEvent, FlowStatusResponse` (needs models module export)
5. `flow_ui.py:5` — `from vibe3.models.flow import FlowStatusResponse` (needs models module export)
6. `flow_ui_primitives.py:42` — `from vibe3.utils.actor_utils import normalize_actor` (needs utils module export)
7. `flow_ui_primitives.py:67` — `from vibe3.services.path_helpers import resolve_ref_path as _resolve` (needs services module export)
8. `flow_ui.py:160` — `from vibe3.services.spec_ref_service import SpecRefService` (needs services module export)
9. `flow_ui.py:243` — `from vibe3.services.flow_classifier import (...)` (needs services module export)

These violations will be addressed when Epic #1626 sub-issues complete the public interface unification for models, utils, services, and analysis modules.

## Test Plan

- ✅ All 26 UI tests pass
- ✅ All 401 commands tests pass (no regressions)
- ✅ mypy clean on UI module
- ✅ ruff clean on UI module
- ✅ pre-push checks pass (compile, type check, incremental tests, LOC checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
