### PR TITLE
refactor(coverage): convert redundant fields to computed properties

### DIFF
--- a/docs/merge-ready/issue-2286.md
+++ b/docs/merge-ready/issue-2286.md
@@ -1,0 +1,42 @@
+# Merge-Ready Handoff: Issue #2286
+
+## Task Summary
+Convert redundant data fields (total_covered, total_lines, overall_percent) in CoverageReport to @computed_field @property methods.
+
+## Execution Status
+✅ All tests pass (423 tests)
+✅ Type checks pass (mypy clean)
+✅ Lint checks pass (ruff, black)
+✅ Pre-commit hooks pass
+✅ Review passed with VERDICT: PASS
+
+## Commit Information
+- Commit SHA: 8de5294b
+- Commit message: refactor(coverage): convert redundant fields to computed properties
+- Branch: task/issue-2286
+- Base branch: task/issue-2179
+
+## PR Creation Instructions
+1. Ensure current branch is task/issue-2286
+2. Ensure commit 8de5294b is present
+3. Create PR with:
+   - Title: refactor(coverage): convert redundant fields to computed properties
+   - Body:
+     - Summary: Convert total_covered, total_lines, overall_percent to @computed_field @property
+     - Issue reference: #2286
+     - Test results: 423 tests pass
+     - Verification: All checks pass (tests, mypy, ruff, black)
+4. Do NOT push - PR will be created locally first
+5. Write pr_ref after PR creation
+
+## Files Changed
+- src/vibe3/models/coverage.py (converted fields to @computed_field @property)
+- src/vibe3/analysis/coverage_service.py (removed redundant constructor args)
+- tests/vibe3/models/test_coverage_report.py (updated tests)
+- tests/vibe3/commands/conftest.py (updated fixtures)
+
+## References
+- Plan: docs/plans/issue-2286-redundant-coverage-fields.md
+- Report: docs/reports/issue-2286-execution-report.md
+- Audit: docs/reports/issue-2286-audit-report.md
+- Verdict: PASS

--- a/src/vibe3/analysis/coverage_service.py
+++ b/src/vibe3/analysis/coverage_service.py
@@ -70,31 +70,14 @@ class CoverageService:
         commands_cov = self._analyze_layer(coverage_data, "commands")
 
         # 3. Build report
-        total_covered = (
-            services_cov.covered_lines
-            + clients_cov.covered_lines
-            + commands_cov.covered_lines
-        )
-        total_lines = (
-            services_cov.total_lines
-            + clients_cov.total_lines
-            + commands_cov.total_lines
-        )
-        overall_percent = (
-            (total_covered / total_lines * 100) if total_lines > 0 else 0.0
-        )
-
         report = CoverageReport(
             services=services_cov,
             clients=clients_cov,
             commands=commands_cov,
-            total_covered=total_covered,
-            total_lines=total_lines,
-            overall_percent=overall_percent,
         )
 
         logger.info(
-            f"Coverage check complete: {overall_percent:.1f}% overall, "
+            f"Coverage check complete: {report.overall_percent:.1f}% overall, "
             f"all_passing={report.all_passing}"
         )
 

--- a/src/vibe3/models/coverage.py
+++ b/src/vibe3/models/coverage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 
 
 class LayerCoverage(BaseModel):
@@ -31,9 +31,33 @@ class CoverageReport(BaseModel):
     services: LayerCoverage
     clients: LayerCoverage
     commands: LayerCoverage
-    total_covered: int
-    total_lines: int
-    overall_percent: float
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total_covered(self) -> int:
+        """Total covered lines across all layers."""
+        return (
+            self.services.covered_lines
+            + self.clients.covered_lines
+            + self.commands.covered_lines
+        )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total_lines(self) -> int:
+        """Total lines across all layers."""
+        return (
+            self.services.total_lines
+            + self.clients.total_lines
+            + self.commands.total_lines
+        )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def overall_percent(self) -> float:
+        """Overall coverage percentage."""
+        total = self.total_lines
+        return (self.total_covered / total * 100) if total > 0 else 0.0
 
     @property
     def all_passing(self) -> bool:

--- a/tests/vibe3/commands/conftest.py
+++ b/tests/vibe3/commands/conftest.py
@@ -78,9 +78,6 @@ def mock_coverage_all_passing() -> CoverageReport:
             coverage_percent=90.0,
             threshold=80,
         ),
-        total_covered=2170,
-        total_lines=2500,
-        overall_percent=86.8,
     )
 
 
@@ -109,9 +106,6 @@ def mock_coverage_failing() -> CoverageReport:
             coverage_percent=90.0,
             threshold=80,
         ),
-        total_covered=2020,
-        total_lines=2500,
-        overall_percent=80.8,
     )
 
 

--- a/tests/vibe3/models/test_coverage_report.py
+++ b/tests/vibe3/models/test_coverage_report.py
@@ -1,5 +1,7 @@
 """Tests for CoverageReport model."""
 
+import pytest
+
 from vibe3.models.coverage import CoverageReport, LayerCoverage
 
 
@@ -33,9 +35,6 @@ def test_coverage_report_creation() -> None:
         services=services,
         clients=clients,
         commands=commands,
-        total_covered=2170,
-        total_lines=2500,
-        overall_percent=86.8,
     )
 
     assert report.services == services
@@ -43,7 +42,7 @@ def test_coverage_report_creation() -> None:
     assert report.commands == commands
     assert report.total_covered == 2170
     assert report.total_lines == 2500
-    assert report.overall_percent == 86.8
+    assert report.overall_percent == pytest.approx(86.8)
 
 
 def test_coverage_report_all_passing() -> None:
@@ -71,9 +70,6 @@ def test_coverage_report_all_passing() -> None:
             coverage_percent=90.0,
             threshold=80,
         ),
-        total_covered=2170,
-        total_lines=2500,
-        overall_percent=86.8,
     )
     assert all_pass.all_passing is True
 
@@ -100,9 +96,6 @@ def test_coverage_report_all_passing() -> None:
             coverage_percent=90.0,
             threshold=80,
         ),
-        total_covered=2020,
-        total_lines=2500,
-        overall_percent=80.8,
     )
     assert one_fail.all_passing is False
 
@@ -129,9 +122,6 @@ def test_coverage_report_all_passing() -> None:
             coverage_percent=70.0,
             threshold=80,
         ),
-        total_covered=1650,
-        total_lines=2500,
-        overall_percent=66.0,
     )
     assert all_fail.all_passing is False
 
@@ -166,9 +156,6 @@ def test_coverage_report_get_failing_layers() -> None:
         services=services,
         clients=clients,
         commands=commands,
-        total_covered=1870,
-        total_lines=2500,
-        overall_percent=74.8,
     )
 
     failing = report.get_failing_layers()
@@ -203,9 +190,6 @@ def test_coverage_report_no_failing_layers() -> None:
             coverage_percent=90.0,
             threshold=80,
         ),
-        total_covered=2170,
-        total_lines=2500,
-        overall_percent=86.8,
     )
 
     failing = report.get_failing_layers()


### PR DESCRIPTION
## Summary
Convert redundant data fields in CoverageReport to computed properties, eliminating data redundancy and ensuring consistency.

Changed `total_covered`, `total_lines`, and `overall_percent` from stored Pydantic fields to `@computed_field @property` methods computed from layer data.

## Changes
- `src/vibe3/models/coverage.py`: Replace stored fields with computed properties
- `src/vibe3/analysis/coverage_service.py`: Remove redundant constructor arguments
- `tests/vibe3/models/test_coverage_report.py`: Update tests for computed fields
- `tests/vibe3/commands/conftest.py`: Update fixtures

## Testing
✅ All tests pass (423 tests)
✅ Type checks pass (mypy clean)
✅ Lint checks pass (ruff, black)
✅ Pre-commit hooks pass

## Verification
- Computed properties correctly sum layer coverage data
- Division-by-zero guard implemented for overall_percent
- API compatibility maintained (attribute access unchanged)
- Serialization behavior preserved (computed_field included in model_dump)

Closes #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
