### PR TITLE
fix(prompts): revert kind:file to kind:literal for large prompt files

### DIFF
--- a/config/prompts/prompt-recipes.yaml
+++ b/config/prompts/prompt-recipes.yaml
@@ -34,8 +34,26 @@ recipes:
         sections:
           - key: manager.supervisor_content
             source:
-              kind: file
-              path: supervisor/manager.md
+              kind: literal
+              value: |
+                ## Manager 执行指南
+
+                你的完整执行指令和决策规则在以下文件中：
+                `supervisor/manager.md` (约 1000 行)
+
+                **请立即使用 Read tool 阅读此文件**：
+                ```
+                Read("supervisor/manager.md")
+                ```
+
+                该文件包含：
+                - **Role 定义**：Issue Owner 职责边界
+                - **Permission Contract**：允许/禁止的操作
+                - **核心决策逻辑**：做 vs 不做，无中间地带
+                - **State 机器**：ready → claimed → in_progress → review → done/blocked
+                - **Exit 条件**：何时停止执行
+
+                阅读后，按照其中的规则执行 manager 职责。
           - key: manager.target
           - key: manager.quick_commands
 
@@ -170,8 +188,24 @@ recipes:
         kind: literal
         value: supervisor/apply.md
       supervisor_content:
-        kind: file
-        path: supervisor/apply.md
+        kind: literal
+        value: |
+          ## Supervisor Handoff 执行指南
+
+          你的完整执行指令和决策规则在以下文件中：
+          `supervisor/apply.md`
+
+          **请立即使用 Read tool 阅读此文件**：
+          ```
+          Read("supervisor/apply.md")
+          ```
+
+          该文件包含：
+          - **Role 定义**：Supervisor 应用职责边界
+          - **执行逻辑**：如何应用 handoff 指令
+          - **状态转换**：issue state 的变化规则
+
+          阅读后，按照其中的规则执行 supervisor apply 职责。
       server_status:
         kind: provider
         provider: governance.server_status
@@ -222,20 +256,85 @@ recipes:
     material_catalog:
       - name: supervisor/governance/assignee-pool.md
         source:
-          kind: file
-          path: supervisor/governance/assignee-pool.md
+          kind: literal
+          value: |
+            ## Governance 执行指南
+
+            你的完整治理指令和决策规则在以下文件中：
+            `supervisor/governance/assignee-pool.md`
+
+            **请立即使用 Read tool 阅读此文件**：
+            ```
+            Read("supervisor/governance/assignee-pool.md")
+            ```
+
+            该文件包含：
+            - **Role 定义**：Governance 治理观察者的职责边界
+            - **观察范围**：assignee issue pool 状态分析
+            - **允许操作**：最小 label 调整、comment 建议
+            - **禁止操作**：不恢复一般 blocked issue、不执行代码变更
+
+            阅读后，按照其中的规则执行 governance 职责。
       - name: supervisor/governance/roadmap-intake.md
         source:
-          kind: file
-          path: supervisor/governance/roadmap-intake.md
+          kind: literal
+          value: |
+            ## Governance 执行指南
+
+            你的完整治理指令和决策规则在以下文件中：
+            `supervisor/governance/roadmap-intake.md`
+
+            **请立即使用 Read tool 阅读此文件**：
+            ```
+            Read("supervisor/governance/roadmap-intake.md")
+            ```
+
+            该文件包含：
+            - **Role 定义**：roadmap intake triage 的职责边界
+            - **观察范围**：broader repo issue pool
+            - **目标**：识别适合自动化纳入 assignee issue pool 的对象
+
+            阅读后，按照其中的规则执行 governance 职责。
       - name: supervisor/governance/cron-supervisor.md
         source:
-          kind: file
-          path: supervisor/governance/cron-supervisor.md
+          kind: literal
+          value: |
+            ## Governance 执行指南
+
+            你的完整治理指令和决策规则在以下文件中：
+            `supervisor/governance/cron-supervisor.md`
+
+            **请立即使用 Read tool 阅读此文件**：
+            ```
+            Read("supervisor/governance/cron-supervisor.md")
+            ```
+
+            该文件包含：
+            - **Role 定义**：cron-supervisor 的职责边界
+            - **观察范围**：broader repo docs scope
+            - **目标**：挑选最多 5 个需要语义对齐的过时文档对象
+
+            阅读后，按照其中的规则执行 governance 职责。
       - name: supervisor/governance/code-auditor.md
         source:
-          kind: file
-          path: supervisor/governance/code-auditor.md
+          kind: literal
+          value: |
+            ## Governance 执行指南
+
+            你的完整治理指令和决策规则在以下文件中：
+            `supervisor/governance/code-auditor.md`
+
+            **请立即使用 Read tool 阅读此文件**：
+            ```
+            Read("supervisor/governance/code-auditor.md")
+            ```
+
+            该文件包含：
+            - **Role 定义**：code-auditor 的职责边界
+            - **观察范围**：code quality and architecture patterns
+            - **目标**：识别代码质量问题并提出改进建议
+
+            阅读后，按照其中的规则执行 governance 职责。
     variables:
       server_status:
         kind: provider

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -152,6 +152,9 @@ code_limits:
         reason: "配置加载核心模块，包含配置文件查找、YAML 加载、环境变量覆盖、keys.env fallback（repo root 相对路径解析）、变量展开等紧密耦合的配置加载逻辑；新增 load_runtime_config() 统一入口（issue #1925）、target_repo 参数支持、lazy import 注释和 repo root 检测逻辑后略微超标"
 
       # 基础设施核心模块
+      - path: "src/vibe3/agents/backends/codeagent.py"
+        limit: 410
+        reason: "Codeagent backend 核心执行引擎，包含命令构建、session 管理、错误处理、prompt 元数据日志、prompt size 诊断（仅针对 'no agent_message output' 错误）等紧密耦合逻辑；Issue #1897 新增条件性 prompt size 诊断和结构化 metadata 支持（修复 MAJOR audit finding）后略微超标"
       - path: "src/vibe3/agents/backends/async_launcher.py"
         limit: 410
         reason: "Async launcher 聚合，包含 tmux session 管理、log path 分配、env passthrough 等紧密耦合逻辑；新增 VIBE3_ASYNC_CHILD 到 CRITICAL_ENV_PASSTHROUGH 修复 pre-push hook 测试失败"

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -376,14 +376,16 @@ class CodeagentBackend:
                 if diagnosis:
                     error_msg += f"\n\n{diagnosis}"
 
-                # Check for prompt size issue and add diagnostic
-                prompt_size_diagnostic = diagnose_prompt_size_issue(
-                    len(prompt),
-                    effective_options.backend or "default",
-                    effective_options.model or "default",
-                )
-                if prompt_size_diagnostic:
-                    error_msg += f"\n\n{prompt_size_diagnostic}"
+                # Only check prompt size for "no agent_message output" case
+                # to avoid misleading diagnostics for unrelated errors
+                if "completed without agent_message output" in combined_output:
+                    prompt_size_diagnostic = diagnose_prompt_size_issue(
+                        len(prompt),
+                        effective_options.backend or "default",
+                        effective_options.model or "default",
+                    )
+                    if prompt_size_diagnostic:
+                        error_msg += f"\n\n{prompt_size_diagnostic}"
 
                 # Build metadata for structured error info
                 metadata = {

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -377,7 +377,7 @@ class CodeagentBackend:
                     error_msg += f"\n\n{diagnosis}"
 
                 # Only check prompt size for "no agent_message output" case
-                # to avoid misleading diagnostics for unrelated errors
+                # to avoid misleading diagnostics
                 if "completed without agent_message output" in combined_output:
                     prompt_size_diagnostic = diagnose_prompt_size_issue(
                         len(prompt),

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -31,6 +31,7 @@ from vibe3.models import AgentOptions, AgentResult
 from vibe3.utils import (
     build_prompt_file_content,
     diagnose_backend_error,
+    diagnose_prompt_size_issue,
     prepare_prompt_file,
     sanitize_prompt_for_display,
     sanitize_task_shell_meta,
@@ -273,6 +274,16 @@ class CodeagentBackend:
             prepare_prompt_file(prompt, include_global_notice=include_global_notice)
         )
 
+        # Log prompt metadata before execution for debugging
+        effective_options = resolve_effective_agent_options(options)
+        logger.bind(domain="agent_execution").debug(
+            "Executing codeagent-wrapper: "
+            f"backend={effective_options.backend or 'default'}, "
+            f"model={effective_options.model or 'default'}, "
+            f"prompt_length={len(prompt)} chars, "
+            "stdin_mode_threshold=800 chars"
+        )
+
         try:
             command = self._build_command(
                 options,
@@ -365,7 +376,28 @@ class CodeagentBackend:
                 if diagnosis:
                     error_msg += f"\n\n{diagnosis}"
 
-                raise AgentExecutionError(error_msg, log_path=wrapper_log_path)
+                # Check for prompt size issue and add diagnostic
+                prompt_size_diagnostic = diagnose_prompt_size_issue(
+                    len(prompt),
+                    effective_options.backend or "default",
+                    effective_options.model or "default",
+                )
+                if prompt_size_diagnostic:
+                    error_msg += f"\n\n{prompt_size_diagnostic}"
+
+                # Build metadata for structured error info
+                metadata = {
+                    "backend": effective_options.backend or "default",
+                    "model": effective_options.model or "default",
+                    "prompt_length": str(len(prompt)),
+                    "exit_code": str(agent_result.exit_code),
+                }
+                if wrapper_log_path:
+                    metadata["session_log_path"] = str(wrapper_log_path)
+
+                raise AgentExecutionError(
+                    error_msg, log_path=wrapper_log_path, metadata=metadata
+                )
 
             return agent_result
         finally:

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -131,9 +131,15 @@ class SystemError(VibeError):
 class AgentExecutionError(SystemError):
     """Agent execution failed (wrapper/API/backend error)."""
 
-    def __init__(self, message: str, log_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        log_path: Path | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
         super().__init__(message)
         self.log_path: Path | None = log_path
+        self.metadata: dict[str, str] | None = metadata
 
 
 class ModelsJsonSyncError(SystemError):

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from vibe3.utils.codeagent_helpers import (
         build_prompt_file_content,
         diagnose_backend_error,
+        diagnose_prompt_size_issue,
         prepare_prompt_file,
         sanitize_prompt_for_display,
         sanitize_task_shell_meta,
@@ -55,6 +56,7 @@ _LAZY_IMPORTS = {
     "build_prompt_file_content": "vibe3.utils.codeagent_helpers",
     "clean_error_message": "vibe3.utils.error_message_cleaner",
     "diagnose_backend_error": "vibe3.utils.codeagent_helpers",
+    "diagnose_prompt_size_issue": "vibe3.utils.codeagent_helpers",
     "find_parent_branch": "vibe3.utils.branch_utils",
     "format_age_aware_time": "vibe3.utils.time_format",
     "get_branch_handoff_dir": "vibe3.utils.git_helpers",
@@ -94,6 +96,7 @@ __all__ = [
     "build_prompt_file_content",
     "clean_error_message",
     "diagnose_backend_error",
+    "diagnose_prompt_size_issue",
     "find_parent_branch",
     "format_age_aware_time",
     "get_branch_handoff_dir",

--- a/src/vibe3/utils/codeagent_helpers.py
+++ b/src/vibe3/utils/codeagent_helpers.py
@@ -40,8 +40,10 @@ KNOWN_BACKEND_ERROR_PATTERNS: Final[tuple[tuple[str, str, str], ...]] = (
     (
         "completed without agent_message output",
         "No agent output",
-        "Backend completed but produced no output. Try: 1) Use a different model, "
-        "2) Check if the model supports structured output, 3) Simplify the task",
+        "Backend completed but produced no output. This often indicates prompt size "
+        "issue (stdin mode threshold ~800 chars). Try: 1) Check prompt-recipes.yaml "
+        "for large kind:file sources, 2) Use kind:literal + Read instruction instead, "
+        "3) Use a different model",
     ),
 )
 
@@ -51,6 +53,35 @@ def diagnose_backend_error(output: str) -> str | None:
     for pattern, title, suggestion in KNOWN_BACKEND_ERROR_PATTERNS:
         if pattern in output:
             return f"[{title}] {suggestion}"
+    return None
+
+
+def diagnose_prompt_size_issue(prompt_len: int, backend: str, model: str) -> str | None:
+    """Diagnose if prompt size exceeds stdin-mode threshold.
+
+    codeagent-wrapper enters stdin mode when prompt exceeds ~800 chars,
+    which can cause parsing failures. Returns diagnostic message if size
+    exceeds threshold, None otherwise.
+
+    Args:
+        prompt_len: Length of the prompt in characters
+        backend: Backend name (e.g., "openai", "anthropic")
+        model: Model name (e.g., "claude-3-5-sonnet")
+
+    Returns:
+        Diagnostic message if prompt exceeds threshold, None otherwise
+    """
+    # codeagent-wrapper stdin mode threshold is approximately 800 characters
+    stdin_mode_threshold = 800
+
+    if prompt_len > stdin_mode_threshold:
+        return (
+            f"Prompt size ({prompt_len} chars) exceeds stdin-mode threshold "
+            f"({stdin_mode_threshold} chars) for {backend}/{model}. "
+            f"This may cause codeagent-wrapper to enter stdin mode and fail silently. "
+            f"Consider using kind:literal + Read instruction in prompt-recipes.yaml "
+            f"instead of kind:file for large files."
+        )
     return None
 
 

--- a/tests/vibe3/prompts/test_prompt_manifest.py
+++ b/tests/vibe3/prompts/test_prompt_manifest.py
@@ -251,3 +251,82 @@ recipes:
     assert recipe.loaded_definition is not None
     vars = recipe.loaded_definition.variables
     assert vars["supervisor_content"].kind == VariableSourceKind.FILE
+
+
+def test_no_large_file_sources_in_default_recipes() -> None:
+    """Regression test: no recipe section with kind:file should reference large files.
+
+    Large files (>2048 bytes) should use kind:literal with Read instruction instead
+    to avoid codeagent-wrapper stdin-mode threshold (~800 chars).
+
+    This prevents regressions where runtime centralization accidentally reverts
+    the kind:literal fix (as happened in commit 44d26faf).
+    """
+    from vibe3.prompts.models import VariableSourceKind
+
+    # Size limit for kind:file sources
+    max_file_size_bytes = 2048
+
+    manifest = PromptManifest.load_default()
+
+    violations: list[str] = []
+
+    # Check all recipes in the manifest
+    for recipe_key, recipe in manifest.recipes.items():
+
+        # Check section_recipe sections
+        if recipe.kind == "section_recipe" and recipe.loaded_definition:
+            for variant_key, variant in recipe.loaded_definition.variants.items():
+                for section in variant.sections:
+                    if (
+                        section.source
+                        and section.source.kind == VariableSourceKind.FILE
+                    ):
+                        # Resolve the file path
+                        file_path = _resolve_repo_path(Path(section.source.path))
+                        if file_path.exists():
+                            file_size = file_path.stat().st_size
+                            if file_size > max_file_size_bytes:
+                                violations.append(
+                                    f"{recipe_key}/{variant_key}/{section.key}: "
+                                    f"{section.source.path} is {file_size} bytes "
+                                    f"(limit: {max_file_size_bytes})"
+                                )
+
+        # Check template_recipe variables
+        if recipe.kind == "template_recipe" and recipe.loaded_definition:
+            for var_name, var_source in recipe.loaded_definition.variables.items():
+                if var_source.kind == VariableSourceKind.FILE:
+                    # Resolve the file path
+                    file_path = _resolve_repo_path(Path(var_source.path))
+                    if file_path.exists():
+                        file_size = file_path.stat().st_size
+                        if file_size > max_file_size_bytes:
+                            violations.append(
+                                f"{recipe_key}/variable/{var_name}: "
+                                f"{var_source.path} is {file_size} bytes "
+                                f"(limit: {max_file_size_bytes})"
+                            )
+
+        # Check template_recipe material_catalog
+        if recipe.kind == "template_recipe" and recipe.loaded_definition:
+            if recipe.loaded_definition.material_catalog:
+                for material in recipe.loaded_definition.material_catalog:
+                    if material.source.kind == VariableSourceKind.FILE:
+                        # Resolve the file path
+                        file_path = _resolve_repo_path(Path(material.source.path))
+                        if file_path.exists():
+                            file_size = file_path.stat().st_size
+                            if file_size > max_file_size_bytes:
+                                violations.append(
+                                    f"{recipe_key}/material/{material.name}: "
+                                    f"{material.source.path} is {file_size} bytes "
+                                    f"(limit: {max_file_size_bytes})"
+                                )
+
+    if violations:
+        violation_list = "\n  - ".join([""] + violations)
+        pytest.fail(
+            f"Found large file sources with kind:file (should use kind:literal):"
+            f"{violation_list}"
+        )

--- a/tests/vibe3/roles/test_governance_recipe_render.py
+++ b/tests/vibe3/roles/test_governance_recipe_render.py
@@ -53,14 +53,15 @@ class TestBuildGovernanceRecipe:
         assert "supervisor_name" in recipe.variables
         assert "server_status" in recipe.variables
 
-    def test_supervisor_content_uses_file_source(self):
+    def test_supervisor_content_uses_literal_source(self):
         config = _make_config()
         recipe = build_governance_recipe(config)
         from vibe3.prompts.models import VariableSourceKind
 
         src = recipe.variables["supervisor_content"]
-        assert src.kind == VariableSourceKind.FILE
-        assert src.path == "supervisor/governance/assignee-pool.md"
+        # After fix for issue #1897, materials use kind:literal with Read instruction
+        assert src.kind == VariableSourceKind.LITERAL
+        assert "Read(" in src.value
 
     def test_missing_material_catalog_fails_instead_of_using_python_fallback(
         self, tmp_path, monkeypatch
@@ -159,4 +160,6 @@ class TestRenderGovernancePrompt:
         assert (
             "Supervisor=supervisor/governance/roadmap-intake.md" in result.rendered_text
         )
-        assert "GLOBAL ROADMAP INTAKE MATERIAL" in result.rendered_text
+        # After fix for issue #1897, materials use literal with Read instruction
+        assert "Read(" in result.rendered_text
+        assert "Governance 执行指南" in result.rendered_text


### PR DESCRIPTION
Fixes #1897

## Summary

Reverted \`kind:file\` to \`kind:literal\` for large prompt files causing stdin-mode failures in manager backend.

## Root Cause

Commit 44d26faf reverted the fixes from 3471f3d8 and 4a3775f7, re-introducing 62KB prompt injection that exceeded codeagent-wrapper's stdin-mode threshold (~800 chars), causing silent failures with no \`agent_message\` output.

## Changes

1. **config/prompts/prompt-recipes.yaml**:
   - \`manager.default.first.bootstrap.sections[0].source\`: Changed \`kind:file\` → \`kind:literal\` with Read instruction
   - \`governance.scan.material_catalog[*].source\`: Changed all 4 entries to \`kind:literal\`
   - \`supervisor.handoff.variables.supervisor_content\`: Changed \`kind:file\` → \`kind:literal\`

2. **Error diagnostics enhancement**:
   - Added \`metadata\` parameter to \`AgentExecutionError\` for structured diagnostic info
   - Enhanced error messages with backend, model, prompt_length, and session log path
   - Added \`diagnose_prompt_size_issue()\` helper (only fires for "no agent_message output" case after review fix)

3. **Regression prevention**:
   - Added test: no \`kind:file\` source should exceed 2048 bytes

## Test Plan

- All tests pass (438 passed, 1 skipped)
- Type checking clean (mypy)
- Linting clean (ruff)
- Regression test added and passing

## Verification

\`\`\`bash
# Run tests
uv run pytest tests/vibe3/prompts/ tests/vibe3/roles/ tests/vibe3/utils/ tests/vibe3/agents/ -q

# Type check
uv run mypy src/vibe3/agents/backends/codeagent.py src/vibe3/utils/codeagent_helpers.py src/vibe3/exceptions/__init__.py

# Lint
uv run ruff check src/vibe3/agents/backends/codeagent.py src/vibe3/utils/codeagent_helpers.py src/vibe3/exceptions/__init__.py
\`\`\`

## Review Notes

- Initial implementation had a MAJOR finding: \`diagnose_prompt_size_issue\` fired for all errors
- Fixed in commit 9bea8651: restricted to only fire for "no agent_message output" case
- Final audit verdict: PASS
- Minor finding: \`diagnose_prompt_size_issue\` lacks unit test (low risk, can be addressed later)

---

## Contributors

claude/opus
