### PR TITLE
refactor(flow): cache-first PR lookup in get_flow_status with robust error handling

### DIFF
--- a/src/vibe3/services/flow_read_mixin.py
+++ b/src/vibe3/services/flow_read_mixin.py
@@ -54,11 +54,22 @@ class FlowReadMixin:
         # Cache-first: derive pr_number from local pr_ref if available
         pr_ref = flow_data.get("pr_ref")
         if isinstance(pr_ref, str) and pr_ref:
-            pr_number = int(pr_ref.rsplit("/", 1)[-1])
-            pr_ready = False  # Draft status unavailable from cache
+            try:
+                pr_number = int(pr_ref.rsplit("/", 1)[-1])
+                pr_ready = False  # Draft status unavailable from cache
+            except (ValueError, IndexError) as e:
+                # Malformed pr_ref: fall through to PRService fallback
+                logger.bind(domain="flow", branch=branch).warning(
+                    f"Malformed pr_ref '{pr_ref}': {e}"
+                )
+                pr_number, pr_ready = None, False
+                # Continue to PRService fallback below
+                pr_ref = None  # Clear to trigger fallback path
         else:
-            # Fallback: hydrate from GitHub via PRService
             pr_number, pr_ready = None, False
+
+        if not pr_ref:
+            # Fallback: hydrate from GitHub via PRService
             try:
                 from vibe3.services.pr.service import PRService
 

--- a/src/vibe3/services/flow_read_mixin.py
+++ b/src/vibe3/services/flow_read_mixin.py
@@ -51,24 +51,29 @@ class FlowReadMixin:
         if not flow_data:
             return None
 
-        # Fetch PR info from GitHub (truth)
-        pr_number, pr_ready = None, False  # Default values
+        # Cache-first: derive pr_number from local pr_ref if available
+        pr_ref = flow_data.get("pr_ref")
+        if isinstance(pr_ref, str) and pr_ref:
+            pr_number = int(pr_ref.rsplit("/", 1)[-1])
+            pr_ready = False  # Draft status unavailable from cache
+        else:
+            # Fallback: hydrate from GitHub via PRService
+            pr_number, pr_ready = None, False
+            try:
+                from vibe3.services.pr.service import PRService
 
-        try:
-            from vibe3.services.pr.service import PRService
-
-            gh = getattr(self, "github_client", None) or GitHubClient()
-            pr = PRService(
-                github_client=cast(GitHubClientProtocol, gh),
-                store=self.store,
-            ).get_branch_pr_status(branch)
-            if pr:
-                pr_number = pr.number
-                pr_ready = pr.is_ready
-        except Exception as e:
-            logger.bind(domain="flow", branch=branch).warning(
-                f"Failed to hydrate PR status from GitHub: {e}"
-            )
+                gh = getattr(self, "github_client", None) or GitHubClient()
+                pr = PRService(
+                    github_client=cast(GitHubClientProtocol, gh),
+                    store=self.store,
+                ).get_branch_pr_status(branch)
+                if pr:
+                    pr_number = pr.number
+                    pr_ready = pr.is_ready
+            except Exception as e:
+                logger.bind(domain="flow", branch=branch).warning(
+                    f"Failed to hydrate PR status from GitHub: {e}"
+                )
 
         issue_links = self.store.get_issue_links(branch)
         issues = [IssueLink(**link) for link in issue_links]

--- a/tests/vibe3/services/test_flow_status.py
+++ b/tests/vibe3/services/test_flow_status.py
@@ -66,6 +66,32 @@ class TestFlowStatus:
         assert result.pr_number == 99
         assert result.pr_ready_for_review is True
 
+    def test_get_flow_status_malformed_pr_ref(self, mock_store) -> None:
+        """Test fallback when pr_ref is malformed (triggers ValueError/IndexError)."""
+        mock_store.get_flow_state.return_value = {
+            "branch": "test-branch",
+            "flow_slug": "test-slug",
+            "flow_status": "active",
+            "updated_at": "2026-03-16T00:00:00",
+            "pr_ref": "https://github.com/test/repo/pull/not-a-number",
+        }
+        mock_store.get_issue_links.return_value = []
+
+        service = FlowService(store=mock_store)
+        # Should fall back to PRService when int() fails
+        with patch("vibe3.services.pr.service.PRService") as mock_pr_service_class:
+            mock_pr_service = mock_pr_service_class.return_value
+            mock_pr = MagicMock()
+            mock_pr.number = 88
+            mock_pr.is_ready = False
+            mock_pr_service.get_branch_pr_status.return_value = mock_pr
+
+            result = service.get_flow_status("test-branch")
+
+        assert result is not None
+        assert result.pr_number == 88  # From PRService fallback
+        assert result.pr_ready_for_review is False
+
     def test_get_flow_status_not_found(self, mock_store) -> None:
         """Test getting flow status for non-existent branch."""
         mock_store.get_flow_state.return_value = None

--- a/tests/vibe3/services/test_flow_status.py
+++ b/tests/vibe3/services/test_flow_status.py
@@ -22,7 +22,27 @@ class TestFlowStatus:
     """Tests for individual flow status."""
 
     def test_get_flow_status_success(self, mock_store) -> None:
-        """Test getting flow status successfully."""
+        """Test getting flow status successfully with cache-first pr_ref."""
+        mock_store.get_flow_state.return_value = {
+            "branch": "test-branch",
+            "flow_slug": "test-slug",
+            "flow_status": "active",
+            "updated_at": "2026-03-16T00:00:00",
+            "pr_ref": "https://github.com/test/repo/pull/42",
+        }
+        mock_store.get_issue_links.return_value = []
+
+        service = FlowService(store=mock_store)
+        result = service.get_flow_status("test-branch")
+
+        assert result is not None
+        assert result.branch == "test-branch"
+        assert result.flow_status == "active"
+        assert result.pr_number == 42
+        assert result.pr_ready_for_review is False
+
+    def test_get_flow_status_pr_ref_fallback(self, mock_store) -> None:
+        """Test fallback to PRService when pr_ref is absent."""
         mock_store.get_flow_state.return_value = {
             "branch": "test-branch",
             "flow_slug": "test-slug",
@@ -32,16 +52,19 @@ class TestFlowStatus:
         mock_store.get_issue_links.return_value = []
 
         service = FlowService(store=mock_store)
-        # GitHubClient is imported inside get_flow_status, need to patch it
-        with patch("vibe3.services.flow_read_mixin.GitHubClient") as mock_gh_class:
-            mock_gh = mock_gh_class.return_value
-            mock_gh.get_pr.return_value = None
+        # Patch PRService at the point where it's imported (lazy import)
+        with patch("vibe3.services.pr.service.PRService") as mock_pr_service_class:
+            mock_pr_service = mock_pr_service_class.return_value
+            mock_pr = MagicMock()
+            mock_pr.number = 99
+            mock_pr.is_ready = True
+            mock_pr_service.get_branch_pr_status.return_value = mock_pr
 
             result = service.get_flow_status("test-branch")
 
         assert result is not None
-        assert result.branch == "test-branch"
-        assert result.flow_status == "active"
+        assert result.pr_number == 99
+        assert result.pr_ready_for_review is True
 
     def test_get_flow_status_not_found(self, mock_store) -> None:
         """Test getting flow status for non-existent branch."""


### PR DESCRIPTION
Closes #2358

## Summary

Implements cache-first PR lookup strategy in `get_flow_status` to eliminate unnecessary GitHub API calls, with robust error handling for edge cases.

## Changes

### Performance Optimization

- **Cache-first extraction**: Derive `pr_number` from local `pr_ref` field when available
- **Conditional fallback**: Only instantiate `PRService` + hit GitHub API when `pr_ref` is absent
- **Performance gain**: Eliminates unnecessary instantiation and API calls on every status lookup

### Robust Error Handling

- **Defensive coding**: Added try/except around `int()` conversion to catch malformed pr_ref
- **Graceful degradation**: Falls back to PRService on ValueError/IndexError
- **Logging**: Records malformed pr_ref values for debugging
- **Edge case coverage**: Handles empty strings, non-numeric values, corrupted data

### Implementation Details

**Modified Files**:
- `src/vibe3/services/flow_read_mixin.py`: Cache-first logic with error handling
- `tests/vibe3/services/test_flow_status.py`: Added test for malformed pr_ref edge case

**Test Coverage**:
- ✅ Cache-first path with well-formed pr_ref (test_get_flow_status_success)
- ✅ Fallback path with absent pr_ref (test_get_flow_status_pr_ref_fallback)
- ✅ Error handling with malformed pr_ref (test_get_flow_status_malformed_pr_ref)
- ✅ All 13 tests pass (9 direct + 4 affected)

**Type Safety**: mypy clean
**Lint**: ruff clean
**LOC**: All files under CI block threshold (400 lines)

## Verification

- Tests: `pytest tests/vibe3/services/test_flow_status.py tests/vibe3/services/test_flow_auto_ensure.py`
- Type check: `mypy src/vibe3/services/flow_read_mixin.py`
- Lint: `ruff check src/vibe3/services/flow_read_mixin.py`

All verification steps pass.

## Risk Assessment

- **pr_ready defaults to False**: Acceptable - UI display only, not gating logic
- **pr_ref format**: Protected by error handling with fallback
- **Stale pr_ref**: Mitigated by `_sync_pr_flow_state` always writing latest URL
- **Backward compatibility**: Fallback path unchanged, no breaking changes

---

Issue: #2358

---

## Contributors

claude/opus
