### PR TITLE
refactor: migrate remaining imports to shared.* and fix test mock paths (#2413)

### DIFF
--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -286,7 +286,7 @@ def main() -> None:
         if isinstance(e, MissingResourceError):
             try:
                 from vibe3.exceptions.error_codes import E_CONFIG_MISSING
-                from vibe3.services.shared.errors import record_error
+                from vibe3.services import record_error
 
                 record_error(
                     error_code=E_CONFIG_MISSING,

--- a/src/vibe3/cli.py
+++ b/src/vibe3/cli.py
@@ -286,7 +286,7 @@ def main() -> None:
         if isinstance(e, MissingResourceError):
             try:
                 from vibe3.exceptions.error_codes import E_CONFIG_MISSING
-                from vibe3.services.error_helpers import record_error
+                from vibe3.services.shared.errors import record_error
 
                 record_error(
                     error_code=E_CONFIG_MISSING,

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -210,7 +210,7 @@ def update(
         if name:
             updates["flow_slug"] = name
         if actor:
-            from vibe3.services.signature_service import SignatureService
+            from vibe3.services import SignatureService
 
             updates["latest_actor"] = SignatureService.resolve_actor(
                 explicit_actor=actor

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -171,7 +171,7 @@ def update(
         output_format = "json"
     from vibe3.clients.git_client import GitClient
     from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.services.branch_arg import resolve_branch_arg
+    from vibe3.services.shared.branches import resolve_branch_arg
     from vibe3.utils.issue_ref import try_parse_issue_number
 
     target_branch = resolve_branch_arg(branch)
@@ -444,7 +444,7 @@ def restore_flow(
         typer.echo("Error: Branch is required for flow restore", err=True)
         raise typer.Exit(1)
 
-    from vibe3.services.branch_arg import resolve_branch_arg
+    from vibe3.services.shared.branches import resolve_branch_arg
 
     target_branch = resolve_branch_arg(branch)
 

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -171,7 +171,7 @@ def update(
         output_format = "json"
     from vibe3.clients.git_client import GitClient
     from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.services.shared.branches import resolve_branch_arg
+    from vibe3.services import resolve_branch_arg
     from vibe3.utils.issue_ref import try_parse_issue_number
 
     target_branch = resolve_branch_arg(branch)
@@ -444,7 +444,7 @@ def restore_flow(
         typer.echo("Error: Branch is required for flow restore", err=True)
         raise typer.Exit(1)
 
-    from vibe3.services.shared.branches import resolve_branch_arg
+    from vibe3.services import resolve_branch_arg
 
     target_branch = resolve_branch_arg(branch)
 

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -125,7 +125,7 @@ def show(
     if trace:
         enable_method_trace()
 
-    from vibe3.services.handoff_resolution import resolve_handoff_target
+    from vibe3.services import resolve_handoff_target
 
     if target is None:
         typer.echo(_HANDOFF_SHOW_HELP)

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -125,7 +125,7 @@ def show(
     if trace:
         enable_method_trace()
 
-    from vibe3.services.path_helpers import resolve_handoff_target
+    from vibe3.services.handoff_resolution import resolve_handoff_target
 
     if target is None:
         typer.echo(_HANDOFF_SHOW_HELP)

--- a/src/vibe3/exceptions/__init__.py
+++ b/src/vibe3/exceptions/__init__.py
@@ -226,7 +226,7 @@ class InvalidBranchLinkError(SystemError):
 # Error classification and tracking references:
 #   from vibe3.exceptions.error_classification import classify_error
 #   from vibe3.exceptions.error_codes import E_MODEL_NOT_FOUND, ...
-#   from vibe3.services.error_helpers import record_error
+#   from vibe3.services.shared.errors import record_error
 
 
 # Lazy imports to avoid circular dependencies

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -40,8 +40,7 @@ from vibe3.roles.definitions import (
     RoleOutputContract,
     TriggerableRoleDefinition,
 )
-from vibe3.services import fail_manager_issue
-from vibe3.services.flow_factory import create_flow_manager
+from vibe3.services import create_flow_manager, fail_manager_issue
 
 MANAGER_ROLE = TriggerableRoleDefinition(
     name="manager",

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -186,7 +186,7 @@ def build_manager_request(
 
         # Record to error_log table (with guard to avoid masking original error)
         try:
-            from vibe3.services.shared.errors import record_error
+            from vibe3.services import record_error
 
             record_error(
                 error_code="E_DISPATCH_FAILURE",

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -186,7 +186,7 @@ def build_manager_request(
 
         # Record to error_log table (with guard to avoid masking original error)
         try:
-            from vibe3.services.error_helpers import record_error
+            from vibe3.services.shared.errors import record_error
 
             record_error(
                 error_code="E_DISPATCH_FAILURE",

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -199,7 +199,8 @@ def ensure_plan_file_exists(
         return
     if Path(plan_file).is_absolute() and Path(plan_file).exists():
         return
-    from vibe3.services.path_helpers import resolve_handoff_target
+    # Import via public API for cross-module call (allows test patching)
+    from vibe3.services import resolve_handoff_target
 
     try:
         resolve_handoff_target(plan_file, branch=branch)

--- a/src/vibe3/roles/run_helpers.py
+++ b/src/vibe3/roles/run_helpers.py
@@ -133,7 +133,7 @@ def publish_run_command_failure(
     reason: str,
 ) -> None:
     """Publish run failure lifecycle for command-mode execution."""
-    from vibe3.services.event_helpers import emit_issue_failed
+    from vibe3.services import emit_issue_failed
 
     emit_issue_failed(issue_number=issue_number, reason=reason, actor="agent:run")
 

--- a/src/vibe3/roles/scan_service.py
+++ b/src/vibe3/roles/scan_service.py
@@ -121,7 +121,7 @@ def fetch_supervisor_candidates(
         - total_issues_scanned: Total number of open issues queried
         - matching_candidates: List of candidate issues (number, title, labels)
     """
-    from vibe3.services.label_utils import normalize_labels
+    from vibe3.services.shared.labels import normalize_labels
 
     try:
         raw_issues = github_client.list_issues(limit=100, state="open", repo=repo)

--- a/src/vibe3/roles/scan_service.py
+++ b/src/vibe3/roles/scan_service.py
@@ -121,7 +121,7 @@ def fetch_supervisor_candidates(
         - total_issues_scanned: Total number of open issues queried
         - matching_candidates: List of candidate issues (number, title, labels)
     """
-    from vibe3.services.shared.labels import normalize_labels
+    from vibe3.services import normalize_labels
 
     try:
         raw_issues = github_client.list_issues(limit=100, state="open", repo=repo)

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from vibe3.services.shared.paths import (
         check_ref_exists,
         ref_to_handoff_cmd,
+        resolve_ref_path,
         sanitize_event_detail_paths,
     )
     from vibe3.services.status_query_service import StatusQueryService

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
     from vibe3.services.check_service import CheckResult, CheckService
     from vibe3.services.coordination_resolver import CoordinationResolver
     from vibe3.services.error_tracking_service import ErrorTrackingService
+
+    # Functions used in domain/execution/roles
+    from vibe3.services.event_helpers import emit_issue_failed
     from vibe3.services.flow_cleanup_service import FlowCleanupService
+    from vibe3.services.flow_factory import create_flow_manager
     from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
     from vibe3.services.flow_projection_service import FlowProjectionService
     from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
@@ -45,8 +49,6 @@ if TYPE_CHECKING:
     from vibe3.services.pr.ready import PrReadyAbortedError, PrReadyUsecase
     from vibe3.services.pr.service import PRService
     from vibe3.services.role_policy_helpers import get_role_block_function
-
-    # Functions used in domain/execution/roles
     from vibe3.services.shared.errors import (
         record_dispatch_failure_if_unexpected,
         record_error,
@@ -63,6 +65,7 @@ if TYPE_CHECKING:
         resolve_ref_path,
         sanitize_event_detail_paths,
     )
+    from vibe3.services.signature_service import SignatureService
     from vibe3.services.status_query_service import StatusQueryService
     from vibe3.services.task_binding_guard import build_bind_task_hint
     from vibe3.services.task_resume_operations import TaskResumeOperations

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.models import PRState
-from vibe3.services.label_utils import normalize_labels
+from vibe3.services.shared.labels import normalize_labels
 
 if TYPE_CHECKING:
     from vibe3.clients import GitClient, GitHubClient, SQLiteClient

--- a/src/vibe3/services/flow_consistency_check.py
+++ b/src/vibe3/services/flow_consistency_check.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Mapping
 
-from vibe3.services.path_helpers import check_ref_exists
+from vibe3.services.shared.paths import check_ref_exists
 
 
 class FlowConsistencyCode(StrEnum):

--- a/src/vibe3/services/flow_read_mixin.py
+++ b/src/vibe3/services/flow_read_mixin.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models import FlowEvent, FlowState, FlowStatusResponse, IssueLink
-from vibe3.services.git_path_client import GitPathProtocol, get_git_common_dir
+from vibe3.services.shared.paths import GitPathProtocol, get_git_common_dir
 
 
 class FlowReadMixin:

--- a/src/vibe3/services/flow_service.py
+++ b/src/vibe3/services/flow_service.py
@@ -4,7 +4,7 @@ from vibe3.clients import GitClient, SQLiteClient
 from vibe3.config import VibeConfig
 from vibe3.services.flow_block_mixin import FlowLifecycleMixin
 from vibe3.services.flow_transition import FlowTransitionMixin
-from vibe3.services.git_path_client import GitPathProtocol
+from vibe3.services.shared.paths import GitPathProtocol
 
 
 class FlowService(FlowLifecycleMixin, FlowTransitionMixin):

--- a/src/vibe3/services/flow_transition.py
+++ b/src/vibe3/services/flow_transition.py
@@ -16,8 +16,8 @@ from vibe3.config import VibeConfig
 from vibe3.exceptions import UserError
 from vibe3.models import FlowStatusResponse, MainBranchProtectedError
 from vibe3.services.flow_write_mixin import FlowWriteMixin
-from vibe3.services.git_path_client import GitPathProtocol
 from vibe3.services.issue.flow import IssueFlowService
+from vibe3.services.shared.paths import GitPathProtocol
 from vibe3.services.signature_service import SignatureService
 
 

--- a/src/vibe3/services/handoff_service.py
+++ b/src/vibe3/services/handoff_service.py
@@ -14,10 +14,10 @@ from vibe3.services.actor_support import (
 )
 from vibe3.services.artifact_parser import ArtifactParser
 from vibe3.services.external_events import ExternalEventRecorder
-from vibe3.services.git_path_client import GitPathProtocol
+from vibe3.services.handoff_resolution import _SHARED_HANDOFF_PREFIX
 from vibe3.services.handoff_storage import HandoffStorage
 from vibe3.services.handoff_validation import validate_authoritative_ref
-from vibe3.services.path_helpers import _SHARED_HANDOFF_PREFIX
+from vibe3.services.shared.paths import GitPathProtocol
 from vibe3.services.signature_service import SignatureService
 
 if TYPE_CHECKING:

--- a/src/vibe3/services/handoff_storage.py
+++ b/src/vibe3/services/handoff_storage.py
@@ -6,8 +6,11 @@ from pathlib import Path
 from loguru import logger
 
 from vibe3.clients import GitClient
-from vibe3.services.git_path_client import GitPathProtocol
-from vibe3.services.path_helpers import get_git_common_dir, normalize_ref_path
+from vibe3.services.shared.paths import (
+    GitPathProtocol,
+    get_git_common_dir,
+    normalize_ref_path,
+)
 from vibe3.utils import get_branch_handoff_dir
 
 

--- a/src/vibe3/services/handoff_validation.py
+++ b/src/vibe3/services/handoff_validation.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Callable
 
 from vibe3.exceptions import UserError
-from vibe3.services.git_path_client import GitPathProtocol
+from vibe3.services.shared.paths import GitPathProtocol
 
 
 def is_log_like_path(path: Path) -> bool:

--- a/src/vibe3/services/issue_dispatch_policy.py
+++ b/src/vibe3/services/issue_dispatch_policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vibe3.models import IssueInfo, IssueState
-from vibe3.services.label_utils import has_manager_assignee
+from vibe3.services.shared.labels import has_manager_assignee
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/services/pr_status_checker.py
+++ b/src/vibe3/services/pr_status_checker.py
@@ -14,7 +14,7 @@ from typing import Any
 from loguru import logger
 
 from vibe3.clients import GitHubClient, MergedPRCache
-from vibe3.services.git_path_client import get_git_common_dir
+from vibe3.services.shared.paths import get_git_common_dir
 
 
 def get_merged_pr_for_issue(

--- a/src/vibe3/services/spec_ref_service.py
+++ b/src/vibe3/services/spec_ref_service.py
@@ -127,7 +127,7 @@ class SpecRefService:
             return "\n".join(parts) if parts else None
 
         if info.kind == "file" and info.file_path:
-            from vibe3.services.path_helpers import resolve_handoff_target
+            from vibe3.services.handoff_resolution import resolve_handoff_target
 
             # Use resolve_handoff_target for correct worktree path resolution
             try:
@@ -153,7 +153,7 @@ class SpecRefService:
         if issue_number is not None:
             return True, ""
 
-        from vibe3.services.path_helpers import resolve_handoff_target
+        from vibe3.services.handoff_resolution import resolve_handoff_target
 
         try:
             resolve_handoff_target(spec_ref, branch=branch)

--- a/src/vibe3/services/task/classifier.py
+++ b/src/vibe3/services/task/classifier.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from enum import Enum
 
 from vibe3.models import IssueState
-from vibe3.services.label_utils import has_manager_assignee
+from vibe3.services.shared.labels import has_manager_assignee
 
 
 class TaskStatusBucket(str, Enum):

--- a/src/vibe3/services/task/show.py
+++ b/src/vibe3/services/task/show.py
@@ -12,8 +12,8 @@ from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models import FlowStatusResponse, PRResponse
 from vibe3.services.artifact_parser import ArtifactParser
 from vibe3.services.flow_service import FlowService
-from vibe3.services.path_helpers import resolve_ref_path
 from vibe3.services.pr.service import PRService
+from vibe3.services.shared.paths import resolve_ref_path
 from vibe3.utils import is_human_comment
 
 

--- a/src/vibe3/services/verdict_service.py
+++ b/src/vibe3/services/verdict_service.py
@@ -15,8 +15,8 @@ from vibe3.clients import GitClient, SQLiteClient
 from vibe3.models import VerdictRecord, VerdictValue
 from vibe3.services.actor_support import extract_role_from_actor
 from vibe3.services.flow_service import FlowService
-from vibe3.services.git_path_client import GitPathProtocol
 from vibe3.services.handoff_storage import HandoffStorage
+from vibe3.services.shared.paths import GitPathProtocol
 from vibe3.services.signature_service import SignatureService
 
 

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -62,8 +62,8 @@ def resolve_ref_path(
 ) -> str:
     """Resolve a reference path for display.
 
-    Redirects to vibe3.services.shared.paths.resolve_ref_path.
+    Redirects to vibe3.services (public API).
     """
-    from vibe3.services.shared.paths import resolve_ref_path as _resolve
+    from vibe3.services import resolve_ref_path as _resolve
 
     return _resolve(ref_value, worktree_root, absolute=absolute)

--- a/src/vibe3/ui/flow_ui_primitives.py
+++ b/src/vibe3/ui/flow_ui_primitives.py
@@ -62,8 +62,8 @@ def resolve_ref_path(
 ) -> str:
     """Resolve a reference path for display.
 
-    Redirects to vibe3.services.path_helpers.resolve_ref_path.
+    Redirects to vibe3.services.shared.paths.resolve_ref_path.
     """
-    from vibe3.services.path_helpers import resolve_ref_path as _resolve
+    from vibe3.services.shared.paths import resolve_ref_path as _resolve
 
     return _resolve(ref_value, worktree_root, absolute=absolute)

--- a/tests/vibe3/domain/test_flow_manager_imports.py
+++ b/tests/vibe3/domain/test_flow_manager_imports.py
@@ -16,8 +16,8 @@ def test_manager_uses_flow_factory():
     # Should NOT import FlowManager from domain
     assert "from vibe3.domain import FlowManager" not in content
 
-    # Should use create_flow_manager from services.flow_factory
-    assert "from vibe3.services.flow_factory import create_flow_manager" in content
+    # Should use create_flow_manager via services public API
+    assert "from vibe3.services import create_flow_manager" in content
 
 
 def test_server_registry_imports_from_domain():

--- a/tests/vibe3/integration/test_ci_parity.py
+++ b/tests/vibe3/integration/test_ci_parity.py
@@ -17,7 +17,7 @@ class TestWorkingDirectoryIndependence:
         """Verify repo root detection works from any subdirectory."""
         import os
 
-        from vibe3.services.path_helpers import get_worktree_root
+        from vibe3.services.shared.paths import get_worktree_root
 
         # Save current working directory
         original_cwd = os.getcwd()
@@ -45,7 +45,7 @@ class TestWorkingDirectoryIndependence:
         import os
 
         from vibe3.config.loader import get_config
-        from vibe3.services.path_helpers import get_worktree_root
+        from vibe3.services.shared.paths import get_worktree_root
 
         # Save current working directory
         original_cwd = os.getcwd()

--- a/tests/vibe3/roles/test_run.py
+++ b/tests/vibe3/roles/test_run.py
@@ -254,9 +254,9 @@ class TestEnsurePlanFileExists:
                 return plan_file
             raise FileNotFoundError(f"Mock: {target}")
 
-        # Mock the import inside ensure_plan_file_exists
+        # Mock the public API import (cross-module call uses public API)
         monkeypatch.setattr(
-            "vibe3.services.path_helpers.resolve_handoff_target",
+            "vibe3.services.resolve_handoff_target",
             mock_resolve,
         )
 

--- a/tests/vibe3/services/test_path_helpers.py
+++ b/tests/vibe3/services/test_path_helpers.py
@@ -6,7 +6,7 @@ from vibe3.services.handoff_resolution import (
     is_shared_handoff_ref,
     to_display_target,
 )
-from vibe3.services.path_helpers import (
+from vibe3.services.shared.paths import (
     ref_to_handoff_cmd,
     resolve_ref_path,
     sanitize_event_detail_paths,


### PR DESCRIPTION
## Summary
- Batch migrate source imports from path_helpers to shared.paths
- Fix cross-module import in run_helpers to use public API (lazy import)
- Update test mock patches to use public API paths
- Update test imports for shared.paths module

## Architecture Compliance
- ✅ Cross-module imports use public API (`vibe3.services.*`)
- ✅ Tests patch public API symbols for mock injection
- ✅ Module-specific imports use direct paths (`shared.paths`)

## Test Results
- ✅ All 3020 tests pass (4 xfailed, 1 xpassed)
- ✅ mypy strict passes (413 source files)

## Related
- Follows: #2411 (Phase 1 architecture fix)
- Related: #2392 (original migration PR)
- Issue: #2413 (Phase 2a-2c migration tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)