### PR TITLE
fix(flow_lifecycle): restore lazy ConventionResolver evaluation in blocked()

### DIFF
--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -11,6 +11,7 @@ from vibe3.services import (
     FlowService,
     load_issue_info,
     resolve_branch_and_issue,
+    resolve_branch_arg,
 )
 from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 
@@ -50,7 +51,7 @@ def blocked(
 
     service = FlowService()
 
-    target_branch, issue_number = resolve_branch_and_issue(branch)
+    target_branch = resolve_branch_arg(branch)
 
     logger.bind(
         command="flow blocked",
@@ -63,7 +64,8 @@ def blocked(
     flow_status = service.get_flow_status(target_branch)
 
     if not flow_status:
-        # Try to auto-create flow if branch matches task/dev convention
+        # Lazy: only resolve issue_number when flow doesn't exist
+        _, issue_number = resolve_branch_and_issue(branch)
         if issue_number:
             logger.bind(
                 branch=target_branch,


### PR DESCRIPTION
## Summary

Fixes #2266

PR #2259 引入了 `blocked()` 的行为回归：`resolve_branch_and_issue()` 无条件调用 `ConventionResolver`，即使 flow 已存在。

## Change

恢复惰性求值：先用轻量的 `resolve_branch_arg()` 解析分支名，只在 flow 不存在时才调用 `resolve_branch_and_issue()` 解析 issue_number。

- `flow_lifecycle.py:54` — `resolve_branch_and_issue(branch)` → `resolve_branch_arg(branch)`
- `flow_lifecycle.py:68` — 在 `not flow_status` 分支内调用 `resolve_branch_and_issue(branch)`

## Testing

- 23 个相关测试全部通过（`test_flow_blocked`, `test_flow_rebuild`, `test_flow_lifecycle`）

## Contributors

- @jacobcy (human): diagnosis and review
- claude-sonnet-4-6 (agent): implementation