### PR TITLE
refactor(models): export PlanScope, PlanSpecInput, ReviewScope to public API

### DIFF
--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from vibe3.models.issue_body import FlowStateProjection
     from vibe3.models.orchestra_config import OrchestraConfig, SupervisorHandoffConfig
     from vibe3.models.orchestration import IssueInfo, IssueState, StateTransition
-    from vibe3.models.plan import PlanRequest
+    from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
     from vibe3.models.pr import (
         CreatePRRequest,
         PRMetadata,
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     )
     from vibe3.models.prompt_meta import PromptContextMode
     from vibe3.models.queue_entry import QueueEntry
-    from vibe3.models.review import ReviewRequest
+    from vibe3.models.review import ReviewRequest, ReviewScope
     from vibe3.models.review_runner import AgentOptions, AgentResult
     from vibe3.models.session_types import SessionRole
     from vibe3.models.snapshot import (
@@ -108,9 +108,12 @@ _LAZY_IMPORTS = {
     "PRResponse": "vibe3.models.pr",
     "PRState": "vibe3.models.pr",
     "PlanRequest": "vibe3.models.plan",
+    "PlanScope": "vibe3.models.plan",
+    "PlanSpecInput": "vibe3.models.plan",
     "PromptContextMode": "vibe3.models.prompt_meta",
     "QueueEntry": "vibe3.models.queue_entry",
     "ReviewRequest": "vibe3.models.review",
+    "ReviewScope": "vibe3.models.review",
     "AgentOptions": "vibe3.models.review_runner",
     "AgentResult": "vibe3.models.review_runner",
     "SessionRole": "vibe3.models.session_types",
@@ -192,12 +195,16 @@ __all__: list[str] = [
     "PRCriticalAnalysis",
     "PRMetadata",
     "PRResponse",
+    "PlanRequest",
+    "PlanScope",
+    "PlanSpecInput",
     "PRSource",
     "PRState",
     "PlanRequest",
     "PromptContextMode",
     "QueueEntry",
     "ReviewRequest",
+    "ReviewScope",
     "SessionRole",
     "StateTransition",
     "StructureDiff",

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -36,11 +36,11 @@ from vibe3.models import (
     IssueInfo,
     IssueState,
     OrchestraConfig,
+    PlanRequest,
+    PlanScope,
+    PlanSpecInput,
     WorktreeRequirement,
 )
-
-# public-api: pending upstream export
-from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
 from vibe3.roles.definitions import (
     IssueRoleSyncSpec,
     RoleOutputContract,

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -44,12 +44,11 @@ from vibe3.models import (
     IssueInfo,
     IssueState,
     OrchestraConfig,
+    ReviewRequest,
+    ReviewScope,
     StructureDiff,
     WorktreeRequirement,
 )
-
-# public-api: pending upstream export
-from vibe3.models.review import ReviewRequest, ReviewScope
 from vibe3.roles.definitions import (
     IssueRoleSyncSpec,
     RoleOutputContract,

--- a/tests/vibe3/agents/test_plan_prompt.py
+++ b/tests/vibe3/agents/test_plan_prompt.py
@@ -5,7 +5,7 @@ from vibe3.agents.plan_prompt import (
     build_plan_prompt_body,
     build_plan_task_section,
 )
-from vibe3.models.plan import PlanRequest, PlanScope
+from vibe3.models import PlanRequest, PlanScope
 
 
 def test_build_plan_prompt_body_includes_task_guidance() -> None:

--- a/tests/vibe3/agents/test_review_prompt.py
+++ b/tests/vibe3/agents/test_review_prompt.py
@@ -16,7 +16,7 @@ from vibe3.agents.review_prompt import (
     build_review_prompt_body,
     build_review_task_section,
 )
-from vibe3.models.review import ReviewRequest, ReviewScope
+from vibe3.models import ReviewRequest, ReviewScope
 
 
 class TestBuildPolicySection:

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -9,7 +9,7 @@ from vibe3.agents.run_prompt import (
     build_run_task_section,
 )
 from vibe3.config.settings import VibeConfig
-from vibe3.models.plan import PlanRequest, PlanScope
+from vibe3.models import PlanRequest, PlanScope
 
 FORBIDDEN_INTERNAL_TOKENS = (
     "common.md",

--- a/tests/vibe3/commands/test_review.py
+++ b/tests/vibe3/commands/test_review.py
@@ -34,7 +34,7 @@ class TestReviewContextBuilderUsesAssembler:
         """make_review_context_builder should invoke build_review_prompt_body."""
         from vibe3.agents.review_prompt import make_review_context_builder
         from vibe3.config.settings import VibeConfig
-        from vibe3.models.review import ReviewRequest, ReviewScope
+        from vibe3.models import ReviewRequest, ReviewScope
 
         config = VibeConfig.get_defaults()
         request = ReviewRequest(scope=ReviewScope.for_base("main"))

--- a/tests/vibe3/models/test_review.py
+++ b/tests/vibe3/models/test_review.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from vibe3.models.review import ReviewRequest, ReviewScope
+from vibe3.models import ReviewRequest, ReviewScope
 
 
 class TestReviewScope:

--- a/tests/vibe3/roles/test_review.py
+++ b/tests/vibe3/roles/test_review.py
@@ -214,7 +214,7 @@ class TestDispatchAsyncManualReviewWorktreeRequirement:
             mock_coord.dispatch_execution.return_value = MagicMock(launched=True)
             mock_coord_cls.return_value = mock_coord
 
-            from vibe3.models.review import ReviewRequest, ReviewScope
+            from vibe3.models import ReviewRequest, ReviewScope
             from vibe3.roles.review import _dispatch_async_manual_review
 
             request = ReviewRequest(

--- a/tests/vibe3/roles/test_review_manual_sync.py
+++ b/tests/vibe3/roles/test_review_manual_sync.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from vibe3.roles.review import ReviewRequest, ReviewRunResult, ReviewScope
+from vibe3.models import ReviewRequest, ReviewScope
+from vibe3.roles.review import ReviewRunResult
 
 
 def test_execute_manual_review_sync_imports_session_service_from_execution(


### PR DESCRIPTION
Closes #2190

## Summary

Add PlanScope, PlanSpecInput, ReviewScope to models/__init__.py lazy-export registry and replace all deep imports (from vibe3.models.plan/review import) across src and tests with public API imports (from vibe3.models import).

## Changes

- **models/__init__.py**: Add PlanScope, PlanSpecInput, ReviewScope to TYPE_CHECKING, _LAZY_IMPORTS, and __all__
- **roles/plan.py**: Use public API imports instead of deep imports
- **roles/review.py**: Use public API imports instead of deep imports
- **7 test files**: Update imports to use public API

## Test Plan

- ✅ All 981 pre-push tests pass
- ✅ Type check passes (mypy: no issues in 397 source files)
- ✅ Lint passes (ruff check)
- ✅ 64 targeted tests pass (models, agents, roles, commands)

## Context

This addresses the "blocked imports" identified in commit 096c2999 (refactor(roles): switch deep imports to public APIs). The three symbols (PlanScope, PlanSpecInput, ReviewScope) were listed as needing upstream public API exports.

Issue: #2190

---

## Contributors

claude/opus
