### PR TITLE
refactor(modularity): Phase 1d - eliminate orchestra + agents cross-module re-exports

### DIFF
--- a/src/vibe3/agents/README.md
+++ b/src/vibe3/agents/README.md
@@ -91,10 +91,9 @@ agents/
 
 ## 外部依赖
 
-- **models/**: AgentOptions, AgentResult, PlanRequest, ReviewRequest
+- **models/**: AgentOptions, AgentResult, PlanRequest, ReviewRequest, PromptContextMode
 - **prompts/**: PromptContextBuilder, PromptManifest
 - **config/**: VibeConfig
-- **execution/**: PromptContextMode
 - **analysis/**: build_snapshot_diff_section (review_prompt only)
 
 ## 被依赖

--- a/src/vibe3/agents/__init__.py
+++ b/src/vibe3/agents/__init__.py
@@ -22,8 +22,6 @@ Prompt Builders:
   agent prompt construction
 - ``build_review_prompt_body`` / ``make_review_context_builder`` — review
   agent prompt construction
-- ``build_tools_guide_section`` — shared utility for building tools guide
-  sections (re-exported from prompts.sections)
 - ``describe_plan_sections`` / ``describe_run_plan_sections`` /
   ``describe_review_sections`` — section key inspectors for dry-run summaries
 
@@ -32,8 +30,6 @@ Review Helpers:
 - ``run_inspect_json`` — helper to call inspect subcommand for review analysis
 
 Types:
-- ``PromptContextMode`` — literal type for prompt context mode
-  (bootstrap/resume)
 - ``RunPromptMode`` — literal type for run prompt mode (coding/retry)
 
 Backend Config:
@@ -44,9 +40,6 @@ Backend Config:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-
-# Cross-module imports (not self-references) - kept minimal per modularity rules
-from vibe3.models import PromptContextMode
 
 if TYPE_CHECKING:
     from vibe3.agents.backends.async_launcher import start_async_command
@@ -81,7 +74,6 @@ if TYPE_CHECKING:
         make_run_context_builder,
         make_skill_context_builder,
     )
-    from vibe3.prompts.sections import build_tools_guide_section
 
 
 # Lazy imports for self-references (avoid circular init dependencies)
@@ -108,7 +100,6 @@ _LAZY_IMPORTS = {
     "make_publish_context_builder": "vibe3.agents.run_prompt",
     "make_run_context_builder": "vibe3.agents.run_prompt",
     "make_skill_context_builder": "vibe3.agents.run_prompt",
-    "build_tools_guide_section": "vibe3.prompts.sections",
 }
 
 
@@ -128,13 +119,11 @@ __all__ = [
     "CodeagentCommand",
     "CodeagentResult",
     "ExecutionRole",
-    "PromptContextMode",
     "RunPromptMode",
     "build_plan_prompt_body",
     "build_review_prompt_body",
     "build_run_prompt_body",
     "build_snapshot_diff",
-    "build_tools_guide_section",
     "create_codeagent_command",
     "describe_plan_sections",
     "describe_review_sections",

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -68,7 +68,7 @@ def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
         material_override: Optional governance role to override material rotation
     """
     from vibe3.execution.governance_sync_runner import run_governance_sync
-    from vibe3.orchestra.logging import append_governance_event
+    from vibe3.observability import append_governance_event
     from vibe3.roles.governance_factory import build_default_governance_fns
 
     # Call internal governance runner with dry_run=True

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -22,7 +22,7 @@ from vibe3.commands.common import (
 )
 from vibe3.config.env_override import OVERRIDE_RULES
 from vibe3.models import OrchestraConfig
-from vibe3.orchestra import orchestra_events_log_path
+from vibe3.observability import orchestra_events_log_path
 from vibe3.server import validate_pid_file
 from vibe3.services import get_manager_usernames
 from vibe3.ui import console

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -4,31 +4,15 @@ Primary entry point: HeartbeatServer (vibe3 serve start)
   - OrchestrationFacade: unified service for governance, supervisor, and dispatch
   - Polling heartbeat every 15 min via on_tick()
 
-This module serves as the unified public interface for orchestra components.
-Import from vibe3.orchestra instead of submodules to ensure clean dependencies.
+Self-module re-exports for orchestra components.
+Import from vibe3.orchestra for symbols defined within this module.
+For cross-module symbols (domain, observability, services, models, clients),
+import directly from their source modules.
 """
 
 from typing import TYPE_CHECKING
 
-# Module-level re-exports from clients/ (safe, no cycle risk)
-from vibe3.clients import GitClient
-
-# Module-level re-exports from models/ (safe, no cycle risk)
-from vibe3.models import OrchestraConfig
-
 if TYPE_CHECKING:
-    from vibe3.domain.dispatch_coordinator import MAX_INTENTS_PER_TICK
-    from vibe3.domain.failed_gate import FailedGate, GateResult, GateStatus
-    from vibe3.domain.qualify_gate import QualifyGateService
-    from vibe3.domain.role_resolver import find_role_for_state
-    from vibe3.models import QueueEntry
-    from vibe3.observability import (
-        append_governance_event,
-        append_orchestra_event,
-        append_orchestra_run_separator,
-        orchestra_events_log_path,
-        orchestra_log_dir,
-    )
     from vibe3.orchestra.dispatch_health_check import DispatchHealthCheckService
     from vibe3.orchestra.issue_loader import (
         get_flow_context,
@@ -48,39 +32,12 @@ if TYPE_CHECKING:
         select_ready_issues_from_collected_issues,
     )
     from vibe3.orchestra.queue_persistence_service import QueuePersistenceService
-    from vibe3.services import (
-        CheckResult,
-        get_manager_usernames,
-        should_skip_from_queue,
-    )
-    from vibe3.utils.queue_ordering import (
-        resolve_priority,
-        resolve_roadmap_rank,
-        sort_ready_issues,
-    )
 
 _LAZY_IMPORTS: dict[str, str] = {
-    # Models
-    "QueueEntry": "vibe3.models",
-    # Domain
-    "FailedGate": "vibe3.domain.failed_gate",
-    "GateResult": "vibe3.domain.failed_gate",
-    "GateStatus": "vibe3.domain.failed_gate",
-    "MAX_INTENTS_PER_TICK": "vibe3.domain.dispatch_coordinator",
-    "QualifyGateService": "vibe3.domain.qualify_gate",
-    "find_role_for_state": "vibe3.domain.role_resolver",
-    # Observability
-    "append_governance_event": "vibe3.observability",
-    "append_orchestra_event": "vibe3.observability",
-    "append_orchestra_run_separator": "vibe3.observability",
-    "orchestra_events_log_path": "vibe3.observability",
-    "orchestra_log_dir": "vibe3.observability",
-    # Utils
-    "resolve_priority": "vibe3.utils.queue_ordering",
-    "resolve_roadmap_rank": "vibe3.utils.queue_ordering",
-    "sort_ready_issues": "vibe3.utils.queue_ordering",
-    # Orchestra submodules
-    "create_global_dispatch_coordinator": "vibe3.orchestra.dispatch_coordinator_factory",  # noqa: E501
+    # Orchestra submodules (self-module re-exports only)
+    "create_global_dispatch_coordinator": (
+        "vibe3.orchestra.dispatch_coordinator_factory"
+    ),
     "select_ready_issues_from_collected_issues": "vibe3.orchestra.queue_operations",
     "promote_progressed_entries": "vibe3.orchestra.queue_operations",
     "QueuePersistenceService": "vibe3.orchestra.queue_persistence_service",
@@ -88,17 +45,13 @@ _LAZY_IMPORTS: dict[str, str] = {
     "get_flow_context": "vibe3.orchestra.issue_loader",
     "load_issue": "vibe3.orchestra.issue_loader",
     "is_auto_task_branch": "vibe3.orchestra.issue_loader",
-    # Protocols
+    # Protocols (self-module re-exports only)
     "CheckServiceProtocol": "vibe3.orchestra.protocols",
     "FlowServiceProtocol": "vibe3.orchestra.protocols",
     "CapacityServiceProtocol": "vibe3.orchestra.protocols",
     "IssueCollectionServiceProtocol": "vibe3.orchestra.protocols",
     "FlowManagerProtocol": "vibe3.orchestra.protocols",
     "LabelDispatchCallable": "vibe3.orchestra.protocols",
-    # Services
-    "CheckResult": "vibe3.services",
-    "should_skip_from_queue": "vibe3.services",
-    "get_manager_usernames": "vibe3.services",
 }
 
 
@@ -112,44 +65,20 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
-    # Models
-    "OrchestraConfig",
-    # Orchestra submodules
-    "QueueEntry",
-    "FailedGate",
-    "append_governance_event",
-    "append_orchestra_event",
-    "append_orchestra_run_separator",
-    "orchestra_events_log_path",
-    "orchestra_log_dir",
-    "resolve_priority",
-    "resolve_roadmap_rank",
-    "sort_ready_issues",
+    # Orchestra submodules (self-module re-exports only)
+    "create_global_dispatch_coordinator",
     "select_ready_issues_from_collected_issues",
     "promote_progressed_entries",
     "QueuePersistenceService",
     "DispatchHealthCheckService",
-    "create_global_dispatch_coordinator",
     "get_flow_context",
     "load_issue",
     "is_auto_task_branch",
-    # Protocols
+    # Protocols (self-module re-exports only)
     "CheckServiceProtocol",
     "FlowServiceProtocol",
     "CapacityServiceProtocol",
     "IssueCollectionServiceProtocol",
     "FlowManagerProtocol",
     "LabelDispatchCallable",
-    # Clients
-    "GitClient",
-    # Domain (via __getattr__)
-    "MAX_INTENTS_PER_TICK",
-    "QualifyGateService",
-    "find_role_for_state",
-    "GateResult",
-    "GateStatus",
-    # Services (via __getattr__)
-    "CheckResult",
-    "should_skip_from_queue",
-    "get_manager_usernames",
 ]

--- a/src/vibe3/orchestra/dispatch_health_check.py
+++ b/src/vibe3/orchestra/dispatch_health_check.py
@@ -17,11 +17,8 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from vibe3.models import IssueInfo, IssueState
-from vibe3.orchestra import (
-    CheckServiceProtocol,
-    FlowServiceProtocol,
-    append_orchestra_event,
-)
+from vibe3.observability import append_orchestra_event
+from vibe3.orchestra import CheckServiceProtocol, FlowServiceProtocol
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient

--- a/src/vibe3/orchestra/failed_gate.py
+++ b/src/vibe3/orchestra/failed_gate.py
@@ -7,7 +7,6 @@ All symbols are also available from their canonical locations:
 - GateStatus: vibe3.domain.failed_gate.GateStatus
 """
 
-from vibe3.domain import FailedGate
-from vibe3.orchestra import GateResult, GateStatus
+from vibe3.domain import FailedGate, GateResult, GateStatus
 
 __all__ = ["FailedGate", "GateResult", "GateStatus"]

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -8,10 +8,7 @@ All symbols are also available from their canonical locations:
 """
 
 # Re-export GlobalDispatchCoordinator from domain
-from vibe3.domain import GlobalDispatchCoordinator
-
-# Re-export MAX_INTENTS_PER_TICK from orchestra (re-exported from domain)
-# Re-export QueueEntry from orchestra (still in orchestra layer)
-from vibe3.orchestra import MAX_INTENTS_PER_TICK, QueueEntry
+from vibe3.domain import MAX_INTENTS_PER_TICK, GlobalDispatchCoordinator
+from vibe3.models import QueueEntry
 
 __all__ = ["GlobalDispatchCoordinator", "QueueEntry", "MAX_INTENTS_PER_TICK"]

--- a/src/vibe3/orchestra/global_dispatch_coordinator.py
+++ b/src/vibe3/orchestra/global_dispatch_coordinator.py
@@ -3,7 +3,7 @@
 Re-exports GlobalDispatchCoordinator from domain layer for legacy imports.
 All symbols are also available from their canonical locations:
 - GlobalDispatchCoordinator: vibe3.domain.dispatch_coordinator.GlobalDispatchCoordinator
-- QueueEntry: vibe3.orchestra.queue.QueueEntry
+- QueueEntry: vibe3.models.QueueEntry
 - MAX_INTENTS_PER_TICK: vibe3.domain.dispatch_coordinator.MAX_INTENTS_PER_TICK
 """
 

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -5,15 +5,10 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Callable
 
+from vibe3.domain import QualifyGateService, find_role_for_state
 from vibe3.models import IssueInfo, IssueState, OrchestraConfig, QueueEntry
-from vibe3.orchestra import (
-    QualifyGateService,
-    append_orchestra_event,
-    find_role_for_state,
-    get_flow_context,
-    is_auto_task_branch,
-    load_issue,
-)
+from vibe3.observability import append_orchestra_event
+from vibe3.orchestra import get_flow_context, is_auto_task_branch, load_issue
 from vibe3.utils.queue_ordering import sort_ready_issues
 
 if TYPE_CHECKING:

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -15,8 +15,11 @@ import uvicorn
 from vibe3.clients import GitClient
 from vibe3.config import find_missing_backend_commands, load_orchestra_config
 from vibe3.models import OrchestraConfig
-from vibe3.observability import setup_logging
-from vibe3.orchestra import orchestra_events_log_path, orchestra_log_dir
+from vibe3.observability import (
+    orchestra_events_log_path,
+    orchestra_log_dir,
+    setup_logging,
+)
 from vibe3.runtime import OrchestraInstanceInfo, write_instance_info
 
 from .registry import (

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -21,7 +21,7 @@ from vibe3.environment import SessionRegistryService
 from vibe3.execution import CapacityService
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
 from vibe3.models import OrchestraConfig
-from vibe3.orchestra import orchestra_events_log_path, orchestra_log_dir
+from vibe3.observability import orchestra_events_log_path, orchestra_log_dir
 from vibe3.orchestra.dispatch_coordinator_factory import (
     create_global_dispatch_coordinator,
 )

--- a/tests/vibe3/orchestra/test_failed_gate.py
+++ b/tests/vibe3/orchestra/test_failed_gate.py
@@ -260,7 +260,7 @@ class TestFailedGateIntegration:
                     blocked_ticks=0,
                 )
                 runner = CliRunner()
-                with patch("vibe3.server.app.setup_logging"):
+                with patch("vibe3.observability.setup_logging"):
                     with patch("vibe3.server.app.validate_pid_file") as mock_pid:
                         mock_pid.return_value = (None, False)
                         with patch(


### PR DESCRIPTION
Closes #2282

## Summary

Remove all cross-module re-exports from `orchestra/__init__.py` (18 symbols from 6 external modules) and `agents/__init__.py` (2 symbols from 2 external modules). Redirect affected consumer files to import from source modules via their public APIs (`__all__`).

This is the final sub-task of Phase 1 modularity refactoring, completing the elimination of cross-module re-export chains across all top-level modules.

## Changes

### Orchestra Module

**orchestra/__init__.py**
- Removed eager imports: `GitClient`, `OrchestraConfig`
- Removed 18 lazy import entries for cross-module symbols (domain, observability, utils, services, models)
- Removed cross-module entries from `TYPE_CHECKING` and `__all__`
- Kept all self-module re-exports from `vibe3.orchestra.*` submodules

### Agents Module

**agents/__init__.py**
- Removed eager import: `PromptContextMode` (from models)
- Removed lazy import: `build_tools_guide_section` (from prompts.sections)
- Updated docstring and README to reflect correct dependencies

### Consumer Files (8 files updated)

1. `orchestra/failed_gate.py`: Import from `vibe3.domain`
2. `orchestra/dispatch_health_check.py`: Import from `vibe3.observability`
3. `orchestra/global_dispatch_coordinator.py`: Import from source modules
4. `orchestra/queue_operations.py`: Split imports (self-module vs cross-module)
5. `server/registry.py`: Import from `vibe3.observability`
6. `server/app.py`: Import from `vibe3.observability`
7. `commands/status.py`: Import from `vibe3.observability`
8. `commands/scan.py`: Import from `vibe3.observability`

### Documentation & Tests

- Updated `agents/README.md`: Corrected `PromptContextMode` dependency path
- Fixed `test_failed_gate.py`: Updated mock target for `setup_logging`

## Verification

✅ **Modularity tests**: 25 passed, 4 xfailed
✅ **Full regression**: 3019 tests passed
✅ **Type check**: Clean (mypy)
✅ **Lint check**: Clean (ruff)
✅ **LOC check**: All files under CI block threshold (400 lines)
✅ **Audit**: MINOR finding resolved (stale docstring reference fixed)

## Phase 1 Complete

This finalizes Phase 1 of the modularity refactoring initiative. All top-level modules now:
- Import from their own submodules
- Import from other modules' public APIs via `__all__`
- No cross-module re-export chains remain

Related issues:
- #2281 (Phase 1c - execution + adapters + services)
- #2282 (this PR - orchestra + agents)

---

## Contributors

claude/sonnet-4.5

---

## Contributors

claude/opus
