### PR TITLE
docs(runtime-kernel): fix stale comment direction in taxonomy

### DIFF
--- a/src/vibe3/runtime/taxonomy.py
+++ b/src/vibe3/runtime/taxonomy.py
@@ -51,9 +51,9 @@ MODULE_CATEGORY_MAP: Final[dict[str, ModuleCategory]] = {
     "domain": ModuleCategory.OBSERVATION,
 }
 
-# Allowed dependency directions: category N may import from categories >= N
-# Kernel (1) must not import from command-adapter (2), policy (3),
-# plugin (4), observation (5) internals
+# Allowed dependency directions: category N may import from categories <= N
+# (lower categories are foundational; higher categories depend on lower ones)
+# Kernel (1) may only import from itself (category 1)
 # Observation (5) may import from all categories (event core needs full access)
 # Plugin-surface (4) may import from kernel, adapter, policy, and itself
 CATEGORY_ALLOWED_DEPS: Final[dict[ModuleCategory, set[ModuleCategory]]] = {

--- a/tests/vibe3/test_modularity/test_taxonomy.py
+++ b/tests/vibe3/test_modularity/test_taxonomy.py
@@ -5,7 +5,6 @@ Validates that:
 2. Dependency directions follow category rules
 3. Kernel (runtime + orchestra) does not import adapter/policy/observation internals
    at module level
-4. Observation (domain) has access to all categories (event core)
 
 Taxonomy alignment with kernel startup boundary (#2161/#2293):
   KERNEL: runtime, orchestra
@@ -270,7 +269,7 @@ class TestCategoryDependencyDirection:
     ) -> None:
         """Verify imports respect category dependency rules.
 
-        Category N may only import from categories >= N.
+        Category N may only import from categories <= N.
         """
         violations = []
 


### PR DESCRIPTION
## Summary

Fixed three instances of stale comments/docstrings in the kernel taxonomy that incorrectly described the dependency direction as `>= N` (higher categories can be imported), when the actual rule implemented in `CATEGORY_ALLOWED_DEPS` is `<= N` (lower categories are foundational; higher categories depend on lower ones).

## Changes

1. **src/vibe3/runtime/taxonomy.py** (lines 54-58)
   - Fixed comment: `>= N` → `<= N`
   - Enhanced with clearer explanation of dependency direction

2. **tests/vibe3/test_modularity/test_taxonomy.py** (line 272)
   - Fixed docstring in `test_category_dependency_direction`

3. **tests/vibe3/test_modularity/test_taxonomy.py** (lines 7-8)
   - Removed item 4 from module docstring (no dedicated OBSERVATION test exists)

## Testing

- ✅ All tests pass (3 passed, 1 xfailed as expected)
- ✅ Ruff: All checks passed
- ✅ MyPy: Success, no issues found
- ✅ LOC checks: All files under CI block threshold

## Related

- Closes #2290
- Parent issue: #2162

---

## Contributors

claude/opus
