### PR TITLE
fix(status): exclude BLOCKED state from is_remote judgment

### DIFF
--- a/src/vibe3/services/status_query_service.py
+++ b/src/vibe3/services/status_query_service.py
@@ -335,7 +335,7 @@ class StatusQueryService:
                     pr_state = pr.state.value
 
             # Calculate remote flag: issue claimed by manager but no local flow
-            # Mark as remote for active states and BLOCKED state
+            # Blocked issues are not remote — they display in Blocked Issues section
             is_remote = (
                 state
                 in {
@@ -344,7 +344,6 @@ class StatusQueryService:
                     IssueState.HANDOFF,
                     IssueState.REVIEW,
                     IssueState.MERGE_READY,
-                    IssueState.BLOCKED,
                 }
                 and assignee is not None
                 and assignee in (manager_usernames or [])

--- a/tests/vibe3/services/test_status_query_utils.py
+++ b/tests/vibe3/services/test_status_query_utils.py
@@ -191,7 +191,8 @@ class TestRemoteField:
         assert result[0]["remote"] is False
 
     def test_blocked_state_remote_when_manager_assigned_no_flow(self) -> None:
-        """BLOCKED state should be remote when manager-assigned without flow."""
+        """BLOCKED state should not be remote even when manager-assigned
+        without flow."""
         service = self._make_mock_service()
         service.github.list_issues.return_value = [
             {
@@ -210,7 +211,7 @@ class TestRemoteField:
         )
 
         assert len(result) == 1
-        assert result[0]["remote"] is True
+        assert result[0]["remote"] is False
         assert result[0]["state"] == IssueState.BLOCKED
 
     def test_blocked_remote_parses_reason_from_body(self) -> None:
@@ -241,7 +242,7 @@ class TestRemoteField:
         )
 
         assert len(result) == 1
-        assert result[0]["remote"] is True
+        assert result[0]["remote"] is False
         assert result[0]["state"] == IssueState.BLOCKED
         assert result[0]["blocked_reason"] == "Waiting for external dependency"
         assert result[0]["blocked_by"] == (123, 456)


### PR DESCRIPTION
Remove IssueState.BLOCKED from is_remote calculation to prevent blocked issues from being marked as remote tasks. Blocked issues display in the Blocked Issues section and should not be treated as remote tasks.

## Changes
- status_query_service.py: Remove IssueState.BLOCKED from is_remote state set
- test_status_query_utils.py: Update test assertions to expect remote=False for blocked issues

## Verification
- mypy: PASS
- pytest (direct tests): 15 passed
- pytest (full scope): 739 passed (services + task_status_dashboard)
- pre-push checks: PASS

## Test Plan
- Run direct tests: `uv run pytest tests/vibe3/services/test_status_query_utils.py -v`
- Run full scope: `uv run pytest tests/vibe3/services/ tests/vibe3/commands/test_task_status_dashboard.py -q`

Closes #2239

---

## Contributors

claude/opus
