### PR TITLE
refactor(services): 公共接口统一 + 消除内部导入 (issue #2133)

### DIFF
--- a/src/vibe3/analysis/__init__.py
+++ b/src/vibe3/analysis/__init__.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from vibe3.analysis.pr_scoring import (
         PRDimensions,
         RiskLevel,
+        RiskScore,
         calculate_risk_score,
         determine_risk_level,
         generate_score_report,
@@ -80,6 +81,7 @@ _LAZY_IMPORTS = {
     "is_test_file": "vibe3.analysis.change_scope_service",
     "PRDimensions": "vibe3.analysis.pr_scoring",
     "RiskLevel": "vibe3.analysis.pr_scoring",
+    "RiskScore": "vibe3.analysis.pr_scoring",
     "calculate_risk_score": "vibe3.analysis.pr_scoring",
     "determine_risk_level": "vibe3.analysis.pr_scoring",
     "generate_score_report": "vibe3.analysis.pr_scoring",
@@ -125,6 +127,7 @@ __all__ = [
     # PR scoring
     "PRDimensions",
     "RiskLevel",
+    "RiskScore",
     "calculate_risk_score",
     "determine_risk_level",
     "generate_score_report",

--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -5,9 +5,22 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient, find_repo_root
+    from vibe3.clients.ai_client import AIClient
+    from vibe3.clients.ai_suggestion_client import AISuggestionClient
+    from vibe3.clients.git_client import GitClient, GitClientProtocol, find_repo_root
+    from vibe3.clients.git_worktree_ops import prune_worktrees, remove_worktree
     from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.protocols import BackendProtocol
+    from vibe3.clients.github_issues_ops import parse_blocked_by, parse_linked_issues
+    from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
+    from vibe3.clients.merged_pr_cache import MergedPRCache
+    from vibe3.clients.protocols import (
+        BackendProtocol,
+        BaseResolver,
+        FlowReader,
+        GitHubClientProtocol,
+        GitPathProtocol,
+    )
+    from vibe3.clients.recent_pr_cache import RecentPRCache
     from vibe3.clients.serena_client import (
         SerenaClient,
         count_references,
@@ -18,15 +31,30 @@ if TYPE_CHECKING:
 
 # Lazy imports
 _LAZY_IMPORTS = {
-    "GitClient": "vibe3.clients.git_client",
-    "find_repo_root": "vibe3.clients.git_client",
-    "GitHubClient": "vibe3.clients.github_client",
+    "AIClient": "vibe3.clients.ai_client",
+    "AISuggestionClient": "vibe3.clients.ai_suggestion_client",
     "BackendProtocol": "vibe3.clients.protocols",
+    "BaseResolver": "vibe3.clients.protocols",
+    "FlowReader": "vibe3.clients.protocols",
+    "GhIssueLabelPort": "vibe3.clients.github_labels",
+    "GitClient": "vibe3.clients.git_client",
+    "GitClientProtocol": "vibe3.clients.git_client",
+    "GitHubClient": "vibe3.clients.github_client",
+    "GitHubClientProtocol": "vibe3.clients.protocols",
+    "GitPathProtocol": "vibe3.clients.protocols",
+    "IssueLabelPort": "vibe3.clients.github_labels",
+    "MergedPRCache": "vibe3.clients.merged_pr_cache",
+    "RecentPRCache": "vibe3.clients.recent_pr_cache",
     "SerenaClient": "vibe3.clients.serena_client",
+    "SQLiteClient": "vibe3.clients.sqlite_client",
     "count_references": "vibe3.clients.serena_client",
     "extract_function_names": "vibe3.clients.serena_client",
-    "SQLiteClient": "vibe3.clients.sqlite_client",
+    "find_repo_root": "vibe3.clients.git_client",
     "get_store": "vibe3.clients.store_context",
+    "parse_blocked_by": "vibe3.clients.github_issues_ops",
+    "parse_linked_issues": "vibe3.clients.github_issues_ops",
+    "prune_worktrees": "vibe3.clients.git_worktree_ops",
+    "remove_worktree": "vibe3.clients.git_worktree_ops",
 }
 
 
@@ -41,13 +69,28 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    "AIClient",
+    "AISuggestionClient",
     "BackendProtocol",
+    "BaseResolver",
+    "FlowReader",
+    "GhIssueLabelPort",
     "GitClient",
+    "GitClientProtocol",
     "GitHubClient",
+    "GitHubClientProtocol",
+    "GitPathProtocol",
+    "IssueLabelPort",
+    "MergedPRCache",
+    "RecentPRCache",
     "SerenaClient",
     "SQLiteClient",
     "count_references",
     "extract_function_names",
     "find_repo_root",
     "get_store",
+    "parse_blocked_by",
+    "parse_linked_issues",
+    "prune_worktrees",
+    "remove_worktree",
 ]

--- a/src/vibe3/config/__init__.py
+++ b/src/vibe3/config/__init__.py
@@ -21,7 +21,10 @@ if TYPE_CHECKING:
         load_runtime_config,
         reload_config,
     )
-    from vibe3.config.manager_config import get_manager_usernames
+    from vibe3.config.manager_config import (
+        get_handoff_state_label,
+        get_manager_usernames,
+    )
     from vibe3.config.orchestra_config import PeriodicCheckConfig
     from vibe3.config.orchestra_settings import load_orchestra_config
     from vibe3.config.profile_config import ProfileConfig
@@ -58,7 +61,10 @@ if TYPE_CHECKING:
         TotalFileLocConfig,
         VibeConfig,
     )
-    from vibe3.config.timeline_comment_policy import TimelineCommentPolicy
+    from vibe3.config.timeline_comment_policy import (
+        DEFAULT_COMMENT_POLICY,
+        TimelineCommentPolicy,
+    )
 
 __all__ = [
     "AIConfig",
@@ -67,6 +73,7 @@ __all__ = [
     "CodeLimitsConfig",
     "CodePathsConfig",
     "ConventionResolver",
+    "DEFAULT_COMMENT_POLICY",
     "EXECUTOR_GATE_CONFIG",
     "FlowConfig",
     "GOVERNANCE_GATE_CONFIG",
@@ -94,6 +101,7 @@ __all__ = [
     "VibeConfig",
     "find_missing_backend_commands",
     "get_config",
+    "get_handoff_state_label",
     "get_manager_usernames",
     "get_role_output_contract",
     "get_role_section",
@@ -139,7 +147,9 @@ _SYMBOL_MODULES = {
     "RunConfig": "vibe3.config.settings",
     "SingleFileLocConfig": "vibe3.config.settings",
     "TestPathsConfig": "vibe3.config.settings",
+    "DEFAULT_COMMENT_POLICY": "vibe3.config.timeline_comment_policy",
     "TimelineCommentPolicy": "vibe3.config.timeline_comment_policy",
+    "get_handoff_state_label": "vibe3.config.manager_config",
     "TotalFileLocConfig": "vibe3.config.settings",
     "VibeConfig": "vibe3.config.settings",
     "find_missing_backend_commands": "vibe3.config.agent_preset",

--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
     from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
     from vibe3.domain.failed_gate import FailedGate
     from vibe3.domain.flow_manager import FlowManager
+    from vibe3.domain.state_machine import (
+        STATE_LABEL_META,
+        VIBE_TASK_LABEL,
+        validate_transition,
+    )
 
 if TYPE_CHECKING:
     from vibe3.domain.publisher import EventPublisher
@@ -75,7 +80,7 @@ def subscribe(event_type: str, handler: "Callable[[DomainEvent], None]") -> None
     return _subscribe(event_type, handler)
 
 
-def __getattr__(name: str) -> type:
+def __getattr__(name: str) -> object:
     """Lazy import for heavy modules to avoid circular dependencies."""
     # Events
     if name == "DomainEvent":
@@ -152,6 +157,18 @@ def __getattr__(name: str) -> type:
         from vibe3.domain.failed_gate import FailedGate
 
         return FailedGate
+    if name == "STATE_LABEL_META":
+        from vibe3.domain.state_machine import STATE_LABEL_META
+
+        return STATE_LABEL_META
+    if name == "VIBE_TASK_LABEL":
+        from vibe3.domain.state_machine import VIBE_TASK_LABEL
+
+        return VIBE_TASK_LABEL
+    if name == "validate_transition":
+        from vibe3.domain.state_machine import validate_transition
+
+        return validate_transition
     if name == "EventPublisher":
         from vibe3.domain.publisher import EventPublisher
 
@@ -179,6 +196,10 @@ __all__ = [
     "SupervisorApplyStarted",
     "SupervisorApplyCompleted",
     "SupervisorApplyDelegated",
+    # State machine
+    "STATE_LABEL_META",
+    "VIBE_TASK_LABEL",
+    "validate_transition",
     # Orchestration
     "FlowManager",
     "GlobalDispatchCoordinator",

--- a/src/vibe3/environment/__init__.py
+++ b/src/vibe3/environment/__init__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         SessionManager,
         TmuxSessionContext,
     )
+    from vibe3.environment.session_naming import get_manager_session_name
     from vibe3.environment.session_registry import SessionRegistryService
     from vibe3.environment.worktree import WorktreeManager
     from vibe3.environment.worktree_context import WorktreeContext
@@ -29,6 +30,7 @@ _LAZY_IMPORTS = {
     "SessionRegistryService": "vibe3.environment.session_registry",
     "WorktreeManager": "vibe3.environment.worktree",
     "WorktreeContext": "vibe3.environment.worktree_context",
+    "get_manager_session_name": "vibe3.environment.session_naming",
 }
 
 
@@ -49,6 +51,7 @@ __all__ = [
     "CodeagentSessionContext",
     "SessionManager",
     "SessionRegistryService",
+    "get_manager_session_name",
     "resolve_prompt_config",
     "resolve_runtime_asset",
     "runtime_assets_root",

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from vibe3.exceptions.error_classification import (
+        classify_error_hybrid,
+        get_error_handling_contract,
+    )
+    from vibe3.exceptions.error_codes import is_api_error, is_model_error
+    from vibe3.exceptions.error_severity import ErrorSeverity
     from vibe3.exceptions.runtime_errors import GitHubAPIError
 
 
@@ -215,7 +221,12 @@ class InvalidBranchLinkError(SystemError):
 
 # Lazy imports to avoid circular dependencies
 _LAZY_IMPORTS = {
+    "ErrorSeverity": "vibe3.exceptions.error_severity",
     "GitHubAPIError": "vibe3.exceptions.runtime_errors",
+    "classify_error_hybrid": "vibe3.exceptions.error_classification",
+    "get_error_handling_contract": "vibe3.exceptions.error_classification",
+    "is_api_error": "vibe3.exceptions.error_codes",
+    "is_model_error": "vibe3.exceptions.error_codes",
 }
 
 
@@ -246,7 +257,12 @@ __all__ = [
     "SerenaError",
     "PRNotFoundError",
     "CapacityDeferredError",
+    "ErrorSeverity",
     "InvalidTransitionError",
     "InvalidBranchLinkError",
     "GitHubAPIError",
+    "classify_error_hybrid",
+    "get_error_handling_contract",
+    "is_api_error",
+    "is_model_error",
 ]

--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
         execution_prefix,
         persist_execution_lifecycle_event,
     )
+    from vibe3.execution.governance_sync_runner import run_governance_sync
+    from vibe3.execution.issue_role_sync_runner import (
+        run_issue_role_async,
+        run_issue_role_sync,
+    )
     from vibe3.execution.noop_gate import apply_unified_noop_gate
     from vibe3.execution.session_service import load_session_id
 
@@ -27,6 +32,9 @@ _LAZY_IMPORTS = {
     "persist_execution_lifecycle_event": "vibe3.execution.execution_lifecycle",
     "apply_unified_noop_gate": "vibe3.execution.noop_gate",
     "load_session_id": "vibe3.execution.session_service",
+    "run_governance_sync": "vibe3.execution.governance_sync_runner",
+    "run_issue_role_async": "vibe3.execution.issue_role_sync_runner",
+    "run_issue_role_sync": "vibe3.execution.issue_role_sync_runner",
 }
 
 
@@ -54,4 +62,8 @@ __all__ = [
     "load_session_id",
     # Gates
     "apply_unified_noop_gate",
+    # Sync runners
+    "run_governance_sync",
+    "run_issue_role_async",
+    "run_issue_role_sync",
 ]

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -14,14 +14,38 @@ if TYPE_CHECKING:
         PRSource,
         UncommittedSource,
     )
+    from vibe3.models.coordination_truth import CoordinationTruth
     from vibe3.models.coverage import CoverageReport, LayerCoverage
+    from vibe3.models.data_source import DataSource
     from vibe3.models.dead_code import DeadCodeFinding, DeadCodeReport
     from vibe3.models.execution_handle import AsyncExecutionHandle
     from vibe3.models.execution_request import ExecutionLaunchResult, ExecutionRequest
+    from vibe3.models.flow import (
+        FlowEvent,
+        FlowState,
+        FlowStatusResponse,
+        IssueLink,
+        MainBranchProtectedError,
+        TimelineEvent,
+    )
     from vibe3.models.inspection import CallNode, CommandInspection
+    from vibe3.models.issue_body import FlowStateProjection
     from vibe3.models.orchestra_config import OrchestraConfig, SupervisorHandoffConfig
-    from vibe3.models.orchestration import IssueInfo, IssueState
+    from vibe3.models.orchestration import IssueInfo, IssueState, StateTransition
     from vibe3.models.plan import PlanRequest
+    from vibe3.models.pr import (
+        CreatePRRequest,
+        PRMetadata,
+        PRResponse,
+        PRState,
+        VersionBumpResponse,
+        VersionBumpType,
+    )
+    from vibe3.models.pr_analysis import (
+        CommitInfo,
+        CriticalFileInfo,
+        PRCriticalAnalysis,
+    )
     from vibe3.models.prompt_meta import PromptContextMode
     from vibe3.models.queue_entry import QueueEntry
     from vibe3.models.review import ReviewRequest
@@ -50,6 +74,11 @@ if TYPE_CHECKING:
 _LAZY_IMPORTS = {
     "BranchConvention": "vibe3.models.branch_convention",
     "BranchSource": "vibe3.models.change_source",
+    "CommitInfo": "vibe3.models.pr_analysis",
+    "CoordinationTruth": "vibe3.models.coordination_truth",
+    "CreatePRRequest": "vibe3.models.pr",
+    "CriticalFileInfo": "vibe3.models.pr_analysis",
+    "DataSource": "vibe3.models.data_source",
     "ChangeSource": "vibe3.models.change_source",
     "ChangeSourceType": "vibe3.models.change_source",
     "CommitSource": "vibe3.models.change_source",
@@ -66,8 +95,18 @@ _LAZY_IMPORTS = {
     "CommandInspection": "vibe3.models.inspection",
     "OrchestraConfig": "vibe3.models.orchestra_config",
     "SupervisorHandoffConfig": "vibe3.models.orchestra_config",
+    "FlowEvent": "vibe3.models.flow",
+    "FlowState": "vibe3.models.flow",
+    "FlowStateProjection": "vibe3.models.issue_body",
+    "FlowStatusResponse": "vibe3.models.flow",
     "IssueInfo": "vibe3.models.orchestration",
+    "IssueLink": "vibe3.models.flow",
     "IssueState": "vibe3.models.orchestration",
+    "MainBranchProtectedError": "vibe3.models.flow",
+    "PRCriticalAnalysis": "vibe3.models.pr_analysis",
+    "PRMetadata": "vibe3.models.pr",
+    "PRResponse": "vibe3.models.pr",
+    "PRState": "vibe3.models.pr",
     "PlanRequest": "vibe3.models.plan",
     "PromptContextMode": "vibe3.models.prompt_meta",
     "QueueEntry": "vibe3.models.queue_entry",
@@ -89,8 +128,12 @@ _LAZY_IMPORTS = {
     "StructureSnapshot": "vibe3.models.snapshot",
     "ExecutionStep": "vibe3.models.trace",
     "TraceOutput": "vibe3.models.trace",
+    "StateTransition": "vibe3.models.orchestration",
+    "TimelineEvent": "vibe3.models.flow",
     "VerdictRecord": "vibe3.models.verdict",
     "VerdictValue": "vibe3.models.verdict_types",
+    "VersionBumpResponse": "vibe3.models.pr",
+    "VersionBumpType": "vibe3.models.pr",
     "WorktreeRequirement": "vibe3.models.worktree",
 }
 
@@ -115,8 +158,13 @@ __all__: list[str] = [
     "ChangeSource",
     "ChangeSourceType",
     "CommandInspection",
+    "CommitInfo",
     "CommitSource",
+    "CoordinationTruth",
     "CoverageReport",
+    "CreatePRRequest",
+    "CriticalFileInfo",
+    "DataSource",
     "DeadCodeFinding",
     "DeadCodeReport",
     "DependencyChange",
@@ -128,26 +176,40 @@ __all__: list[str] = [
     "ExecutionStep",
     "FileChange",
     "FileSnapshot",
+    "FlowEvent",
+    "FlowState",
+    "FlowStateProjection",
+    "FlowStatusResponse",
     "FunctionSnapshot",
+    "IssueInfo",
+    "IssueLink",
+    "IssueState",
     "LayerCoverage",
+    "MainBranchProtectedError",
     "ModuleChange",
     "ModuleSnapshot",
-    "IssueInfo",
-    "IssueState",
     "OrchestraConfig",
-    "PlanRequest",
+    "PRCriticalAnalysis",
+    "PRMetadata",
+    "PRResponse",
     "PRSource",
+    "PRState",
+    "PlanRequest",
     "PromptContextMode",
     "QueueEntry",
     "ReviewRequest",
     "SessionRole",
+    "StateTransition",
     "StructureDiff",
     "StructureMetrics",
     "StructureSnapshot",
     "SupervisorHandoffConfig",
+    "TimelineEvent",
     "TraceOutput",
     "UncommittedSource",
     "VerdictRecord",
     "VerdictValue",
+    "VersionBumpResponse",
+    "VersionBumpType",
     "WorktreeRequirement",
 ]

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -18,11 +18,12 @@ from vibe3.models.orchestra_config import OrchestraConfig
 
 # Lazy imports via __getattr__ for everything else to avoid circular dependencies
 if TYPE_CHECKING:
-    from vibe3.domain.failed_gate import GateResult, GateStatus
+    from vibe3.domain.failed_gate import FailedGate, GateResult, GateStatus
     from vibe3.domain.qualify_gate import QualifyGateService
     from vibe3.domain.role_resolver import find_role_for_state
     from vibe3.models.queue_entry import QueueEntry
     from vibe3.observability.orchestra_log import (
+        append_governance_event,
         append_orchestra_event,
         append_orchestra_run_separator,
         orchestra_events_log_path,
@@ -46,7 +47,11 @@ if TYPE_CHECKING:
         promote_progressed_entries,
         select_ready_issues_from_collected_issues,
     )
-    from vibe3.orchestra.queue_ordering import sort_ready_issues
+    from vibe3.orchestra.queue_ordering import (
+        resolve_priority,
+        resolve_roadmap_rank,
+        sort_ready_issues,
+    )
     from vibe3.orchestra.queue_persistence_service import QueuePersistenceService
     from vibe3.services.check_service import CheckResult
     from vibe3.services.label_utils import should_skip_from_queue
@@ -64,6 +69,14 @@ def __getattr__(name: str) -> object:
         from vibe3.models.queue_entry import QueueEntry
 
         return QueueEntry
+    if name == "FailedGate":
+        from vibe3.domain.failed_gate import FailedGate
+
+        return FailedGate
+    if name == "append_governance_event":
+        from vibe3.observability.orchestra_log import append_governance_event
+
+        return append_governance_event
     if name == "append_orchestra_event":
         from vibe3.observability.orchestra_log import append_orchestra_event
 
@@ -80,6 +93,14 @@ def __getattr__(name: str) -> object:
         from vibe3.observability.orchestra_log import orchestra_log_dir
 
         return orchestra_log_dir
+    if name == "resolve_priority":
+        from vibe3.orchestra.queue_ordering import resolve_priority
+
+        return resolve_priority
+    if name == "resolve_roadmap_rank":
+        from vibe3.orchestra.queue_ordering import resolve_roadmap_rank
+
+        return resolve_roadmap_rank
     if name == "sort_ready_issues":
         from vibe3.orchestra.queue_ordering import sort_ready_issues
 
@@ -179,10 +200,14 @@ __all__ = [
     "OrchestraConfig",
     # Orchestra submodules
     "QueueEntry",
+    "FailedGate",
+    "append_governance_event",
     "append_orchestra_event",
     "append_orchestra_run_separator",
     "orchestra_events_log_path",
     "orchestra_log_dir",
+    "resolve_priority",
+    "resolve_roadmap_rank",
     "sort_ready_issues",
     "select_ready_issues_from_collected_issues",
     "promote_progressed_entries",

--- a/src/vibe3/prompts/__init__.py
+++ b/src/vibe3/prompts/__init__.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from vibe3.prompts.template_loader import (
         DEFAULT_PROMPTS_PATH,
         resolve_prompt_template,
+        resolve_prompts_path,
     )
     from vibe3.prompts.validation import (
         PromptValidationResult,
@@ -92,6 +93,7 @@ _LAZY_IMPORTS = {
     "resolve_common_rules_path": "vibe3.prompts.sections",
     "DEFAULT_PROMPTS_PATH": "vibe3.prompts.template_loader",
     "resolve_prompt_template": "vibe3.prompts.template_loader",
+    "resolve_prompts_path": "vibe3.prompts.template_loader",
     "PromptValidationResult": "vibe3.prompts.validation",
     "PromptValidationService": "vibe3.prompts.validation",
     "ValidationIssue": "vibe3.prompts.validation",
@@ -144,6 +146,7 @@ __all__ = [
     # Template helpers
     "DEFAULT_PROMPTS_PATH",
     "resolve_prompt_template",
+    "resolve_prompts_path",
     # Section builders
     "build_tools_guide_section",
     "resolve_common_rules_path",

--- a/src/vibe3/services/abandon_flow_service.py
+++ b/src/vibe3/services/abandon_flow_service.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueState
 
 if TYPE_CHECKING:

--- a/src/vibe3/services/actor_support.py
+++ b/src/vibe3/services/actor_support.py
@@ -1,8 +1,8 @@
 """Shared actor formatting helpers for execution and handoff."""
 
-from vibe3.config.agent_preset import resolve_effective_agent_options
+from vibe3.config import resolve_effective_agent_options
 from vibe3.exceptions import AgentPresetNotFoundError
-from vibe3.models.review_runner import AgentOptions
+from vibe3.models import AgentOptions
 
 
 def resolve_actor_backend_model(options: AgentOptions) -> tuple[str, str | None]:

--- a/src/vibe3/services/base_resolution_usecase.py
+++ b/src/vibe3/services/base_resolution_usecase.py
@@ -3,10 +3,10 @@
 from dataclasses import dataclass
 from typing import Callable, Literal
 
-from vibe3.clients.git_client import GitClient, GitClientProtocol
+from vibe3.clients import GitClient, GitClientProtocol
 from vibe3.exceptions import UserError
-from vibe3.models.change_source import BranchSource
-from vibe3.utils.branch_utils import find_parent_branch
+from vibe3.models import BranchSource
+from vibe3.utils import find_parent_branch
 
 MAIN_BRANCH_NAME = "main"
 MAIN_BRANCH_REF = "origin/main"

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.models import IssueState
-from vibe3.models.issue_body import FlowStateProjection
+from vibe3.clients import GitHubClient
+from vibe3.models import FlowStateProjection, IssueState
 from vibe3.services.blocked_state_types import BlockedState
 from vibe3.services.issue_body_service import merge_projection, parse_projection
 from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/blocked_state_service.py
+++ b/src/vibe3/services/blocked_state_service.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueState
 from vibe3.services.blocked_state_io import BlockedStateIO
 from vibe3.services.blocked_state_types import (

--- a/src/vibe3/services/check_cleanup_service.py
+++ b/src/vibe3/services/check_cleanup_service.py
@@ -12,14 +12,12 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from vibe3.clients.protocols import BackendProtocol
-from vibe3.models.flow import FlowStatusResponse
+from vibe3.clients import BackendProtocol
+from vibe3.models import FlowStatusResponse
 from vibe3.services.task_resume_operations import TaskResumeOperations
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.services.flow_cleanup_service import FlowCleanupService
 
 
@@ -62,7 +60,7 @@ class CheckCleanupService:
         Returns:
             Dict with summary and details of cleaned branches.
         """
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
         from vibe3.services.expired_resource_cleanup_service import (
             ExpiredResourceCleanupService,
         )
@@ -217,7 +215,7 @@ class CheckCleanupService:
             SystemError: If query fails, preventing accidental cleanup.
         """
         try:
-            from vibe3.environment.session_registry import SessionRegistryService
+            from vibe3.environment import SessionRegistryService
 
             # Use injected backend, fallback to None (read-only mode)
             backend = self._backend
@@ -345,7 +343,7 @@ class CheckCleanupService:
                 )
                 return
 
-            from vibe3.clients.github_client import GitHubClient
+            from vibe3.clients import GitHubClient
             from vibe3.services.flow_service import FlowService
             from vibe3.services.issue_flow_service import IssueFlowService
             from vibe3.services.label_service import LabelService
@@ -505,7 +503,7 @@ class CheckCleanupService:
             current_cwd = os.getcwd()
 
             # Load protected worktree names from config
-            from vibe3.config.settings import VibeConfig
+            from vibe3.config import VibeConfig
             from vibe3.services.expired_resource_cleanup_service import (
                 _is_protected_worktree,
             )

--- a/src/vibe3/services/check_lock.py
+++ b/src/vibe3/services/check_lock.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Generator
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
 
 @contextmanager

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -11,14 +11,12 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.models.pr import PRState
+from vibe3.models import PRState
 from vibe3.services.label_utils import normalize_labels
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.models.pr import PRResponse
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
+    from vibe3.models import PRResponse
     from vibe3.services.flow_status_service import FlowStatusService
 
 

--- a/src/vibe3/services/check_remote.py
+++ b/src/vibe3/services/check_remote.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients.github_issues_ops import parse_linked_issues
-from vibe3.models import IssueState
-from vibe3.models.flow import IssueLink
+from vibe3.clients import parse_linked_issues
+from vibe3.models import IssueLink, IssueState
 
 
 @dataclass
@@ -119,7 +118,7 @@ class CheckRemote:
         ).info("Remote index build done (Path A)")
 
         # Path B: rebuild merged PR cache
-        from vibe3.clients.merged_pr_cache import MergedPRCache
+        from vibe3.clients import MergedPRCache
 
         # Resolve repo path from git common dir
         git_common_dir = this.git_client.get_git_common_dir()

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -8,13 +8,9 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.config.settings import VibeConfig
-from vibe3.models import IssueState
-from vibe3.models.pr import PRState
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
+from vibe3.config import VibeConfig
+from vibe3.models import IssueState, PRState
 from vibe3.services.check_lock import check_lock
 from vibe3.services.check_pr_service import CheckPRService
 from vibe3.services.check_remote import (
@@ -26,7 +22,7 @@ from vibe3.services.flow_status_service import FlowStatusService
 from vibe3.services.pr_service import PRService
 
 if TYPE_CHECKING:
-    from vibe3.models.pr import PRResponse
+    from vibe3.models import PRResponse
 
 
 @dataclass

--- a/src/vibe3/services/coordination_resolver.py
+++ b/src/vibe3/services/coordination_resolver.py
@@ -6,12 +6,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.models.coordination_truth import CoordinationTruth
-from vibe3.models.data_source import DataSource
-from vibe3.observability.degraded_mode import (
-    DegradedModeReason,
-    get_degraded_manager,
-)
+from vibe3.models import CoordinationTruth, DataSource
+from vibe3.observability import DegradedModeReason, get_degraded_manager
 from vibe3.services.flow_status_resolver import FlowStatusResolver
 
 if TYPE_CHECKING:
@@ -171,7 +167,7 @@ class CoordinationResolver:
             Dict with projection_state/blocked_reason/blocked_by_issue/dependencies
             from body, or None if read failed
         """
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
         from vibe3.services.issue_body_service import parse_projection
 
         client = GitHubClient()

--- a/src/vibe3/services/error_helpers.py
+++ b/src/vibe3/services/error_helpers.py
@@ -8,8 +8,8 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient
-    from vibe3.exceptions.error_severity import ErrorSeverity
-    from vibe3.models.execution_request import ExecutionLaunchResult
+    from vibe3.exceptions import ErrorSeverity
+    from vibe3.models import ExecutionLaunchResult
 
 
 def has_recent_specific_error(
@@ -34,7 +34,7 @@ def has_recent_specific_error(
     """
     import sqlite3
 
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     if store is None:
         store = SQLiteClient()
@@ -121,8 +121,8 @@ def record_dispatch_failure_if_unexpected(
 
     # Handle exception-level failures
     if exception is not None:
-        from vibe3.clients.sqlite_client import SQLiteClient
-        from vibe3.exceptions.error_classification import classify_error_hybrid
+        from vibe3.clients import SQLiteClient
+        from vibe3.exceptions import classify_error_hybrid
 
         # Detect test mock leaks - skip recording entirely
         exc_str = str(exception)
@@ -173,7 +173,7 @@ def record_dispatch_failure_if_unexpected(
     # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
     # If no, record E_DISPATCH_FAILURE for infrastructure visibility
     if reason_code == "launch_failed":
-        from vibe3.clients.sqlite_client import SQLiteClient
+        from vibe3.clients import SQLiteClient
 
         _store = SQLiteClient()
         if has_recent_specific_error(
@@ -186,7 +186,7 @@ def record_dispatch_failure_if_unexpected(
             return
         # else: fall through to record E_DISPATCH_FAILURE
 
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     # Include dispatch_source marker and reason_code for disambiguation
     reason_detail = result.reason or "(no detail)"

--- a/src/vibe3/services/error_tracking_queries.py
+++ b/src/vibe3/services/error_tracking_queries.py
@@ -11,8 +11,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.exceptions.error_codes import is_api_error, is_model_error
-from vibe3.exceptions.error_severity import ErrorSeverity
+from vibe3.exceptions import ErrorSeverity, is_api_error, is_model_error
 
 # Known canonical severity values
 _KNOWN_SEVERITIES = {"CRITICAL", "ERROR", "WARNING"}

--- a/src/vibe3/services/error_tracking_service.py
+++ b/src/vibe3/services/error_tracking_service.py
@@ -15,8 +15,7 @@ from typing import Any
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.exceptions.error_classification import get_error_handling_contract
-from vibe3.exceptions.error_severity import ErrorSeverity
+from vibe3.exceptions import ErrorSeverity, get_error_handling_contract
 from vibe3.services.error_tracking_cleanup import (
     cleanup_old_errors as _cleanup_old_errors,
 )

--- a/src/vibe3/services/expired_resource_cleanup_service.py
+++ b/src/vibe3/services/expired_resource_cleanup_service.py
@@ -14,8 +14,7 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients.git_worktree_ops import remove_worktree
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol, remove_worktree
 
 
 def _is_protected_worktree(
@@ -38,10 +37,7 @@ def _is_protected_worktree(
 
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.protocols import BackendProtocol
+    from vibe3.clients import BackendProtocol, GitClient, GitHubClient, SQLiteClient
     from vibe3.services.pr_service import PRService
 
 
@@ -205,7 +201,7 @@ class ExpiredResourceCleanupService:
             )
 
         # Load protected branches from config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
 
         config = VibeConfig.get_defaults()
         protected = set(config.flow.protected_branches)
@@ -350,7 +346,7 @@ class ExpiredResourceCleanupService:
             )
 
         # Load protected branches and worktree names from config
-        from vibe3.config.settings import VibeConfig
+        from vibe3.config import VibeConfig
 
         config = VibeConfig.get_defaults()
         protected = set(config.flow.protected_branches)
@@ -609,7 +605,7 @@ class ExpiredResourceCleanupService:
             SystemError: If query fails, preventing accidental cleanup.
         """
         try:
-            from vibe3.environment.session_registry import SessionRegistryService
+            from vibe3.environment import SessionRegistryService
 
             backend = self._backend
             registry = SessionRegistryService(store=self.store, backend=backend)

--- a/src/vibe3/services/external_events.py
+++ b/src/vibe3/services/external_events.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.models.flow import FlowEvent
+from vibe3.models import FlowEvent
 from vibe3.services.handoff_storage import HandoffStorage
 
 

--- a/src/vibe3/services/flow_classifier.py
+++ b/src/vibe3/services/flow_classifier.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from vibe3.models.flow import FlowStatusResponse
+from vibe3.models import FlowStatusResponse
 from vibe3.services.status_query_service import is_auto_task_branch
 
 

--- a/src/vibe3/services/flow_cleanup_service.py
+++ b/src/vibe3/services/flow_cleanup_service.py
@@ -19,8 +19,7 @@ from loguru import logger
 from vibe3.clients import BackendProtocol
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient, SQLiteClient
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService
     from vibe3.services.pr_service import PRService
@@ -63,8 +62,7 @@ class FlowCleanupService:
             issue_flow_service: Service for issue-flow mapping
             backend: Backend protocol for tmux session checks
         """
-        from vibe3.clients import SQLiteClient
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient, SQLiteClient
 
         self.git_client = git_client or GitClient()
         self.store = store or SQLiteClient()
@@ -191,7 +189,7 @@ class FlowCleanupService:
                     logger.bind(domain="cleanup", branch=branch).warning(
                         f"Failed to remove worktree, trying prune: {exc}"
                     )
-                    from vibe3.clients.git_worktree_ops import prune_worktrees
+                    from vibe3.clients import prune_worktrees
 
                     prune_worktrees()
                     # Mark as failed even after prune - prune is just cleanup
@@ -325,7 +323,7 @@ class FlowCleanupService:
         """
         import subprocess
 
-        from vibe3.environment.session_naming import get_manager_session_name
+        from vibe3.environment import get_manager_session_name
 
         issue_number = self.issue_flow_service.parse_issue_number(branch)
         if issue_number is None:
@@ -334,7 +332,7 @@ class FlowCleanupService:
         # DEFENSIVE LAYER 2: Query runtime_session table for live sessions
         # This catches race conditions where sessions started after pre-filter
         try:
-            from vibe3.environment.session_registry import SessionRegistryService
+            from vibe3.environment import SessionRegistryService
 
             backend = self._backend
             registry = SessionRegistryService(store=self.store, backend=backend)

--- a/src/vibe3/services/flow_orchestrator_service.py
+++ b/src/vibe3/services/flow_orchestrator_service.py
@@ -9,13 +9,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.environment.worktree import WorktreeManager
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
+from vibe3.environment import WorktreeManager
 from vibe3.exceptions import GitError
-from vibe3.models.pr import PRState
+from vibe3.models import PRState
 from vibe3.services.flow_cleanup_service import FlowCleanupService
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_failure_service import block_manager_noop_issue
@@ -26,8 +23,7 @@ from vibe3.services.signature_service import SignatureService
 from vibe3.services.task_service import TaskService
 
 if TYPE_CHECKING:
-    from vibe3.config.orchestra_config import OrchestraConfig
-    from vibe3.models import IssueInfo
+    from vibe3.models import IssueInfo, OrchestraConfig
     from vibe3.services.orchestra_status_service import OrchestraSnapshot
 
 # Retry configuration for Git fetch operations

--- a/src/vibe3/services/flow_projection_service.py
+++ b/src/vibe3/services/flow_projection_service.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.models.flow import FlowStatusResponse
+from vibe3.clients import GitHubClient, SQLiteClient
+from vibe3.models import FlowStatusResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.pr_service import PRService
 from vibe3.services.task_service import TaskService

--- a/src/vibe3/services/flow_read_mixin.py
+++ b/src/vibe3/services/flow_read_mixin.py
@@ -5,10 +5,8 @@ from typing import Literal, Self, cast
 from loguru import logger
 from pydantic import ValidationError
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.models.flow import FlowEvent, FlowState, FlowStatusResponse, IssueLink
+from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
+from vibe3.models import FlowEvent, FlowState, FlowStatusResponse, IssueLink
 from vibe3.services.git_path_client import GitPathProtocol, get_git_common_dir
 
 

--- a/src/vibe3/services/flow_reader.py
+++ b/src/vibe3/services/flow_reader.py
@@ -1,5 +1,5 @@
 """Re-export shim — FlowReader has moved to clients.protocols.flow."""
 
-from vibe3.clients.protocols.flow import FlowReader
+from vibe3.clients import FlowReader
 
 __all__ = ["FlowReader"]

--- a/src/vibe3/services/flow_rebuild_usecase.py
+++ b/src/vibe3/services/flow_rebuild_usecase.py
@@ -9,10 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.sqlite_client import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
+from vibe3.clients import GitClient, GitHubClient, SQLiteClient
+from vibe3.config import load_orchestra_config
 from vibe3.models import IssueInfo
 from vibe3.services.flow_cleanup_service import FlowCleanupService
 from vibe3.services.flow_rebuild_postconditions import assert_rebuild_postconditions
@@ -145,8 +143,7 @@ class FlowRebuildUsecase:
         Post-rebuild: consistency is guaranteed (we just rebuilt), so we
         skip the classify step and go straight to clearing blocked state.
         """
-        from vibe3.models import IssueState
-        from vibe3.models.flow import FlowState
+        from vibe3.models import FlowState, IssueState
         from vibe3.services.blocked_state_service import BlockedStateService
         from vibe3.services.flow_resume_resolver import infer_resume_label
 

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -27,9 +27,7 @@ from vibe3.services.flow_consistency_check import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
 
 
 class RecoveryAction(StrEnum):
@@ -214,8 +212,7 @@ class FlowRecoveryService:
         Raises:
             RuntimeError: If label write fails (RC2: prevents silent failure)
         """
-        from vibe3.models import IssueState
-        from vibe3.models.flow import FlowState
+        from vibe3.models import FlowState, IssueState
         from vibe3.services.blocked_state_service import BlockedStateService
         from vibe3.services.flow_resume_resolver import infer_resume_label
 

--- a/src/vibe3/services/flow_resume_resolver.py
+++ b/src/vibe3/services/flow_resume_resolver.py
@@ -4,9 +4,7 @@ Provides pure logic to infer the correct GitHub state label for a flow based
 on its local reference states (pr_ref, audit_ref, plan_ref, report_ref).
 """
 
-from vibe3.models import IssueState
-from vibe3.models.flow import FlowState
-from vibe3.models.verdict_types import VerdictValue
+from vibe3.models import FlowState, IssueState, VerdictValue
 from vibe3.services.verdict_policy import passes_review
 
 

--- a/src/vibe3/services/flow_service.py
+++ b/src/vibe3/services/flow_service.py
@@ -1,8 +1,7 @@
 """Flow service implementation."""
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.config.settings import VibeConfig
+from vibe3.clients import GitClient, SQLiteClient
+from vibe3.config import VibeConfig
 from vibe3.services.flow_block_mixin import FlowLifecycleMixin
 from vibe3.services.flow_transition import FlowTransitionMixin
 from vibe3.services.git_path_client import GitPathProtocol

--- a/src/vibe3/services/flow_status_resolver.py
+++ b/src/vibe3/services/flow_status_resolver.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.models.data_source import DataSource
-from vibe3.models.flow import FlowStatusResponse
+from vibe3.models import DataSource, FlowStatusResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_body_service import parse_projection
 
@@ -121,7 +120,7 @@ class FlowStatusResolver:
         if issue_number is None:
             raise ValueError("issue_number required for remote source")
 
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
         from vibe3.services.timeline_parser import parse_timeline_from_comments
 
         github_client = GitHubClient()

--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitClient, GitHubClient, SQLiteClient
 from vibe3.models import IssueState
 
 

--- a/src/vibe3/services/flow_timeline_service.py
+++ b/src/vibe3/services/flow_timeline_service.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.config.timeline_comment_policy import TimelineCommentPolicy
+    from vibe3.clients import GitHubClient, SQLiteClient
+    from vibe3.config import TimelineCommentPolicy
 
 
 # Event type to display text mapping
@@ -47,8 +46,7 @@ class FlowTimelineService:
         github_client: GitHubClient | None = None,
     ) -> None:
         """Initialize timeline service."""
-        from vibe3.clients import SQLiteClient
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient, SQLiteClient
 
         self.store = SQLiteClient() if store is None else store
         self.github_client = GitHubClient() if github_client is None else github_client
@@ -79,7 +77,7 @@ class FlowTimelineService:
 
         # Use default policy if not provided
         if policy is None:
-            from vibe3.config.timeline_comment_policy import DEFAULT_COMMENT_POLICY
+            from vibe3.config import DEFAULT_COMMENT_POLICY
 
             policy = DEFAULT_COMMENT_POLICY
 

--- a/src/vibe3/services/flow_transition.py
+++ b/src/vibe3/services/flow_transition.py
@@ -11,11 +11,10 @@ from typing import Self, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.config.settings import VibeConfig
+from vibe3.clients import GitHubClient, SQLiteClient
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
-from vibe3.models.flow import FlowStatusResponse, MainBranchProtectedError
+from vibe3.models import FlowStatusResponse, MainBranchProtectedError
 from vibe3.services.flow_write_mixin import FlowWriteMixin
 from vibe3.services.git_path_client import GitPathProtocol
 from vibe3.services.issue_flow_service import IssueFlowService

--- a/src/vibe3/services/flow_write_mixin.py
+++ b/src/vibe3/services/flow_write_mixin.py
@@ -8,9 +8,9 @@ from typing import Any, Self
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
-from vibe3.models.flow import FlowState, FlowStatusResponse, MainBranchProtectedError
+from vibe3.models import FlowState, FlowStatusResponse, MainBranchProtectedError
 from vibe3.services.flow_read_mixin import FlowReadMixin
 from vibe3.services.signature_service import SignatureService
 

--- a/src/vibe3/services/git_path_client.py
+++ b/src/vibe3/services/git_path_client.py
@@ -2,13 +2,13 @@
 
 from pathlib import Path
 
-from vibe3.clients.protocols.git import GitPathProtocol
+from vibe3.clients import GitPathProtocol
 
 
 def _get_git_client(git_client: GitPathProtocol | None = None) -> GitPathProtocol:
     """Get or create a GitClient instance."""
     if git_client is None:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         return GitClient()
     return git_client

--- a/src/vibe3/services/handoff_resolution.py
+++ b/src/vibe3/services/handoff_resolution.py
@@ -247,7 +247,7 @@ def _resolve_shared_artifact(
 
     # Special handling for @current (per-branch artifact)
     if key == "current":
-        from vibe3.utils.git_helpers import get_branch_handoff_dir
+        from vibe3.utils import get_branch_handoff_dir
 
         if not branch:
             # Try to get current branch if not specified

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -6,11 +6,9 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient, SQLiteClient
 from vibe3.exceptions import UserError
-from vibe3.models.flow import FlowEvent
-from vibe3.models.verdict import VerdictRecord
+from vibe3.models import FlowEvent, VerdictRecord
 from vibe3.services.actor_support import (
     extract_role_from_actor,
 )
@@ -23,7 +21,7 @@ from vibe3.services.path_helpers import _SHARED_HANDOFF_PREFIX
 from vibe3.services.signature_service import SignatureService
 
 if TYPE_CHECKING:
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
 
 
 class HandoffService:
@@ -102,7 +100,7 @@ class HandoffService:
             git_client: Git client for branch/worktree operations
             github_client: GitHub client for API operations (optional)
         """
-        from vibe3.clients.github_client import GitHubClient
+        from vibe3.clients import GitHubClient
 
         self.store = store or SQLiteClient()
         self.git_client = git_client or GitClient()

--- a/src/vibe3/services/handoff_status_service.py
+++ b/src/vibe3/services/handoff_status_service.py
@@ -4,11 +4,9 @@ import threading
 from dataclasses import dataclass
 from typing import Any
 
-from vibe3.clients import BackendProtocol, SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.environment.session_registry import SessionRegistryService
-from vibe3.models.flow import FlowEvent, FlowState
-from vibe3.models.verdict import VerdictRecord
+from vibe3.clients import BackendProtocol, GitClient, SQLiteClient
+from vibe3.environment import SessionRegistryService
+from vibe3.models import FlowEvent, FlowState, VerdictRecord
 from vibe3.services.flow_service import FlowService
 from vibe3.services.handoff_service import HandoffService
 from vibe3.services.verdict_service import VerdictService

--- a/src/vibe3/services/handoff_storage.py
+++ b/src/vibe3/services/handoff_storage.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
+from vibe3.clients import GitClient
 from vibe3.services.git_path_client import GitPathProtocol
 from vibe3.services.path_helpers import get_git_common_dir, normalize_ref_path
-from vibe3.utils.git_helpers import get_branch_handoff_dir
+from vibe3.utils import get_branch_handoff_dir
 
 
 def _get_handoff_template(branch: str) -> str:

--- a/src/vibe3/services/issue_body_service.py
+++ b/src/vibe3/services/issue_body_service.py
@@ -3,7 +3,7 @@
 import re
 from typing import Final, Literal, cast
 
-from vibe3.models.issue_body import FlowStateProjection
+from vibe3.models import FlowStateProjection
 
 # Managed section markers
 MANAGED_SECTION_START: Final[str] = "<!-- vibe3-flow-state-start -->"

--- a/src/vibe3/services/issue_collection_service.py
+++ b/src/vibe3/services/issue_collection_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.models import IssueInfo
 
 

--- a/src/vibe3/services/issue_context_loader.py
+++ b/src/vibe3/services/issue_context_loader.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.exceptions import UserError
-from vibe3.models import IssueInfo
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models import IssueInfo, OrchestraConfig
 
 
 def load_issue_info(

--- a/src/vibe3/services/issue_flow_service.py
+++ b/src/vibe3/services/issue_flow_service.py
@@ -4,12 +4,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vibe3.clients import SQLiteClient
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.config.settings import VibeConfig
+from vibe3.config import VibeConfig, load_orchestra_config
 from vibe3.exceptions import InvalidBranchLinkError
 
 if TYPE_CHECKING:
-    from vibe3.models.orchestra_config import OrchestraConfig
+    from vibe3.models import OrchestraConfig
     from vibe3.services.convention_resolver import ConventionResolver
 
 

--- a/src/vibe3/services/issue_title_cache_service.py
+++ b/src/vibe3/services/issue_title_cache_service.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.clients import SQLiteClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient, SQLiteClient
 
 
 class IssueTitleCacheService:
@@ -48,7 +47,7 @@ class IssueTitleCacheService:
     def github_client(self) -> GitHubClient:
         """Lazy-initialized GitHub client."""
         if self._github_client is None:
-            from vibe3.clients.github_client import GitHubClient
+            from vibe3.clients import GitHubClient
 
             self._github_client = GitHubClient()
         return self._github_client

--- a/src/vibe3/services/label_service.py
+++ b/src/vibe3/services/label_service.py
@@ -10,16 +10,11 @@ from typing import Literal
 
 from loguru import logger
 
-from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.domain.state_machine import (
-    STATE_LABEL_META,
-    VIBE_TASK_LABEL,
-    validate_transition,
-)
+from vibe3.clients import GhIssueLabelPort, IssueLabelPort
+from vibe3.config import load_orchestra_config
+from vibe3.domain import STATE_LABEL_META, VIBE_TASK_LABEL, validate_transition
 from vibe3.exceptions import InvalidTransitionError, SystemError
-from vibe3.models import IssueState
-from vibe3.models.orchestration import StateTransition
+from vibe3.models import IssueState, StateTransition
 
 
 class LabelService:

--- a/src/vibe3/services/label_utils.py
+++ b/src/vibe3/services/label_utils.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from vibe3.clients.github_labels import GhIssueLabelPort
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.clients import GhIssueLabelPort
+from vibe3.models import OrchestraConfig
 
 if TYPE_CHECKING:
     from vibe3.models import IssueInfo

--- a/src/vibe3/services/loc_service.py
+++ b/src/vibe3/services/loc_service.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.config.settings import VibeConfig
-from vibe3.models.change_source import BranchSource, ChangeSource, PRSource
+from vibe3.clients import GitClient
+from vibe3.config import VibeConfig
+from vibe3.models import BranchSource, ChangeSource, PRSource
 
 
 @dataclass(frozen=True)
@@ -149,6 +149,6 @@ class LocService:
 
         # Exclude test files
         # Reuse the test file detection logic from change_scope_service
-        from vibe3.analysis.change_scope_service import is_test_file
+        from vibe3.analysis import is_test_file
 
         return not is_test_file(filepath)

--- a/src/vibe3/services/orchestra_helpers.py
+++ b/src/vibe3/services/orchestra_helpers.py
@@ -11,9 +11,6 @@ For new code, import directly from config/manager_config.py:
     )
 """
 
-from vibe3.config.manager_config import (
-    get_handoff_state_label,
-    get_manager_usernames,
-)
+from vibe3.config import get_handoff_state_label, get_manager_usernames
 
 __all__ = ["get_manager_usernames", "get_handoff_state_label"]

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.github_issues_ops import parse_blocked_by
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.models import IssueState
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.orchestra.logging import orchestra_events_log_path
+from vibe3.clients import (
+    GitClient,
+    GitHubClient,
+    GitHubClientProtocol,
+    parse_blocked_by,
+)
+from vibe3.models import IssueState, OrchestraConfig
+from vibe3.orchestra import orchestra_events_log_path
 from vibe3.services.flow_reader import FlowReader
 from vibe3.services.label_service import LabelService
 from vibe3.services.orchestra_helpers import get_manager_usernames

--- a/src/vibe3/services/pr_analysis_service.py
+++ b/src/vibe3/services/pr_analysis_service.py
@@ -9,16 +9,9 @@ from typing import cast
 
 from loguru import logger
 
-from vibe3.analysis import dag_service
-from vibe3.analysis.pr_scoring import PRDimensions
-from vibe3.analysis.serena_service import SerenaService
-from vibe3.config.loader import get_config
-from vibe3.models.change_source import PRSource
-from vibe3.models.pr_analysis import (
-    CommitInfo,
-    CriticalFileInfo,
-    PRCriticalAnalysis,
-)
+from vibe3.analysis import PRDimensions, SerenaService, dag_service
+from vibe3.config import get_config
+from vibe3.models import CommitInfo, CriticalFileInfo, PRCriticalAnalysis, PRSource
 from vibe3.services.pr_scoring_service import generate_score_report
 
 
@@ -38,8 +31,7 @@ def build_pr_analysis(pr_number: int, verbose: bool = False) -> PRCriticalAnalys
     """
     log = logger.bind(domain="pr_analysis", action="analyze", pr_number=pr_number)
     log.info("Analyzing PR")
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
 
@@ -88,8 +80,7 @@ def build_pr_analysis(pr_number: int, verbose: bool = False) -> PRCriticalAnalys
 
 def _get_pr_changed_files(pr_number: int) -> list[str]:
     """Return changed file paths for a PR, including deleted files."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
     all_changed_files = git.get_changed_files(PRSource(pr_number=pr_number))
@@ -138,8 +129,7 @@ def _analyze_critical_files(
     pr_number: int,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Extract changed symbols and DAG impact for critical Python files."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitClient, GitHubClient
 
     git = GitClient(github_client=GitHubClient())
     svc = SerenaService(git_client=git)
@@ -207,7 +197,7 @@ def _fetch_pr_commit_shas(pr_number: int) -> list[str]:
 
 def _get_recent_commits(pr_number: int, limit: int = 5) -> list[CommitInfo]:
     """Return latest commit messages for a PR via direct gh CLI call."""
-    from vibe3.utils.git_helpers import get_commit_message
+    from vibe3.utils import get_commit_message
 
     try:
         commit_shas = _fetch_pr_commit_shas(pr_number)

--- a/src/vibe3/services/pr_branch_resolver.py
+++ b/src/vibe3/services/pr_branch_resolver.py
@@ -4,7 +4,7 @@ import shutil
 
 import typer
 
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitHubClient
 from vibe3.exceptions import UserError
 from vibe3.services.convention_resolver import ConventionResolver
 from vibe3.services.flow_service import FlowService

--- a/src/vibe3/services/pr_create_usecase.py
+++ b/src/vibe3/services/pr_create_usecase.py
@@ -7,11 +7,9 @@ from loguru import logger
 from rich.console import Console
 from rich.prompt import Prompt
 
-from vibe3.clients.ai_client import AIClient
-from vibe3.clients.ai_suggestion_client import AISuggestionClient
-from vibe3.clients.protocols.pr import BaseResolver
-from vibe3.config.settings import VibeConfig
-from vibe3.prompts.template_loader import resolve_prompts_path
+from vibe3.clients import AIClient, AISuggestionClient, BaseResolver
+from vibe3.config import VibeConfig
+from vibe3.prompts import resolve_prompts_path
 from vibe3.services.base_resolution_usecase import BaseResolutionUsecase
 from vibe3.services.flow_service import FlowService
 from vibe3.services.task_binding_guard import ensure_task_issue_bound

--- a/src/vibe3/services/pr_loc_comment_service.py
+++ b/src/vibe3/services/pr_loc_comment_service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol
 from vibe3.services.loc_service import LocService, LOCStats
 
 LOC_SENTINEL = "<!-- vibe3:pr-loc-summary -->"

--- a/src/vibe3/services/pr_ready_usecase.py
+++ b/src/vibe3/services/pr_ready_usecase.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Callable
 
 from vibe3.exceptions import UserError
-from vibe3.models.pr import PRResponse
+from vibe3.models import PRResponse
 
 if TYPE_CHECKING:
     from vibe3.services.pr_service import PRService

--- a/src/vibe3/services/pr_review_briefing_service.py
+++ b/src/vibe3/services/pr_review_briefing_service.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitHubClientProtocol
 
 SENTINEL = "<!-- vibe3:pr-review-briefing -->"
 

--- a/src/vibe3/services/pr_scoring_service.py
+++ b/src/vibe3/services/pr_scoring_service.py
@@ -5,7 +5,7 @@ compatibility. The actual implementation lives in the analysis layer to avoid
 bidirectional dependencies between analysis and services.
 """
 
-from vibe3.analysis.pr_scoring import (
+from vibe3.analysis import (
     PRDimensions,
     RiskLevel,
     RiskScore,

--- a/src/vibe3/services/pr_service.py
+++ b/src/vibe3/services/pr_service.py
@@ -7,13 +7,15 @@ from typing import cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.clients.recent_pr_cache import RecentPRCache
+from vibe3.clients import (
+    GitClient,
+    GitHubClient,
+    GitHubClientProtocol,
+    RecentPRCache,
+    SQLiteClient,
+)
 from vibe3.exceptions import GitError, PRNotFoundError, UserError
-from vibe3.models.pr import (
+from vibe3.models import (
     CreatePRRequest,
     PRResponse,
     PRState,

--- a/src/vibe3/services/pr_status_checker.py
+++ b/src/vibe3/services/pr_status_checker.py
@@ -13,8 +13,7 @@ from typing import Any
 
 from loguru import logger
 
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.merged_pr_cache import MergedPRCache
+from vibe3.clients import GitHubClient, MergedPRCache
 from vibe3.services.git_path_client import get_git_common_dir
 
 

--- a/src/vibe3/services/pr_utils.py
+++ b/src/vibe3/services/pr_utils.py
@@ -2,12 +2,9 @@
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_issues_ops import parse_linked_issues
+from vibe3.clients import GitClient, SQLiteClient, parse_linked_issues
 from vibe3.exceptions import GitError, UserError
-from vibe3.models.flow import IssueLink
-from vibe3.models.pr import PRMetadata
+from vibe3.models import IssueLink, PRMetadata
 
 
 def get_metadata_from_flow(store: SQLiteClient, branch: str) -> PRMetadata | None:

--- a/src/vibe3/services/scan_service.py
+++ b/src/vibe3/services/scan_service.py
@@ -54,9 +54,9 @@ def dispatch_governance_execution(
             (resolves tick conflict)
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.execution.governance_sync_runner import run_governance_sync
-    from vibe3.orchestra.logging import append_governance_event
-    from vibe3.roles.governance_factory import build_default_governance_fns
+    from vibe3.execution import run_governance_sync
+    from vibe3.orchestra import append_governance_event
+    from vibe3.roles import build_default_governance_fns
 
     run_governance_sync(
         tick_count=tick_count,
@@ -79,7 +79,7 @@ def dispatch_supervisor_execution(issue_number: int, no_async: bool = False) -> 
         issue_number: Issue to apply supervisor handoff
         no_async: Run synchronously instead of async tmux session
     """
-    from vibe3.execution.issue_role_sync_runner import (
+    from vibe3.execution import (
         run_issue_role_async,
         run_issue_role_sync,
     )
@@ -210,7 +210,7 @@ def validate_governance_material_consistency(
         Possible types: missing_adapter, missing_recipe, missing_file, orphaned_adapter.
     """
     from vibe3.adapters import get_adapter
-    from vibe3.prompts.manifest import PromptManifest
+    from vibe3.prompts import PromptManifest
 
     issues: list[dict] = []
 
@@ -227,7 +227,7 @@ def validate_governance_material_consistency(
             )
             return issues
     if repo_root is None:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         git_client = GitClient()
         git_common_dir = git_client.get_git_common_dir()

--- a/src/vibe3/services/serve_status_service.py
+++ b/src/vibe3/services/serve_status_service.py
@@ -7,16 +7,15 @@ import re
 from rich.console import Console
 from rich.table import Table
 
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.orchestra.failed_gate import FailedGate
-from vibe3.orchestra.logging import orchestra_events_log_path
+from vibe3.config import load_orchestra_config
+from vibe3.models import OrchestraConfig
+from vibe3.orchestra import FailedGate, orchestra_events_log_path
 from vibe3.services.error_tracking_service import ErrorTrackingService
-from vibe3.utils.error_message_cleaner import (
+from vibe3.utils import (
     CODEAGENT_WRAPPER_RE,
     clean_error_message,
+    format_age_aware_time,
 )
-from vibe3.utils.time_format import format_age_aware_time
 
 
 class ServeStatusService:

--- a/src/vibe3/services/signature_service.py
+++ b/src/vibe3/services/signature_service.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-from vibe3.clients.git_client import GitClient
-from vibe3.utils.actor_utils import normalize_actor as _normalize_actor_for_display
+from vibe3.clients import GitClient
+from vibe3.utils import normalize_actor as _normalize_actor_for_display
 
 WORKFLOW_ACTOR = "workflow"
 AI_ASSISTANT_ACTORS = {"ai-assistant", "ai_assistant"}

--- a/src/vibe3/services/spec_ref_service.py
+++ b/src/vibe3/services/spec_ref_service.py
@@ -43,7 +43,7 @@ class SpecRefService:
         )
 
     def _try_parse_issue_number(self, spec_ref: str) -> int | None:
-        from vibe3.utils.issue_ref import try_parse_issue_number
+        from vibe3.utils import try_parse_issue_number
 
         return try_parse_issue_number(spec_ref)
 

--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -10,12 +10,9 @@ from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
+from vibe3.clients import GitClient, GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models import IssueInfo, IssueState
-from vibe3.orchestra.queue_ordering import (
+from vibe3.orchestra import (
     resolve_priority,
     resolve_roadmap_rank,
     sort_ready_issues,
@@ -24,7 +21,7 @@ from vibe3.services.issue_collection_service import IssueCollectionService
 from vibe3.services.issue_dispatch_policy import IssueDispatchPolicy
 
 if TYPE_CHECKING:
-    from vibe3.models.flow import FlowStatusResponse
+    from vibe3.models import FlowStatusResponse
     from vibe3.services.issue_title_cache_service import IssueTitleCacheService
 
 

--- a/src/vibe3/services/task_resume_candidates.py
+++ b/src/vibe3/services/task_resume_candidates.py
@@ -13,7 +13,7 @@ from loguru import logger
 from vibe3.models import IssueState
 
 if TYPE_CHECKING:
-    from vibe3.models.flow import FlowStatusResponse
+    from vibe3.models import FlowStatusResponse
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService
     from vibe3.services.label_service import LabelService

--- a/src/vibe3/services/task_resume_operations.py
+++ b/src/vibe3/services/task_resume_operations.py
@@ -13,9 +13,8 @@ from vibe3.exceptions import UserError
 from vibe3.models import IssueState
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.models.flow import FlowStatusResponse
+    from vibe3.clients import GitClient, GitHubClient
+    from vibe3.models import FlowStatusResponse
     from vibe3.services.flow_service import FlowService
     from vibe3.services.issue_flow_service import IssueFlowService
     from vibe3.services.label_service import LabelService
@@ -99,7 +98,7 @@ class TaskResumeOperations:
             # Skip session check if backend not provided (e.g., manual CLI use)
             return
 
-        from vibe3.environment.session_registry import SessionRegistryService
+        from vibe3.environment import SessionRegistryService
 
         registry = SessionRegistryService(
             store=self.flow_service.store,
@@ -118,7 +117,7 @@ class TaskResumeOperations:
         label_state: str,
     ) -> IssueState:
         if not label_state:
-            from vibe3.models.flow import FlowState
+            from vibe3.models import FlowState
             from vibe3.services.flow_resume_resolver import infer_resume_label
 
             fs_dict = (

--- a/src/vibe3/services/task_resume_usecase.py
+++ b/src/vibe3/services/task_resume_usecase.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
 
-from vibe3.clients.git_client import GitClient
-from vibe3.clients.github_client import GitHubClient
+from vibe3.clients import GitClient, GitHubClient
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue_flow_service import IssueFlowService
 from vibe3.services.label_service import LabelService
@@ -20,7 +19,7 @@ from vibe3.services.task_resume_candidates import TaskResumeCandidates
 from vibe3.services.task_resume_operations import TaskResumeOperations
 
 if TYPE_CHECKING:
-    from vibe3.models.flow import FlowStatusResponse
+    from vibe3.models import FlowStatusResponse
 
 
 # Type alias for progress callback: (issue_number, branch, step, status) -> None

--- a/src/vibe3/services/task_service.py
+++ b/src/vibe3/services/task_service.py
@@ -4,17 +4,22 @@ from typing import Any, Literal, cast
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.config.orchestra_settings import load_orchestra_config
-from vibe3.config.settings import VibeConfig
+from vibe3.clients import (
+    GhIssueLabelPort,
+    GitHubClient,
+    GitHubClientProtocol,
+    IssueLabelPort,
+    SQLiteClient,
+)
+from vibe3.config import VibeConfig, load_orchestra_config
 from vibe3.exceptions import InvalidBranchLinkError
-from vibe3.models import IssueState
-from vibe3.models.flow import FlowStatusResponse, IssueLink
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.models.pr import PRResponse
+from vibe3.models import (
+    FlowStatusResponse,
+    IssueLink,
+    IssueState,
+    OrchestraConfig,
+    PRResponse,
+)
 from vibe3.services.flow_service import FlowService
 from vibe3.services.label_service import LabelService
 from vibe3.services.pr_service import PRService
@@ -160,7 +165,7 @@ class TaskService:
         # Auto-mirror vibe-task label for task role
         # Only add label if the branch actually exists (true local flow)
         if role == "task":
-            from vibe3.clients.git_client import GitClient
+            from vibe3.clients import GitClient
 
             git = GitClient()
             if git.branch_exists(normalized_branch):

--- a/src/vibe3/services/task_show_service.py
+++ b/src/vibe3/services/task_show_service.py
@@ -8,16 +8,13 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.github_client import GitHubClient
-from vibe3.clients.protocols import GitHubClientProtocol
-from vibe3.models.flow import FlowStatusResponse
-from vibe3.models.pr import PRResponse
+from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
+from vibe3.models import FlowStatusResponse, PRResponse
 from vibe3.services.artifact_parser import ArtifactParser
 from vibe3.services.flow_service import FlowService
 from vibe3.services.path_helpers import resolve_ref_path
 from vibe3.services.pr_service import PRService
-from vibe3.utils.comment_utils import is_human_comment
+from vibe3.utils import is_human_comment
 
 
 @dataclass

--- a/src/vibe3/services/task_status_service.py
+++ b/src/vibe3/services/task_status_service.py
@@ -3,9 +3,7 @@
 from dataclasses import dataclass
 from typing import Any, cast
 
-from vibe3.models import IssueState
-from vibe3.models.flow import FlowStatusResponse
-from vibe3.models.orchestra_config import OrchestraConfig
+from vibe3.models import FlowStatusResponse, IssueState, OrchestraConfig
 from vibe3.services.flow_service import FlowService
 from vibe3.services.orchestra_status_service import OrchestraSnapshot
 from vibe3.services.status_query_service import StatusQueryService, is_auto_task_branch
@@ -52,7 +50,7 @@ def fetch_task_status_data(
     snapshot_found = orch_snapshot is not None
 
     if not orch_snapshot:
-        from vibe3.runtime.orchestra_instance import (
+        from vibe3.runtime import (
             read_instance_info,
             validate_instance,
         )

--- a/src/vibe3/services/timeline_parser.py
+++ b/src/vibe3/services/timeline_parser.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 from typing import Any
 
-from vibe3.models.flow import TimelineEvent
+from vibe3.models import TimelineEvent
 from vibe3.services.flow_timeline_service import TIMELINE_DISPLAY_MAP
 
 

--- a/src/vibe3/services/verdict_policy.py
+++ b/src/vibe3/services/verdict_policy.py
@@ -2,7 +2,7 @@
 
 from typing import Final
 
-from vibe3.models.verdict_types import VerdictValue
+from vibe3.models import VerdictValue
 
 ALL_VERDICTS: Final[tuple[VerdictValue, ...]] = (
     "PASS",

--- a/src/vibe3/services/verdict_service.py
+++ b/src/vibe3/services/verdict_service.py
@@ -11,10 +11,8 @@ from datetime import UTC, datetime
 
 from loguru import logger
 
-from vibe3.clients import SQLiteClient
-from vibe3.clients.git_client import GitClient
-from vibe3.models.verdict import VerdictRecord
-from vibe3.models.verdict_types import VerdictValue
+from vibe3.clients import GitClient, SQLiteClient
+from vibe3.models import VerdictRecord, VerdictValue
 from vibe3.services.actor_support import extract_role_from_actor
 from vibe3.services.flow_service import FlowService
 from vibe3.services.git_path_client import GitPathProtocol

--- a/src/vibe3/services/version_service.py
+++ b/src/vibe3/services/version_service.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from vibe3.models.pr import VersionBumpResponse, VersionBumpType
+from vibe3.models import VersionBumpResponse, VersionBumpType
 
 
 class VersionService:

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -12,6 +12,8 @@ from vibe3.clients.runtime_assets import (
 )
 
 if TYPE_CHECKING:
+    from vibe3.utils.actor_utils import normalize_actor
+    from vibe3.utils.branch_utils import find_parent_branch
     from vibe3.utils.codeagent_helpers import (
         build_prompt_file_content,
         diagnose_backend_error,
@@ -21,24 +23,41 @@ if TYPE_CHECKING:
         stream_reader,
         summarize_backend_output,
     )
+    from vibe3.utils.comment_utils import is_human_comment
     from vibe3.utils.constants import (
         AUTOMATED_MARKERS,
         GENERIC_AGENT_MARKER_PATTERN,
         STARTING_TIMEOUT_SECONDS,
     )
+    from vibe3.utils.error_message_cleaner import (
+        CODEAGENT_WRAPPER_RE,
+        clean_error_message,
+    )
+    from vibe3.utils.git_helpers import get_branch_handoff_dir, get_commit_message
+    from vibe3.utils.issue_ref import try_parse_issue_number
+    from vibe3.utils.time_format import format_age_aware_time
 
 # Lazy imports
 _LAZY_IMPORTS = {
+    "AUTOMATED_MARKERS": "vibe3.utils.constants",
+    "CODEAGENT_WRAPPER_RE": "vibe3.utils.error_message_cleaner",
+    "GENERIC_AGENT_MARKER_PATTERN": "vibe3.utils.constants",
+    "STARTING_TIMEOUT_SECONDS": "vibe3.utils.constants",
     "build_prompt_file_content": "vibe3.utils.codeagent_helpers",
+    "clean_error_message": "vibe3.utils.error_message_cleaner",
     "diagnose_backend_error": "vibe3.utils.codeagent_helpers",
+    "find_parent_branch": "vibe3.utils.branch_utils",
+    "format_age_aware_time": "vibe3.utils.time_format",
+    "get_branch_handoff_dir": "vibe3.utils.git_helpers",
+    "get_commit_message": "vibe3.utils.git_helpers",
+    "is_human_comment": "vibe3.utils.comment_utils",
+    "normalize_actor": "vibe3.utils.actor_utils",
     "prepare_prompt_file": "vibe3.utils.codeagent_helpers",
     "sanitize_prompt_for_display": "vibe3.utils.codeagent_helpers",
     "sanitize_task_shell_meta": "vibe3.utils.codeagent_helpers",
     "stream_reader": "vibe3.utils.codeagent_helpers",
     "summarize_backend_output": "vibe3.utils.codeagent_helpers",
-    "AUTOMATED_MARKERS": "vibe3.utils.constants",
-    "GENERIC_AGENT_MARKER_PATTERN": "vibe3.utils.constants",
-    "STARTING_TIMEOUT_SECONDS": "vibe3.utils.constants",
+    "try_parse_issue_number": "vibe3.utils.issue_ref",
 }
 
 
@@ -54,10 +73,18 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "AUTOMATED_MARKERS",
+    "CODEAGENT_WRAPPER_RE",
     "GENERIC_AGENT_MARKER_PATTERN",
     "STARTING_TIMEOUT_SECONDS",
     "build_prompt_file_content",
+    "clean_error_message",
     "diagnose_backend_error",
+    "find_parent_branch",
+    "format_age_aware_time",
+    "get_branch_handoff_dir",
+    "get_commit_message",
+    "is_human_comment",
+    "normalize_actor",
     "prepare_prompt_file",
     "resolve_prompt_config",
     "resolve_runtime_asset",
@@ -66,4 +93,5 @@ __all__ = [
     "sanitize_task_shell_meta",
     "stream_reader",
     "summarize_backend_output",
+    "try_parse_issue_number",
 ]


### PR DESCRIPTION
## Summary

Fixes #2133 - services 模块内部导入违规清零（228 → 2 刻意保留）。

### Changes

**预处理（11 个目标模块公共 API 扩展）**：
- `models/__init__.py`: 添加 FlowState/FlowStatusResponse/FlowEvent/IssueLink/PRState/PRResponse 等 20 个导出
- `clients/__init__.py`: 添加 GitClientProtocol/GitHubClientProtocol/GhIssueLabelPort/MergedPRCache/AIClient 等 16 个导出
- `exceptions/__init__.py`: 添加 ErrorSeverity/classify_error_hybrid/is_api_error 等 5 个
- `utils/__init__.py`: 添加 try_parse_issue_number/normalize_actor/get_commit_message 等 9 个
- domain/config/environment/execution/orchestra/prompts/analysis: 共添加 21 个导出

**services 违规修复（226 处）**：
- 将 226 处 `from vibe3.X.Y import Z` 改为 `from vibe3.X import Z`
- 保留 2 个函数级懒导入子模块路径（避免 `vibe3.config` `globals()` 缓存导致测试 mock 失效）
- 恢复 `convention_resolver.py` 直接子模块导入（避免 mypy Any 类型传播）

### Test Plan
- [x] ruff check: All checks passed
- [x] mypy: 0 errors
- [x] 385 tests passed
- [x] 修复 `vibe3.config.__getattr__` 缓存导致测试 mock 失效的潜在问题

## Contributors
- Executor: Claude Sonnet 4.6 (claude/hungry-goldberg-7c49e4)

---

## Contributors

AI Agent
