### PR TITLE
refactor(runtime): switch to public API imports (14 violations fixed)

### DIFF
--- a/src/vibe3/runtime/__init__.py
+++ b/src/vibe3/runtime/__init__.py
@@ -2,25 +2,11 @@
 
 Public interface for runtime components including circuit breaker,
 heartbeat server, periodic check executors, and orchestra instance management.
-
-This module serves as the unified public interface for runtime components.
-Import from vibe3.runtime instead of external modules to ensure clean dependencies.
 """
 
 from typing import TYPE_CHECKING
 
-from vibe3.config.orchestra_config import PeriodicCheckConfig
-
-# Module-level re-exports from models/ and config/ (safe, no cycle risk)
-from vibe3.models.orchestra_config import OrchestraConfig
-
-# Module-level re-exports from orchestra.logging (safe, no cycle risk)
-from vibe3.orchestra.logging import (
-    append_orchestra_event,
-    append_orchestra_run_separator,
-)
-
-# Lazy imports via __getattr__ for everything else to avoid circular dependencies
+# Lazy imports via __getattr__ for everything to avoid circular dependencies
 if TYPE_CHECKING:
     from vibe3.runtime.circuit_breaker import (
         CircuitBreaker,
@@ -38,14 +24,12 @@ if TYPE_CHECKING:
     )
     from vibe3.runtime.periodic_check_executor import execute_periodic_check
     from vibe3.runtime.service_protocol import ServiceBase
-    from vibe3.services.error_tracking_service import ErrorTrackingService
 
 
 def __getattr__(name: str) -> object:
     """Lazy import for all symbols to avoid circular dependencies.
 
-    All symbols (runtime submodules, services) are imported lazily
-    to prevent circular import issues.
+    All symbols are imported lazily to prevent circular import issues.
     """
     # Orchestra instance management
     if name == "OrchestraInstanceInfo":
@@ -99,39 +83,20 @@ def __getattr__(name: str) -> object:
 
         return ServiceBase
 
-    # Services symbols (services/ may import from runtime)
-    if name == "ErrorTrackingService":
-        from vibe3.services.error_tracking_service import ErrorTrackingService
-
-        return ErrorTrackingService
-
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
-    # Circuit breaker
     "CircuitBreaker",
     "CircuitState",
     "ErrorCategory",
     "classify_failure",
-    # Cleanup executor
     "execute_expired_resource_cleanup",
-    # Heartbeat server
     "HeartbeatServer",
-    # Periodic check executor
     "execute_periodic_check",
-    # Service protocol
     "ServiceBase",
-    # Orchestra instance management
     "OrchestraInstanceInfo",
     "read_instance_info",
     "validate_instance",
     "write_instance_info",
-    # External dependencies
-    "OrchestraConfig",
-    "PeriodicCheckConfig",
-    "append_orchestra_event",
-    "append_orchestra_run_separator",
-    # Services (via __getattr__)
-    "ErrorTrackingService",
 ]

--- a/src/vibe3/runtime/cleanup_executor.py
+++ b/src/vibe3/runtime/cleanup_executor.py
@@ -2,8 +2,8 @@
 
 from loguru import logger
 
-from vibe3.config.orchestra_config import PeriodicCheckConfig
-from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.config import PeriodicCheckConfig
+from vibe3.orchestra import append_orchestra_event
 
 
 async def execute_expired_resource_cleanup(
@@ -20,9 +20,7 @@ async def execute_expired_resource_cleanup(
         tick_number: Current tick number (for logging)
     """
     # Delay imports to avoid circular dependencies
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
     from vibe3.services.expired_resource_cleanup_service import (
         ExpiredResourceCleanupService,
     )

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Protocol
 
 from loguru import logger
 
-from vibe3.models.orchestra_config import OrchestraConfig
-from vibe3.orchestra.logging import (
+from vibe3.models import OrchestraConfig
+from vibe3.orchestra import (
     append_orchestra_event,
     append_orchestra_run_separator,
 )
@@ -197,7 +197,7 @@ class HeartbeatServer:
 
             # Cleanup old error records (maintenance)
             # Delay import to avoid circular dependency
-            from vibe3.services.error_tracking_service import ErrorTrackingService
+            from vibe3.services import ErrorTrackingService
 
             error_tracking = ErrorTrackingService.get_instance()
 

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -9,8 +9,8 @@ Runs two phases on each interval tick:
 
 from loguru import logger
 
-from vibe3.config.orchestra_config import PeriodicCheckConfig
-from vibe3.orchestra.logging import append_orchestra_event
+from vibe3.config import PeriodicCheckConfig
+from vibe3.orchestra import append_orchestra_event
 
 
 async def execute_periodic_check(
@@ -30,7 +30,7 @@ async def execute_periodic_check(
     """
     # Delay imports to avoid circular dependencies
     from vibe3.clients import SQLiteClient
-    from vibe3.services.check_service import CheckService
+    from vibe3.services import CheckService
 
     # Initialize services
     store = SQLiteClient()


### PR DESCRIPTION
## Summary

Replace 14 internal module imports with public API imports:
- `config.orchestra_config.PeriodicCheckConfig` → `config.PeriodicCheckConfig`
- `models.orchestra_config.OrchestraConfig` → `models.OrchestraConfig`
- `orchestra.logging.append_orchestra_event` → `orchestra.append_orchestra_event`
- `orchestra.logging.append_orchestra_run_separator` → `orchestra.append_orchestra_run_separator`
- `services.error_tracking_service.ErrorTrackingService` → `services.ErrorTrackingService`
- `services.check_service.CheckService` → `services.CheckService`
- `clients.git_client.GitClient` → `clients.GitClient`
- `clients.github_client.GitHubClient` → `clients.GitHubClient`
- `clients.sqlite_client.SQLiteClient` → `clients.SQLiteClient`

Remove 5 external re-exports from `runtime/__init__.py`:
- PeriodicCheckConfig, OrchestraConfig
- append_orchestra_event, append_orchestra_run_separator
- ErrorTrackingService

## Scope

- ✅ Only modified `src/vibe3/runtime/` (4 files)
- ✅ No behavioral changes, only import path refactoring
- ✅ Zero external consumers of removed re-exports

## Test Results

- ✅ 51 tests passed (runtime + failed_gate integration)
- ✅ mypy: no errors
- ✅ ruff: all checks passed
- ✅ All pre-push checks passed (35 tests in 0.15s)

## Remaining Items

- ℹ️ 1 documented exception: `ExpiredResourceCleanupService` (not in services public API)

## Verification

All import switches verified correct:
- 14 violations fixed
- Public API resolution confirmed
- Type check passes
- Lint passes

Follows pattern from #1936 (clients module public interface unification).

Closes #2138

---

## Contributors

claude/opus
