### PR TITLE
fix(qualify_gate): set flow_status=aborted when terminalizing closed issues

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -29,8 +29,8 @@ code_limits:
 
       # Exceptions 聚合 —— 允许 480-600
       - path: "src/vibe3/domain/qualify_gate.py"
-        limit: 600
-        reason: "Qualify gate 域服务，包含 truth-first 决策流程、blocked 对齐、auto-resume、worktree 健康检查、依赖检查、github_state CLOSED guard、dep-closure detection 等紧密耦合逻辑；PR #1983 重构后新增统一 closed issue 检测（_terminalize_closed_issue 方法），将 HealthCheck 的业务逻辑迁移到 QualifyGate，实现单一职责（business qualification）；PR #2349 新增 dep-closure detection（_notify_dep_resolved 方法）并统一架构（使用 FlowRecoveryService）"
+        limit: 620
+        reason: "Qualify gate 域服务，包含 truth-first 决策流程、blocked 对齐、auto-resume、worktree 健康检查、依赖检查、github_state CLOSED guard、dep-closure detection 等紧密耦合逻辑；PR #1983 重构后新增统一 closed issue 检测（_terminalize_closed_issue 方法），将 HealthCheck 的业务逻辑迁移到 QualifyGate，实现单一职责（business qualification）；PR #2349 新增 dep-closure detection（_notify_dep_resolved 方法）并统一架构（使用 FlowRecoveryService）；Issue #2369 新增 mark_flow_aborted 调用与 terminal-state guard 逻辑（+13 行）"
       - path: "src/vibe3/services/handoff_service.py"
         limit: 650
         reason: "Handoff 记录管理核心服务，内聚度高，模板函数共生；包含 terminology 统一映射逻辑；--branch 参数统一支持后略微膨胀；新增 blocked_reason 自动清除逻辑（当 plan_ref/report_ref 写入时）；新增 event 驱动架构支持（FlowTimelineService 集成，issue_number 查询，event 记录逻辑）"

--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -79,6 +79,22 @@ class QualifyGateService:
             f"qualify_gate skip (#{issue.number}): "
             "issue closed on GitHub — terminalizing local flow",
         )
+
+        # Mark flow as aborted unless already in a terminal state
+        flow_state = self._store.get_flow_state(branch)
+        current_status = flow_state.get("flow_status") if flow_state else None
+        if current_status not in ("done", "aborted"):
+            from vibe3.services.flow_status_service import FlowStatusService
+
+            FlowStatusService(
+                store=self._store,
+                git_client=self._flow_manager.git,
+                github_client=self._github,
+            ).mark_flow_aborted(
+                branch,
+                f"Issue #{issue.number} closed on GitHub",
+            )
+
         from vibe3.services import FlowCleanupService
 
         FlowCleanupService(store=self._store).cleanup_flow_scene(

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from vibe3.services.flow_recovery_service import FlowRecoveryService
     from vibe3.services.flow_resume_resolver import infer_resume_label
     from vibe3.services.flow_service import FlowService
+    from vibe3.services.flow_status_service import FlowStatusService
     from vibe3.services.handoff_service import HandoffService
     from vibe3.services.handoff_status_service import HandoffStatusService
     from vibe3.services.issue.collection import IssueCollectionService
@@ -92,6 +93,7 @@ __all__ = [
     "FlowService",
     "FlowState",
     "FlowStatusResolver",
+    "FlowStatusService",
     "HandoffService",
     "HandoffStatusService",
     "InitResult",
@@ -196,6 +198,7 @@ _SYMBOL_MODULES = {
     "FlowService": "vibe3.services.flow_service",
     "FlowState": "vibe3.services.flow_classifier",
     "FlowStatusResolver": "vibe3.services.flow_status_resolver",
+    "FlowStatusService": "vibe3.services.flow_status_service",
     "HandoffService": "vibe3.services.handoff_service",
     "HandoffStatusService": "vibe3.services.handoff_status_service",
     "InitResult": "vibe3.services.check_remote",

--- a/tests/vibe3/domain/test_qualify_gate_closed.py
+++ b/tests/vibe3/domain/test_qualify_gate_closed.py
@@ -74,9 +74,10 @@ class TestQualifyGateGitHubClosed:
         state: IssueState,
         labels: list[str],
         explicit_branch: str = "auto",
-    ) -> tuple[object, Mock]:
-        """Run qualify gate for a CLOSED issue, returning (result, mock_cleanup_svc).
+    ) -> tuple[object, Mock, Mock]:
+        """Run qualify gate for a CLOSED issue.
 
+        Returns (result, mock_cleanup_svc, mock_flow_status_svc).
         Pass explicit_branch="" to test the empty-branch code path.
         """
         effective_branch = (
@@ -91,7 +92,12 @@ class TestQualifyGateGitHubClosed:
             labels=labels,
             github_state="CLOSED",
         )
-        with patch("vibe3.services.FlowCleanupService") as mock_svc:
+        with (
+            patch(
+                "vibe3.services.flow_status_service.FlowStatusService"
+            ) as mock_flow_status_svc,
+            patch("vibe3.services.FlowCleanupService") as mock_cleanup_svc,
+        ):
             result = qualify_gate_service.run_qualify_gate(
                 issue=closed_issue,
                 branch=effective_branch,
@@ -99,18 +105,26 @@ class TestQualifyGateGitHubClosed:
                 labels=labels,
                 trigger_state=state,
             )
-        return result, mock_svc
+        return result, mock_cleanup_svc, mock_flow_status_svc
 
     def test_closed_ready_issue_terminates(
         self, qualify_gate_service: QualifyGateService
     ) -> None:
         """READY + CLOSED → None and cleanup_flow_scene called with correct args."""
-        result, mock_svc = self._run_with_closed_issue(
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
             qualify_gate_service, 101, IssueState.READY, ["state/ready"]
         )
 
         assert result is None
-        mock_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+
+        # Verify mark_flow_aborted is called
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_called_once_with(
+            "task/issue-101",
+            "Issue #101 closed on GitHub",
+        )
+
+        # Verify cleanup_flow_scene is called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
             "task/issue-101",
             include_remote=False,
             terminate_sessions=True,
@@ -121,12 +135,20 @@ class TestQualifyGateGitHubClosed:
         self, qualify_gate_service: QualifyGateService
     ) -> None:
         """CLAIMED + CLOSED → None and cleanup_flow_scene called with correct args."""
-        result, mock_svc = self._run_with_closed_issue(
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
             qualify_gate_service, 102, IssueState.CLAIMED, ["state/claimed"]
         )
 
         assert result is None
-        mock_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+
+        # Verify mark_flow_aborted is called
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_called_once_with(
+            "task/issue-102",
+            "Issue #102 closed on GitHub",
+        )
+
+        # Verify cleanup_flow_scene is called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
             "task/issue-102",
             include_remote=False,
             terminate_sessions=True,
@@ -137,12 +159,20 @@ class TestQualifyGateGitHubClosed:
         self, qualify_gate_service: QualifyGateService
     ) -> None:
         """IN_PROGRESS + CLOSED → None and cleanup_flow_scene called correctly."""
-        result, mock_svc = self._run_with_closed_issue(
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
             qualify_gate_service, 103, IssueState.IN_PROGRESS, ["state/in-progress"]
         )
 
         assert result is None
-        mock_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+
+        # Verify mark_flow_aborted is called
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_called_once_with(
+            "task/issue-103",
+            "Issue #103 closed on GitHub",
+        )
+
+        # Verify cleanup_flow_scene is called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
             "task/issue-103",
             include_remote=False,
             terminate_sessions=True,
@@ -193,7 +223,7 @@ class TestQualifyGateGitHubClosed:
         self, qualify_gate_service: QualifyGateService
     ) -> None:
         """CLOSED issue with empty branch → returns None but cleanup not called."""
-        result, mock_svc = self._run_with_closed_issue(
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
             qualify_gate_service,
             106,
             IssueState.READY,
@@ -202,4 +232,93 @@ class TestQualifyGateGitHubClosed:
         )
 
         assert result is None
-        mock_svc.assert_not_called()
+        mock_cleanup_svc.assert_not_called()
+        mock_flow_status_svc.assert_not_called()
+
+    def test_closed_issue_already_done_not_overwritten(
+        self, qualify_gate_service: QualifyGateService
+    ) -> None:
+        """flow_status=done → mark_flow_aborted NOT called.
+
+        cleanup_flow_scene still called.
+        """
+        # Setup flow_state with done status
+        qualify_gate_service._store.get_flow_state = Mock(
+            return_value={"flow_status": "done"}
+        )
+
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
+            qualify_gate_service, 107, IssueState.READY, ["state/ready"]
+        )
+
+        assert result is None
+
+        # Verify mark_flow_aborted is NOT called (already done)
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_not_called()
+
+        # Verify cleanup_flow_scene is still called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-107",
+            include_remote=False,
+            terminate_sessions=True,
+            keep_flow_record=True,
+        )
+
+    def test_closed_issue_already_aborted_not_overwritten(
+        self, qualify_gate_service: QualifyGateService
+    ) -> None:
+        """flow_status=aborted → mark_flow_aborted NOT called.
+
+        cleanup_flow_scene still called.
+        """
+        # Setup flow_state with aborted status
+        qualify_gate_service._store.get_flow_state = Mock(
+            return_value={"flow_status": "aborted"}
+        )
+
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
+            qualify_gate_service, 108, IssueState.READY, ["state/ready"]
+        )
+
+        assert result is None
+
+        # Verify mark_flow_aborted is NOT called (already aborted)
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_not_called()
+
+        # Verify cleanup_flow_scene is still called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-108",
+            include_remote=False,
+            terminate_sessions=True,
+            keep_flow_record=True,
+        )
+
+    def test_closed_issue_no_flow_state_marks_aborted(
+        self, qualify_gate_service: QualifyGateService
+    ) -> None:
+        """flow_state=None → mark_flow_aborted IS called.
+
+        Treats missing state as non-terminal.
+        """
+        # Setup flow_state as None (no flow record exists)
+        qualify_gate_service._store.get_flow_state = Mock(return_value=None)
+
+        result, mock_cleanup_svc, mock_flow_status_svc = self._run_with_closed_issue(
+            qualify_gate_service, 109, IssueState.READY, ["state/ready"]
+        )
+
+        assert result is None
+
+        # Verify mark_flow_aborted IS called (missing state treated as non-terminal)
+        mock_flow_status_svc.return_value.mark_flow_aborted.assert_called_once_with(
+            "task/issue-109",
+            "Issue #109 closed on GitHub",
+        )
+
+        # Verify cleanup_flow_scene is still called
+        mock_cleanup_svc.return_value.cleanup_flow_scene.assert_called_once_with(
+            "task/issue-109",
+            include_remote=False,
+            terminate_sessions=True,
+            keep_flow_record=True,
+        )


### PR DESCRIPTION
## Summary
Fixed `_terminalize_closed_issue` to properly set `flow_status=aborted` when terminalizing closed GitHub issues, preventing state inconsistency.

## Changes
- Added `mark_flow_aborted` call with terminal-state guard in `_terminalize_closed_issue`
- Guard prevents overwriting `done` status from merged PRs
- Updated all existing tests to verify `mark_flow_aborted` calls
- Added 3 edge-case tests for terminal states

## Test Plan
- [x] Unit tests: 9/9 passed (test_qualify_gate_closed.py)
- [x] Domain tests: 114/114 passed (no regressions)
- [x] Type check: mypy passed
- [x] Lint: ruff + black passed

Fixes #2369

---

## Contributors

claude/opus
