### PR TITLE
config(loc): update test_execution_lifecycle.py limit to 660 for PR #2352 error_contract tests

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -191,8 +191,8 @@ code_limits:
         limit: 500
         reason: "Codeagent async 执行测试集，覆盖异步启动、日志收集、错误处理等场景，共享 fixture"
       - path: "tests/vibe3/execution/test_execution_lifecycle.py"
-        limit: 570
-        reason: "Execution lifecycle 测试集，5 个测试类围绕同一服务契约，共享 fixture；新增 test_empty_session_id_does_not_backfill 边缘情况测试（38 行）验证空字符串 session_id 处理逻辑"
+        limit: 660
+        reason: "Execution lifecycle 测试集，5 个测试类围绕同一服务契约，共享 fixture；新增 test_empty_session_id_does_not_backfill 边缘情况测试（38 行）验证空字符串 session_id 处理逻辑；PR #2352 新增 error_contract 参数测试验证 runtime error 状态保留后略微超标"
       - path: "tests/vibe3/execution/test_coordinator.py"
         limit: 600
         reason: "Coordinator 核心测试，12 个测试函数围绕调度逻辑（async/sync dispatch、capacity、error handling），共享 mock_dependencies fixture，拆分收益低"


### PR DESCRIPTION
## Summary

更新 `tests/vibe3/execution/test_execution_lifecycle.py` 的 LOC 限制从 570 提升到 660，以支持 PR #2352 新增的 error_contract 参数测试。

## Context

PR #2352 新增了 error_contract 参数相关测试，验证 runtime error 状态保留逻辑，导致测试文件行数增加，触发 CI 阻塞。

## Changes

- 更新 `config/v3/loc_limits.yaml` 中 `tests/vibe3/execution/test_execution_lifecycle.py` 的 limit 从 570 → 660
- 更新 reason 说明，记录 PR #2352 的改动

## Test plan

- [x] 本地 pre-push 检查通过
- [ ] CI 检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)