### PR TITLE
refactor(analysis): move global metric calculation to compute_diff

### DIFF
--- a/docs/handoffs/issue-2179-merge-ready.md
+++ b/docs/handoffs/issue-2179-merge-ready.md
@@ -1,0 +1,33 @@
+# Publish Indicate — Issue #2179
+
+**Branch**: task/issue-2179
+**Issue**: #2179 — Roundabout Logic: Misplaced global metric calculation in _diff_files
+
+## Action
+Execute commit + PR creation (vibe-commit skill).
+
+## Context
+- Review VERDICT: PASS (trusted audit)
+- Commit: 7eba599c refactor(analysis): move global metric calculation to compute_diff
+- Net change: 1 file modified, +1 LOC (pure refactor)
+- Change: Moved `total_loc_delta` and `total_functions_delta` from `_diff_files` to `compute_diff`
+- 139 tests passing (136 analysis + 3 snapshot model)
+- Type checking: PASS (mypy)
+- Linting: PASS (ruff)
+- Baseline structural diff: minimal (no new modules/dependencies/functions)
+
+## Notes
+- Pure refactor, no functional changes
+- Placement after `DiffSummary.__add__` is correct and preserves values
+- Downstream consumers validated (snapshot_diff_section.py, snapshot.py)
+- Risk: LOW — code movement only, all tests pass
+
+## Requirements
+- PR title: `refactor(analysis): move global metric calculation to compute_diff`
+- PR description should explain:
+  - This is a pure refactor moving global metrics to the correct location
+  - `total_loc_delta` and `total_functions_delta` moved from `_diff_files` to `compute_diff`
+  - No functional changes, all tests pass (139 tests)
+  - Type checking and linting pass
+- Link to issue #2179
+- Target branch: main

--- a/src/vibe3/analysis/snapshot_diff.py
+++ b/src/vibe3/analysis/snapshot_diff.py
@@ -77,11 +77,6 @@ def _diff_files(
             )
             summary.files_modified += 1
 
-    summary.total_loc_delta = current.metrics.total_loc - baseline.metrics.total_loc
-    summary.total_functions_delta = (
-        current.metrics.total_functions - baseline.metrics.total_functions
-    )
-
     return file_changes, summary
 
 
@@ -223,6 +218,12 @@ def compute_diff(
         dep_changes, dep_summary = _diff_dependencies(baseline, current)
 
         summary = file_summary + module_summary + dep_summary
+
+        # Compute global metrics (must be after __add__ to avoid being overwritten)
+        summary.total_loc_delta = current.metrics.total_loc - baseline.metrics.total_loc
+        summary.total_functions_delta = (
+            current.metrics.total_functions - baseline.metrics.total_functions
+        )
 
         diff = StructureDiff(
             baseline_id=baseline.snapshot_id,


### PR DESCRIPTION
## Summary
This is a pure refactor that moves global metric calculation (`total_loc_delta` and `total_functions_delta`) from `_diff_files` to `compute_diff`, where it logically belongs as a global-level computation.

## Changes
- **Removed** from `_diff_files`: Misplaced global metric calculation (lines 80-83)
- **Added** to `compute_diff`: Global metric calculation after `DiffSummary.__add__` aggregation (lines 223-226)
- **Rationale**: Global metrics represent snapshot-level calculations, not file-level. Placing them in `_diff_files` was conceptually wrong and created a hidden dependency on snapshot metrics. Moving to `compute_diff` makes the logic explicit and correctly scoped.

## Technical Details
- The assignment is placed **after** `DiffSummary.__add__` aggregation to preserve correct values
- If placed before, the `__add__` would overwrite these values with sums of zero-valued sub-summaries
- No functional changes - the computed values remain identical

## Verification
- ✅ All tests pass (136 analysis tests + 3 snapshot model tests)
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff)
- ✅ No LOC violations

Closes #2179

---

## Contributors

claude/opus
