### PR TITLE
docs: align label semantics and clarify V2/V3 boundaries (#2185)

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -32,10 +32,12 @@
 ### 2.2 Setup（自动化环境准备）
 
 ```bash
+vibe3 internal bootstrap  # 现代 V3 推荐方式
+# 或使用 legacy 脚本
 ./scripts/init.sh
 ```
 
-当你执行 `vibe flow start <feature>`、`wtnew <branch>`，或由 V3 runtime 自动创建 worktree 时，`scripts/init.sh` 会自动运行，完成以下工作：
+当你执行 `vibe flow start <feature>`（Legacy）、`wtnew <branch>`，或由 V3 runtime 自动创建 worktree 时，`scripts/init.sh` 或 `vibe3 internal bootstrap` 会自动运行，完成以下工作：
 1. 安装并配置 `openSpec` 和 `Superpowers`
 2. 在 `.agent/skills/` 建立项目自有技能和第三方技能的符号链接
 3. 为 Trae 编辑器用户准备相同的技能环境
@@ -46,27 +48,28 @@
 uv tool install -e .
 ```
 
-如果你是手动 `git worktree add ...` 创建工作树，则需要手动运行一次 `./scripts/init.sh`。
+如果你是手动 `git worktree add ...` 创建工作树，则需要手动运行一次 `vibe3 internal bootstrap` 或 `./scripts/init.sh`。
 
 ### 2.3 验证环境
 
 ```bash
-bin/vibe check       # 环境诊断（V2）
-vibe3 check          # V3 Handoff 存储一致性与共享状态审计
-vibe3 snapshot show  # V3 项目健康度、指标与 LOC 限制度量
-bats tests/          # 运行所有测试（应看到 20 tests, 0 failures）
+bin/vibe check       # 环境诊断（Legacy / V2）
+vibe3 check          # [Active] V3 Handoff 存储一致性与共享状态审计
+vibe3 snapshot show  # [Active] V3 项目健康度、指标与 LOC 限制度量
+bats tests/          # 运行 V2 测试（应看到 20 tests, 0 failures）
 bash scripts/hooks/lint.sh # 双层 lint 检查（0 errors）
 ```
 
 
 ### 2.4 V3 开发入口
 
-V3 相关工作优先用 Python 入口和 V3 标准来校准语义。支持通过 `uv tool install -e .` 安装全局 `vibe3` 命令：
+V3 相关工作优先用 Python 入口 and V3 标准来校准语义。支持通过 `uv tool install -e .` 安装全局 `vibe3` 命令：
 
 ```bash
 vibe3 check
 vibe3 status
 vibe3 flow show
+vibe3 flow update    # 注册/同步当前分支 flow
 vibe3 handoff show
 uv run pytest tests/vibe3
 ```
@@ -343,6 +346,7 @@ tests/                 # bats-core 测试（≥20 个用例）
 
 ```bash
 # 开发工作流（V2，仅供参考）
+# 推荐使用 V3 命令：vibe3 internal bootstrap && vibe3 flow update
 bin/vibe flow start <feature>  # 创建 worktree + 分支
 bin/vibe flow review           # Pre-PR 检查
 bin/vibe flow pr               # 创建 PR
@@ -375,6 +379,7 @@ vibe3 flow update       # 注册/更新当前分支为活跃 flow
 vibe3 flow bind         # 显式绑定 issue-flow 关系
 vibe3 handoff show      # 查看 agent 间的 handoff 链路
 vibe3 handoff append    # 向当前 flow 追加 handoff 记录
+vibe3 internal bootstrap # 初始化/同步当前 flow 环境
 
 # 代码智能与执行 (Agent 模式)
 vibe3 inspect symbols   # AST 级代码结构分析

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -7,7 +7,7 @@ audience: both
 review_frequency: on-change
 author: Claude Sonnet 4.5
 created: 2024-01-15
-last_updated: 2026-06-03
+last_updated: 2026-06-05
 related_docs:
   - SOUL.md
   - CLAUDE.md
@@ -41,10 +41,10 @@ vibe-center/
 ├── README.md                    # 项目介绍（面向用户）
 │
 ├── bin/                         # CLI 入口
-│   ├── vibe                     # V2 Shell 入口
-│   └── vibe3                    # V3 Python 入口
+│   ├── vibe                     # [Legacy / V2] Shell 入口
+│   └── vibe3                    # [Active Core] Python 入口
 │
-├── src/vibe3/                   # V3 Python 实现（主要）
+├── src/vibe3/                   # [Active Core] V3 Python 实现（主要）
 │   ├── cli.py                   # CLI 主入口
 │   ├── __main__.py              # 进程入口（vibe3 serve）
 │   ├── adapters/                # 逻辑适配器与集成桥接
@@ -69,7 +69,7 @@ vibe-center/
 │   ├── ui/                      # CLI 输出格式化
 │   └── utils/                   # 工具函数
 │
-├── lib/                         # V2 Shell 核心逻辑
+├── lib/                         # [Legacy / V2] Shell 核心逻辑
 │   ├── *.sh                     # 各功能模块
 │   └── ...
 │
@@ -81,8 +81,8 @@ vibe-center/
 │   └── aliases/                 # 命令别名
 │
 ├── tests/                       # 测试
-│   ├── vibe3/                   # V3 测试
-│   └── vibe2/                   # V2 测试
+│   ├── vibe3/                   # [Active Core] V3 测试
+│   └── vibe2/                   # [Legacy / V2] 测试
 │
 ├── skills/                      # 技能定义（canonical source）
 │   └── */                       # 各技能目录

--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -9,8 +9,9 @@ authority:
   - cleanup-orchestration
 author: Claude Sonnet 4.6
 created: 2026-04-28
-last_updated: 2026-04-28
+last_updated: 2026-06-05
 related_docs:
+  - docs/standards/label-semantics.md
   - docs/standards/glossary.md
   - docs/standards/v3/error-severity-and-blocking-standard.md
   - docs/standards/vibe3-role-checks-and-balances-standard.md
@@ -62,7 +63,7 @@ new → active ↔ blocked
   - `failed` 已废弃，通过 `active` 状态配合 `blocked_reason` 表达
 
 - **Issue State**：`ready/claimed/in-progress/blocked/handoff/review/merge-ready/done`（GitHub label）
-  - 描述 issue 的编排状态
+  - 描述 issue 的编排状态。详细语义见 [label-semantics.md](./label-semantics.md)。
   - IssueState.FAILED 已废弃，统一到 BLOCKED
 
 **关系**：

--- a/docs/standards/label-semantics.md
+++ b/docs/standards/label-semantics.md
@@ -9,7 +9,7 @@ authority:
   - legacy-mapping
 maintainer: Vibe Team
 created: 2026-06-01
-last_updated: 2026-06-01
+last_updated: 2026-06-05
 related_docs:
   - supervisor/roadmap-common.md
   - supervisor/governance/assignee-pool.md
@@ -73,6 +73,36 @@ related_docs:
 |-------|------|----------|
 | `roadmap/rfc` | 需要人类决策 | 架构方向未定、需要讨论 |
 | `roadmap/epic` | 需要拆分 | 范围过大、需拆分为多个 sub-issues |
+
+## Issue States (state/*)
+
+`state/*` 标签用于描述 Issue 在 Orchestra 编排流中的当前阶段。
+
+### 状态定义
+
+| Label | 语义 | Orchestra 行为 |
+|-------|------|----------------|
+| `state/ready` | 待绪 | 允许 Orchestra 扫描并派发给空闲的 Manager |
+| `state/claimed` | 已认领 | Manager 已认领任务，正在初始化 worktree 或环境 |
+| `state/in-progress` | 执行中 | 任务正在被 Agent 活跃执行中 |
+| `state/blocked` | 阻塞 | 任务因错误、依赖未满足或人工干预而暂停 |
+| `state/handoff` | 交接中 | 任务正在进行 Agent 间的上下文交接（Handoff） |
+| `state/review` | 评审中 | 任务已提交（如 PR 已创建），等待人工或自动化评审 |
+| `state/merge-ready` | 待合并 | 评审通过，等待合并到主分支 |
+| `state/done` | 已完成 | 任务执行完毕，由 Orchestra 或 Manager 最终确认 |
+
+### 废弃状态
+
+- `state/failed`: **已废弃**。统一并入 `state/blocked`。执行失败通过 `blocked_reason` 或 `error_log` 表达。
+
+### 在 Orchestra 中的作用
+
+Orchestra 使用 `state/*` 标签进行核心调度决策：
+
+1.  **派发过滤**：只扫描 `state/ready` 且未被绑定的 Issue。
+2.  **状态监控**：通过订阅 Webhook 或周期性 Tick 观察标签变化，更新本地 `flow_state`。
+3.  **自动解封**：检测到依赖 Issue 关闭后，将 `state/blocked` 自动恢复为 `state/ready`（前提是无手动 `blocked_reason`）。
+4.  **超时处理**：监控 `state/claimed` 或 `state/in-progress` 的停留时间，触发健康检查或重试。
 
 ## Legacy Priority Labels
 


### PR DESCRIPTION
This PR completes governance issue #2185 by:
1. Adding state/* label semantics and Orchestra role to docs/standards/label-semantics.md.
2. Marking V2 components (bin/vibe, lib/, tests/vibe2/) as legacy in STRUCTURE.md and emphasizing V3 as active core.
3. Updating DEVELOPER.md command examples to prefer V3 (vibe3 internal bootstrap, vibe3 flow update).
4. Aligning flow-lifecycle-standard.md with the new state definitions.