### PR TITLE
feat(orchestra): add queue refresh at tick 10 for priority reordering

### DIFF
--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -525,6 +525,21 @@ class GlobalDispatchCoordinator:
         if self._frozen_queue is None:
             self._frozen_queue = []
 
+        queue_refreshed = False
+        periodic_check = self._config.periodic_check
+        if (
+            tick_id > 0
+            and periodic_check.enabled
+            and tick_id % periodic_check.interval_ticks == 0
+        ):
+            fresh = await self._collect_frozen_queue()
+            self._check_service.invalidate_pr_cache()
+            self._dispatch_paused = bool(
+                fresh and all(entry.collected_state == "blocked" for entry in fresh)
+            )
+            self._frozen_queue = fresh
+            queue_refreshed = True
+
         paused_with_pending_blocked = False
 
         # Step 3: Paused mode waits for human task resume to create a
@@ -566,7 +581,9 @@ class GlobalDispatchCoordinator:
             return
 
         # Step 6: Rebuild active candidates once active queue is exhausted.
-        need_collect = self._should_collect_after_dispatch(dispatched_count)
+        need_collect = not queue_refreshed and self._should_collect_after_dispatch(
+            dispatched_count
+        )
         if need_collect:
             fresh = await self._collect_frozen_queue()
             # Invalidate PR cache after fresh collection

--- a/tests/vibe3/orchestra/test_degraded_logging.py
+++ b/tests/vibe3/orchestra/test_degraded_logging.py
@@ -67,6 +67,10 @@ def test_dispatch_logs_degraded_mode(mock_get_manager_usernames):
     mock_supervisor_handoff = MagicMock()
     mock_supervisor_handoff.issue_label = "supervisor"
     mock_config.supervisor_handoff = mock_supervisor_handoff
+    mock_periodic_check = MagicMock()
+    mock_periodic_check.enabled = True
+    mock_periodic_check.interval_ticks = 10
+    mock_config.periodic_check = mock_periodic_check
 
     # Create BLOCKED issue
     blocked_issue = IssueInfo(
@@ -172,6 +176,10 @@ def test_dispatch_no_log_when_not_degraded(mock_get_manager_usernames):
     mock_supervisor_handoff = MagicMock()
     mock_supervisor_handoff.issue_label = "supervisor"
     mock_config.supervisor_handoff = mock_supervisor_handoff
+    mock_periodic_check = MagicMock()
+    mock_periodic_check.enabled = True
+    mock_periodic_check.interval_ticks = 10
+    mock_config.periodic_check = mock_periodic_check
 
     # Create BLOCKED issue
     blocked_issue = IssueInfo(

--- a/tests/vibe3/orchestra/test_dispatch_actionable_trigger.py
+++ b/tests/vibe3/orchestra/test_dispatch_actionable_trigger.py
@@ -25,6 +25,8 @@ def mock_coordinator(mock_get_manager_usernames) -> GlobalDispatchCoordinator:
     config.repo = "owner/repo"
     config.manager_usernames = ["manager-bot"]
     config.supervisor_handoff.issue_label = "supervisor"
+    config.periodic_check.enabled = True
+    config.periodic_check.interval_ticks = 10
     config.max_concurrent_flows = 10
 
     capacity = MagicMock()
@@ -323,6 +325,38 @@ class TestActionableTriggeredCollection:
         # Should NOT have called _collect_frozen_queue
         # (because queue still has actionable entries)
         mock_coordinator._collect_frozen_queue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_periodic_check_tick_refreshes_queue_when_actionable_available(
+        self, mock_coordinator
+    ):
+        """Periodic check ticks refresh queue before exhaustion."""
+        mock_coordinator._config.periodic_check.enabled = True
+        mock_coordinator._config.periodic_check.interval_ticks = 10
+        mock_coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="ready", waiting_state=None),
+            QueueEntry(issue_number=2, collected_state="ready", waiting_state=None),
+        ]
+
+        mock_coordinator._queue_persistence.promote = MagicMock(return_value=False)
+        mock_coordinator._dispatch_loop = MagicMock(return_value=0)
+        mock_coordinator._collect_frozen_queue = AsyncMock(
+            return_value=[
+                QueueEntry(issue_number=2, collected_state="ready"),
+                QueueEntry(issue_number=1, collected_state="ready"),
+                QueueEntry(issue_number=3, collected_state="ready"),
+            ]
+        )
+        mock_coordinator._queue_persistence.persist = MagicMock()
+
+        await mock_coordinator.coordinate(tick_id=10)
+
+        mock_coordinator._collect_frozen_queue.assert_called_once()
+        assert [entry.issue_number for entry in mock_coordinator._frozen_queue] == [
+            2,
+            1,
+            3,
+        ]
 
     @pytest.mark.asyncio
     async def test_merge_after_collect(self, mock_coordinator):


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `codex/tick10-queue-refresh` is behind `main` by **7 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin codex/tick10-queue-refresh
```


---

## Summary

实现最小化的 tick 10 队列刷新机制，在 tick 间隔（可通过 `periodic_check.interval_ticks` 配置）时重新收集队列，更新优先级排序。

**核心改动**：
- 在 `coordinate()` 方法中添加 tick 10 队列刷新逻辑
- 如果队列已刷新，跳过 Step 6 的重复收集
- 添加测试覆盖 tick 10 队列刷新行为

**设计理念**：
- 复用现有配置和机制，而非重新发明
- 最小化改动（52 行新增），替代过度工程的 PR #2192
- 利用 `periodic_check` 配置，无需新增参数

**替代方案**：
- PR #2192：过度工程，添加了复杂的 `force_recollect_queue` 机制（1388 行改动）
- Issue #2147：原始需求（已关闭）

## Test plan

- [x] 添加测试用例验证 tick 10 队列刷新行为
- [x] 所有现有测试通过（无回归）
- [x] Pre-commit 检查通过（black, ruff, mypy）
- [x] LOC 检查通过（无文件超过 400 行阈值）
- [ ] CI 验证（等待 PR 创建后检查）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet-4.6
