### PR TITLE
cleanup(services/issue): minor quality improvements after subpackage migration

### DIFF
--- a/src/vibe3/services/issue/failure.py
+++ b/src/vibe3/services/issue/failure.py
@@ -2,11 +2,13 @@
 
 This module handles failure/block transitions for issues when
 executor or manager runs fail or make no progress.
+
+Intra-subpackage dependency: failure → flow (one-directional; do not reverse).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from loguru import logger
 
@@ -274,7 +276,3 @@ def block_reviewer_noop_issue(
         repo=repo,
         is_noop=True,
     )
-
-
-if TYPE_CHECKING:
-    pass


### PR DESCRIPTION
Closes #2340

## Summary

Two minor quality cleanups in `services/issue/failure.py`:
- Remove dead `if TYPE_CHECKING: pass` block and unused TYPE_CHECKING import
- Document intra-subpackage dependency direction: `failure → flow`

## Changes

- **Line 11**: Removed unused `TYPE_CHECKING` from typing imports
- **Lines 279-280**: Deleted empty `if TYPE_CHECKING: pass` block
- **Line 6**: Added docstring note documenting dependency direction

## Test Plan

- [x] `ruff check src/vibe3/services/issue/failure.py` - All checks passed
- [x] `mypy src/vibe3/services/issue/failure.py` - No type errors
- [x] `pytest tests/vibe3/services/test_check_cleanup_service.py -q` - 20/20 tests passed
- [x] Module-level checks: `ruff check` and `mypy` on entire `services/issue/` module passed

## Verification

Purely cosmetic cleanup with no functional impact. All linting, type checking, and tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
