### PR TITLE
refactor(modularity): Phase 1a - 消除 utils 跨模块转手 re-export

### DIFF
--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -9,6 +9,8 @@ from typing import Any
 import yaml
 from loguru import logger
 
+from vibe3.clients import runtime_assets_root
+
 # public-api: pending upstream export
 from vibe3.clients.runtime_assets import check_runtime_asset
 from vibe3.config import MANAGER_GATE_CONFIG, ConventionResolver
@@ -40,7 +42,6 @@ from vibe3.roles.definitions import (
 )
 from vibe3.services import fail_manager_issue
 from vibe3.services.flow_factory import create_flow_manager
-from vibe3.utils import runtime_assets_root
 
 MANAGER_ROLE = TriggerableRoleDefinition(
     name="manager",

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -16,7 +16,7 @@ from vibe3.agents import (
     make_run_context_builder,
     make_skill_context_builder,
 )
-from vibe3.clients import SQLiteClient
+from vibe3.clients import SQLiteClient, resolve_runtime_asset
 from vibe3.config import ConventionResolver, VibeConfig, load_orchestra_config
 from vibe3.config.cli_overrides import RoleCliOverrides
 from vibe3.exceptions import SkillNotAvailableError
@@ -33,7 +33,6 @@ from vibe3.roles.run_helpers import (
     publish_run_command_success,
 )
 from vibe3.services import record_dispatch_failure_if_unexpected
-from vibe3.utils import resolve_runtime_asset
 
 
 def resolve_skill_path(

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -4,13 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-# Cross-module imports (not self-references)
-from vibe3.clients.runtime_assets import (
-    resolve_prompt_config,
-    resolve_runtime_asset,
-    runtime_assets_root,
-)
-
 if TYPE_CHECKING:
     from vibe3.utils.actor_utils import normalize_actor
     from vibe3.utils.branch_utils import find_parent_branch
@@ -147,11 +140,8 @@ __all__ = [
     "parse_issue_number",
     "prepare_prompt_file",
     "read_instance_info",
-    "resolve_prompt_config",
     "resolve_priority",
     "resolve_roadmap_rank",
-    "resolve_runtime_asset",
-    "runtime_assets_root",
     "sanitize_prompt_for_display",
     "sanitize_task_shell_meta",
     "stream_reader",


### PR DESCRIPTION
## Summary
Remove cross-module re-exports from \`vibe3.utils\` to \`vibe3.clients.runtime_assets\`:
- \`resolve_prompt_config\`
- \`resolve_runtime_asset\`
- \`runtime_assets_root\`

## Changes
- **utils/__init__.py**: Remove cross-module import block and \`__all__\` entries (lines 7-12)
- **roles/manager.py**: Import \`runtime_assets_root\` from \`vibe3.clients\`
- **roles/run_command.py**: Import \`resolve_runtime_asset\` from \`vibe3.clients\`

## Rationale
This eliminates the indirection layer where \`utils\` re-exported symbols from \`clients\`, improving module boundary clarity and maintaining proper dependency direction.

## Testing
- ✅ Modularity tests: 25 passed, 4 xfailed
- ✅ Utils tests: 133 passed
- ✅ Type check (mypy): No errors
- ✅ Lint (ruff): All checks passed

## Scope
- **In scope**: Remove 3 re-exported symbols from utils, update 2 consumer files
- **Out of scope**: Other modules and deep imports

Closes #2279

---

## Contributors

claude/opus
