### PR TITLE
refactor(domain,orchestra): migrate lazy imports to dict dispatch

### DIFF
--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -11,7 +11,10 @@ Reference: docs/standards/v3/worktree-lifecycle-standard.md
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
-    from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
+    from vibe3.domain.dispatch_coordinator import (
+        MAX_INTENTS_PER_TICK,
+        GlobalDispatchCoordinator,
+    )
     from vibe3.domain.events import (
         DomainEvent,
         ExecutorDispatchIntent,
@@ -29,9 +32,20 @@ if TYPE_CHECKING:
         SupervisorIssueIdentified,
         SupervisorPromptRendered,
     )
-    from vibe3.domain.failed_gate import FailedGate
+    from vibe3.domain.failed_gate import FailedGate, GateResult, GateStatus
     from vibe3.domain.flow_manager import FlowManager
+    from vibe3.domain.orchestration_facade import OrchestrationFacade
+    from vibe3.domain.protocols import (
+        CapacityServiceProtocol,
+        CheckServiceProtocol,
+        FlowManagerProtocol,
+        FlowServiceProtocol,
+        LabelDispatchCallable,
+        ServiceBase,
+    )
     from vibe3.domain.publisher import EventPublisher
+    from vibe3.domain.qualify_gate import QualifyGateService
+    from vibe3.domain.role_resolver import find_role_for_state
     from vibe3.domain.state_machine import (
         STATE_LABEL_META,
         VIBE_TASK_LABEL,
@@ -63,6 +77,20 @@ _LAZY_IMPORTS: dict[str, str] = {
     "STATE_LABEL_META": "vibe3.models.state_machine",
     "VIBE_TASK_LABEL": "vibe3.models.state_machine",
     "validate_transition": "vibe3.models.state_machine",
+    # Protocols
+    "CapacityServiceProtocol": "vibe3.domain.protocols",
+    "CheckServiceProtocol": "vibe3.domain.protocols",
+    "FlowServiceProtocol": "vibe3.domain.protocols",
+    "FlowManagerProtocol": "vibe3.domain.protocols",
+    "LabelDispatchCallable": "vibe3.domain.protocols",
+    "ServiceBase": "vibe3.domain.protocols",
+    # Additional domain classes
+    "GateResult": "vibe3.domain.failed_gate",
+    "GateStatus": "vibe3.domain.failed_gate",
+    "MAX_INTENTS_PER_TICK": "vibe3.domain.dispatch_coordinator",
+    "OrchestrationFacade": "vibe3.domain.orchestration_facade",
+    "QualifyGateService": "vibe3.domain.qualify_gate",
+    "find_role_for_state": "vibe3.domain.role_resolver",
     # Publisher
     "EventPublisher": "vibe3.domain.publisher",
 }
@@ -135,6 +163,19 @@ __all__ = [
     "FlowManager",
     "GlobalDispatchCoordinator",
     "FailedGate",
+    "GateResult",
+    "GateStatus",
+    "MAX_INTENTS_PER_TICK",
+    "OrchestrationFacade",
+    "QualifyGateService",
+    "find_role_for_state",
+    # Protocols
+    "CapacityServiceProtocol",
+    "CheckServiceProtocol",
+    "FlowServiceProtocol",
+    "FlowManagerProtocol",
+    "LabelDispatchCallable",
+    "ServiceBase",
     # Publisher
     "EventPublisher",
     "get_publisher",

--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -11,20 +11,17 @@ Reference: docs/standards/v3/worktree-lifecycle-standard.md
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
+    from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
     from vibe3.domain.events import (
-        # Base
         DomainEvent,
         ExecutorDispatchIntent,
-        # L1 Governance Events
         GovernanceDecisionRequired,
         GovernanceScanCompleted,
         GovernanceScanStarted,
-        # L3 Flow Lifecycle Events
         IssueFailed,
         ManagerDispatchIntent,
         PlannerDispatchIntent,
         ReviewerDispatchIntent,
-        # L2 Supervisor Apply Events
         SupervisorApplyCompleted,
         SupervisorApplyDelegated,
         SupervisorApplyDispatched,
@@ -32,22 +29,43 @@ if TYPE_CHECKING:
         SupervisorIssueIdentified,
         SupervisorPromptRendered,
     )
-
-# Import orchestration components lazily to avoid circular imports
-# FlowManager, GlobalDispatchCoordinator, and FailedGate are available through
-# __getattr__ for runtime access
-if TYPE_CHECKING:
-    from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
     from vibe3.domain.failed_gate import FailedGate
     from vibe3.domain.flow_manager import FlowManager
+    from vibe3.domain.publisher import EventPublisher
     from vibe3.domain.state_machine import (
         STATE_LABEL_META,
         VIBE_TASK_LABEL,
         validate_transition,
     )
 
-if TYPE_CHECKING:
-    from vibe3.domain.publisher import EventPublisher
+_LAZY_IMPORTS: dict[str, str] = {
+    # Events
+    "DomainEvent": "vibe3.domain.events",
+    "GovernanceDecisionRequired": "vibe3.domain.events",
+    "GovernanceScanCompleted": "vibe3.domain.events",
+    "GovernanceScanStarted": "vibe3.domain.events",
+    "IssueFailed": "vibe3.domain.events",
+    "ManagerDispatchIntent": "vibe3.domain.events",
+    "PlannerDispatchIntent": "vibe3.domain.events",
+    "ExecutorDispatchIntent": "vibe3.domain.events",
+    "ReviewerDispatchIntent": "vibe3.domain.events",
+    "SupervisorApplyCompleted": "vibe3.domain.events",
+    "SupervisorApplyDelegated": "vibe3.domain.events",
+    "SupervisorApplyDispatched": "vibe3.domain.events",
+    "SupervisorApplyStarted": "vibe3.domain.events",
+    "SupervisorIssueIdentified": "vibe3.domain.events",
+    "SupervisorPromptRendered": "vibe3.domain.events",
+    # Orchestration
+    "FlowManager": "vibe3.domain.flow_manager",
+    "GlobalDispatchCoordinator": "vibe3.domain.dispatch_coordinator",
+    "FailedGate": "vibe3.domain.failed_gate",
+    # State machine
+    "STATE_LABEL_META": "vibe3.models.state_machine",
+    "VIBE_TASK_LABEL": "vibe3.models.state_machine",
+    "validate_transition": "vibe3.models.state_machine",
+    # Publisher
+    "EventPublisher": "vibe3.domain.publisher",
+}
 
 
 def register_event_handlers() -> None:
@@ -81,98 +99,11 @@ def subscribe(event_type: str, handler: "Callable[[DomainEvent], None]") -> None
 
 
 def __getattr__(name: str) -> object:
-    """Lazy import for heavy modules to avoid circular dependencies."""
-    # Events
-    if name == "DomainEvent":
-        from vibe3.domain.events import DomainEvent
+    if name in _LAZY_IMPORTS:
+        import importlib
 
-        return DomainEvent
-    if name == "GovernanceDecisionRequired":
-        from vibe3.domain.events import GovernanceDecisionRequired
-
-        return GovernanceDecisionRequired
-    if name == "GovernanceScanCompleted":
-        from vibe3.domain.events import GovernanceScanCompleted
-
-        return GovernanceScanCompleted
-    if name == "GovernanceScanStarted":
-        from vibe3.domain.events import GovernanceScanStarted
-
-        return GovernanceScanStarted
-    if name == "IssueFailed":
-        from vibe3.domain.events import IssueFailed
-
-        return IssueFailed
-    if name == "ManagerDispatchIntent":
-        from vibe3.domain.events import ManagerDispatchIntent
-
-        return ManagerDispatchIntent
-    if name == "PlannerDispatchIntent":
-        from vibe3.domain.events import PlannerDispatchIntent
-
-        return PlannerDispatchIntent
-    if name == "ExecutorDispatchIntent":
-        from vibe3.domain.events import ExecutorDispatchIntent
-
-        return ExecutorDispatchIntent
-    if name == "ReviewerDispatchIntent":
-        from vibe3.domain.events import ReviewerDispatchIntent
-
-        return ReviewerDispatchIntent
-    if name == "SupervisorApplyCompleted":
-        from vibe3.domain.events import SupervisorApplyCompleted
-
-        return SupervisorApplyCompleted
-    if name == "SupervisorApplyDelegated":
-        from vibe3.domain.events import SupervisorApplyDelegated
-
-        return SupervisorApplyDelegated
-    if name == "SupervisorApplyDispatched":
-        from vibe3.domain.events import SupervisorApplyDispatched
-
-        return SupervisorApplyDispatched
-    if name == "SupervisorApplyStarted":
-        from vibe3.domain.events import SupervisorApplyStarted
-
-        return SupervisorApplyStarted
-    if name == "SupervisorIssueIdentified":
-        from vibe3.domain.events import SupervisorIssueIdentified
-
-        return SupervisorIssueIdentified
-    if name == "SupervisorPromptRendered":
-        from vibe3.domain.events import SupervisorPromptRendered
-
-        return SupervisorPromptRendered
-
-    # Orchestration
-    if name == "FlowManager":
-        from vibe3.domain.flow_manager import FlowManager
-
-        return FlowManager
-    if name == "GlobalDispatchCoordinator":
-        from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
-
-        return GlobalDispatchCoordinator
-    if name == "FailedGate":
-        from vibe3.domain.failed_gate import FailedGate
-
-        return FailedGate
-    if name == "STATE_LABEL_META":
-        from vibe3.models.state_machine import STATE_LABEL_META
-
-        return STATE_LABEL_META
-    if name == "VIBE_TASK_LABEL":
-        from vibe3.models.state_machine import VIBE_TASK_LABEL
-
-        return VIBE_TASK_LABEL
-    if name == "validate_transition":
-        from vibe3.models.state_machine import validate_transition
-
-        return validate_transition
-    if name == "EventPublisher":
-        from vibe3.domain.publisher import EventPublisher
-
-        return EventPublisher
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -16,7 +16,6 @@ from vibe3.clients import GitClient
 # Module-level re-exports from models/ (safe, no cycle risk)
 from vibe3.models import OrchestraConfig
 
-# Lazy imports via __getattr__ for everything else to avoid circular dependencies
 if TYPE_CHECKING:
     from vibe3.domain.dispatch_coordinator import MAX_INTENTS_PER_TICK
     from vibe3.domain.failed_gate import FailedGate, GateResult, GateStatus
@@ -60,145 +59,54 @@ if TYPE_CHECKING:
         sort_ready_issues,
     )
 
+_LAZY_IMPORTS: dict[str, str] = {
+    # Models
+    "QueueEntry": "vibe3.models",
+    # Domain
+    "FailedGate": "vibe3.domain.failed_gate",
+    "GateResult": "vibe3.domain.failed_gate",
+    "GateStatus": "vibe3.domain.failed_gate",
+    "MAX_INTENTS_PER_TICK": "vibe3.domain.dispatch_coordinator",
+    "QualifyGateService": "vibe3.domain.qualify_gate",
+    "find_role_for_state": "vibe3.domain.role_resolver",
+    # Observability
+    "append_governance_event": "vibe3.observability",
+    "append_orchestra_event": "vibe3.observability",
+    "append_orchestra_run_separator": "vibe3.observability",
+    "orchestra_events_log_path": "vibe3.observability",
+    "orchestra_log_dir": "vibe3.observability",
+    # Utils
+    "resolve_priority": "vibe3.utils.queue_ordering",
+    "resolve_roadmap_rank": "vibe3.utils.queue_ordering",
+    "sort_ready_issues": "vibe3.utils.queue_ordering",
+    # Orchestra submodules
+    "select_ready_issues_from_collected_issues": "vibe3.orchestra.queue_operations",
+    "promote_progressed_entries": "vibe3.orchestra.queue_operations",
+    "QueuePersistenceService": "vibe3.orchestra.queue_persistence_service",
+    "DispatchHealthCheckService": "vibe3.orchestra.dispatch_health_check",
+    "get_flow_context": "vibe3.orchestra.issue_loader",
+    "load_issue": "vibe3.orchestra.issue_loader",
+    "is_auto_task_branch": "vibe3.orchestra.issue_loader",
+    # Protocols
+    "CheckServiceProtocol": "vibe3.orchestra.protocols",
+    "FlowServiceProtocol": "vibe3.orchestra.protocols",
+    "CapacityServiceProtocol": "vibe3.orchestra.protocols",
+    "IssueCollectionServiceProtocol": "vibe3.orchestra.protocols",
+    "FlowManagerProtocol": "vibe3.orchestra.protocols",
+    "LabelDispatchCallable": "vibe3.orchestra.protocols",
+    # Services
+    "CheckResult": "vibe3.services",
+    "should_skip_from_queue": "vibe3.services",
+    "get_manager_usernames": "vibe3.services",
+}
+
 
 def __getattr__(name: str) -> object:
-    """Lazy import for all symbols to avoid circular dependencies.
+    if name in _LAZY_IMPORTS:
+        import importlib
 
-    All symbols (orchestra submodules, domain, services) are imported lazily
-    to prevent circular import issues.
-    """
-    # Orchestra submodule symbols
-    if name == "QueueEntry":
-        from vibe3.models import QueueEntry
-
-        return QueueEntry
-    if name == "FailedGate":
-        from vibe3.domain.failed_gate import FailedGate
-
-        return FailedGate
-    if name == "append_governance_event":
-        from vibe3.observability import append_governance_event
-
-        return append_governance_event
-    if name == "append_orchestra_event":
-        from vibe3.observability import append_orchestra_event
-
-        return append_orchestra_event
-    if name == "append_orchestra_run_separator":
-        from vibe3.observability import append_orchestra_run_separator
-
-        return append_orchestra_run_separator
-    if name == "orchestra_events_log_path":
-        from vibe3.observability import orchestra_events_log_path
-
-        return orchestra_events_log_path
-    if name == "orchestra_log_dir":
-        from vibe3.observability import orchestra_log_dir
-
-        return orchestra_log_dir
-    if name == "resolve_priority":
-        from vibe3.utils.queue_ordering import resolve_priority
-
-        return resolve_priority
-    if name == "resolve_roadmap_rank":
-        from vibe3.utils.queue_ordering import resolve_roadmap_rank
-
-        return resolve_roadmap_rank
-    if name == "sort_ready_issues":
-        from vibe3.utils.queue_ordering import sort_ready_issues
-
-        return sort_ready_issues
-    if name == "select_ready_issues_from_collected_issues":
-        from vibe3.orchestra.queue_operations import (
-            select_ready_issues_from_collected_issues,
-        )
-
-        return select_ready_issues_from_collected_issues
-    if name == "promote_progressed_entries":
-        from vibe3.orchestra.queue_operations import promote_progressed_entries
-
-        return promote_progressed_entries
-    if name == "QueuePersistenceService":
-        from vibe3.orchestra.queue_persistence_service import QueuePersistenceService
-
-        return QueuePersistenceService
-    if name == "DispatchHealthCheckService":
-        from vibe3.orchestra.dispatch_health_check import DispatchHealthCheckService
-
-        return DispatchHealthCheckService
-    if name == "get_flow_context":
-        from vibe3.orchestra.issue_loader import get_flow_context
-
-        return get_flow_context
-    if name == "load_issue":
-        from vibe3.orchestra.issue_loader import load_issue
-
-        return load_issue
-    if name == "is_auto_task_branch":
-        from vibe3.orchestra.issue_loader import is_auto_task_branch
-
-        return is_auto_task_branch
-    if name == "CheckServiceProtocol":
-        from vibe3.orchestra.protocols import CheckServiceProtocol
-
-        return CheckServiceProtocol
-    if name == "FlowServiceProtocol":
-        from vibe3.orchestra.protocols import FlowServiceProtocol
-
-        return FlowServiceProtocol
-    if name == "CapacityServiceProtocol":
-        from vibe3.orchestra.protocols import CapacityServiceProtocol
-
-        return CapacityServiceProtocol
-    if name == "IssueCollectionServiceProtocol":
-        from vibe3.orchestra.protocols import IssueCollectionServiceProtocol
-
-        return IssueCollectionServiceProtocol
-    if name == "FlowManagerProtocol":
-        from vibe3.orchestra.protocols import FlowManagerProtocol
-
-        return FlowManagerProtocol
-    if name == "LabelDispatchCallable":
-        from vibe3.orchestra.protocols import LabelDispatchCallable
-
-        return LabelDispatchCallable
-
-    # Domain symbols (domain/ imports from orchestra submodules)
-    if name == "MAX_INTENTS_PER_TICK":
-        from vibe3.domain.dispatch_coordinator import MAX_INTENTS_PER_TICK
-
-        return MAX_INTENTS_PER_TICK
-    if name == "QualifyGateService":
-        from vibe3.domain.qualify_gate import QualifyGateService
-
-        return QualifyGateService
-    if name == "find_role_for_state":
-        from vibe3.domain.role_resolver import find_role_for_state
-
-        return find_role_for_state
-    if name == "GateResult":
-        from vibe3.domain.failed_gate import GateResult
-
-        return GateResult
-    if name == "GateStatus":
-        from vibe3.domain.failed_gate import GateStatus
-
-        return GateStatus
-
-    # Services symbols (services/ may import from orchestra)
-    if name == "CheckResult":
-        from vibe3.services import CheckResult
-
-        return CheckResult
-    if name == "should_skip_from_queue":
-        from vibe3.services import should_skip_from_queue
-
-        return should_skip_from_queue
-    if name == "get_manager_usernames":
-        from vibe3.services import get_manager_usernames
-
-        return get_manager_usernames
-
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -80,6 +80,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "resolve_roadmap_rank": "vibe3.utils.queue_ordering",
     "sort_ready_issues": "vibe3.utils.queue_ordering",
     # Orchestra submodules
+    "create_global_dispatch_coordinator": "vibe3.orchestra.dispatch_coordinator_factory",  # noqa: E501
     "select_ready_issues_from_collected_issues": "vibe3.orchestra.queue_operations",
     "promote_progressed_entries": "vibe3.orchestra.queue_operations",
     "QueuePersistenceService": "vibe3.orchestra.queue_persistence_service",
@@ -128,6 +129,7 @@ __all__ = [
     "promote_progressed_entries",
     "QueuePersistenceService",
     "DispatchHealthCheckService",
+    "create_global_dispatch_coordinator",
     "get_flow_context",
     "load_issue",
     "is_auto_task_branch",


### PR DESCRIPTION
## Summary

Migrate `domain/__init__.py` and `orchestra/__init__.py` from if-chain lazy imports to dict-based dispatch, matching the pattern used by all other modules (`analysis`, `clients`, `config`, `models`, `roles`, `prompts`).

This PR **supersedes** the domain/__init__.py and orchestra/__init__.py changes in PR #2270 — those files no longer need modification there.

## Before / After

```python
# Before: 3 lines per symbol, 50+ repetitive blocks
if name == "CapacityServiceProtocol":
    from vibe3.domain.protocols import CapacityServiceProtocol
    return CapacityServiceProtocol

# After: 1 dict entry
"CapacityServiceProtocol": "vibe3.domain.protocols",
```

## Symbols included

**New in this PR** (previously in if-chain, migrated to dict):
- 15 domain events (`DomainEvent`, `IssueFailed`, `ManagerDispatchIntent`, ...)
- Orchestration: `FlowManager`, `GlobalDispatchCoordinator`, `FailedGate`
- State machine: `STATE_LABEL_META`, `VIBE_TASK_LABEL`, `validate_transition`
- Publisher: `EventPublisher`

**Also added** (new symbols from PR #2270 scope, in dict format from the start):
- Protocols: `CapacityServiceProtocol`, `CheckServiceProtocol`, `FlowServiceProtocol`, `FlowManagerProtocol`, `LabelDispatchCallable`, `ServiceBase`
- Domain classes: `GateResult`, `GateStatus`, `MAX_INTENTS_PER_TICK`, `OrchestrationFacade`, `QualifyGateService`, `find_role_for_state`
- Orchestra: `create_global_dispatch_coordinator`

## Impact

- Net: **-161 lines** across 2 files in the base migration
- 150 existing tests pass
- All new symbols resolve correctly at runtime
- mypy + ruff clean

## Merge order

This PR should be merged **before** PR #2270. After merge, PR #2270 no longer needs to touch `domain/__init__.py` or `orchestra/__init__.py`.

## Test plan

- [x] `uv run pytest tests/vibe3/test_domain_public_api.py tests/vibe3/orchestra/` — 150 passed
- [x] Runtime smoke test: all 29 symbols resolve correctly
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — passed via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)