### PR TITLE
refactor(prompts): remove UnusedVariableError dead code

### DIFF
--- a/src/vibe3/prompts/__init__.py
+++ b/src/vibe3/prompts/__init__.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
         PromptAssemblyError,
         ProviderNotFoundError,
         TemplateNotFoundError,
-        UnusedVariableError,
     )
     from vibe3.prompts.manifest import (
         PromptManifest,
@@ -74,7 +73,6 @@ _LAZY_IMPORTS = {
     "PromptAssemblyError": "vibe3.prompts.exceptions",
     "ProviderNotFoundError": "vibe3.prompts.exceptions",
     "TemplateNotFoundError": "vibe3.prompts.exceptions",
-    "UnusedVariableError": "vibe3.prompts.exceptions",
     "PromptManifest": "vibe3.prompts.manifest",
     "PromptProvider": "vibe3.prompts.manifest",
     "PromptRecipeDefinition": "vibe3.prompts.manifest",
@@ -140,7 +138,6 @@ __all__ = [
     "MissingVariableError",
     "ProviderNotFoundError",
     "TemplateNotFoundError",
-    "UnusedVariableError",
     # Validation
     "PromptValidationResult",
     "PromptValidationService",

--- a/src/vibe3/prompts/exceptions.py
+++ b/src/vibe3/prompts/exceptions.py
@@ -28,18 +28,6 @@ class MissingVariableError(PromptAssemblyError):
         )
 
 
-class UnusedVariableError(PromptAssemblyError):
-    """Raised when a declared recipe variable is not referenced in the template."""
-
-    def __init__(self, variable: str, template_key: str) -> None:
-        self.variable = variable
-        self.template_key = template_key
-        super().__init__(
-            f"Recipe for '{template_key}' declares variable '{variable}' "
-            "but the template never references it."
-        )
-
-
 class TemplateNotFoundError(PromptAssemblyError):
     """Raised when a template key cannot be resolved."""
 

--- a/tests/vibe3/prompts/test_models.py
+++ b/tests/vibe3/prompts/test_models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from vibe3.prompts.exceptions import MissingVariableError, UnusedVariableError
 from vibe3.prompts.models import (
     PromptRecipe,
     PromptRenderResult,
@@ -135,15 +134,3 @@ class TestPromptRenderResult:
         )
         with pytest.raises((AttributeError, TypeError, ValidationError)):
             result.rendered_text = "other"  # type: ignore[misc]
-
-
-class TestPromptExceptions:
-    def test_missing_variable_error(self) -> None:
-        exc = MissingVariableError(variable="skill_content", template_key="test.key")
-        assert "skill_content" in str(exc)
-        assert "test.key" in str(exc)
-
-    def test_unused_variable_error(self) -> None:
-        exc = UnusedVariableError(variable="extra_var", template_key="test.key")
-        assert "extra_var" in str(exc)
-        assert "test.key" in str(exc)


### PR DESCRIPTION
## Summary

Remove `UnusedVariableError` exception class and associated placebo tests. The exception was never raised in any business logic and had no behavioral test coverage.

## Changes

- **exceptions.py**: Removed `UnusedVariableError` class (never raised in production)
- **__init__.py**: Cleaned up all re-exports (TYPE_CHECKING, _LAZY_IMPORTS, __all__)
- **test_models.py**: Removed placebo tests (both `test_unused_variable_error` and `test_missing_variable_error`)

## Verification

- ✅ All 65 prompts module tests pass
- ✅ mypy: no issues found in 11 source files
- ✅ ruff: all checks passed
- ✅ MissingVariableError has proper behavioral test coverage in test_assembler.py

## Test Plan

- Run: `uv run pytest tests/vibe3/prompts/ -v`
- Run: `uv run mypy src/vibe3/prompts/`
- Run: `uv run ruff check src/vibe3/prompts/ tests/vibe3/prompts/`

Closes #2312

---

## Contributors

claude/opus
