### PR TITLE
test: strengthen weak assertions in test_execution_role_policy.py

### DIFF
--- a/tests/vibe3/execution/test_execution_role_policy.py
+++ b/tests/vibe3/execution/test_execution_role_policy.py
@@ -4,12 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from vibe3.execution.execution_role_policy import (
-    ConcurrencyClass,
-    ExecutionRolePolicyService,
-    PromptContract,
-    SessionStrategy,
-)
+from vibe3.execution.execution_role_policy import ExecutionRolePolicyService
 from vibe3.models.orchestra_config import (
     AssigneeDispatchConfig,
     GovernanceConfig,
@@ -70,7 +65,6 @@ def test_resolve_prompt_contract_manager(sample_config: OrchestraConfig) -> None
     service = ExecutionRolePolicyService(config=sample_config)
     contract = service.resolve_prompt_contract("manager")
 
-    assert isinstance(contract, PromptContract)
     assert contract.template == "orchestra.assignee_dispatch.manager"
 
 
@@ -79,7 +73,6 @@ def test_resolve_prompt_contract_supervisor(sample_config: OrchestraConfig) -> N
     service = ExecutionRolePolicyService(config=sample_config)
     contract = service.resolve_prompt_contract("supervisor")
 
-    assert isinstance(contract, PromptContract)
     assert contract.template == "orchestra.supervisor.apply"
 
 
@@ -88,7 +81,6 @@ def test_resolve_session_strategy_manager(sample_config: OrchestraConfig) -> Non
     service = ExecutionRolePolicyService(config=sample_config)
     strategy = service.resolve_session_strategy("manager")
 
-    assert isinstance(strategy, SessionStrategy)
     # Manager with use_worktree=True and async_mode=True should use tmux
     assert strategy.mode == "tmux"
     assert strategy.timeout == 3600
@@ -99,8 +91,8 @@ def test_resolve_session_strategy_unknown_role(sample_config: OrchestraConfig) -
     service = ExecutionRolePolicyService(config=sample_config)
     strategy = service.resolve_session_strategy("unknown_role")
 
-    assert isinstance(strategy, SessionStrategy)
     assert strategy.mode == "async"
+    assert strategy.timeout is None
 
 
 def test_resolve_concurrency_class_manager(sample_config: OrchestraConfig) -> None:
@@ -108,7 +100,6 @@ def test_resolve_concurrency_class_manager(sample_config: OrchestraConfig) -> No
     service = ExecutionRolePolicyService(config=sample_config)
     concurrency = service.resolve_concurrency_class("manager")
 
-    assert isinstance(concurrency, ConcurrencyClass)
     assert concurrency.max_concurrent == 3  # From max_concurrent_flows
     assert concurrency.semaphore_key == "manager"
 
@@ -118,7 +109,6 @@ def test_resolve_concurrency_class_other_role(sample_config: OrchestraConfig) ->
     service = ExecutionRolePolicyService(config=sample_config)
     concurrency = service.resolve_concurrency_class("planner")
 
-    assert isinstance(concurrency, ConcurrencyClass)
     assert concurrency.max_concurrent == 10  # Default for agents
     assert concurrency.semaphore_key == "planner"
 
@@ -127,25 +117,28 @@ def test_all_roles_resolve_backend(sample_config: OrchestraConfig) -> None:
     """Test that all valid orchestra roles can resolve backend."""
     service = ExecutionRolePolicyService(config=sample_config)
 
-    # Only orchestra roles are handled by ExecutionRolePolicyService
-    roles = ["manager", "supervisor", "governance"]
-    for role in roles:
+    expected_backends = {
+        "manager": "claude",
+        "supervisor": "claude",
+        "governance": "openai",
+    }
+    for role, expected_backend in expected_backends.items():
         backend = service.resolve_backend(role)
-        assert isinstance(backend, str)
-        assert isinstance(backend, str)
-        assert backend in ["claude", "openai"]
+        assert backend == expected_backend
 
 
 def test_all_roles_resolve_prompt_contract(sample_config: OrchestraConfig) -> None:
     """Test that all valid orchestra roles can resolve prompt contract."""
     service = ExecutionRolePolicyService(config=sample_config)
 
-    # Only orchestra roles are handled by ExecutionRolePolicyService
-    roles = ["manager", "supervisor", "governance"]
-    for role in roles:
+    expected_templates = {
+        "manager": "orchestra.assignee_dispatch.manager",
+        "supervisor": "orchestra.supervisor.apply",
+        "governance": "orchestra.governance.plan",
+    }
+    for role, expected_template in expected_templates.items():
         contract = service.resolve_prompt_contract(role)
-        assert isinstance(contract, PromptContract)
-        assert contract.template  # Non-empty template
+        assert contract.template == expected_template
 
 
 @patch("vibe3.execution.execution_role_policy.sync_models_json")


### PR DESCRIPTION
## Summary
Remove redundant isinstance() type checks and strengthen test assertions to verify business logic instead of Python's type system.

## Changes
- Remove 7 redundant isinstance() checks that only tested Python's type system
- Strengthen test_all_roles_resolve_backend with per-role expected values
- Strengthen test_all_roles_resolve_prompt_contract with per-role expected values
- Add missing timeout assertion for unknown role session strategy
- Remove unused imports (ConcurrencyClass, PromptContract, SessionStrategy)

## Testing
- All 12 tests pass
- Type check: clean (mypy success)
- Lint: clean (ruff all checks passed)

Closes #2272

---

## Contributors

claude/opus
