### PR TITLE
fix(resume): change infer_resume_label default to READY

### DIFF
--- a/src/vibe3/services/flow_resume_resolver.py
+++ b/src/vibe3/services/flow_resume_resolver.py
@@ -20,7 +20,7 @@ def infer_resume_label(flow_state: FlowState) -> IssueState:
     2. latest_verdict exists -> MERGE_READY / IN_PROGRESS / HANDOFF (Based on verdict)
     3. report_ref exists -> REVIEW (Code is written, needs review)
     4. plan_ref exists -> IN_PROGRESS (Plan exists, needs execution)
-    5. default -> CLAIMED (Start fresh)
+    5. default -> READY (Ready to be picked up)
 
     Args:
         flow_state: The current local state of the flow
@@ -63,5 +63,5 @@ def infer_resume_label(flow_state: FlowState) -> IssueState:
         # Plan exists but no code (report) yet
         return IssueState.IN_PROGRESS
 
-    # Everything is missing -> Need to start from the beginning
-    return IssueState.CLAIMED
+    # No plan_ref -> ready to be picked up by executor
+    return IssueState.READY

--- a/tests/vibe3/services/test_flow_resume_resolver.py
+++ b/tests/vibe3/services/test_flow_resume_resolver.py
@@ -119,9 +119,9 @@ def test_infer_resume_label_plan_only() -> None:
 
 
 def test_infer_resume_label_empty() -> None:
-    """Nothing exists -> CLAIMED."""
+    """Nothing exists -> READY."""
     state = FlowState(
         branch="task/issue-1",
         flow_slug="test",
     )
-    assert infer_resume_label(state) == IssueState.CLAIMED
+    assert infer_resume_label(state) == IssueState.READY

--- a/tests/vibe3/services/test_task_resume_usecase_blocked_sync.py
+++ b/tests/vibe3/services/test_task_resume_usecase_blocked_sync.py
@@ -97,10 +97,7 @@ class TestAutoResumeRestoresInferredState:
             latest_actor=None,
         )
         label = infer_resume_label(fs)
-        assert label in {
-            IssueState.READY,
-            IssueState.CLAIMED,
-        }
+        assert label == IssueState.READY
 
     def test_infer_resume_label_with_actor_restores_in_progress(self, usecase):
         """Active flow with actor should restore to IN_PROGRESS or CLAIMED."""


### PR DESCRIPTION
## Summary

Changed default return value of `infer_resume_label()` from `IssueState.CLAIMED` to `IssueState.READY` to prevent resumed issues without plan_ref from being misclassified as Remote Tasks.

## Changes

- `src/vibe3/services/flow_resume_resolver.py:67`: Return READY instead of CLAIMED
- Updated docstring to reflect new default behavior (line 23)
- `test_flow_resume_resolver.py:127`: Updated test assertion to expect READY
- `test_task_resume_usecase_blocked_sync.py:100`: Tightened assertion to only accept READY

## Verification

- ✅ All 14 tests pass in affected test files
- ✅ mypy type check passes
- ✅ ruff lint check passes
- ✅ pre-commit hooks pass
- ✅ pre-push checks pass

## Test Results

```
tests/vibe3/services/test_flow_resume_resolver.py: 11/11 passed
tests/vibe3/services/test_task_resume_usecase_blocked_sync.py: 3/3 passed
```

## Rationale

This change makes `infer_resume_label()` consistent with its callers:
- `task_resume_operations.py:131` already uses `IssueState.READY` as fallback
- `flow_rebuild_usecase.py:155` already uses `IssueState.READY` as fallback
- `flow_recovery_service.py:226` already uses `IssueState.READY` as fallback

State machine validation: `READY → CLAIMED` is a valid transition, ensuring the Ready Queue dispatcher can still claim these issues normally.

Fixes #2231

---

## Contributors

claude/opus
