### PR TITLE
refactor(github): add fields parameter to list_issues to eliminate body over-fetching

### DIFF
--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -20,6 +20,8 @@ _BLOCKED_BY_RE = re.compile(
     re.IGNORECASE,
 )
 
+_DEFAULT_LIST_FIELDS = "number,title,state,updatedAt,labels,assignees,milestone"
+
 
 def parse_blocked_by(body: str) -> list[int]:
     """Parse issue numbers from 'Blocked by' or 'Depends on' lines in issue body.
@@ -118,6 +120,7 @@ class IssuesMixin(IssueAdminMixin):
         repo: str | None = None,
         label: str | None = None,
         search: str | None = None,
+        fields: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """List GitHub issues.
 
@@ -129,6 +132,8 @@ class IssuesMixin(IssueAdminMixin):
                 CLI so GitHub returns only matching issues, reducing both network
                 payload and client-side filtering work.
             search: Server-side GitHub issue search query.
+            fields: List of fields to fetch. If None, defaults to a set that
+                excludes the expensive ``body`` field.
         """
         logger.bind(
             external="github",
@@ -138,7 +143,9 @@ class IssuesMixin(IssueAdminMixin):
             assignee=assignee,
             label=label,
             search=search,
+            fields=fields,
         ).debug("Calling GitHub API: list_issues")
+        json_fields = ",".join(fields) if fields is not None else _DEFAULT_LIST_FIELDS
         cmd = [
             "gh",
             "issue",
@@ -148,7 +155,7 @@ class IssuesMixin(IssueAdminMixin):
             "--state",
             state,
             "--json",
-            "number,title,body,state,updatedAt,labels,assignees,milestone",
+            json_fields,
         ]
         if assignee:
             cmd.extend(["--assignee", assignee])
@@ -189,6 +196,7 @@ class IssuesMixin(IssueAdminMixin):
                 state="all",
                 repo=repo,
                 search=search_terms,
+                fields=["number", "title"],
             )
         except Exception as e:
             logger.bind(

--- a/src/vibe3/services/issue/collection.py
+++ b/src/vibe3/services/issue/collection.py
@@ -19,6 +19,15 @@ class IssueCollectionService:
             state="open",
             assignee=None,
             repo=self._repo,
+            fields=[
+                "number",
+                "title",
+                "state",
+                "labels",
+                "assignees",
+                "milestone",
+                "body",
+            ],
         )
 
         issues: list[IssueInfo] = []

--- a/src/vibe3/services/orchestra_status_service.py
+++ b/src/vibe3/services/orchestra_status_service.py
@@ -503,12 +503,16 @@ class OrchestraStatusService:
 
         for username in get_manager_usernames(self.config):
             try:
+                # fmt: off
                 result = self._github.list_issues(
                     state="open",
                     assignee=username,
                     limit=50,
                     repo=self.config.repo,
+                    fields=["number", "title", "state", "labels",
+                            "assignees", "milestone", "body"],
                 )
+                # fmt: on
                 if not result:
                     continue
                 for issue in result:

--- a/tests/vibe3/clients/test_github_batch_issues.py
+++ b/tests/vibe3/clients/test_github_batch_issues.py
@@ -24,6 +24,7 @@ class TestIssuesBatchFetch:
             state="all",
             repo=None,
             search="#123 #456",
+            fields=["number", "title"],
         )
 
     def test_batch_get_issues_includes_closed_issues_and_filters_results(self):
@@ -42,6 +43,7 @@ class TestIssuesBatchFetch:
             state="all",
             repo=None,
             search="#123",
+            fields=["number", "title"],
         )
 
     def test_batch_get_issues_empty_list(self):

--- a/tests/vibe3/clients/test_github_client_issues.py
+++ b/tests/vibe3/clients/test_github_client_issues.py
@@ -316,3 +316,68 @@ def test_list_issue_comments_failure(github_client: GitHubClient) -> None:
         result = github_client.list_issue_comments(issue_number=999)
 
         assert result == []
+
+
+def test_list_issues_default_fields_excludes_body(github_client: GitHubClient) -> None:
+    """list_issues should exclude body field by default."""
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"number": 1, "title": "Test"}]),
+        )
+
+        github_client.list_issues()
+
+        args = mock_run.call_args[0][0]
+        json_arg = args[args.index("--json") + 1]
+        assert "body" not in json_arg
+        assert "number" in json_arg
+        assert "title" in json_arg
+
+
+def test_list_issues_custom_fields(github_client: GitHubClient) -> None:
+    """list_issues should use custom fields when provided."""
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"number": 1, "title": "Test"}]),
+        )
+
+        github_client.list_issues(fields=["number", "title"])
+
+        args = mock_run.call_args[0][0]
+        json_arg = args[args.index("--json") + 1]
+        assert json_arg == "number,title"
+
+
+def test_list_issues_default_fields_backward_compat(
+    github_client: GitHubClient,
+) -> None:
+    """list_issues default fields should return expected shape."""
+    with patch("vibe3.clients.github_client_base.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "title": "Test Issue",
+                        "state": "open",
+                        "updatedAt": "2024-01-01T00:00:00Z",
+                        "labels": [{"name": "bug"}],
+                        "assignees": [{"login": "user1"}],
+                        "milestone": {"title": "v1.0"},
+                    }
+                ]
+            ),
+        )
+
+        issues = github_client.list_issues()
+
+        assert len(issues) == 1
+        assert issues[0]["number"] == 1
+        assert issues[0]["title"] == "Test Issue"
+        assert issues[0]["state"] == "open"
+        assert "labels" in issues[0]
+        assert "assignees" in issues[0]
+        assert "milestone" in issues[0]

--- a/tests/vibe3/services/test_issue_collection_service.py
+++ b/tests/vibe3/services/test_issue_collection_service.py
@@ -37,6 +37,15 @@ def test_collect_open_issues_calls_github_once_without_label_filter() -> None:
         state="open",
         assignee=None,
         repo="owner/repo",
+        fields=[
+            "number",
+            "title",
+            "state",
+            "labels",
+            "assignees",
+            "milestone",
+            "body",
+        ],
     )
     assert [issue.number for issue in issues] == [1521, 1492]
     assert issues[0].state is None


### PR DESCRIPTION
Closes #2404

## Summary

Follows the same pattern as `view_issue` (commit 764dbace): add an optional `fields` parameter to `list_issues`, default to a set that excludes the expensive `body` field, and update callers that need `body` to explicitly request it.

## Changes

- Added `_DEFAULT_LIST_FIELDS` constant excluding body
- Added `fields: list[str] | None = None` parameter to `list_issues` method
- Updated `batch_get_issues` to request minimal fields (number, title only)
- Updated `orchestra_status_service` to explicitly request body field
- Updated `collection` service to explicitly request body field
- Added 3 new tests for default fields exclusion, custom fields, and backward compat
- Updated existing mock assertions to expect new `fields` parameter

## Performance Impact

Eliminates over-fetching for 4 of 6 callers:
- `orchestration_facade` (needs only number, title, labels)
- `governance_utils` callers (need only number, title)
- `batch_get_issues` (needs only number, title)

Only 2 callers explicitly request body field where needed.

## Test Coverage

- All tests pass: 3046 passed
- Type checking: mypy PASS (413 source files)
- Linting: ruff PASS (all checks)
- LOC limits: all files under limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
