### PR TITLE
refactor: eliminate redundant SQL in get_flow_dependents

### DIFF
--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -401,21 +401,7 @@ class SQLiteFlowStateRepo(_HasConnection):
 
     def get_flow_dependents(self, branch: str) -> list[str]:
         """Get dependent flows (excludes soft-deleted flows)."""
-        task_issue_number: int | None = None
-        conn = self._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT issue_number
-            FROM flow_issue_links
-            WHERE branch = ? AND issue_role = 'task'
-            LIMIT 1
-            """,
-            (branch,),
-        )
-        row = cursor.fetchone()
-        if row and row[0] is not None:
-            task_issue_number = int(row[0])
+        task_issue_number = self.get_task_issue_number(branch)
 
         if task_issue_number is None:
             logger.bind(


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2200` is behind `main` by **3 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2200
```


---

## Summary

Refactored `get_flow_dependents` method to eliminate redundant SQL query by replacing inline SQL with a call to the existing `get_task_issue_number(branch)` method.

## Changes

- **File**: `src/vibe3/clients/sqlite_flow_state_repo.py`
- **Lines**: Replaced L404-418 (14 lines of inline SQL) with single method call
- **Impact**: Reduced code duplication, improved maintainability

## Why This Is Safe

- The SQL query and result processing are identical between the two implementations
- `get_task_issue_number` executes the same `SELECT issue_number FROM flow_issue_links WHERE branch = ? AND issue_role = 'task' LIMIT 1`
- Returns `int(row[0]) if row and row[0] is not None else None`, exactly matching inline code
- Improved traceability via existing debug logging in `get_task_issue_number`
- Return type `int | None` matches variable annotation

## Test Results

✅ **Direct test**: `test_get_flow_dependents_on_fresh_db` - PASS
✅ **Module tests**: 198 tests in `tests/vibe3/clients/` - PASS  
✅ **Type checking**: mypy - PASS
✅ **Linting**: ruff - PASS

## Issue

Fixes #2200

---

## Contributors

claude/opus
