### PR TITLE
refactor(check): rename handle_closed_pr and clean up kept_records field

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -263,8 +263,8 @@ code_limits:
         limit: 600
         reason: "Check PR 状态测试集，覆盖 PR closed 检测、terminal 状态判断、duplicate handling、check priority fix (PR merged before issue-closed) 等紧密耦合场景，新增 PR merged with closed issue 回归测试后略微超标（#2284）"
       - path: "tests/vibe3/services/test_check_service.py"
-        limit: 520
-        reason: "Check service bridge issue 测试集，覆盖 9 个关键场景（bridge 创建、idempotency、API 失败保护、PR 编号精确匹配等），共享 mock setup，新增边缘情况测试后略微超标（#1895）"
+        limit: 540
+        reason: "Check service bridge issue 测试集，覆盖 9 个关键场景（bridge 创建、idempotency、API 失败保护、PR 编号精确匹配等），共享 mock setup，新增边缘情况测试后略微超标（#1895）；Issue #2329 rename handle_closed_pr → handle_pr_terminal_state 增加行数（长方法名需换行，2个超长函数名需 noqa 注释）"
       - path: "tests/vibe3/services/test_handoff_service.py"
         limit: 500
         reason: "Handoff service 测试集，覆盖 plan/report/audit/indicate 记录、artifact 解析、verdict 处理、next step 管理、passive artifact 记录等紧密耦合场景，共享 fixture 和 mock setup，拆分收益低；架构重构后新增 ref_field 参数验证测试略微超标（#1908）"

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -160,7 +160,7 @@ class CheckPRService:
             ).warning(warning_msg)
             return (None, [warning_msg])
 
-    def handle_closed_pr(
+    def handle_pr_terminal_state(
         self,
         branch: str,
         pr: "PRResponse",
@@ -183,7 +183,7 @@ class CheckPRService:
         if pr.state == PRState.CLOSED:
             if self._already_handled_pr_closed(branch, pr):
                 return (False, [], [])
-            return self._handle_closed_pr(branch, pr)
+            return self._handle_closed_pr_flow(branch, pr)
 
         # PR still open, nothing to handle
         return (False, [], [])
@@ -213,7 +213,7 @@ class CheckPRService:
 
         return (True, [], warnings)
 
-    def _handle_closed_pr(
+    def _handle_closed_pr_flow(
         self, branch: str, pr: "PRResponse"
     ) -> tuple[bool, list[str], list[str]]:
         """Handle closed PR (without merge): reset issue, clean up.

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -349,7 +349,7 @@ class CheckService(CheckRemote):
             pr = self._branch_to_pr.get(branch)
             if pr:
                 handled, pr_issues, pr_warnings = (
-                    self._check_pr_service.handle_closed_pr(branch, pr)
+                    self._check_pr_service.handle_pr_terminal_state(branch, pr)
                 )
                 if handled:
                     return CheckResult(
@@ -364,7 +364,7 @@ class CheckService(CheckRemote):
                     cached_or_remote_pr = self._pr_service.get_branch_pr_status(branch)
                     if cached_or_remote_pr:
                         handled, pr_issues, pr_warnings = (
-                            self._check_pr_service.handle_closed_pr(
+                            self._check_pr_service.handle_pr_terminal_state(
                                 branch, cached_or_remote_pr
                             )
                         )

--- a/tests/vibe3/services/test_check_cleanup_service.py
+++ b/tests/vibe3/services/test_check_cleanup_service.py
@@ -325,7 +325,7 @@ class TestCleanResidualBranches:
 
         result = cleanup_service.clean_residual_branches()
 
-        # Done flow record should be soft-deleted (in cleaned, not kept_records)
+        # Done flow record should be soft-deleted (in cleaned list)
         assert len(result["cleaned"]) == 1
         assert "feature/done-branch" in result["cleaned"]
         assert "feature/done-branch" in result["cleaned_done"]

--- a/tests/vibe3/services/test_check_pr_status.py
+++ b/tests/vibe3/services/test_check_pr_status.py
@@ -406,7 +406,7 @@ class TestMergedPRCacheIntegration:
 class TestClosedPRIdempotency:
     """Test idempotency guard for closed PR handling."""
 
-    def test_handle_closed_pr_idempotency_skips_second_call(self, tmp_path):
+    def test_handle_pr_terminal_state_idempotency_skips_second_call(self, tmp_path):
         """Should skip handling if already handled with same closed_at."""
         from datetime import datetime, timezone
 
@@ -450,7 +450,7 @@ class TestClosedPRIdempotency:
             ci_passed=True,
         )
 
-        # ACT: Call handle_closed_pr
+        # ACT: Call handle_pr_terminal_state
         service = CheckPRService(
             store=store,
             git_client=git_client,
@@ -458,7 +458,7 @@ class TestClosedPRIdempotency:
             flow_status_service=flow_status_service,
         )
         with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
-            handled, issues, warnings = service.handle_closed_pr(
+            handled, issues, warnings = service.handle_pr_terminal_state(
                 "task/my-feature", closed_pr
             )
 
@@ -468,7 +468,7 @@ class TestClosedPRIdempotency:
             assert warnings == []
             mock_reset.assert_not_called()
 
-    def test_handle_closed_pr_retriggers_after_reclose(self, tmp_path):
+    def test_handle_pr_terminal_state_retriggers_after_reclose(self, tmp_path):
         """Should handle again if PR was closed again (updated_at before closed_at)."""
         from datetime import datetime, timezone
 
@@ -512,7 +512,7 @@ class TestClosedPRIdempotency:
             ci_passed=True,
         )
 
-        # ACT: Call handle_closed_pr
+        # ACT: Call handle_pr_terminal_state
         service = CheckPRService(
             store=store,
             git_client=git_client,
@@ -521,7 +521,7 @@ class TestClosedPRIdempotency:
         )
         with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
             mock_reset.return_value = (None, [])
-            handled, issues, warnings = service.handle_closed_pr(
+            handled, issues, warnings = service.handle_pr_terminal_state(
                 "task/my-feature", closed_pr
             )
 
@@ -529,7 +529,7 @@ class TestClosedPRIdempotency:
             assert handled is True
             mock_reset.assert_called_once()
 
-    def test_handle_closed_pr_no_initiated_by_triggers_reset(self, tmp_path):
+    def test_handle_pr_terminal_state_no_initiated_by_triggers_reset(self, tmp_path):
         """Should handle if initiated_by is not 'check:pr_closed'."""
         from datetime import datetime, timezone
 
@@ -571,7 +571,7 @@ class TestClosedPRIdempotency:
             ci_passed=True,
         )
 
-        # ACT: Call handle_closed_pr
+        # ACT: Call handle_pr_terminal_state
         service = CheckPRService(
             store=store,
             git_client=git_client,
@@ -580,7 +580,7 @@ class TestClosedPRIdempotency:
         )
         with patch.object(service, "_reset_issue_after_pr_closed") as mock_reset:
             mock_reset.return_value = (None, [])
-            handled, issues, warnings = service.handle_closed_pr(
+            handled, issues, warnings = service.handle_pr_terminal_state(
                 "task/my-feature", closed_pr
             )
 

--- a/tests/vibe3/services/test_check_service.py
+++ b/tests/vibe3/services/test_check_service.py
@@ -26,7 +26,7 @@ def _make_check_pr_service():
     )
 
 
-def test_handle_closed_pr_creates_bridge_issue() -> None:
+def test_handle_pr_terminal_state_creates_bridge_issue() -> None:
     """When PR is closed (not merged), create bridge issue instead of rebuilding."""
     service = _make_check_pr_service()
 
@@ -72,7 +72,9 @@ def test_handle_closed_pr_creates_bridge_issue() -> None:
             "flow_record": True,
         }
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify bridge issue was created
         service.github_client.create_issue.assert_called_once()
@@ -102,7 +104,7 @@ def test_handle_closed_pr_creates_bridge_issue() -> None:
         assert len(issues) == 0
 
 
-def test_handle_closed_pr_does_not_call_rebuild() -> None:
+def test_handle_pr_terminal_state_does_not_call_rebuild() -> None:
     """Verify that FlowRebuildUsecase is NOT called when PR closes."""
     service = _make_check_pr_service()
 
@@ -137,7 +139,9 @@ def test_handle_closed_pr_does_not_call_rebuild() -> None:
         mock_cleanup_cls.return_value = mock_cleanup
         mock_cleanup.cleanup_flow_scene.return_value = {}
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # CRITICAL: Verify FlowRebuildUsecase was NOT instantiated
         rebuild_cls.assert_not_called()
@@ -145,7 +149,7 @@ def test_handle_closed_pr_does_not_call_rebuild() -> None:
         assert handled is True
 
 
-def test_handle_closed_pr_with_closed_issue_marks_flow_aborted() -> None:
+def test_handle_pr_terminal_state_with_closed_issue_marks_flow_aborted() -> None:
     """When PR closed and issue already closed, mark flow as aborted and cleanup."""
     service = _make_check_pr_service()
 
@@ -176,7 +180,9 @@ def test_handle_closed_pr_with_closed_issue_marks_flow_aborted() -> None:
             "flow_record": True,
         }
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify flow was marked as aborted
         service._flow_status_service.mark_flow_aborted.assert_called_once()
@@ -200,7 +206,7 @@ def test_handle_closed_pr_with_closed_issue_marks_flow_aborted() -> None:
         assert "Issue #456 already closed" in warnings[0]
 
 
-def test_handle_closed_pr_bridge_idempotency() -> None:
+def test_handle_pr_terminal_state_bridge_idempotency() -> None:
     """When bridge marker already exists, skip creation and just cleanup."""
     service = _make_check_pr_service()
 
@@ -240,7 +246,9 @@ def test_handle_closed_pr_bridge_idempotency() -> None:
         mock_cleanup.cleanup_flow_scene.return_value = {}
         service.github_client.close_issue_if_open.return_value = "closed"
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify bridge issue was NOT created (idempotency)
         service.github_client.create_issue.assert_not_called()
@@ -263,7 +271,9 @@ def test_handle_closed_pr_bridge_idempotency() -> None:
         assert len(issues) == 0
 
 
-def test_handle_closed_pr_existing_bridge_close_failure_does_not_cleanup() -> None:
+def test_handle_pr_terminal_state_existing_bridge_close_failure_does_not_cleanup() -> (
+    None
+):  # noqa: E501
     """When bridge marker exists but original close fails, preserve flow for retry."""
     service = _make_check_pr_service()
 
@@ -300,7 +310,9 @@ def test_handle_closed_pr_existing_bridge_close_failure_does_not_cleanup() -> No
         mock_cleanup = MagicMock()
         mock_cleanup_cls.return_value = mock_cleanup
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         service.github_client.create_issue.assert_not_called()
         service._flow_status_service.mark_flow_aborted.assert_not_called()
@@ -313,7 +325,9 @@ def test_handle_closed_pr_existing_bridge_close_failure_does_not_cleanup() -> No
         assert warnings == []
 
 
-def test_handle_closed_pr_ignores_bridge_marker_for_prefixed_pr_number() -> None:
+def test_handle_pr_terminal_state_ignores_bridge_marker_for_prefixed_pr_number() -> (
+    None
+):  # noqa: E501
     """Bridge marker matching must not treat PR #1234 as PR #123."""
     service = _make_check_pr_service()
 
@@ -354,7 +368,9 @@ def test_handle_closed_pr_ignores_bridge_marker_for_prefixed_pr_number() -> None
         mock_cleanup_cls.return_value = mock_cleanup
         mock_cleanup.cleanup_flow_scene.return_value = {}
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         service.github_client.create_issue.assert_called_once()
         service.github_client.close_issue_if_open.assert_called_once()
@@ -366,7 +382,7 @@ def test_handle_closed_pr_ignores_bridge_marker_for_prefixed_pr_number() -> None
         assert len(warnings) == 1
 
 
-def test_handle_closed_pr_when_view_issue_fails_does_not_cleanup() -> None:
+def test_handle_pr_terminal_state_when_view_issue_fails_does_not_cleanup() -> None:
     """When view_issue() fails (network/auth), do not cleanup flow, allow retry."""
     service = _make_check_pr_service()
 
@@ -388,7 +404,9 @@ def test_handle_closed_pr_when_view_issue_fails_does_not_cleanup() -> None:
         mock_cleanup = MagicMock()
         mock_cleanup_cls.return_value = mock_cleanup
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify flow was NOT marked as aborted
         service._flow_status_service.mark_flow_aborted.assert_not_called()
@@ -403,7 +421,7 @@ def test_handle_closed_pr_when_view_issue_fails_does_not_cleanup() -> None:
         assert "retry" in issues[0].lower()
 
 
-def test_handle_closed_pr_when_close_original_fails_does_not_cleanup() -> None:
+def test_handle_pr_terminal_state_when_close_original_fails_does_not_cleanup() -> None:
     """When close original issue fails, do not cleanup flow, preserve for retry."""
     service = _make_check_pr_service()
 
@@ -434,7 +452,9 @@ def test_handle_closed_pr_when_close_original_fails_does_not_cleanup() -> None:
         mock_cleanup = MagicMock()
         mock_cleanup_cls.return_value = mock_cleanup
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify flow was NOT marked as aborted
         service._flow_status_service.mark_flow_aborted.assert_not_called()
@@ -449,7 +469,7 @@ def test_handle_closed_pr_when_close_original_fails_does_not_cleanup() -> None:
         assert "failed to add marker" in issues[0]
 
 
-def test_handle_closed_pr_when_add_marker_fails_does_not_cleanup() -> None:
+def test_handle_pr_terminal_state_when_add_marker_fails_does_not_cleanup() -> None:
     """When add bridge marker fails, do not cleanup flow, preserve for retry."""
     service = _make_check_pr_service()
 
@@ -478,7 +498,9 @@ def test_handle_closed_pr_when_add_marker_fails_does_not_cleanup() -> None:
         mock_cleanup = MagicMock()
         mock_cleanup_cls.return_value = mock_cleanup
 
-        handled, issues, warnings = service.handle_closed_pr("task/issue-456", mock_pr)
+        handled, issues, warnings = service.handle_pr_terminal_state(
+            "task/issue-456", mock_pr
+        )
 
         # Verify bridge issue was created
         service.github_client.create_issue.assert_called_once()


### PR DESCRIPTION
## Summary

- Renamed `CheckPRService.handle_closed_pr()` → `handle_pr_terminal_state()` to accurately reflect that it handles both merged and closed PR terminal states, not just closed PRs
- Renamed private method `_handle_closed_pr()` → `_handle_closed_pr_flow()` to keep the "closed" qualifier since it genuinely only handles closed (non-merged) PRs  
- Updated all call sites in `check_service.py`
- Renamed all test functions and updated method calls in `test_check_service.py` and `test_check_pr_status.py`
- Cleaned up stale `kept_records` comment in `test_check_cleanup_service.py`
- Updated LOC exception limit for `test_check_service.py` to accommodate necessary line breaks

## Test Coverage

- All 40 tests pass across affected test files
- mypy: ✓ (410 source files)
- ruff: ✓ (all checks passed)
- LOC: ✓ (updated exception to 540 lines)

## Verification

All verification steps from the plan passed:
- ✅ All method references updated (verified with `rg`)
- ✅ All test functions renamed  
- ✅ No stale references to old names
- ✅ No behavior change (pure cosmetic rename)

Closes #2329

---

## Contributors

claude/opus
