### PR TITLE
refactor(clients): 公共接口统一 + 消除内部导入 (11 violations)

### DIFF
--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -75,7 +75,7 @@ from vibe3.clients.git_worktree_ops import (
     remove_worktree as _remove_worktree,
 )
 from vibe3.exceptions import GitError
-from vibe3.models.change_source import (
+from vibe3.models import (
     BranchSource,
     ChangeSource,
     ChangeSourceType,

--- a/src/vibe3/clients/git_status_ops.py
+++ b/src/vibe3/clients/git_status_ops.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from vibe3.exceptions import GitError, SystemError
-from vibe3.models.change_source import (
+from vibe3.models import (
     BranchSource,
     ChangeSource,
     ChangeSourceType,

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from loguru import logger
 
-# PR symbols not in models' public API yet - follow-up issue needed
+# public-api: pending upstream export
 from vibe3.models.pr import CICheck, PRMetadata, PRResponse, PRState
 
 _ACTIONS_RUN_LINK_RE = re.compile(

--- a/src/vibe3/clients/github_pr_read_ops.py
+++ b/src/vibe3/clients/github_pr_read_ops.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from loguru import logger
 
+# PR symbols not in models' public API yet - follow-up issue needed
 from vibe3.models.pr import CICheck, PRMetadata, PRResponse, PRState
 
 _ACTIONS_RUN_LINK_RE = re.compile(

--- a/src/vibe3/clients/github_pr_write_ops.py
+++ b/src/vibe3/clients/github_pr_write_ops.py
@@ -8,7 +8,7 @@ from loguru import logger
 from vibe3.clients.github_client_base import raise_gh_pr_error
 from vibe3.exceptions import PRNotFoundError
 
-# PR symbols not in models' public API yet - follow-up issue needed
+# public-api: pending upstream export
 from vibe3.models.pr import (
     CreatePRRequest,
     PRResponse,

--- a/src/vibe3/clients/github_pr_write_ops.py
+++ b/src/vibe3/clients/github_pr_write_ops.py
@@ -7,7 +7,13 @@ from loguru import logger
 
 from vibe3.clients.github_client_base import raise_gh_pr_error
 from vibe3.exceptions import PRNotFoundError
-from vibe3.models.pr import CreatePRRequest, PRResponse, UpdatePRRequest
+
+# PR symbols not in models' public API yet - follow-up issue needed
+from vibe3.models.pr import (
+    CreatePRRequest,
+    PRResponse,
+    UpdatePRRequest,
+)
 
 
 class PRWriteMixin:

--- a/src/vibe3/clients/protocols/backend.py
+++ b/src/vibe3/clients/protocols/backend.py
@@ -11,8 +11,7 @@ Import paths:
 from pathlib import Path
 from typing import Protocol
 
-from vibe3.models.execution_handle import AsyncExecutionHandle
-from vibe3.models.review_runner import AgentOptions, AgentResult
+from vibe3.models import AgentOptions, AgentResult, AsyncExecutionHandle
 
 
 class BackendProtocol(Protocol):

--- a/src/vibe3/clients/protocols/flow.py
+++ b/src/vibe3/clients/protocols/flow.py
@@ -9,9 +9,6 @@ Import paths:
 
     # Backward compatible (package re-export)
     from vibe3.clients.protocols import FlowReader
-
-    # Legacy (services shim re-export)
-    from vibe3.services.flow_reader import FlowReader
 """
 
 from __future__ import annotations

--- a/src/vibe3/clients/protocols/git.py
+++ b/src/vibe3/clients/protocols/git.py
@@ -6,9 +6,6 @@ Import paths:
 
     # Backward compatible (package re-export)
     from vibe3.clients.protocols import GitPathProtocol
-
-    # Legacy (services shim re-export)
-    from vibe3.services.git_path_client import GitPathProtocol
 """
 
 from pathlib import Path

--- a/src/vibe3/clients/protocols/github.py
+++ b/src/vibe3/clients/protocols/github.py
@@ -10,7 +10,12 @@ Import paths:
 
 from typing import Any, Protocol
 
-from vibe3.models.pr import CreatePRRequest, PRResponse, UpdatePRRequest
+# PR symbols not in models' public API yet - follow-up issue needed
+from vibe3.models.pr import (
+    CreatePRRequest,
+    PRResponse,
+    UpdatePRRequest,
+)
 
 
 class GitHubAuthPort(Protocol):

--- a/src/vibe3/clients/protocols/github.py
+++ b/src/vibe3/clients/protocols/github.py
@@ -10,7 +10,7 @@ Import paths:
 
 from typing import Any, Protocol
 
-# PR symbols not in models' public API yet - follow-up issue needed
+# public-api: pending upstream export
 from vibe3.models.pr import (
     CreatePRRequest,
     PRResponse,

--- a/src/vibe3/clients/protocols/pr.py
+++ b/src/vibe3/clients/protocols/pr.py
@@ -6,9 +6,6 @@ Import paths:
 
     # Backward compatible (package re-export)
     from vibe3.clients.protocols import BaseResolver
-
-    # Legacy (services shim re-export)
-    from vibe3.services.pr_create_usecase import BaseResolver
 """
 
 from typing import Protocol


### PR DESCRIPTION
Closes #2140

## Summary

Refactor clients module to use public API imports for models symbols, eliminating cross-module internal imports.

**Changes**:
- Replace `from vibe3.models.xxx import` → `from vibe3.models import` for symbols in models' `__all__`
- Remove legacy import path examples from protocol docstrings
- Unify comment convention to project standard `# public-api: pending upstream export`

**Files modified**: 9 files in `src/vibe3/clients/`

## Accepted Exceptions

3 files retain internal imports for PR symbols not yet in models' public API:
- `protocols/github.py`
- `github_pr_read_ops.py`
- `github_pr_write_ops.py`

These use `# public-api: pending upstream export` annotation. Follow-up issue #2202 will add these symbols to models' public API.

## Verification

- ✅ Tests: 187 passed (clients/)
- ✅ Type check: mypy passes
- ✅ Lint: ruff passes
- ✅ No behavioral changes

## Related

- Issue: #2140
- Epic: #1626
- Follow-up: #2202 (add PR symbols to models public API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
