### PR TITLE
refactor(agents): replace manual JSON parsing with read_models_json helper

### DIFF
--- a/src/vibe3/agents/backends/codeagent_config.py
+++ b/src/vibe3/agents/backends/codeagent_config.py
@@ -5,7 +5,7 @@ Handles syncing effective backend/model settings to ``~/.codeagent/models.json``
 
 import json
 from pathlib import Path
-from typing import Any, Final
+from typing import Final
 
 from loguru import logger
 
@@ -33,15 +33,7 @@ def sync_models_json(options: AgentOptions) -> None:
     if not effective.backend:
         return  # no repo-local backend mapping available
 
-    try:
-        existing: dict[str, Any] = {}
-        if MODELS_JSON_PATH.exists():
-            existing = json.loads(MODELS_JSON_PATH.read_text())
-    except Exception as exc:
-        logger.bind(domain="review_runner").warning(
-            f"Failed to read models.json, will overwrite: {exc}"
-        )
-        existing = {}
+    existing = read_models_json(MODELS_JSON_PATH)
 
     # Sync complete agents presets from repo config
     repo_data = read_models_json(repo_models_json_path())


### PR DESCRIPTION
## Summary

Replace manual `json.loads()` try/except block in `sync_models_json` with the already-imported `read_models_json()` helper from `vibe3.config`.

## Changes

- **src/vibe3/agents/backends/codeagent_config.py**: 
  - Replaced manual JSON parsing (L36-44) with single call to `read_models_json(MODELS_JSON_PATH)`
  - Removed unused `Any` import
  - Net change: -8 lines of code

## Behavioral Improvements

1. **Env var override coverage**: `VIBE_DEFAULT_BACKEND` and `VIBE_DEFAULT_MODEL` now influence the initial config
2. **Non-dict JSON validation**: Helper returns `{}` for non-dict JSON (latent bug fix)
3. **Identical error handling**: File not found and parse errors both return `{}`

## Tests

- **Direct tests**: 7/7 passed
- **Module tests**: 124/124 passed  
- **Type checking**: ✅ mypy success
- **Linting**: ✅ ruff all checks passed

Fixes #2238

---

## Contributors

claude/opus
