### PR TITLE
refactor(config): use get_env_override for VIBE_PROFILE in ConventionResolver

### DIFF
--- a/src/vibe3/config/convention_resolver.py
+++ b/src/vibe3/config/convention_resolver.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from vibe3.config.env_override import get_env_override
 from vibe3.config.profile_convention import ProfileConvention
 
 if TYPE_CHECKING:
@@ -112,7 +113,6 @@ class ConventionResolver:
         if self._profile_cache is not None:
             return self._profile_cache
 
-        import os
         import subprocess
 
         import yaml
@@ -124,7 +124,7 @@ class ConventionResolver:
             return result
 
         # Step 2: Check environment variable
-        env_profile = os.getenv("VIBE_PROFILE")
+        env_profile: str | None = get_env_override("VIBE_PROFILE")
         if env_profile:
             self._profile_cache = env_profile
             return env_profile


### PR DESCRIPTION
## Summary

Replaces raw `os.getenv("VIBE_PROFILE")` with unified `get_env_override("VIBE_PROFILE")` in ConventionResolver to align with the project's canonical environment variable access pattern.

## Changes

- **src/vibe3/config/convention_resolver.py**:
  - Added top-level import: `from vibe3.config.env_override import get_env_override`
  - Removed local `import os` from inside `_detect_profile()` method
  - Replaced `os.getenv("VIBE_PROFILE")` with `get_env_override("VIBE_PROFILE")`
  - Added type annotation `str | None` for mypy compliance

## Motivation

Direct `os.getenv` bypasses the unified configuration management layer. Using `get_env_override` provides:
- Centralized environment variable access
- Type conversion with error handling
- Consistent logging and monitoring

## Testing

- **Direct tests**: 13 passed (test_convention_resolver.py)
- **Module tests**: 157 passed (tests/vibe3/config/)
- **Type checks**: mypy PASS
- **Lint**: ruff PASS

## Related

Closes #2348

---

## Contributors

claude/opus
