### PR TITLE
fix(qualify_gate): use READY instead of CLAIMED for None flow_state

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -233,8 +233,8 @@ code_limits:
         limit: 610
         reason: "Qualify gate remote-first + E2E blocked reconciliation 测试集，覆盖 blocked_reason、dependencies、blocked_by_issue 的 remote/local 分支、blocked state change via service layer (#1206)，包含 #994 类 E2E 回归场景，测试类结构清晰，拆分收益低"
       - path: "tests/vibe3/domain/test_qualify_gate.py"
-        limit: 540
-        reason: "Qualify gate truth-first 决策流程测试集，覆盖 manual block、dependency block、auto-resume、stale state alignment、blocked state change via service layer (#1206) 等场景，共享 fixture；PR #1983 已将 GitHub closed 检测测试拆分至 test_qualify_gate_closed.py，当前 ~536 行"
+        limit: 560
+        reason: "Qualify gate truth-first 决策流程测试集，覆盖 manual block、dependency block、auto-resume、stale state alignment、blocked state change via service layer (#1206) 等场景，共享 fixture；PR #1983 已将 GitHub closed 检测测试拆分至 test_qualify_gate_closed.py；Issue #2242 新增 test_auto_resume_blocked_with_none_flow_state_returns_ready 测试验证 flow_state=None 路径返回 READY"
       - path: "tests/vibe3/services/test_flow_orchestrator_service.py"
         limit: 560
         reason: "Flow orchestrator 服务测试集，覆盖 dispatch 协调、frozen queue 管理、issue 状态处理、Git ref lock 冲突重试等紧密耦合场景，共享 fixture，拆分收益低；Issue #2143 新增 2 个 retry 测试（test_bootstrap_issue_flow_retries_fetch_on_ref_lock_conflict, test_bootstrap_issue_flow_raises_after_exhausted_retries）后略微超标"

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -339,7 +339,7 @@ class QualifyGateService:
             fs_obj = FlowState.model_validate(flow_state)
             target_label = infer_resume_label(fs_obj)
         else:
-            target_label = IssueState.CLAIMED
+            target_label = IssueState.READY
 
         from typing import Literal, cast
 

--- a/tests/vibe3/domain/test_qualify_gate.py
+++ b/tests/vibe3/domain/test_qualify_gate.py
@@ -531,3 +531,26 @@ def test_auto_resume_blocked_uses_task_resume_operations() -> None:
         assert call["issue_number"] == 303
         assert call["label_state"] == ""
         assert result != IssueState.BLOCKED
+
+
+def test_auto_resume_blocked_with_none_flow_state_returns_ready() -> None:
+    """When flow_state is None, _auto_resume_blocked should return READY."""
+    from unittest.mock import MagicMock, patch
+
+    from vibe3.domain.qualify_gate import QualifyGateService
+    from vibe3.models.orchestra_config import OrchestraConfig
+    from vibe3.models.orchestration import IssueState
+
+    service = QualifyGateService(
+        OrchestraConfig(repo="owner/repo"), MagicMock(), MagicMock(), MagicMock()
+    )
+
+    with patch("vibe3.domain.qualify_gate.TaskResumeOperations"):
+        result = service._auto_resume_blocked(
+            issue_number=303,
+            branch="task/issue-303",
+            labels=["state/blocked"],
+            flow_state=None,
+        )
+
+        assert result == IssueState.READY


### PR DESCRIPTION
## Summary
Fixed bug in `qualify_gate.py:342` where `_auto_resume_blocked` was returning `IssueState.CLAIMED` instead of `IssueState.READY` when `flow_state` is `None`.

## Changes
- **qualify_gate.py:342**: Changed `IssueState.CLAIMED` → `IssueState.READY` for the `flow_state=None` fallback path
- **test_qualify_gate.py**: Added `test_auto_resume_blocked_with_none_flow_state_returns_ready()` to verify the fix
- **loc_limits.yaml**: Updated exception limit for test file (540 → 560 lines) to accommodate the new test

## Rationale
This change aligns the `flow_state=None` fallback behavior with all other similar cases in the codebase:
- `task_resume_operations.py:131` → `IssueState.READY`
- `flow_rebuild_usecase.py:155` → `IssueState.READY`
- `flow_recovery_service.py:226` → `IssueState.READY`

The `READY` state is semantically correct: an issue with no flow state should return to the ready pool for re-claiming.

## Test Coverage
- ✅ All 40 qualify_gate tests pass
- ✅ New test verifies `READY` is returned for `flow_state=None`
- ✅ No type errors (mypy)
- ✅ No lint errors (ruff)
- ✅ Pre-commit hooks passed

## Verification
- Ran full qualify_gate test suite: `uv run pytest tests/vibe3/domain/test_qualify_gate*.py -v`
- All 40 tests passed
- Type checking passed: `uv run mypy src/vibe3/domain/qualify_gate.py`
- Lint checks passed: `uv run ruff check src/vibe3/domain/qualify_gate.py`

Fixes #2242

---

## Contributors

claude/opus
