### PR TITLE
docs(governance): consolidate pre-flow dependency rules + add vibe-task role

### DIFF
--- a/skills/vibe-roadmap/SKILL.md
+++ b/skills/vibe-roadmap/SKILL.md
@@ -258,3 +258,17 @@ RFC (需讨论)
 - 不根据当前 runtime 现场做即时抢占排序（转 `vibe-orchestra`）
 - 所有操作通过 GitHub labels，不在本地存储
 - 所有决策必须写 `[roadmap decision]` marker，**禁止**写 `[governance suggest]`
+
+## Pre-flow Dependency Rules
+
+> 完整规范见 [roadmap-common.md § Pre-flow Dependency Rules](../supervisor/roadmap-common.md)
+
+vibe-roadmap 在 pre-flow 阶段（issue 无 flow/branch context）的约束：
+
+- ✅ 在 issue body 正文中用自然语言说明依赖：`Blocked by #N`、`Depends on #N`
+- ✅ 添加 `roadmap/*`、`priority/*` 规划类 labels
+- ❌ 禁止直接添加 `state/blocked` 标签 — pre-flow 无法保证三源（label/body/cache）原子写入，会导致 dispatcher 无法识别
+- ❌ 禁止直接写 managed section（`Blocked by:` / `Dependencies:` 结构化字段）
+- ❌ 禁止调用 `vibe3 flow blocked / flow bind` — 这两个命令需要 branch 存在
+
+依赖的正式注册（写入 managed section + flow_issue_links）由 manager 入场后完成；pre-flow 只负责把依赖关系说清楚。

--- a/skills/vibe-task/SKILL.md
+++ b/skills/vibe-task/SKILL.md
@@ -266,3 +266,17 @@ Epic Issues（依赖图梳理）
 - **不做版本规划建议**：由 `vibe-roadmap` 管理
 - **不做复杂审计或修复**：只处理 RFC、blocked、epic issues
 - **不补充 CLI 未提供的字段**：基于真源，只读 shell 输出
+
+## Pre-flow Dependency Rules
+
+> 完整规范见 [roadmap-common.md § Pre-flow Dependency Rules](../supervisor/roadmap-common.md)
+
+vibe-task 在 pre-flow 阶段（issue 无 flow/branch context）的约束：
+
+- ✅ 在 issue body 正文中用自然语言说明依赖：`Blocked by #N`、`Depends on #N`
+- ✅ 添加 `roadmap/*`、`priority/*` 规划类 labels
+- ❌ 禁止直接添加 `state/blocked` 标签 — pre-flow 无法保证三源（label/body/cache）原子写入，会导致 dispatcher 无法识别
+- ❌ 禁止直接写 managed section（`Blocked by:` / `Dependencies:` 结构化字段）
+- ❌ 禁止调用 `vibe3 flow blocked / flow bind` — 这两个命令需要 branch 存在
+
+依赖的正式注册（写入 managed section + flow_issue_links）由 manager 入场后完成；pre-flow 只负责把依赖关系说清楚。

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -839,3 +839,19 @@ Sub-issues 状态：
 - 对于未完成的 Epic，按 assignee 决定是否只记录 stdout 或添加 `orchestra-governed`
 - 对于已完成的 Epic，直接关闭
 - **关键**：assignee-pool 是 Epic 进度的最后守门员；不要重复 suggest，也不要制造 cleanup/scan 循环
+
+---
+
+## Pre-flow Dependency Rules
+
+> 完整规范见 [roadmap-common.md § Pre-flow Dependency Rules](../roadmap-common.md)
+
+assignee-pool 在评估和决策阶段的依赖操作约束：
+
+- ✅ 在 decide/suggest comment 中说明依赖关系（"需先完成 #N"、"阻塞于 #N 的基础设施"）
+- ✅ 添加 `roadmap/*`、`priority/*` 规划类 labels；决策后打 `orchestra-governed`
+- ❌ 禁止直接添加 `state/blocked` 标签 — 即使 issue 已有 assignee，正式 blocked 状态需由 manager 通过 `vibe3 flow blocked --task <N>` 建立
+- ❌ 禁止写 managed section（`<!-- vibe3-flow-state-start -->` 块中的结构化字段）
+- ❌ 禁止调用 `vibe3 flow blocked / flow bind` — pool 层无 flow 执行权限
+
+**记录方式**：依赖关系和阻塞原因写在 `[governance decide][assignee-pool]` 评论中，manager 入场时读取并执行 `vibe3 flow blocked --task <N>` 完成正式注册。

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -428,3 +428,19 @@ gh issue edit <issue-number> --add-label "orchestra-scanned"
 - [ ] 确认标签已添加（可选：`gh issue view <number> --json labels` 验证）
 
 **缺少标签的后果**：跳过的 issue 会被下次扫描重复处理，造成资源浪费。
+
+---
+
+## Pre-flow Dependency Rules
+
+> 完整规范见 [roadmap-common.md § Pre-flow Dependency Rules](../roadmap-common.md)
+
+roadmap-intake 在扫描和决策阶段的依赖操作约束：
+
+- ✅ 在 suggest comment 中用自然语言说明依赖关系（"建议先等 #N 完成"、"依赖 #N 的 API 设计"）
+- ✅ 添加 `roadmap/*`、`priority/*` 规划类 labels
+- ❌ 禁止直接添加 `state/blocked` 标签 — intake 层无法保证三源（label/body/cache）原子写入
+- ❌ 禁止写 managed section（`<!-- vibe3-flow-state-start -->` 块中的结构化字段）
+- ❌ 禁止调用 `vibe3 flow blocked / flow bind` — issue 尚未进入执行池，无 flow context
+
+**记录方式**：依赖关系写在 `[governance suggest][roadmap-intake]` 评论中，由 manager 入场后通过 `vibe3 flow blocked --task <N>` 正式建立。

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -58,6 +58,7 @@ broader repo --> Layer 1: roadmap-intake (入口层)
 | **roadmap-intake** | supervisor/governance/roadmap-intake.md | `[governance suggest][roadmap-intake]` | 入口观察者：扫描 broader repo，决定是否纳入 pool | 跳过时打 `orchestra-scanned` |
 | **assignee-pool** | supervisor/governance/assignee-pool.md | `[governance suggest][assignee-pool]` / `[governance decide][assignee-pool]` | 入池前/池内准入 decider：对本机 manager pool 中 issue 做 rfc/epic/ready/close 决策 | 决策后打 `orchestra-governed`，高置信度 close 直接终局 |
 | **vibe-roadmap** | skills/vibe-roadmap/SKILL.md | `[roadmap decision]` | 上层审查者：审查 governance 决策，纠正和补全 | 审查后打 `roadmap-reviewed` |
+| **vibe-task** | skills/vibe-task/SKILL.md | 无（human-facing，不写 marker） | 人机协作规划辅助：帮助人类处理 blocked/RFC/epic issues，整理依赖关系说明，pre-flow 阶段仅写 issue body 自然语言 | 不操作 `state/*` 标签，不写 managed section |
 
 ---
 
@@ -291,6 +292,42 @@ vibe-roadmap 是治理-决策双轨中的**决策者**，不是 observer。marke
 **审查范围**：`roadmap/rfc`、`state/blocked`、未 reviewed 的 issue
 **权限**：可覆盖 pool 的决策（rfc → continue、epic → split 等）
 **标签**：审查完打 `roadmap-reviewed`，写 memory.md
+
+### Vibe Task（人机协作规划辅助）
+
+**职责**：human-facing skill，帮助人类处理 blocked/RFC/epic 问题类 issue，整理依赖关系，监控 epic 进度
+**操作权限**：
+- ✅ 读取 issue/flow/task 现场信息
+- ✅ 在 issue body 正文中用自然语言说明依赖关系（"Blocked by #N", "Depends on #N"）
+- ✅ 添加 `roadmap/*`、`priority/*` 规划类 labels
+- ❌ 不操作 `state/*` 标签（blocked/ready/handoff 等均不允许）
+- ❌ 不直接写 managed section（`<!-- vibe3-flow-state-start -->` 块）
+- ❌ 不调用 `vibe3 flow blocked / flow bind` 命令（需要 flow context，pre-flow 阶段不存在）
+**与 governance 层的边界**：vibe-task 是人类规划阶段的辅助工具，不参与自动化 governance 循环；它写入的依赖说明由 manager 入场后转化为正式 flow_issue_links
+
+---
+
+## Pre-flow Dependency Rules
+
+**适用范围**：所有在 pre-flow 阶段操作的角色（vibe-task、vibe-roadmap、roadmap-intake、assignee-pool）
+
+pre-flow 阶段指 issue 尚未进入执行池、无 branch、无 flow context 的状态。此阶段的核心约束：
+
+**Allowed**:
+- issue body 中用自然语言说明依赖关系：`Blocked by #N`、`Depends on #N`、`依赖 #N 完成后推进`
+- 添加 `roadmap/*`、`priority/*` 等规划类 labels
+
+**Forbidden**:
+- ❌ 直接添加 `state/blocked` 标签
+- ❌ 直接写 managed section（`<!-- vibe3-flow-state-start --> ... <!-- vibe3-flow-state-end -->` 块中的 `Blocked by:`/`Dependencies:` 等结构化字段）
+- ❌ 调用 `vibe3 flow blocked`、`vibe3 flow bind` 命令
+
+**理由**：
+1. pre-flow 阶段无 flow context，`flow blocked / flow bind` 命令需要 branch 存在才能执行
+2. 直接添加 `state/blocked` 标签而不写 managed section，会导致三源（label/body/local cache）不一致，orchestra dispatcher 无法正确识别和清除
+3. 依赖关系的正式注册（写入 managed section + flow_issue_links）由 **manager 入场后**通过 `vibe3 flow blocked --task <N>` 完成；pre-flow 只需写清楚依赖关系的自然语言描述即可
+
+**Manager 的衔接职责**：manager 入场时须读取 issue body 中的依赖声明，与 flow_issue_links 比对，补全未注册的依赖。
 
 ---
 


### PR DESCRIPTION
## Summary

- `supervisor/roadmap-common.md` 新增两个 canonical section：**Vibe Task 职责边界** + **Pre-flow Dependency Rules**
- 角色分工表补充 `vibe-task`（此前完全缺席）
- 4 个文件（vibe-roadmap、vibe-task、roadmap-intake、assignee-pool）各加**概述+引用**，避免裸引用（agent 读不到引用内容时仍能了解关键约束）

## 问题背景

PR #2349 在 4 个文件里分别加了完全相同的 `Pre-flow Constraints` 块，违反了 `roadmap-common.md` 引用指南原则（各文件引用不重复定义）。同时 `vibe-task` 在角色分工表中完全缺席。

## 变更说明

### roadmap-common.md（核心）

1. **角色分工表** 新增 vibe-task 行，说明其 human-facing 属性和操作限制
2. **各层职责边界** 新增 Vibe Task 小节
3. **Pre-flow Dependency Rules** 新增 canonical section，包含：
   - 适用范围（所有 pre-flow 角色）
   - Allowed / Forbidden 清单
   - 禁止直接操作 `state/blocked` 标签的理由（三源不一致问题）
   - Manager 的衔接职责

### 4 个 material 文件

每个文件末尾新增一节，格式为：
- 首行：`> 完整规范见 roadmap-common.md §...`（引用）
- 以下：该角色视角的 3-5 条关键规则概述

这样即使 agent 没有读引用内容，也能从概述中理解约束。

## 与 PR 2349 的关系

本 PR 解决 #2349 材料部分的结构问题。建议 #2349 合并时删除其在 4 个文件中加入的重复 `Pre-flow Constraints` 块（改为本 PR 的概述+引用格式），保留其 `qualify_gate.py` 和 `manager.md` 的代码/文档修改。

Relates to #2339