### PR TITLE
refactor(config): extract _resolve_agent_entry helper

### DIFF
--- a/src/vibe3/config/agent_preset.py
+++ b/src/vibe3/config/agent_preset.py
@@ -108,6 +108,30 @@ def find_missing_backend_commands(
     return missing
 
 
+def _resolve_agent_entry(
+    agents: dict[str, Any], agent_name: str
+) -> tuple[str, dict[str, Any]] | None:
+    """Resolve agent preset entry with vibe- prefix fallback.
+
+    Args:
+        agents: Dict of agent presets from models.json
+        agent_name: Agent name to look up
+
+    Returns:
+        (resolved_name, entry_dict) on success, None on failure
+    """
+    raw = agents.get(agent_name)
+    if isinstance(raw, dict):
+        return agent_name, raw
+
+    prefixed_name = f"vibe-{agent_name}"
+    raw = agents.get(prefixed_name)
+    if isinstance(raw, dict):
+        return prefixed_name, raw
+
+    return None
+
+
 def resolve_repo_agent_preset(
     agent_name: str,
 ) -> tuple[str | None, str | None] | None:
@@ -141,14 +165,10 @@ def resolve_repo_agent_preset(
     if not isinstance(agents, dict):
         return None
 
-    # Try direct lookup first
-    raw = agents.get(agent_name)
-    if not isinstance(raw, dict):
-        # Try with 'vibe-' prefix if direct lookup fails
-        prefixed_name = f"vibe-{agent_name}"
-        raw = agents.get(prefixed_name)
-        if not isinstance(raw, dict):
-            return None
+    resolved = _resolve_agent_entry(agents, agent_name)
+    if resolved is None:
+        return None
+    _, raw = resolved
 
     backend = raw.get("backend")
     model = raw.get("model")
@@ -173,15 +193,11 @@ def resolve_repo_agent_preset_name(agent_name: str) -> str | None:
     if not isinstance(agents, dict):
         return None
 
-    raw = agents.get(agent_name)
-    if isinstance(raw, dict):
-        return agent_name
-
-    prefixed_name = f"vibe-{agent_name}"
-    raw = agents.get(prefixed_name)
-    if isinstance(raw, dict):
-        return prefixed_name
-    return None
+    resolved = _resolve_agent_entry(agents, agent_name)
+    if resolved is None:
+        return None
+    resolved_name, _ = resolved
+    return resolved_name
 
 
 def has_agent_env_override(agent_name: str) -> bool:

--- a/tests/vibe3/agents/test_agent_preset_resolution.py
+++ b/tests/vibe3/agents/test_agent_preset_resolution.py
@@ -238,3 +238,36 @@ class TestResolveRepoAgentPreset:
             result = resolve_repo_agent_preset("any-preset")
 
         assert result is None
+
+
+class TestResolveAgentEntry:
+    """Tests for the _resolve_agent_entry helper."""
+
+    def test_direct_lookup(self) -> None:
+        from vibe3.config.agent_preset import _resolve_agent_entry
+
+        agents = {"reviewer": {"backend": "claude"}}
+        assert _resolve_agent_entry(agents, "reviewer") == (
+            "reviewer",
+            {"backend": "claude"},
+        )
+
+    def test_prefixed_fallback(self) -> None:
+        from vibe3.config.agent_preset import _resolve_agent_entry
+
+        agents = {"vibe-reviewer": {"backend": "claude"}}
+        assert _resolve_agent_entry(agents, "reviewer") == (
+            "vibe-reviewer",
+            {"backend": "claude"},
+        )
+
+    def test_not_found(self) -> None:
+        from vibe3.config.agent_preset import _resolve_agent_entry
+
+        assert _resolve_agent_entry({}, "unknown") is None
+
+    def test_non_dict_entry_ignored(self) -> None:
+        from vibe3.config.agent_preset import _resolve_agent_entry
+
+        agents = {"reviewer": "not-a-dict"}
+        assert _resolve_agent_entry(agents, "reviewer") is None


### PR DESCRIPTION
Closes #2236

## Summary

- Extract duplicated agent resolution logic into private `_resolve_agent_entry` helper
- Refactor both `resolve_repo_agent_preset` and `resolve_repo_agent_preset_name` to use the helper
- Add 4 targeted tests for the new helper function

Eliminates code duplication between `resolve_repo_agent_preset` and `resolve_repo_agent_preset_name`, both of which implement the same "direct lookup → vibe- prefix fallback" pattern.

## Changes

**src/vibe3/config/agent_preset.py**:
- Added `_resolve_agent_entry(agents, agent_name)` helper (L111-132)
- Refactored `resolve_repo_agent_preset` to use helper (L168-171)
- Refactored `resolve_repo_agent_preset_name` to use helper (L196-200)

**tests/vibe3/agents/test_agent_preset_resolution.py**:
- Added `TestResolveAgentEntry` test class with 4 tests

## Test Plan

- [x] All existing tests pass (128 passed in tests/vibe3/agents/)
- [x] New tests added for helper function (4 tests)
- [x] Type checking clean (mypy: Success)
- [x] Linting clean (ruff: All checks passed)
- [x] No public API changes (private helper only)
- [x] Behavior preserved identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
