### PR TITLE
feat(models): add CICheck and UpdatePRRequest to public API

### DIFF
--- a/docs/publish/issue-2202.md
+++ b/docs/publish/issue-2202.md
@@ -1,0 +1,69 @@
+# Publish Directive: Issue #2202
+
+## Context
+- Issue: #2202 - 系统改进：将 PR symbols 添加到 models 公共 API
+- Branch: task/issue-2202
+- Commit: 69087369 (already committed)
+- Verdict: PASS
+- State: merge-ready
+
+## Task
+Execute commit + PR creation for issue #2202.
+
+## Commit Instructions
+✅ **Commit already exists** (1cdb81c3):
+- Commit message follows standards
+- Changes already committed
+- No additional commit needed
+
+## PR Creation Instructions
+Create a PR with the following specifications:
+
+### PR Title
+```
+feat(models): add CICheck and UpdatePRRequest to public API
+```
+
+### PR Body
+```markdown
+## Summary
+- Added `CICheck` and `UpdatePRRequest` to models public API
+- Symbols can now be imported via `from vibe3.models import CICheck, UpdatePRRequest`
+- Added verification tests for importability and `__all__` membership
+
+## Changes
+- `src/vibe3/models/__init__.py`:
+  - Added CICheck and UpdatePRRequest to TYPE_CHECKING import block
+  - Added both symbols to _LAZY_IMPORTS for lazy loading
+  - Added both symbols to __all__ for public API exposure
+- `tests/vibe3/test_public_api_exports.py`:
+  - Added test_models_pr_symbols_importable to verify imports work
+  - Added test_models_all_contains_pr_symbols to verify __all__ membership
+
+## Test Results
+- ✅ 19 tests passed in test_public_api_exports.py
+- ✅ 133 tests passed in tests/vibe3/models/ (no regressions)
+- ✅ mypy: Success (no type errors)
+- ✅ ruff: All checks passed (no lint errors)
+
+## Related Issues
+- Closes #2202
+- See also #2232 (follow-up: remove duplicate PlanRequest from __all__)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### PR Options
+- Base branch: main
+- Draft: false (ready for review)
+- Labels: (will be inherited from issue)
+
+## Post-PR Creation
+1. Record PR reference to `pr_ref` in flow state
+2. Transition issue to `state/done` after PR is created
+3. Write issue comment confirming PR creation
+
+## Notes
+- Both symbols were already defined in `vibe3.models.pr` and used extensively
+- This change only exposes them through public API path
+- No breaking changes or behavior modifications

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -40,10 +40,12 @@ if TYPE_CHECKING:
     )
     from vibe3.models.plan import PlanRequest, PlanScope, PlanSpecInput
     from vibe3.models.pr import (
+        CICheck,
         CreatePRRequest,
         PRMetadata,
         PRResponse,
         PRState,
+        UpdatePRRequest,
         VersionBumpResponse,
         VersionBumpType,
     )
@@ -88,6 +90,7 @@ _LAZY_IMPORTS = {
     "DataSource": "vibe3.models.data_source",
     "ChangeSource": "vibe3.models.change_source",
     "ChangeSourceType": "vibe3.models.change_source",
+    "CICheck": "vibe3.models.pr",
     "CommitSource": "vibe3.models.change_source",
     "FORBIDDEN_TRANSITIONS": "vibe3.models.orchestration",
     "PRSource": "vibe3.models.change_source",
@@ -139,6 +142,7 @@ _LAZY_IMPORTS = {
     "StructureSnapshot": "vibe3.models.snapshot",
     "ExecutionStep": "vibe3.models.trace",
     "TraceOutput": "vibe3.models.trace",
+    "UpdatePRRequest": "vibe3.models.pr",
     "StateTransition": "vibe3.models.orchestration",
     "TimelineEvent": "vibe3.models.flow",
     "VerdictRecord": "vibe3.models.verdict",
@@ -169,6 +173,7 @@ __all__: list[str] = [
     "CallNode",
     "ChangeSource",
     "ChangeSourceType",
+    "CICheck",
     "CommandInspection",
     "CommitInfo",
     "CommitSource",
@@ -224,6 +229,7 @@ __all__: list[str] = [
     "TimelineEvent",
     "TraceOutput",
     "UncommittedSource",
+    "UpdatePRRequest",
     "VerdictRecord",
     "VerdictValue",
     "VersionBumpResponse",

--- a/tests/vibe3/test_public_api_exports.py
+++ b/tests/vibe3/test_public_api_exports.py
@@ -106,3 +106,17 @@ def test_exceptions_all_contains_github_api_error():
     from vibe3.exceptions import __all__
 
     assert "GitHubAPIError" in __all__
+
+
+def test_models_pr_symbols_importable():
+    from vibe3.models import CICheck, UpdatePRRequest
+
+    assert CICheck is not None
+    assert UpdatePRRequest is not None
+
+
+def test_models_all_contains_pr_symbols():
+    from vibe3.models import __all__
+
+    assert "CICheck" in __all__
+    assert "UpdatePRRequest" in __all__


### PR DESCRIPTION
## Summary
- Added CICheck and UpdatePRRequest to models public API
- Symbols can now be imported via from vibe3.models import CICheck, UpdatePRRequest
- Added verification tests for importability and __all__ membership

## Changes
- src/vibe3/models/__init__.py:
  - Added CICheck and UpdatePRRequest to TYPE_CHECKING import block
  - Added both symbols to _LAZY_IMPORTS for lazy loading
  - Added both symbols to __all__ for public API exposure
- tests/vibe3/test_public_api_exports.py:
  - Added test_models_pr_symbols_importable to verify imports work
  - Added test_models_all_contains_pr_symbols to verify __all__ membership

## Test Results
- ✅ 19 tests passed in test_public_api_exports.py
- ✅ 133 tests passed in tests/vibe3/models/ (no regressions)
- ✅ mypy: Success (no type errors)
- ✅ ruff: All checks passed (no lint errors)

## Related Issues
- Closes #2202
- See also #2232 (follow-up: remove duplicate PlanRequest from __all__)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
