### PR TITLE
perf(qualify_gate): avoid double coordination truth resolution

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -236,8 +236,8 @@ code_limits:
         limit: 610
         reason: "Qualify gate remote-first + E2E blocked reconciliation 测试集，覆盖 blocked_reason、dependencies、blocked_by_issue 的 remote/local 分支、blocked state change via service layer (#1206)，包含 #994 类 E2E 回归场景，测试类结构清晰，拆分收益低"
       - path: "tests/vibe3/domain/test_qualify_gate.py"
-        limit: 560
-        reason: "Qualify gate truth-first 决策流程测试集，覆盖 manual block、dependency block、auto-resume、stale state alignment、blocked state change via service layer (#1206) 等场景，共享 fixture；PR #1983 已将 GitHub closed 检测测试拆分至 test_qualify_gate_closed.py；Issue #2242 新增 test_auto_resume_blocked_with_none_flow_state_returns_ready 测试验证 flow_state=None 路径返回 READY"
+        limit: 600
+        reason: "Qualify gate truth-first 决策流程测试集，覆盖 manual block、dependency block、auto-resume、stale state alignment、blocked state change via service layer (#1206) 等场景，共享 fixture；PR #1983 已将 GitHub closed 检测测试拆分至 test_qualify_gate_closed.py；Issue #2242 新增 test_auto_resume_blocked_with_none_flow_state_returns_ready 测试验证 flow_state=None 路径返回 READY；Issue #2353 新增 test_qualify_blocked_issue_reuses_truth 测试验证 truth 参数传递优化（消除双重 resolve_coordination 调用）"
       - path: "tests/vibe3/services/test_flow_orchestrator_service.py"
         limit: 560
         reason: "Flow orchestrator 服务测试集，覆盖 dispatch 协调、frozen queue 管理、issue 状态处理、Git ref lock 冲突重试等紧密耦合场景，共享 fixture，拆分收益低；Issue #2143 新增 2 个 retry 测试（test_bootstrap_issue_flow_retries_fetch_on_ref_lock_conflict, test_bootstrap_issue_flow_raises_after_exhausted_retries）后略微超标"

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -96,6 +96,7 @@ class QualifyGateService:
         flow_state: dict[str, object] | None,
         labels: list[str],
         trigger_state: IssueState,
+        truth: CoordinationTruth | None = None,
     ) -> IssueState | None:
         """Run the Qualify Gate for an issue to resolve dependencies and blocking.
 
@@ -112,6 +113,8 @@ class QualifyGateService:
             flow_state: Current flow state from store
             labels: Current issue labels
             trigger_state: The trigger state being evaluated
+            truth: Pre-resolved coordination truth (optional). If provided, skips
+                the resolve_coordination call.
 
         Returns:
             Target IssueState if the issue passes the gate and can be dispatched,
@@ -123,7 +126,10 @@ class QualifyGateService:
             return None
 
         # Step 1: Resolve body/local truth (remote-first)
-        truth = self._coordination_resolver.resolve_coordination(branch, issue.number)
+        if truth is None:
+            truth = self._coordination_resolver.resolve_coordination(
+                branch, issue.number
+            )
 
         # Step 2: Blocked truth alignment — body truth is authoritative
         if truth.is_blocked:
@@ -204,7 +210,12 @@ class QualifyGateService:
 
         flow_state = self._store.get_flow_state(branch)
         result = self.run_qualify_gate(
-            issue, branch, flow_state, list(issue.labels), IssueState.BLOCKED
+            issue,
+            branch,
+            flow_state,
+            list(issue.labels),
+            IssueState.BLOCKED,
+            truth=truth,
         )
 
         if result == IssueState.BLOCKED:

--- a/tests/vibe3/domain/test_qualify_gate.py
+++ b/tests/vibe3/domain/test_qualify_gate.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from vibe3.domain.qualify_gate import QualifyGateService
+from vibe3.models.coordination_truth import CoordinationTruth
+from vibe3.models.data_source import DataSource
 from vibe3.models.orchestra_config import OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
 
@@ -424,6 +426,41 @@ class TestQualifyBlockedIssue:
 
         assert result == IssueState.IN_PROGRESS
         qualify_gate_service.run_qualify_gate.assert_called_once()
+
+    def test_qualify_blocked_issue_reuses_truth(
+        self, qualify_gate_service, sample_issue, mock_flow_manager, mock_store
+    ):
+        """Test that qualify_blocked_issue reuses pre-resolved truth."""
+        mock_flow_manager.get_flow_for_issue.return_value = {
+            "branch": "task/issue-123-test"
+        }
+        mock_truth = CoordinationTruth(
+            blocked_reason="Blocked by #456",
+            blocked_reason_source=DataSource.ISSUE_BODY_FALLBACK,
+            blocked_by_issue=456,
+            blocked_by_issue_source=DataSource.ISSUE_BODY_FALLBACK,
+            dependencies=[],
+            dependencies_source=None,
+            worktree_path="/tmp/worktree",
+            actor="executor",
+        )
+        with patch.object(
+            qualify_gate_service._coordination_resolver,
+            "resolve_coordination",
+            return_value=mock_truth,
+        ) as mock_resolve:
+            qualify_gate_service._is_dependency_satisfied = Mock(return_value=False)
+            qualify_gate_service.run_qualify_gate = Mock(
+                return_value=IssueState.IN_PROGRESS
+            )
+            result = qualify_gate_service.qualify_blocked_issue(sample_issue)
+            assert mock_resolve.call_count == 1
+            mock_resolve.assert_called_once_with("task/issue-123-test", 123)
+            qualify_gate_service.run_qualify_gate.assert_called_once()
+            call_kwargs = qualify_gate_service.run_qualify_gate.call_args.kwargs
+            assert "truth" in call_kwargs
+            assert call_kwargs["truth"] is mock_truth
+            assert result == IssueState.IN_PROGRESS
 
 
 class TestIsDependencySatisfied:


### PR DESCRIPTION
Closes #2353

## Summary

Performance optimization to eliminate redundant `resolve_coordination()` calls in the qualify gate logic. Passes pre-resolved `CoordinationTruth` from `qualify_blocked_issue()` to `run_qualify_gate()` via an optional parameter, reducing GitHub API requests by one per tick for every BLOCKED issue.

## Changes

- Add optional `truth: CoordinationTruth | None = None` parameter to `run_qualify_gate()`
- Conditionally resolve coordination truth only when not provided
- Pass pre-resolved truth from `qualify_blocked_issue()` to avoid duplicate resolution
- Add test verifying `resolve_coordination()` is called exactly once
- Update LOC exception for test file (560→600 lines)

## Performance Impact

**Before**: Each BLOCKED issue tick = 2 `resolve_coordination()` calls  
**After**: Each BLOCKED issue tick = 1 `resolve_coordination()` call  
**Savings**: 1 GitHub API request eliminated per tick per BLOCKED issue

## Test Plan

- All tests pass: 257 tests (111 domain + 146 orchestra)
- Type check clean: mypy success
- Lint check clean: ruff all checks passed
- Backward compatibility: all existing callers unaffected (optional parameter with None default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
