### PR TITLE
refactor(snapshot): remove unused literal values from DiffWarning.type

### DIFF
--- a/src/vibe3/models/snapshot.py
+++ b/src/vibe3/models/snapshot.py
@@ -157,13 +157,7 @@ class DiffSummary(BaseModel):
 class DiffWarning(BaseModel):
     """Warning in structure diff."""
 
-    type: Literal[
-        "file_too_large",
-        "module_growth",
-        "dependency_cycle",
-        "missing_imports",
-        "unusual_pattern",
-    ]
+    type: Literal["module_growth"]
     severity: Literal["info", "warning", "error"]
     message: str
     file: str | None = None


### PR DESCRIPTION
## Summary
- Narrow `DiffWarning.type` from 5 literal values to single used value `"module_growth"`
- Remove 4 unused dead-code entries: `"file_too_large"`, `"dependency_cycle"`, `"missing_imports"`, `"unusual_pattern"`
- Only `"module_growth"` is ever constructed in the codebase (verified in `snapshot_diff.py`)

## Changes
- `src/vibe3/models/snapshot.py`: Changed `DiffWarning.type` from `Literal["file_too_large", "module_growth", "dependency_cycle", "missing_imports", "unusual_pattern"]` to `Literal["module_growth"]`

## Verification
- ✅ `uv run mypy src/vibe3` - no type errors
- ✅ `uv run pytest tests/vibe3/analysis/` - 136 tests pass
- ✅ `uv run pytest tests/vibe3/models/` - 105 tests pass
- ✅ Pre-push checks: 1181 tests pass
- ✅ No consumers dispatch on `w.type` (verified by grep)
- ✅ UI layer only reads `w.severity` and `w.message`

## Test Plan
- [x] Run mypy type checking
- [x] Run analysis module tests
- [x] Run models module tests
- [x] Run full test suite (pre-push checks)
- [x] Verify no runtime behavior changes (Literal narrowing is type-only)

Closes #2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)