### PR TITLE
feat(api): export VERDICT_UNKNOWN and changed_symbols as public APIs

### DIFF
--- a/src/vibe3/analysis/__init__.py
+++ b/src/vibe3/analysis/__init__.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from vibe3.analysis.inspect_output_adapter import (
         as_list,
         as_mapping,
+        changed_symbols,
         dag,
         impact,
         pr_analysis_summary,
@@ -87,6 +88,7 @@ _LAZY_IMPORTS = {
     "generate_score_report": "vibe3.analysis.pr_scoring",
     "as_list": "vibe3.analysis.inspect_output_adapter",
     "as_mapping": "vibe3.analysis.inspect_output_adapter",
+    "changed_symbols": "vibe3.analysis.inspect_output_adapter",
     "score": "vibe3.analysis.inspect_output_adapter",
     "impact": "vibe3.analysis.inspect_output_adapter",
     "dag": "vibe3.analysis.inspect_output_adapter",
@@ -134,6 +136,7 @@ __all__ = [
     # Output adapters
     "as_list",
     "as_mapping",
+    "changed_symbols",
     "score",
     "impact",
     "dag",

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -16,9 +16,7 @@ from vibe3.agents import (
     make_review_context_builder,
     run_inspect_json,
 )
-
-# public-api: pending upstream export
-from vibe3.analysis.inspect_output_adapter import changed_symbols
+from vibe3.analysis import changed_symbols
 from vibe3.config import (
     REVIEWER_GATE_CONFIG,
     ConventionResolver,

--- a/src/vibe3/roles/review_helpers.py
+++ b/src/vibe3/roles/review_helpers.py
@@ -7,9 +7,7 @@ from dataclasses import dataclass
 from loguru import logger
 
 from vibe3.services import FlowService
-
-# public-api: pending upstream export
-from vibe3.utils.constants import VERDICT_UNKNOWN
+from vibe3.utils import VERDICT_UNKNOWN
 
 
 @dataclass

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         AUTOMATED_MARKERS,
         GENERIC_AGENT_MARKER_PATTERN,
         STARTING_TIMEOUT_SECONDS,
+        VERDICT_UNKNOWN,
     )
     from vibe3.utils.error_message_cleaner import (
         CODEAGENT_WRAPPER_RE,
@@ -58,6 +59,7 @@ _LAZY_IMPORTS = {
     "stream_reader": "vibe3.utils.codeagent_helpers",
     "summarize_backend_output": "vibe3.utils.codeagent_helpers",
     "try_parse_issue_number": "vibe3.utils.issue_ref",
+    "VERDICT_UNKNOWN": "vibe3.utils.constants",
 }
 
 
@@ -76,6 +78,7 @@ __all__ = [
     "CODEAGENT_WRAPPER_RE",
     "GENERIC_AGENT_MARKER_PATTERN",
     "STARTING_TIMEOUT_SECONDS",
+    "VERDICT_UNKNOWN",
     "build_prompt_file_content",
     "clean_error_message",
     "diagnose_backend_error",


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2191` is behind `main` by **9 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2191
```


---

## Summary

Add `VERDICT_UNKNOWN` and `changed_symbols` to the lazy-import public API in their respective package `__init__.py` files, then update the two deep imports in roles to use the public paths.

## Changes

- **src/vibe3/utils/__init__.py**: Add `VERDICT_UNKNOWN` to `TYPE_CHECKING` imports, `_LAZY_IMPORTS` dict, and `__all__`
- **src/vibe3/analysis/__init__.py**: Add `changed_symbols` to `TYPE_CHECKING` imports, `_LAZY_IMPORTS` dict, and `__all__`
- **src/vibe3/roles/review_helpers.py**: Change `from vibe3.utils.constants import VERDICT_UNKNOWN` → `from vibe3.utils import VERDICT_UNKNOWN`; remove `# public-api: pending upstream export` comment
- **src/vibe3/roles/review.py**: Change `from vibe3.analysis.inspect_output_adapter import changed_symbols` → `from vibe3.analysis import changed_symbols`; remove `# public-api: pending upstream export` comment

## Verification

- ✅ **mypy**: Success: no issues found in 397 source files
- ✅ **ruff**: All checks passed
- ✅ **pytest**: 383 passed, 1 skipped in 13.61s
- ✅ **LOC check**: No files exceed CI block threshold
- ✅ **Rebased onto latest main**: Successfully rebased and resolved conflicts

## Test Scope

Strategy B (targeted) — this is a pure re-export change with no logic modification.

- Direct: `tests/vibe3/analysis/test_inspect_output_adapter.py` (changed_symbols)
- Affected: `tests/vibe3/roles/` (review_helpers, review imports)
- Affected: `tests/vibe3/utils/` (constants re-export)

## Risks & Considerations

- **Low risk**: This is a pure re-export with no logic changes
- **No circular dependency risk**: `VERDICT_UNKNOWN` is a simple string constant with no transitive imports. `changed_symbols` is a pure function with no module-level side effects
- **No breaking changes**: All existing import paths continue to work; only new public paths are added

Closes #2191

---

## Contributors

claude/opus
