### PR TITLE
docs: archive deprecated standards and fix cross-references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,8 +53,8 @@ docs/
 - **[doc-organization.md](standards/doc-organization.md)** - 文档组织标准
 
 **已废弃文档 (Archives)**：
-- **[vibe3-role-checks-and-balances-standard.md](standards/vibe3-role-checks-and-balances-standard.md)** (DEPRECATED) - Vibe3 角色制衡架构标准 (已废弃，见 v3/human-mirror-architecture-philosophy.md)
-- **[agent-debugging-standard.md](standards/agent-debugging-standard.md)** (DEPRECATED) - Agent 调试标准 (已废弃，见 v3/serve-debugging-guide.md)
+- **[vibe3-role-checks-and-balances-standard.md](archive/vibe3-role-checks-and-balances-standard.md)** (DEPRECATED) - Vibe3 角色制衡架构标准 (已废弃，见 [standards/v3/human-mirror-architecture-philosophy.md](standards/v3/human-mirror-architecture-philosophy.md))
+- **[agent-debugging-standard.md](archive/agent-debugging-standard.md)** (DEPRECATED) - Agent 调试标准 (已废弃，见 [standards/v3/serve-debugging-guide.md](standards/v3/serve-debugging-guide.md))
 - **[vibe3-worktree-ownership-standard.md](archive/vibe3-worktree-ownership-standard.md)** (DEPRECATED) - Worktree 所有权标准 (已废弃，见 standards/v3/worktree-lifecycle-standard.md)
 
 **V3 规范目录**：

--- a/docs/archive/agent-debugging-standard.md
+++ b/docs/archive/agent-debugging-standard.md
@@ -1,4 +1,8 @@
-# Agent 调试标准
+# Agent 调试标准 (DEPRECATED)
+
+> [!CAUTION]
+> **本文档已废弃**。Vibe3 Agent 编排与调试的最新权威指南请参考：[v3/serve-debugging-guide.md](../standards/v3/serve-debugging-guide.md)。
+> 本文档仅保留作为历史背景参考。
 
 > **文档定位**：Vibe3 agent 编排调试的统一入口。涵盖日志规范、链路调试方法、观测手段和项目理解。
 > **适用范围**：所有使用 `vibe3 serve`、`vibe3 run`、`vibe3 plan`、`vibe3 review`、heartbeat、orchestra、Role Adapters (manager) 的 agent 编排调试。

--- a/docs/archive/vibe3-role-checks-and-balances-standard.md
+++ b/docs/archive/vibe3-role-checks-and-balances-standard.md
@@ -1,6 +1,8 @@
-# Vibe3 Role Checks and Balances Standard
+# Vibe3 Role Checks and Balances Standard (DEPRECATED)
 
-状态: Deprecated (见 [v3/human-mirror-architecture-philosophy.md](v3/human-mirror-architecture-philosophy.md))
+> [!CAUTION]
+> **本文档已废弃**。Vibe3 角色制衡与架构哲学的最新权威指南请参考：[v3/human-mirror-architecture-philosophy.md](../standards/v3/human-mirror-architecture-philosophy.md)。
+> 本文档仅保留作为历史背景参考。
 
 ## 1. 目的
 

--- a/docs/standards/flow-context-cache-standard.md
+++ b/docs/standards/flow-context-cache-standard.md
@@ -369,7 +369,7 @@ WHERE branch = ? AND expires_at > datetime('now');
 
 - [glossary.md](glossary.md) — 术语定义
 - [v3/command-standard.md](v3/command-standard.md) — 命令与状态同步标准
-- [agent-debugging-standard.md](agent-debugging-standard.md) — 调试方法
+- [v3/serve-debugging-guide.md](v3/serve-debugging-guide.md) — 调试方法
 
 ## 10. 变更历史
 

--- a/docs/standards/flow-lifecycle-standard.md
+++ b/docs/standards/flow-lifecycle-standard.md
@@ -14,7 +14,7 @@ related_docs:
   - docs/standards/label-semantics.md
   - docs/standards/glossary.md
   - docs/standards/v3/error-severity-and-blocking-standard.md
-  - docs/standards/vibe3-role-checks-and-balances-standard.md
+  - docs/standards/v3/human-mirror-architecture-philosophy.md
   - docs/standards/v3/data-model-standard.md
   - docs/standards/v3/event-driven-standard.md
 ---
@@ -25,7 +25,7 @@ related_docs:
 
 **术语定义** 见 [glossary.md](glossary.md)，本文档不重复定义。
 
-**角色权力边界** 见 [vibe3-role-checks-and-balances-standard.md](vibe3-role-checks-and-balances-standard.md)。
+**角色权力边界** 见 [v3/human-mirror-architecture-philosophy.md](v3/human-mirror-architecture-philosophy.md)。
 
 **数据模型** 见 [v3/data-model-standard.md](v3/data-model-standard.md)。
 
@@ -653,7 +653,7 @@ store.add_event(
 ## 9. 参考文档
 
 - [glossary.md](glossary.md) - 术语定义（权威）
-- [vibe3-role-checks-and-balances-standard.md](vibe3-role-checks-and-balances-standard.md) - 角色权力边界（权威）
+- [v3/human-mirror-architecture-philosophy.md](v3/human-mirror-architecture-philosophy.md) - 角色权力边界（权威）
 - [v3/data-model-standard.md](v3/data-model-standard.md) - 数据模型（权威）
 - [event-driven-standard.md](v3/event-driven-standard.md) - 事件驱动架构
 - [noop-gate-boundary-standard.md](v3/noop-gate-boundary-standard.md) - 阻塞原则与 noop gate 边界

--- a/docs/standards/issue-dependency-standard.md
+++ b/docs/standards/issue-dependency-standard.md
@@ -301,7 +301,7 @@ Blocked Issues:
 - **标签管理**：[roadmap-label-management.md](roadmap-label-management.md)
 - **术语表**：[glossary.md](glossary.md)
 - **Manager 行为规范**：[supervisor/manager.md](../../supervisor/manager.md)
-- **Governance 规范**：[vibe3-role-checks-and-balances-standard.md](vibe3-role-checks-and-balances-standard.md)
+- **Governance 规范**：[v3/human-mirror-architecture-philosophy.md](v3/human-mirror-architecture-philosophy.md)
 
 ---
 

--- a/docs/standards/v3/event-driven-standard.md
+++ b/docs/standards/v3/event-driven-standard.md
@@ -517,7 +517,7 @@ LabelService().transition(
 - **[worktree-ownership-standard.md](worktree-ownership-standard.md)**: 定义执行层级与 worktree 语义，本文件补充事件语义。
 - **[vibe3-orchestra-runtime-standard.md](../vibe3-orchestra-runtime-standard.md)**: 定义 driver/tick/async child 架构，事件发布时机参考该文件。
 - **[command-standard.md](command-standard.md)**: 定义 flow 状态机，事件触发条件参考该文件。
-- **[agent-debugging-standard.md](../agent-debugging-standard.md)**: 调试手册，事件日志规范以本文件为准。
+- **[serve-debugging-guide.md](serve-debugging-guide.md)**: 调试手册，事件日志规范以本文件为准。
 
 ### 11.2 术语真源
 

--- a/docs/standards/v3/handoff-governance-standard.md
+++ b/docs/standards/v3/handoff-governance-standard.md
@@ -157,7 +157,7 @@ V2 到 V3 handoff 系统的关键变化：
 |------|------------|-------------|
 | 存储 | `.agent/context/task.md` | SQLite + Markdown buffer |
 | 路径 | `.git/vibe/` | `.git/vibe3/` |
-| 命令 | `vibe2 flow` | `vibe3` Python CLI |
+| 命令 | `vibe2 flow` (Legacy/Deprecated) | `vibe3` Python CLI |
 | 主键 | worktree name | branch name |
 | 关系 | issue links 内嵌 | 独立表 `flow_issue_links` |
 

--- a/docs/standards/v3/orchestra-runtime-standard.md
+++ b/docs/standards/v3/orchestra-runtime-standard.md
@@ -31,7 +31,7 @@
 - `state/*` 业务含义细节（见 `docs/standards/v3/command-standard.md`）
 - handoff 正文格式
 - skill / supervisor 具体 prompt 文案
-- 日志读取与调试方法（见 `docs/standards/agent-debugging-standard.md`）
+- 日志读取与调试方法（见 `docs/standards/serve-debugging-guide.md`）
 
 ## 2. 核心对象
 
@@ -264,7 +264,7 @@ state trigger 是消费已有 `state/*` labels 的 service 集合。
 
 ## 7. 日志语义
 
-> 完整的日志规范、目录结构和读取方法见 [agent-debugging-standard.md](agent-debugging-standard.md) §三。
+> 完整的日志规范、目录结构和读取方法见 [serve-debugging-guide.md](serve-debugging-guide.md) §三。
 
 ### 7.1 主事件日志
 

--- a/docs/standards/v3/serve-debugging-guide.md
+++ b/docs/standards/v3/serve-debugging-guide.md
@@ -10,7 +10,7 @@ author: planner (Claude Opus 4.6)
 created: 2026-05-01
 last_updated: 2026-05-01
 related_docs:
-  - docs/standards/agent-debugging-standard.md
+  - ../../archive/agent-debugging-standard.md
   - docs/standards/vibe3-orchestra-runtime-standard.md
   - docs/standards/v3/noop-gate-boundary-standard.md
   - docs/standards/v3/command-standard.md
@@ -28,7 +28,7 @@ related_docs:
 
 **调试前必读的权威标准**（按优先级）：
 
-1. **[agent-debugging-standard.md](./agent-debugging-standard.md)**：Agent 调试总入口
+1. **[agent-debugging-standard.md](../../archive/agent-debugging-standard.md)**：(Archive) Agent 调试总入口 (DEPRECATED)
    - 日志规范、链路调试方法、观测手段
    - 上层业务 vs 底层触发的职责边界
    - async/tmux 观察优先原则
@@ -186,8 +186,8 @@ tail -f temp/logs/orchestra/events.log
 | 场景 | 文档 | 用途 |
 |-----|------|------|
 | Reviewer Webhook | [debug-reviewer-webhook.md](../v3/orchestra/debug-reviewer-webhook.md) | Webhook 触发链路、签名验证 |
-| Manager 执行 | 见 agent-debugging-standard.md | 单 issue 执行链 |
-| Supervisor 治理 | 见 agent-debugging-standard.md | 自动化治理链 |
+| Manager 执行 | 见 [agent-debugging-standard.md](../../archive/agent-debugging-standard.md) (Archive) | 单 issue 执行链 |
+| Supervisor 治理 | 见 [agent-debugging-standard.md](../../archive/agent-debugging-standard.md) (Archive) | 自动化治理链 |
 
 **使用原则**：
 - 先读本指南了解整体框架
@@ -266,7 +266,7 @@ vibe3 task status --trace
 
 每次调试前快速检查：
 
-- [ ] 已阅读 [agent-debugging-standard.md](./agent-debugging-standard.md)
+- [ ] 已阅读 [agent-debugging-standard.md](../../archive/agent-debugging-standard.md)
 - [ ] 确认当前 CLI 语法（`serve start` 默认 async，`--no-async` 同步）
 - [ ] 确认日志路径（`temp/logs/orchestra/`、`temp/logs/*.async.log`）
 - [ ] 确认真源路径（`vibe3 flow show`、`vibe3 task status`、GitHub issue）


### PR DESCRIPTION
Archive deprecated standards and fix cross-references as requested in #2283.

### Changes:
- Moved `docs/standards/vibe3-role-checks-and-balances-standard.md` to `docs/archive/`.
- Moved `docs/standards/agent-debugging-standard.md` to `docs/archive/`.
- Updated `docs/README.md` with archived links and fixed descriptions.
- Added DEPRECATED markers to both archived files, pointing to new standards.
- Updated `docs/standards/flow-lifecycle-standard.md` to point to `v3/human-mirror-architecture-philosophy.md`.
- Updated `docs/standards/issue-dependency-standard.md` to point to `v3/human-mirror-architecture-philosophy.md`.
- Updated `docs/standards/v3/handoff-governance-standard.md` to clarify `vibe2 flow` as legacy.
- Updated multiple references to `agent-debugging-standard.md` across the documentation.

Closes #2283