### PR TITLE
fix(codeagent): surface accurate prompt diagnostics

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -153,8 +153,8 @@ code_limits:
 
       # 基础设施核心模块
       - path: "src/vibe3/agents/backends/codeagent.py"
-        limit: 410
-        reason: "Codeagent backend 核心执行引擎，包含命令构建、session 管理、错误处理、prompt 元数据日志、prompt size 诊断（仅针对 'no agent_message output' 错误）等紧密耦合逻辑；Issue #1897 新增条件性 prompt size 诊断和结构化 metadata 支持（修复 MAJOR audit finding）后略微超标"
+        limit: 420
+        reason: "Codeagent backend 核心执行引擎，包含命令构建、session 管理、错误处理、prompt 元数据日志、prompt size 诊断（仅针对 'no agent_message output' 错误）等紧密耦合逻辑；Issue #1897 新增条件性 prompt size 诊断和结构化 metadata 支持，并在 #2265 follow-up 中改为按实际 prompt file payload 计算诊断长度后略微超标"
       - path: "src/vibe3/agents/backends/async_launcher.py"
         limit: 410
         reason: "Async launcher 聚合，包含 tmux session 管理、log path 分配、env passthrough 等紧密耦合逻辑；新增 VIBE3_ASYNC_CHILD 到 CRITICAL_ENV_PASSTHROUGH 修复 pre-push hook 测试失败"
@@ -171,8 +171,8 @@ code_limits:
         limit: 650
         reason: "No-op gate 聚合，包含 verdict-aware ref 检查（PASS 可省略 audit_ref，MINOR/MAJOR/BLOCK 仍需）、单步转换限制检查、全局转换计数检查、state 验证、GitHub API 错误处理、retry counter 机制（3次重试 + 即时持久化）、error/block 分离（GitHub API 失败记录 error_log 不触发 flow block）等多层防御机制，职责单一但紧密耦合"
       - path: "src/vibe3/execution/codeagent_runner.py"
-        limit: 580
-        reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；rebase 后新增 tick_id 参数传递和 before_issue_is_closed 检测逻辑"
+        limit: 590
+        reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；rebase 后新增 tick_id 参数传递和 before_issue_is_closed 检测逻辑，#2265 follow-up 将 AgentExecutionError metadata 写入 error_log 和 lifecycle refs 后略微超标"
       - path: "src/vibe3/services/orchestra_status_service.py"
         limit: 580
         reason: "Orchestra 状态查询服务，包含状态快照和格式化逻辑、IssueState 反序列化类型安全处理、HTTP fetch 集成、live snapshot 解析、pr_number 类型强制转换防御逻辑等紧密耦合逻辑；新增 get_manager_usernames 静态方法提供统一的服务层 API 供 governance.py 和 status.py 使用（#1783）；新增 create() 工厂方法使用动态导入避免循环依赖（#2001），职责单一但方法较多"
@@ -182,8 +182,8 @@ code_limits:
 
       # 强耦合测试例外
       - path: "tests/vibe3/agents/test_codeagent_backend.py"
-        limit: 650
-        reason: "Codeagent backend 核心测试，覆盖 sync/async 执行、tmux 管理、命令构建、preset 传递（新增 preset 执行路径保留测试）等紧密耦合逻辑"
+        limit: 680
+        reason: "Codeagent backend 核心测试，覆盖 sync/async 执行、tmux 管理、命令构建、preset 传递（新增 preset 执行路径保留测试）等紧密耦合逻辑；#2265 follow-up 新增实际 prompt file payload 长度诊断回归测试后略微超标"
       - path: "tests/vibe3/commands/test_command_params_unified.py"
         limit: 700
         reason: "Unified command parameter behavior test matrix (17 tests, 669 lines), covering --branch default resolution, --dry-run, --show-prompt, and config/CLI override behavior across plan/run/review/internal-manager commands; tightly-coupled test suite with strong cohesion, splitting would reduce readability of unified parameter behavior verification; original test file had VibeConfig path bug (now fixed)"
@@ -200,8 +200,8 @@ code_limits:
         limit: 630
         reason: "Governance snapshot context and comment format contract tests, covering 11 test methods across TestBuildSnapshotContext and TestCommentFormatContract classes; includes PR #1783 comment format regression tests; split from original test_governance.py (#1803); Issue #1925 adds keys.env partial loading, layered markers, and local manager boundary tests (3 new test methods)"
       - path: "tests/vibe3/execution/test_codeagent_runner_gate.py"
-        limit: 480
-        reason: "Gate 集成测试，包含完整的 mock 设置和断言场景，拆分会破坏测试逻辑完整性"
+        limit: 520
+        reason: "Gate 集成测试，包含完整的 mock 设置和断言场景，拆分会破坏测试逻辑完整性；#2265 follow-up 新增 AgentExecutionError metadata 写入 error_log/lifecycle refs 回归测试后略微超标"
       - path: "tests/vibe3/execution/test_noop_gate_transition_count.py"
         limit: 480
         reason: "Transition count 测试集，14 个测试围绕 transition_count 功能（全局计数、pair 追踪、事件记录），共享 fixture，拆分收益低"

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -29,7 +29,6 @@ from vibe3.config import (
 from vibe3.exceptions import AgentExecutionError
 from vibe3.models import AgentOptions, AgentResult
 from vibe3.utils import (
-    build_prompt_file_content,
     diagnose_backend_error,
     diagnose_prompt_size_issue,
     prepare_prompt_file,
@@ -231,7 +230,7 @@ class CodeagentBackend:
         """Start codeagent-wrapper in tmux and return the async handle."""
         sync_models_json(options)
 
-        prompt_file_path = prepare_prompt_file(prompt)
+        prompt_file_path, _ = prepare_prompt_file(prompt)
         command = self._build_command(
             options,
             str(prompt_file_path),
@@ -270,11 +269,8 @@ class CodeagentBackend:
         sync_models_json(options)
 
         project_root = str(cwd or Path.cwd())
-        prompt_content = build_prompt_file_content(
+        prompt_file_path, prompt_content = prepare_prompt_file(
             prompt, include_global_notice=include_global_notice
-        )
-        prompt_file_path = str(
-            prepare_prompt_file(prompt_content, include_global_notice=False)
         )
         diagnostic_prompt_length = len(prompt_content)
 
@@ -291,7 +287,7 @@ class CodeagentBackend:
         try:
             command = self._build_command(
                 options,
-                cast(str, prompt_file_path),
+                str(prompt_file_path),
                 task=task,
                 session_id=session_id,
             )
@@ -323,20 +319,17 @@ class CodeagentBackend:
                 if should_retry_without_session(result, session_id=session_id):
                     retry_prompt_path = prompt_file_path
                     if fallback_prompt is not None:
-                        fallback_prompt_content = build_prompt_file_content(
+                        (
+                            retry_prompt_path,
+                            fallback_prompt_content,
+                        ) = prepare_prompt_file(
                             fallback_prompt,
                             include_global_notice=fallback_include_global_notice,
-                        )
-                        retry_prompt_path = str(
-                            prepare_prompt_file(
-                                fallback_prompt_content,
-                                include_global_notice=False,
-                            )
                         )
                         diagnostic_prompt_length = len(fallback_prompt_content)
                     retry_command = self._build_command(
                         options,
-                        cast(str, retry_prompt_path),
+                        str(retry_prompt_path),
                         task=task,
                         session_id=None,
                     )
@@ -410,4 +403,4 @@ class CodeagentBackend:
             return agent_result
         finally:
             if prompt_file_path:
-                Path(prompt_file_path).unlink(missing_ok=True)
+                prompt_file_path.unlink(missing_ok=True)

--- a/src/vibe3/agents/backends/codeagent.py
+++ b/src/vibe3/agents/backends/codeagent.py
@@ -270,9 +270,13 @@ class CodeagentBackend:
         sync_models_json(options)
 
         project_root = str(cwd or Path.cwd())
-        prompt_file_path = str(
-            prepare_prompt_file(prompt, include_global_notice=include_global_notice)
+        prompt_content = build_prompt_file_content(
+            prompt, include_global_notice=include_global_notice
         )
+        prompt_file_path = str(
+            prepare_prompt_file(prompt_content, include_global_notice=False)
+        )
+        diagnostic_prompt_length = len(prompt_content)
 
         # Log prompt metadata before execution for debugging
         effective_options = resolve_effective_agent_options(options)
@@ -280,7 +284,7 @@ class CodeagentBackend:
             "Executing codeagent-wrapper: "
             f"backend={effective_options.backend or 'default'}, "
             f"model={effective_options.model or 'default'}, "
-            f"prompt_length={len(prompt)} chars, "
+            f"prompt_length={diagnostic_prompt_length} chars, "
             "stdin_mode_threshold=800 chars"
         )
 
@@ -300,9 +304,6 @@ class CodeagentBackend:
                 echo(f"command: {' '.join(command)}")
                 if show_prompt and prompt_file_path:
                     echo(f"prompt_file: {prompt_file_path}")
-                    prompt_content = build_prompt_file_content(
-                        prompt, include_global_notice=include_global_notice
-                    )
                     echo(
                         f"prompt_content:\n{sanitize_prompt_for_display(prompt_content)}"
                     )
@@ -322,12 +323,17 @@ class CodeagentBackend:
                 if should_retry_without_session(result, session_id=session_id):
                     retry_prompt_path = prompt_file_path
                     if fallback_prompt is not None:
+                        fallback_prompt_content = build_prompt_file_content(
+                            fallback_prompt,
+                            include_global_notice=fallback_include_global_notice,
+                        )
                         retry_prompt_path = str(
                             prepare_prompt_file(
-                                fallback_prompt,
-                                include_global_notice=fallback_include_global_notice,
+                                fallback_prompt_content,
+                                include_global_notice=False,
                             )
                         )
+                        diagnostic_prompt_length = len(fallback_prompt_content)
                     retry_command = self._build_command(
                         options,
                         cast(str, retry_prompt_path),
@@ -380,7 +386,7 @@ class CodeagentBackend:
                 # to avoid misleading diagnostics
                 if "completed without agent_message output" in combined_output:
                     prompt_size_diagnostic = diagnose_prompt_size_issue(
-                        len(prompt),
+                        diagnostic_prompt_length,
                         effective_options.backend or "default",
                         effective_options.model or "default",
                     )
@@ -391,7 +397,7 @@ class CodeagentBackend:
                 metadata = {
                     "backend": effective_options.backend or "default",
                     "model": effective_options.model or "default",
-                    "prompt_length": str(len(prompt)),
+                    "prompt_length": str(diagnostic_prompt_length),
                     "exit_code": str(agent_result.exit_code),
                 }
                 if wrapper_log_path:

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -45,6 +45,13 @@ def _severity_event_type(role: str, severity: "ErrorSeverity") -> str:
         return f"codeagent_{prefix}_error"
 
 
+def _format_agent_error_metadata(metadata: dict[str, str] | None) -> str:
+    """Format agent error metadata for operator-visible diagnostics."""
+    if not metadata:
+        return ""
+    return ", ".join(f"{key}={value}" for key, value in metadata.items())
+
+
 @dataclass
 class SyncExecutionContext:
     """Execution context for sync execution shell."""
@@ -443,12 +450,21 @@ class CodeagentExecutionService:
 
             # Get handling contract for severity-aware behavior
             error_contract = get_error_handling_contract(error_code)
+            agent_metadata = (
+                exc.metadata if isinstance(exc, AgentExecutionError) else None
+            )
+            metadata_summary = _format_agent_error_metadata(agent_metadata)
+            error_message = str(exc)
+            if metadata_summary:
+                error_message = (
+                    f"{error_message}\n\n[agent metadata] {metadata_summary}"
+                )
 
             # Use store-specific instance to ensure consistency with FailedGate
             # Record error with severity from contract
             record_error(
                 error_code=error_code,
-                error_message=str(exc),
+                error_message=error_message,
                 store=ctx.store,
                 tick_id=command.tick_id,
                 issue_number=command.issue_number,
@@ -465,10 +481,12 @@ class CodeagentExecutionService:
             # Record abort event to flow timeline
             if ctx.branch and ctx.store:
                 abort_refs: dict[str, str] = {
-                    "reason": str(exc),
+                    "reason": error_message,
                     "error_code": error_code,
                     "status": "blocked",
                 }
+                if agent_metadata:
+                    abort_refs.update(agent_metadata)
                 if isinstance(exc, AgentExecutionError) and exc.log_path:
                     abort_refs["log_path"] = str(exc.log_path)
 

--- a/src/vibe3/utils/codeagent_helpers.py
+++ b/src/vibe3/utils/codeagent_helpers.py
@@ -163,8 +163,15 @@ def build_prompt_file_content(prompt: str, include_global_notice: bool = True) -
     return f"{notice}\n\n---\n\n{prompt}"
 
 
-def prepare_prompt_file(prompt: str, include_global_notice: bool = True) -> Path:
-    """Create temporary prompt file with global notice."""
+def prepare_prompt_file(
+    prompt: str, include_global_notice: bool = True
+) -> tuple[Path, str]:
+    """Create temporary prompt file with global notice.
+
+    Returns:
+        tuple of (file_path, prompt_content) to avoid caller needing to
+        call build_prompt_file_content separately for diagnostics.
+    """
     prompt_dir = Path.home() / ".codeagent" / "agents"
     prompt_dir.mkdir(parents=True, exist_ok=True)
     prompt_content = build_prompt_file_content(
@@ -174,7 +181,7 @@ def prepare_prompt_file(prompt: str, include_global_notice: bool = True) -> Path
         mode="w", suffix=".md", delete=False, dir=prompt_dir
     ) as f:
         f.write(prompt_content)
-        return Path(f.name)
+        return Path(f.name), prompt_content
 
 
 def sanitize_task_shell_meta(task: str) -> str:

--- a/tests/vibe3/agents/test_codeagent_backend.py
+++ b/tests/vibe3/agents/test_codeagent_backend.py
@@ -423,6 +423,35 @@ class TestCodeagentBackend:
         assert "codeagent-wrapper failed" in str(exc_info.value)
         assert "something failed" in str(exc_info.value)
 
+    def test_run_error_metadata_uses_assembled_prompt_length(self) -> None:
+        """Prompt diagnostics should measure the actual prompt file payload."""
+        config = VibeConfig(
+            agent_prompt=AgentPromptConfig(global_notice="notice " * 150)
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "claude completed without agent_message output\n"
+        mock_result.stderr = ""
+        raw_prompt = "prompt body"
+
+        with (
+            patch(
+                "vibe3.utils.codeagent_helpers.get_vibe_config",
+                return_value=config,
+            ),
+            patch.object(CodeagentBackend, "_run_subprocess") as mock_run,
+        ):
+            mock_run.return_value = (mock_result, None)
+            backend = CodeagentBackend()
+            assembled_prompt = build_prompt_file_content(raw_prompt)
+
+            with pytest.raises(AgentExecutionError) as exc_info:
+                backend.run(raw_prompt, AgentOptions(agent="vibe-reviewer"))
+
+        assert "Prompt size" in str(exc_info.value)
+        assert exc_info.value.metadata is not None
+        assert exc_info.value.metadata["prompt_length"] == str(len(assembled_prompt))
+
     def test_run_non_zero_exit_prefers_stderr_in_message(self) -> None:
         """Runner should surface stderr details when available."""
         mock_result = MagicMock()

--- a/tests/vibe3/execution/test_codeagent_runner_gate.py
+++ b/tests/vibe3/execution/test_codeagent_runner_gate.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from vibe3.agents.models import CodeagentCommand
+from vibe3.exceptions import AgentExecutionError
 from vibe3.execution.codeagent_runner import (
     CodeagentExecutionService,
 )
@@ -402,6 +403,66 @@ class TestTransitionCountFlow:
 
 class TestSeverityAwareErrorHandling:
     """Test severity-based error handling in codeagent_runner."""
+
+    def test_agent_execution_metadata_is_recorded_on_failure(self) -> None:
+        """Backend diagnostics should reach error log and lifecycle refs."""
+        mock_store = _make_mock_store()
+        command = CodeagentCommand(
+            role="manager",
+            context_builder=lambda: "manager prompt",
+            branch="task/issue-42",
+            issue_number=42,
+        )
+        exc = AgentExecutionError(
+            "codeagent-wrapper failed",
+            metadata={
+                "backend": "claude",
+                "model": "sonnet",
+                "prompt_length": "1234",
+                "exit_code": "1",
+            },
+        )
+
+        with (
+            patch(
+                "vibe3.execution.codeagent_runner.SQLiteClient",
+                return_value=mock_store,
+            ),
+            patch("vibe3.agents.backends.codeagent.CodeagentBackend") as mock_backend,
+            patch(
+                "vibe3.execution.codeagent_runner.load_session_id",
+                return_value=None,
+            ),
+            patch(
+                "vibe3.execution.codeagent_runner.resolve_command_agent_options"
+            ) as mock_opts,
+            patch(
+                "vibe3.execution.codeagent_runner.format_agent_actor",
+                return_value="agent:manager",
+            ),
+            patch("vibe3.services.record_error") as mock_record_error,
+            patch(
+                "vibe3.execution.codeagent_runner.persist_execution_lifecycle_event"
+            ) as mock_persist_event,
+        ):
+            mock_backend.return_value.run.side_effect = exc
+            mock_opts.return_value = MagicMock()
+            service = CodeagentExecutionService()
+
+            try:
+                service.execute_sync(command)
+            except AgentExecutionError:
+                pass
+
+        error_message = mock_record_error.call_args.kwargs["error_message"]
+        assert "backend=claude" in error_message
+        assert "model=sonnet" in error_message
+        assert "prompt_length=1234" in error_message
+
+        refs = mock_persist_event.call_args.kwargs["refs"]
+        assert refs["backend"] == "claude"
+        assert refs["model"] == "sonnet"
+        assert refs["prompt_length"] == "1234"
 
     def test_warning_does_not_fail_issue(self) -> None:
         """Test that WARNING severity errors don't fail the issue."""


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2252 after post-merge subagent review.

Fixes two observability gaps in the codeagent failure path:
- Measure prompt diagnostics using the assembled prompt file payload, including global notice, instead of raw prompt text.
- Surface AgentExecutionError metadata in error_log messages and lifecycle refs so backend/model/prompt/session diagnostics are operator-visible.

## Verification

```bash
uv run pytest tests/vibe3/prompts/ tests/vibe3/roles/ tests/vibe3/utils/ tests/vibe3/agents/ tests/vibe3/execution/test_codeagent_runner_gate.py -q
uv run mypy src/vibe3/agents/backends/codeagent.py src/vibe3/execution/codeagent_runner.py src/vibe3/utils/codeagent_helpers.py src/vibe3/exceptions/__init__.py
uv run ruff check src/vibe3/agents/backends/codeagent.py src/vibe3/execution/codeagent_runner.py tests/vibe3/agents/test_codeagent_backend.py tests/vibe3/execution/test_codeagent_runner_gate.py
```

Results:
- 454 passed, 1 skipped
- mypy: Success, no issues in 4 source files
- ruff: All checks passed
- pre-push: 57 passed

## Contributors

codex/gpt-5
