### PR TITLE
refactor(config): replace subprocess.run with GitClient in ConventionResolver

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -40,8 +40,8 @@ code_limits:
         limit: 540
         reason: "Schema DDL 与迁移聚合，包含 9 个表定义（含 transition_history）、16+ 迁移步骤（含幂等历史数据提取），新增 severity 列迁移与回填逻辑，DDL 字符串和迁移逻辑紧密耦合不宜拆分"
       - path: "src/vibe3/clients/git_client.py"
-        limit: 550
-        reason: "Git 门面聚合，新增 get_all_branches_with_timestamps 支持过期资源清理，新增 find_repo_root() 统一 repo 根目录解析（带 lru_cache 缓存优化），新增 pack_refs_all() 支持 Git 引用存储一致性修复（Issue #2330）"
+        limit: 560
+        reason: "Git 门面聚合，新增 get_all_branches_with_timestamps 支持过期资源清理，新增 find_repo_root() 统一 repo 根目录解析（带 lru_cache 缓存优化），新增 pack_refs_all() 支持 Git 引用存储一致性修复（Issue #2330），新增 get_remote_url() 支持 ConventionResolver 重构（Issue #2346）"
       - path: "src/vibe3/clients/github_pr_read_ops.py"
         limit: 520
         reason: "GitHub PR 只读查询聚合，新增 CI 失败分类与检查步骤解析逻辑，包含失败分类、日志解析、状态映射等紧密耦合逻辑"

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -235,6 +235,20 @@ class GitClient:
             self._git_common_dir = _get_git_common_dir(self._run)
         return self._git_common_dir
 
+    def get_remote_url(self, name: str = "origin") -> str | None:
+        """Get the URL of a git remote.
+
+        Args:
+            name: Remote name (default: "origin")
+
+        Returns:
+            Remote URL string, or None if remote doesn't exist or not a git repo
+        """
+        try:
+            return self._run(["remote", "get-url", name])
+        except GitError:
+            return None
+
     def get_worktree_root(self) -> str:
         """Get the top-level path of the current worktree."""
         return _get_worktree_root(self._run)

--- a/src/vibe3/config/convention_resolver.py
+++ b/src/vibe3/config/convention_resolver.py
@@ -113,8 +113,6 @@ class ConventionResolver:
         if self._profile_cache is not None:
             return self._profile_cache
 
-        import subprocess
-
         import yaml
 
         # Step 1: Check explicit override
@@ -158,24 +156,12 @@ class ConventionResolver:
             logger.debug(f"Failed to resolve git common dir for .vibe/config.yaml: {e}")
 
         # Step 4: Check git remote to detect Vibe Center repo
-        try:
-            git_result = subprocess.run(
-                ["git", "remote", "get-url", "origin"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-                check=False,
-            )
-            if git_result.returncode == 0:
-                remote_url = git_result.stdout.strip().lower()
-                if (
-                    "vibe-center" in remote_url
-                    or "vibe-coding-control-center" in remote_url
-                ):
-                    self._profile_cache = "vibe-center"
-                    return "vibe-center"
-        except Exception as e:
-            logger.debug(f"Git remote check failed: {e}")
+        remote_url = self._get_git_client().get_remote_url()
+        if remote_url:
+            url_lower = remote_url.lower()
+            if "vibe-center" in url_lower or "vibe-coding-control-center" in url_lower:
+                self._profile_cache = "vibe-center"
+                return "vibe-center"
 
         # Step 5: Default to minimal
         self._profile_cache = "minimal"

--- a/tests/vibe3/clients/test_git_client.py
+++ b/tests/vibe3/clients/test_git_client.py
@@ -94,6 +94,33 @@ class TestGetGitCommonDir:
                 client.get_git_common_dir()
 
 
+class TestGetRemoteUrl:
+    """get_remote_url 测试."""
+
+    def test_returns_remote_url_on_success(self) -> None:
+        client = GitClient()
+        url = "https://github.com/user/repo.git"
+        with patch.object(client, "_run", return_value=url) as mock_run:
+            assert client.get_remote_url() == url
+
+        mock_run.assert_called_once_with(["remote", "get-url", "origin"])
+
+    def test_returns_none_on_no_remote(self) -> None:
+        client = GitClient()
+        with patch.object(
+            client, "_run", side_effect=GitError("remote get-url", "no such remote")
+        ):
+            assert client.get_remote_url() is None
+
+    def test_passes_remote_name(self) -> None:
+        client = GitClient()
+        url = "https://github.com/user/upstream.git"
+        with patch.object(client, "_run", return_value=url) as mock_run:
+            assert client.get_remote_url(name="upstream") == url
+
+        mock_run.assert_called_once_with(["remote", "get-url", "upstream"])
+
+
 class TestListWorktrees:
     """list_worktrees 测试."""
 

--- a/tests/vibe3/config/test_convention_resolver.py
+++ b/tests/vibe3/config/test_convention_resolver.py
@@ -10,11 +10,12 @@ Tests verify that:
 """
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
 
+from vibe3.clients.git_client import GitClient
 from vibe3.config.convention_resolver import ConventionResolver
 from vibe3.exceptions import GitError
 
@@ -26,13 +27,14 @@ def test_resolver_returns_minimal_defaults_by_default():
         patch(
             "vibe3.clients.git_client.GitClient.get_git_common_dir"
         ) as mock_git_common_dir,
-        patch("subprocess.run") as mock_run,
+        patch.object(
+            GitClient,
+            "get_remote_url",
+            return_value="https://github.com/other/repo.git",
+        ),
         patch("pathlib.Path.exists") as mock_exists,
     ):
         mock_git_common_dir.return_value = "/tmp/test/.git"
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="https://github.com/other/repo.git\n"
-        )
         mock_exists.return_value = False  # No .vibe/config.yaml
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
@@ -92,13 +94,14 @@ def test_resolver_detects_vibe_center_repo():
         patch(
             "vibe3.clients.git_client.GitClient.get_git_common_dir"
         ) as mock_git_common_dir,
-        patch("subprocess.run") as mock_run,
+        patch.object(
+            GitClient,
+            "get_remote_url",
+            return_value="https://github.com/jacobcy/vibe-center.git",
+        ),
         patch("pathlib.Path.exists") as mock_exists,
     ):
         mock_git_common_dir.return_value = "/tmp/test/.git"
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
-        )
         mock_exists.return_value = False  # No .vibe/config.yaml
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
@@ -111,12 +114,13 @@ def test_resolver_falls_back_when_git_common_dir_lookup_fails():
         patch(
             "vibe3.clients.git_client.GitClient.get_git_common_dir"
         ) as mock_git_common_dir,
-        patch("subprocess.run") as mock_run,
+        patch.object(
+            GitClient,
+            "get_remote_url",
+            return_value="https://github.com/jacobcy/vibe-center.git",
+        ),
     ):
         mock_git_common_dir.side_effect = GitError("rev-parse", "not a git repository")
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="https://github.com/jacobcy/vibe-center.git\n"
-        )
         resolver = ConventionResolver.from_repo()
         convention = resolver.resolve()
         assert convention.branch.task_prefix == "task/issue-"
@@ -152,13 +156,14 @@ def test_detect_profile_is_cached():
         patch(
             "vibe3.clients.git_client.GitClient.get_git_common_dir"
         ) as mock_git_common_dir,
-        patch("subprocess.run") as mock_run,
+        patch.object(
+            GitClient,
+            "get_remote_url",
+            return_value="https://github.com/other/repo.git",
+        ) as mock_get_remote_url,
         patch("pathlib.Path.exists") as mock_exists,
     ):
         mock_git_common_dir.return_value = "/tmp/test/.git"
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="https://github.com/other/repo.git\n"
-        )
         mock_exists.return_value = False
 
         resolver = ConventionResolver.from_repo()
@@ -171,9 +176,8 @@ def test_detect_profile_is_cached():
         assert convention1.branch.task_prefix == "issue-"
         assert convention2.branch.task_prefix == "issue-"
 
-        # subprocess.run should only be called once due to caching
-        # (once for git remote, not for each resolve call)
-        assert mock_run.call_count == 1
+        # get_remote_url should only be called once due to caching
+        assert mock_get_remote_url.call_count == 1
 
 
 def test_detect_profile_cache_invalidation():
@@ -182,13 +186,14 @@ def test_detect_profile_cache_invalidation():
         patch(
             "vibe3.clients.git_client.GitClient.get_git_common_dir"
         ) as mock_git_common_dir,
-        patch("subprocess.run") as mock_run,
+        patch.object(
+            GitClient,
+            "get_remote_url",
+            return_value="https://github.com/other/repo.git",
+        ) as mock_get_remote_url,
         patch("pathlib.Path.exists") as mock_exists,
     ):
         mock_git_common_dir.return_value = "/tmp/test/.git"
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="https://github.com/other/repo.git\n"
-        )
         mock_exists.return_value = False
 
         # First resolver instance
@@ -203,5 +208,5 @@ def test_detect_profile_cache_invalidation():
         assert convention1.branch.task_prefix == "issue-"
         assert convention2.branch.task_prefix == "issue-"
 
-        # Each instance should call subprocess once
-        assert mock_run.call_count == 2
+        # Each instance should call get_remote_url once
+        assert mock_get_remote_url.call_count == 2


### PR DESCRIPTION
## Summary

Refactor ConventionResolver to use GitClient abstraction instead of direct subprocess.run calls for remote URL detection.

## Changes

- **GitClient**: Added `get_remote_url(name="origin")` method with graceful error handling (returns `None` on failure)
- **ConventionResolver**: Removed subprocess dependency, replaced with GitClient call in `_detect_profile()` Step 4
- **Tests**: Added 3 new tests for `get_remote_url()`, updated 5 existing tests to mock GitClient instead of subprocess
- **LOC Config**: Updated exception limit for `git_client.py` from 550 to 560 lines

## Verification

- ✅ All tests pass (50 tests: git_client, convention_resolver, integration)
- ✅ Type check passes (mypy)
- ✅ Lint passes (ruff)
- ✅ LOC limits enforced

## Related Issue

Closes #2346

## Test Plan

- Unit tests added for new `GitClient.get_remote_url()` method
- Existing tests updated to verify refactoring maintains same behavior
- Integration tests confirm no regression in profile detection

---

## Contributors

claude/opus
