### PR TITLE
fix(schema): remove dead column latest_indicate_action from new DB init

### DIFF
--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -303,14 +303,6 @@ def init_schema(conn: sqlite3.Connection) -> None:
                 f"Added {col} column to flow_state"
             )
 
-    # Legacy compatibility: keep old column for existing databases.
-    # New code no longer reads or writes this field.
-    if "latest_indicate_action" not in existing:
-        cursor.execute("ALTER TABLE flow_state ADD COLUMN latest_indicate_action TEXT")
-        logger.bind(external="sqlite", operation="migration").info(
-            "Added latest_indicate_action column to flow_state"
-        )
-
     # Migration: add indicate_ref column for indicate handoff tracking
     if "indicate_ref" not in existing:
         cursor.execute("ALTER TABLE flow_state ADD COLUMN indicate_ref TEXT")

--- a/tests/vibe3/clients/test_sqlite_client_fresh_db.py
+++ b/tests/vibe3/clients/test_sqlite_client_fresh_db.py
@@ -20,7 +20,12 @@ def test_fresh_db_schema_no_deprecated_columns(tmp_path):
             row[1] for row in cursor.execute("PRAGMA table_info(flow_state)").fetchall()
         }
 
-    deprecated = {"task_issue_number", "pr_number", "pr_ready_for_review"}
+    deprecated = {
+        "task_issue_number",
+        "pr_number",
+        "pr_ready_for_review",
+        "latest_indicate_action",
+    }
     assert not (
         deprecated & columns
     ), f"Deprecated columns found: {deprecated & columns}"


### PR DESCRIPTION
## Summary

Remove dead code by deleting the migration block that adds `latest_indicate_action` column to new databases. The column is no longer referenced anywhere in the codebase.

## Changes

- `src/vibe3/clients/sqlite_schema.py`: Deleted migration block (L306-L312)
- `tests/vibe3/clients/test_sqlite_client_fresh_db.py`: Added `latest_indicate_action` to deprecated columns set

## Impact

- **New databases**: Clean schema without deprecated column
- **Existing databases**: Unaffected (column stays but no code references it)
- **No migration needed**: Simply prevents adding column to new DBs

## Verification

✅ All tests pass (6/6 tests in fresh DB suite)
✅ No lint errors (ruff)
✅ No type errors (mypy)
✅ `rg 'latest_indicate_action' src/` returns no results
✅ Full test suite passes (198/198)

Closes #2201

---

## Contributors

claude/opus
