### PR TITLE
fix(models): remove duplicate PlanRequest from __all__

### DIFF
--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -215,7 +215,6 @@ __all__: list[str] = [
     "PlanSpecInput",
     "PRSource",
     "PRState",
-    "PlanRequest",
     "PromptContextMode",
     "QueueEntry",
     "ReviewRequest",


### PR DESCRIPTION
## Summary

Remove duplicate `"PlanRequest"` entry from `__all__` in `src/vibe3/models/__init__.py`.

## Changes

- Removed duplicate entry at line 213
- Kept correct alphabetical entry at line 208 (between `PRResponse` and `PlanScope`)
- `__all__` now has 68 entries (was 69 with duplicate)

## Verification

✅ **All tests pass**: 105 tests in tests/vibe3/models/
✅ **No lint errors**: ruff check passes
✅ **No type errors**: mypy check passes
✅ **No duplicates verified**: Only one `PlanRequest` entry remains

## Impact

- **Risk**: None - pure deduplication of a string in `__all__`
- **Functional**: No behavior change - Python silently ignores duplicates in `__all__`
- **Scope**: Single file, single line deletion

Closes #2232

---

## Contributors

claude/opus
