### PR TITLE
refactor: 消除 orchestra/services/roles/runtime 扩展循环依赖 (issue #2125)

### DIFF
--- a/src/vibe3/analysis/dag_service.py
+++ b/src/vibe3/analysis/dag_service.py
@@ -53,6 +53,21 @@ def _file_to_module(file_path: str, root: str = "src") -> str:
         return str(p.with_suffix("")).replace("/", ".")
 
 
+def _collect_type_checking_node_ids(tree: ast.AST) -> set[int]:
+    """收集 `if TYPE_CHECKING:` 块内所有 AST 节点的 id.
+
+    TYPE_CHECKING 导入仅用于类型注解，不是运行时依赖，应排除在依赖图外。
+    """
+    excluded: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+                for child in ast.walk(node):
+                    excluded.add(id(child))
+    return excluded
+
+
 def _extract_imports(file_path: str) -> list[str]:
     """从 Python 文件提取 import 的模块名.
 
@@ -60,7 +75,7 @@ def _extract_imports(file_path: str) -> list[str]:
         file_path: Python 文件路径
 
     Returns:
-        导入的模块名列表（仅 vibe3 内部模块）
+        导入的模块名列表（仅 vibe3 内部模块，排除 TYPE_CHECKING 块）
     """
     try:
         source = Path(file_path).read_text(encoding="utf-8")
@@ -68,8 +83,12 @@ def _extract_imports(file_path: str) -> list[str]:
     except (SyntaxError, OSError):
         return []
 
+    type_checking_ids = _collect_type_checking_node_ids(tree)
+
     imports: list[str] = []
     for node in ast.walk(tree):
+        if id(node) in type_checking_ids:
+            continue
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name.startswith("vibe3"):

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -73,7 +73,7 @@ def internal_apply_dispatch(
     ] = False,
 ) -> None:
     """L2: Dispatch the Supervisor/Apply agent for a governance issue."""
-    from vibe3.services.scan_service import dispatch_supervisor_execution
+    from vibe3.roles.scan_service import dispatch_supervisor_execution
 
     dispatch_supervisor_execution(issue_number=issue, no_async=no_async)
 
@@ -104,7 +104,7 @@ def internal_governance_dispatch(
     Note: This command is only called via CLI self-invocation (internal governance)
     from the tmux wrapper launched by governance_scan handler. It always runs sync.
     """
-    from vibe3.services.scan_service import dispatch_governance_execution
+    from vibe3.roles.scan_service import dispatch_governance_execution
 
     dispatch_governance_execution(
         tick_count=tick, execution_count=execution_count, material_override=material

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -27,7 +27,7 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.services.scan_service import dispatch_governance_execution
+    from vibe3.roles.scan_service import dispatch_governance_execution
 
     dispatch_governance_execution(material_override=material_override)
 
@@ -93,7 +93,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
-    from vibe3.services.scan_service import (
+    from vibe3.roles.scan_service import (
         dispatch_supervisor_execution,
         fetch_supervisor_candidates,
     )
@@ -122,7 +122,7 @@ def _run_supervisor_scan_dry_run() -> None:
 
     from vibe3.clients.github_client import GitHubClient
     from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.services.scan_service import fetch_supervisor_candidates
+    from vibe3.roles.scan_service import fetch_supervisor_candidates
     from vibe3.ui.scan_display import display_supervisor_dry_run
 
     console = Console()
@@ -175,7 +175,7 @@ def governance(
     """
     from rich.console import Console
 
-    from vibe3.services.scan_service import (
+    from vibe3.roles.scan_service import (
         get_available_governance_materials,
         governance_material_exists,
         list_governance_materials,

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -17,8 +17,8 @@ from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.config import load_orchestra_config
 from vibe3.domain import publish
 from vibe3.domain.events.governance import GovernanceScanStarted
+from vibe3.domain.protocols import ServiceBase
 from vibe3.models import IssueInfo, OrchestraConfig
-from vibe3.runtime import ServiceBase
 
 if TYPE_CHECKING:
     from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator

--- a/src/vibe3/domain/protocols/__init__.py
+++ b/src/vibe3/domain/protocols/__init__.py
@@ -37,6 +37,7 @@ from vibe3.domain.protocols.orchestra_protocols import (
     FailedGateProtocol,
     OrchestraEventLogProtocol,
 )
+from vibe3.domain.protocols.runtime_protocols import ServiceBase
 
 __all__ = [
     "AppendGovernanceEventProtocol",
@@ -58,5 +59,6 @@ __all__ = [
     "QueuePersistenceServiceProtocol",
     "QueueSelectorProtocol",
     "RoleFactoryProtocol",
+    "ServiceBase",
     "TriggerableRoleDefinitionProtocol",
 ]

--- a/src/vibe3/domain/protocols/runtime_protocols.py
+++ b/src/vibe3/domain/protocols/runtime_protocols.py
@@ -1,0 +1,29 @@
+"""Runtime layer protocol interfaces.
+
+Moved from runtime/service_protocol.py to domain/protocols/ to break
+domain→runtime circular dependency. Domain can now import ServiceBase
+without depending on the runtime layer.
+"""
+
+from abc import ABC
+
+
+class ServiceBase(ABC):
+    """Abstract protocol for runtime services observed by HeartbeatServer."""
+
+    @property
+    def service_name(self) -> str:
+        """Human-readable service name for orchestration logs."""
+        return type(self).__name__
+
+    @property
+    def is_dispatch_service(self) -> bool:
+        """Whether this service initiates automated flow/task actions."""
+        return True
+
+    async def on_tick(self, tick_id: int = 0) -> None:
+        """Called on each heartbeat tick.
+
+        Args:
+            tick_id: Current tick number (0 if not available)
+        """

--- a/src/vibe3/roles/scan_service.py
+++ b/src/vibe3/roles/scan_service.py
@@ -1,4 +1,8 @@
-"""Scan service functions - business logic for scan commands."""
+"""Scan service functions - governance material scanning and dispatch.
+
+Moved from services/ to roles/ to break services→roles circular dependency.
+This module orchestrates governance execution using both roles and execution layers.
+"""
 
 from pathlib import Path
 from typing import Any

--- a/src/vibe3/runtime/orchestra_instance.py
+++ b/src/vibe3/runtime/orchestra_instance.py
@@ -1,97 +1,19 @@
-"""Orchestra instance information management."""
+"""Orchestra instance information management.
 
-from __future__ import annotations
+Re-exports from vibe3.utils.orchestra_instance.
+Actual implementation moved to utils/ to break services→runtime circular dependency.
+"""
 
-import json
-import os
-from dataclasses import dataclass
-from datetime import datetime
-from pathlib import Path
+from vibe3.utils.orchestra_instance import (
+    OrchestraInstanceInfo,
+    read_instance_info,
+    validate_instance,
+    write_instance_info,
+)
 
-
-@dataclass
-class OrchestraInstanceInfo:
-    """Serve instance information stored in global PID file."""
-
-    pid: int
-    cwd: Path
-    port: int
-    started_at: datetime
-
-    def to_dict(self) -> dict:
-        """Serialize instance info to JSON-compatible dict."""
-        return {
-            "pid": self.pid,
-            "cwd": str(self.cwd),
-            "port": self.port,
-            "started_at": self.started_at.isoformat(),
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> OrchestraInstanceInfo:
-        """Deserialize instance info from JSON dict."""
-        return cls(
-            pid=data["pid"],
-            cwd=Path(data["cwd"]),
-            port=data["port"],
-            started_at=datetime.fromisoformat(data["started_at"]),
-        )
-
-
-def read_instance_info(pid_file: Path) -> OrchestraInstanceInfo | None:
-    """Read instance info from PID file.
-
-    Returns None if:
-    - File doesn't exist
-    - File has invalid JSON
-    - File has invalid format
-    - File has non-object JSON (TypeError)
-    """
-    if not pid_file.exists():
-        return None
-
-    try:
-        data = json.loads(pid_file.read_text())
-        return OrchestraInstanceInfo.from_dict(data)
-    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
-        return None
-
-
-def write_instance_info(pid_file: Path, info: OrchestraInstanceInfo) -> None:
-    """Write instance info to PID file.
-
-    Creates parent directories if needed.
-    """
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
-    pid_file.write_text(json.dumps(info.to_dict(), indent=2))
-
-
-def validate_instance(info: OrchestraInstanceInfo) -> bool:
-    """Validate that instance is still running and is an orchestra process.
-
-    Returns False if:
-    - Process is dead (os.kill raises ProcessLookupError)
-    - Process is not orchestra (wrong command line)
-    """
-    try:
-        os.kill(info.pid, 0)
-    except (ProcessLookupError, PermissionError):
-        return False
-
-    # Check command line matches orchestra process
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["ps", "-p", str(info.pid), "-o", "command="],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return False
-
-        cmdline = result.stdout.strip().lower()
-        return "vibe3" in cmdline and "serve" in cmdline
-    except Exception:
-        return False
+__all__ = [
+    "OrchestraInstanceInfo",
+    "read_instance_info",
+    "validate_instance",
+    "write_instance_info",
+]

--- a/src/vibe3/runtime/service_protocol.py
+++ b/src/vibe3/runtime/service_protocol.py
@@ -1,27 +1,10 @@
 """Service protocol for runtime observers.
 
-This module defines the minimal runtime service contract used by HeartbeatServer.
+Re-exports ServiceBase from domain/protocols to maintain backward compatibility.
+Actual definition moved to domain/protocols/runtime_protocols.py to break
+the domain→runtime circular dependency.
 """
 
-from abc import ABC
+from vibe3.domain.protocols.runtime_protocols import ServiceBase
 
-
-class ServiceBase(ABC):
-    """Abstract protocol for runtime services observed by HeartbeatServer."""
-
-    @property
-    def service_name(self) -> str:
-        """Human-readable service name for orchestration logs."""
-        return type(self).__name__
-
-    @property
-    def is_dispatch_service(self) -> bool:
-        """Whether this service initiates automated flow/task actions."""
-        return True
-
-    async def on_tick(self, tick_id: int = 0) -> None:
-        """Called on each heartbeat tick.
-
-        Args:
-            tick_id: Current tick number (0 if not available)
-        """
+__all__ = ["ServiceBase"]

--- a/src/vibe3/services/task_status_service.py
+++ b/src/vibe3/services/task_status_service.py
@@ -50,7 +50,7 @@ def fetch_task_status_data(
     snapshot_found = orch_snapshot is not None
 
     if not orch_snapshot:
-        from vibe3.runtime import (
+        from vibe3.utils.orchestra_instance import (
             read_instance_info,
             validate_instance,
         )

--- a/src/vibe3/utils/orchestra_instance.py
+++ b/src/vibe3/utils/orchestra_instance.py
@@ -1,0 +1,101 @@
+"""Orchestra instance information management.
+
+Moved from runtime/ to utils/ to break services→runtime circular dependency.
+Services layer imports these utilities without depending on the runtime layer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass
+class OrchestraInstanceInfo:
+    """Serve instance information stored in global PID file."""
+
+    pid: int
+    cwd: Path
+    port: int
+    started_at: datetime
+
+    def to_dict(self) -> dict:
+        """Serialize instance info to JSON-compatible dict."""
+        return {
+            "pid": self.pid,
+            "cwd": str(self.cwd),
+            "port": self.port,
+            "started_at": self.started_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> OrchestraInstanceInfo:
+        """Deserialize instance info from JSON dict."""
+        return cls(
+            pid=data["pid"],
+            cwd=Path(data["cwd"]),
+            port=data["port"],
+            started_at=datetime.fromisoformat(data["started_at"]),
+        )
+
+
+def read_instance_info(pid_file: Path) -> OrchestraInstanceInfo | None:
+    """Read instance info from PID file.
+
+    Returns None if:
+    - File doesn't exist
+    - File has invalid JSON
+    - File has invalid format
+    - File has non-object JSON (TypeError)
+    """
+    if not pid_file.exists():
+        return None
+
+    try:
+        data = json.loads(pid_file.read_text())
+        return OrchestraInstanceInfo.from_dict(data)
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def write_instance_info(pid_file: Path, info: OrchestraInstanceInfo) -> None:
+    """Write instance info to PID file.
+
+    Creates parent directories if needed.
+    """
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(json.dumps(info.to_dict(), indent=2))
+
+
+def validate_instance(info: OrchestraInstanceInfo) -> bool:
+    """Validate that instance is still running and is an orchestra process.
+
+    Returns False if:
+    - Process is dead (os.kill raises ProcessLookupError)
+    - Process is not orchestra (wrong command line)
+    """
+    try:
+        os.kill(info.pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+
+    # Check command line matches orchestra process
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(info.pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return False
+
+        cmdline = result.stdout.strip().lower()
+        return "vibe3" in cmdline and "serve" in cmdline
+    except Exception:
+        return False

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -129,7 +129,7 @@ def test_internal_apply_dispatch():
 def test_internal_governance_dispatch_forwards_tick_and_material():
     """测试 internal governance 会透传 tick 和 material."""
     with patch(
-        "vibe3.services.scan_service.dispatch_governance_execution"
+        "vibe3.roles.scan_service.dispatch_governance_execution"
     ) as mock_dispatch:
         result = runner.invoke(
             cli_app,

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -65,7 +65,7 @@ class TestGovernanceScan:
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
         """Sync path (--no-async) calls service layer directly, not through facade."""
         with patch(
-            "vibe3.services.scan_service.dispatch_governance_execution"
+            "vibe3.roles.scan_service.dispatch_governance_execution"
         ) as mock_service_run:
             with patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
@@ -113,7 +113,7 @@ class TestScanIntegration:
     def test_governance_scan_registers_handlers(self):
         """Sync governance scan calls service layer directly, not facade."""
         with patch(
-            "vibe3.services.scan_service.dispatch_governance_execution"
+            "vibe3.roles.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
@@ -123,11 +123,9 @@ class TestScanIntegration:
     def test_supervisor_scan_registers_handlers(self):
         """Supervisor scan calls service layer directly, not facade."""
         with (
+            patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
             patch(
-                "vibe3.services.scan_service.fetch_supervisor_candidates"
-            ) as mock_fetch,
-            patch(
-                "vibe3.services.scan_service.dispatch_supervisor_execution"
+                "vibe3.roles.scan_service.dispatch_supervisor_execution"
             ) as mock_apply,
         ):
             mock_fetch.return_value = (
@@ -152,7 +150,7 @@ class TestFailedGateBlocking:
     def test_governance_scan_blocked_by_failed_gate(self):
         """Sync governance scan ignores FailedGate (only for heartbeat)."""
         with patch(
-            "vibe3.services.scan_service.dispatch_governance_execution"
+            "vibe3.roles.scan_service.dispatch_governance_execution"
         ) as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
@@ -162,7 +160,7 @@ class TestFailedGateBlocking:
     def test_supervisor_scan_blocked_by_failed_gate(self):
         """Manual supervisor scan ignores FailedGate (only for heartbeat)."""
         with patch(
-            "vibe3.services.scan_service.fetch_supervisor_candidates"
+            "vibe3.roles.scan_service.fetch_supervisor_candidates"
         ) as mock_fetch:
             mock_fetch.return_value = (0, [])
 
@@ -176,12 +174,10 @@ class TestFailedGateBlocking:
         """Combined scan bypasses FailedGate for both governance and supervisor."""
         with (
             patch(
-                "vibe3.services.scan_service.dispatch_governance_execution"
+                "vibe3.roles.scan_service.dispatch_governance_execution"
             ) as mock_governance,
-            patch(
-                "vibe3.services.scan_service.fetch_supervisor_candidates"
-            ) as mock_fetch,
-            patch("vibe3.services.scan_service.dispatch_supervisor_execution"),
+            patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
+            patch("vibe3.roles.scan_service.dispatch_supervisor_execution"),
         ):
             mock_fetch.return_value = (0, [])
 
@@ -195,10 +191,8 @@ class TestFailedGateBlocking:
 def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
     """Manual supervisor scan fetches candidates and dispatches each."""
     with (
-        patch("vibe3.services.scan_service.fetch_supervisor_candidates") as mock_fetch,
-        patch(
-            "vibe3.services.scan_service.dispatch_supervisor_execution"
-        ) as mock_apply,
+        patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
+        patch("vibe3.roles.scan_service.dispatch_supervisor_execution") as mock_apply,
     ):
         mock_fetch.return_value = (
             2,

--- a/tests/vibe3/services/test_scan_service.py
+++ b/tests/vibe3/services/test_scan_service.py
@@ -2,7 +2,7 @@
 
 import yaml
 
-from vibe3.services.scan_service import (
+from vibe3.roles.scan_service import (
     extract_material_description,
     fetch_supervisor_candidates,
     validate_governance_material_consistency,

--- a/tests/vibe3/test_modularity/test_dependency_direction.py
+++ b/tests/vibe3/test_modularity/test_dependency_direction.py
@@ -308,9 +308,10 @@ class TestCircularDependencies:
             )
 
     @pytest.mark.xfail(
-        reason="Known architectural debt: L3-internal circular deps remain in "
-        "{domain, execution, orchestra, roles, runtime, services} SCC. "
-        "Tracked by epic #1987."
+        reason="Known architectural debt: 3 L3-internal circular deps remain "
+        "in {domain, execution, services, roles} after #2122/#2123/#2125 cleanup. "
+        "Remaining: domain↔execution (2 cycles), domain↔roles (1 cycle). "
+        "Tracked by epic #1987, follow-up in #2098/#2099."
     )
     def test_no_circular_deps_within_l3_core(
         self, import_graph: dict[str, list[str]], module_layer_map: dict[str, int]


### PR DESCRIPTION
## Summary

消除 L3 核心层 4 个循环依赖（8 → 3 个），关闭 issue #2125。

## 目标循环（已消除）

**services → roles → services**
- `services/scan_service.py` 移至 `roles/scan_service.py`（dispatch 逻辑属于 roles 层）
- 同步消除了 `domain→execution→services→roles→domain` 和 `execution→services→roles→execution`

**services → runtime → services**
- `dag_service._extract_imports` 跳过 `if TYPE_CHECKING:` 块（TYPE_CHECKING 导入非运行时依赖）
- `runtime/orchestra_instance.py` 实现移至 `utils/orchestra_instance.py`，runtime 保留重导出存根
- `services/task_status_service.py` 改从 `vibe3.utils.orchestra_instance` 导入

**domain → runtime → domain（附加修复）**
- `ServiceBase` 从 `runtime/service_protocol.py` 移至 `domain/protocols/runtime_protocols.py`
- `domain/orchestration_facade.py` 改从 `domain/protocols` 导入 `ServiceBase`，消除 `domain→runtime` 边

## 剩余循环（不在本 issue 范围）

3 个（原 8 个）：
- `domain → execution → domain`
- `domain → execution → services → domain`  
- `domain → roles → domain`（原本隐藏在更长路径中，现暴露为短循环）

追踪：epic #1987，后续 #2098/#2099

## Test plan

- [x] `uv run mypy src/vibe3` — 400 个文件全通过（0 错误）
- [x] `uv run ruff check` — 全通过
- [x] `uv run pytest tests/vibe3/test_modularity/` — 15 passed, 2 xfailed
- [x] `uv run pytest tests/vibe3/commands/test_scan.py tests/vibe3/commands/test_internal.py` — 35 passed
- [x] 循环依赖测试：8 个 → 3 个（消除 5 个 L3 内部循环）

## Contributors

- Executor: Claude Sonnet 4.6