### PR TITLE
fix(dispatch): add retry for Git ref lock conflicts in bootstrap_issue_flow

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -233,8 +233,8 @@ code_limits:
         limit: 540
         reason: "Qualify gate truth-first 决策流程测试集，覆盖 manual block、dependency block、auto-resume、stale state alignment、blocked state change via service layer (#1206) 等场景，共享 fixture；PR #1983 已将 GitHub closed 检测测试拆分至 test_qualify_gate_closed.py，当前 ~536 行"
       - path: "tests/vibe3/services/test_flow_orchestrator_service.py"
-        limit: 480
-        reason: "Flow orchestrator 服务测试集，覆盖 dispatch 协调、frozen queue 管理、issue 状态处理等紧密耦合场景，共享 fixture，拆分收益低"
+        limit: 560
+        reason: "Flow orchestrator 服务测试集，覆盖 dispatch 协调、frozen queue 管理、issue 状态处理、Git ref lock 冲突重试等紧密耦合场景，共享 fixture，拆分收益低；Issue #2143 新增 2 个 retry 测试（test_bootstrap_issue_flow_retries_fetch_on_ref_lock_conflict, test_bootstrap_issue_flow_raises_after_exhausted_retries）后略微超标"
       - path: "tests/vibe3/exceptions/test_error_tracking.py"
         limit: 650
         reason: "Error tracking 测试集，新增 9 个测试（5 个 get_all_errors_status + 4 个 _display_error_tracking），覆盖 severity 分类、threshold 计数、时间窗口逻辑、NULL severity 默认处理、历史 vs 窗口错误显示"

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -13,6 +14,7 @@ from vibe3.clients.git_client import GitClient
 from vibe3.clients.github_client import GitHubClient
 from vibe3.clients.protocols import GitHubClientProtocol
 from vibe3.environment.worktree import WorktreeManager
+from vibe3.exceptions import GitError
 from vibe3.models.pr import PRState
 from vibe3.services.flow_cleanup_service import FlowCleanupService
 from vibe3.services.flow_service import FlowService
@@ -27,6 +29,10 @@ if TYPE_CHECKING:
     from vibe3.config.orchestra_config import OrchestraConfig
     from vibe3.models import IssueInfo
     from vibe3.services.orchestra_status_service import OrchestraSnapshot
+
+# Retry configuration for Git fetch operations
+MAX_FETCH_RETRIES = 3
+FETCH_RETRY_DELAY = 1.0
 
 
 class FlowOrchestratorService:
@@ -142,8 +148,19 @@ class FlowOrchestratorService:
         try:
             if not self.git.branch_exists(branch):
                 # Ensure scene_base_ref remote is up-to-date before creating branch
-                remote = self.config.scene_base_ref.split("/")[0]
-                self.git.fetch(remote)
+                remote, ref = self.config.scene_base_ref.split("/", 1)
+                for attempt in range(MAX_FETCH_RETRIES):
+                    try:
+                        self.git.fetch(remote, ref)
+                        break
+                    except GitError as e:
+                        if (
+                            "cannot lock ref" in str(e)
+                            and attempt < MAX_FETCH_RETRIES - 1
+                        ):
+                            time.sleep(FETCH_RETRY_DELAY * (attempt + 1))
+                            continue
+                        raise
                 self.git.create_branch_ref(
                     branch,
                     start_ref=self.config.scene_base_ref,

--- a/tests/vibe3/services/test_flow_orchestrator_service.py
+++ b/tests/vibe3/services/test_flow_orchestrator_service.py
@@ -107,7 +107,7 @@ def test_bootstrap_issue_flow_checkouts_branch_in_non_worktree_mode() -> None:
     )
 
     # Verify fetch, create_branch, AND checkout were called
-    git.fetch.assert_called_once_with("origin")
+    git.fetch.assert_called_once_with("origin", "main")
     git.create_branch_ref.assert_called_once_with(
         "dev/issue-999", start_ref=config.scene_base_ref
     )
@@ -149,7 +149,7 @@ def test_bootstrap_issue_flow_skips_checkout_in_worktree_mode() -> None:
         )
 
     # Verify fetch and create_branch were called, but checkout was NOT
-    git.fetch.assert_called_once_with("origin")
+    git.fetch.assert_called_once_with("origin", "main")
     git.create_branch_ref.assert_called_once_with(
         "dev/issue-888", start_ref=config.scene_base_ref
     )
@@ -185,7 +185,7 @@ def test_bootstrap_issue_flow_links_task_and_related_issues() -> None:
     )
 
     # Verify fetch was called before branch creation
-    git.fetch.assert_called_once_with("origin")
+    git.fetch.assert_called_once_with("origin", "main")
     git.create_branch_ref.assert_called_once_with(
         "dev/issue-501", start_ref=config.scene_base_ref
     )
@@ -445,3 +445,72 @@ def test_rebuild_stale_issue_flow_returns_none_when_pr_already_merged() -> None:
         )
 
         assert result is None
+
+
+def test_bootstrap_issue_flow_retries_fetch_on_ref_lock_conflict() -> None:
+    """Fetch should retry on 'cannot lock ref' GitError and succeed."""
+    from vibe3.exceptions import GitError
+
+    config = load_orchestra_config()
+    store = MagicMock()
+    git = MagicMock()
+    github = MagicMock()
+    git.branch_exists.return_value = False
+    git.get_git_common_dir.return_value = "/tmp/repo/.git"
+    store.get_flow_state.return_value = None
+    service = FlowOrchestratorService(config, store=store, git=git, github=github)
+    service.flow_service.create_flow = MagicMock(
+        return_value=MagicMock(model_dump=lambda: {"branch": "dev/issue-999"})
+    )
+
+    # Simulate ref lock conflict on first call, success on second
+    git.fetch.side_effect = [
+        GitError("fetch", "cannot lock ref 'refs/remotes/origin/main': ..."),
+        None,  # Success on retry
+    ]
+
+    with patch("vibe3.services.flow_orchestrator_service.time.sleep") as mock_sleep:
+        result = service.bootstrap_issue_flow(
+            IssueInfo(number=999, title="Retry test"),
+            branch="dev/issue-999",
+            source="skill",
+        )
+
+    # Verify fetch was called twice with same args
+    assert git.fetch.call_count == 2
+    git.fetch.assert_any_call("origin", "main")
+    # Verify sleep was called once (after first failure)
+    mock_sleep.assert_called_once()
+    # Verify bootstrap succeeded
+    assert result["branch"] == "dev/issue-999"
+
+
+def test_bootstrap_issue_flow_raises_after_exhausted_retries() -> None:
+    """Fetch should raise GitError after exhausting retries."""
+    from vibe3.exceptions import GitError
+
+    config = load_orchestra_config()
+    store = MagicMock()
+    git = MagicMock()
+    github = MagicMock()
+    git.branch_exists.return_value = False
+    git.get_git_common_dir.return_value = "/tmp/repo/.git"
+    store.get_flow_state.return_value = None
+    service = FlowOrchestratorService(config, store=store, git=git, github=github)
+
+    # Simulate persistent ref lock conflict
+    git.fetch.side_effect = GitError(
+        "fetch", "cannot lock ref 'refs/remotes/origin/main': ..."
+    )
+
+    with patch("vibe3.services.flow_orchestrator_service.time.sleep"):
+        with pytest.raises(GitError, match="cannot lock ref"):
+            service.bootstrap_issue_flow(
+                IssueInfo(number=888, title="Exhausted retry test"),
+                branch="dev/issue-888",
+                source="skill",
+            )
+
+    # Verify fetch was called 3 times (MAX_FETCH_RETRIES)
+    assert git.fetch.call_count == 3
+    git.fetch.assert_any_call("origin", "main")


### PR DESCRIPTION
## Summary

Fix concurrent Git ref lock conflicts during flow dispatch by implementing a two-part solution:
1. Narrow `git fetch` from all-remotes to a single refspec (remote, ref)
2. Add retry-with-backoff for `GitError("cannot lock ref")` errors

## Changes

### Core Implementation
- **flow_orchestrator_service.py**: 
  - Changed `fetch(remote)` → `fetch(remote, ref)` to reduce lock scope
  - Added retry loop (max 3 attempts, linear backoff) for transient ref lock conflicts
  - Retry only catches `GitError` with "cannot lock ref" message

### Tests
- Updated 3 existing test assertions to match new `fetch(remote, ref)` signature
- Added 2 new tests for retry behavior:
  - `test_bootstrap_issue_flow_retries_fetch_on_ref_lock_conflict`
  - `test_bootstrap_issue_flow_raises_after_exhausted_retries`

## Test Results
- ✅ Direct tests: 15/15 passed
- ✅ Services module tests: 725/725 passed
- ✅ Type check (mypy): No issues found
- ✅ Lint (ruff): All checks passed

## Verification
- All changes committed (git status clean)
- Plan requirements verified (see execution report)
- Verdict: PASS (claude/opus)

Fixes #2143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Contributors
- Planner: claude/opus
- Executor: claude/opus
- Reviewer: claude/opus