### PR TITLE
test(review_prompt): add unit tests for describe_review_sections

### DIFF
--- a/tests/vibe3/agents/test_review_prompt.py
+++ b/tests/vibe3/agents/test_review_prompt.py
@@ -15,6 +15,7 @@ from vibe3.agents.review_prompt import (
     build_policy_section,
     build_review_prompt_body,
     build_review_task_section,
+    describe_review_sections,
 )
 from vibe3.models import ReviewRequest, ReviewScope
 
@@ -207,3 +208,46 @@ class TestBuildReviewPromptBody:
         assert "canonical audit report under `docs/reports/`" in context
         assert "handoff audit" in context
         assert "PASS` and `REFUSE` may omit `audit_ref`" in context
+
+
+class TestDescribeReviewSections:
+    """Tests for describe_review_sections (unit test)."""
+
+    def test_first_bootstrap(self) -> None:
+        """Should return 6 sections for first.bootstrap variant."""
+        sections = describe_review_sections("first", "bootstrap")
+        assert sections == [
+            "review.policy",
+            "common.rules",
+            "review.snapshot_diff",
+            "review.ast_analysis",
+            "review.output_format",
+            "review.exit_contract",
+        ]
+
+    def test_retry_bootstrap(self) -> None:
+        """Should return 7 sections for retry.bootstrap variant."""
+        sections = describe_review_sections("retry", "bootstrap")
+        assert sections == [
+            "review.policy",
+            "common.rules",
+            "review.snapshot_diff",
+            "review.ast_analysis",
+            "review.output_format",
+            "review.retry_task",
+            "review.exit_contract",
+        ]
+
+    def test_retry_resume(self) -> None:
+        """Should return 3 sections for retry.resume variant."""
+        sections = describe_review_sections("retry", "resume")
+        assert sections == [
+            "review.output_format",
+            "review.retry_task",
+            "review.exit_contract",
+        ]
+
+    def test_first_resume_raises(self) -> None:
+        """Should raise KeyError for first.resume variant (not defined in YAML)."""
+        with pytest.raises(KeyError, match="Prompt recipe variant not found"):
+            describe_review_sections("first", "resume")


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2379` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2379
```


---

## Summary

Add unit tests for `describe_review_sections` function covering all valid (mode, context_mode) combinations plus the invalid first.resume gap.

## Changes

- Added `describe_review_sections` to imports in `tests/vibe3/agents/test_review_prompt.py`
- Added `TestDescribeReviewSections` class with 4 test methods:
  - `test_first_bootstrap`: Verifies 6 sections for first.bootstrap variant
  - `test_retry_bootstrap`: Verifies 7 sections for retry.bootstrap variant  
  - `test_retry_resume`: Verifies 3 sections for retry.resume variant
  - `test_first_resume_raises`: Verifies KeyError for undefined first.resume variant

## Test Results

- All 21 tests pass (17 existing + 4 new)
- Type checking: mypy clean
- Linting: ruff clean
- Tests use real YAML manifest (no mocks) to catch unintended recipe changes

## Test Plan

- [x] Run test suite: `PYTHONPATH=src uv run pytest tests/vibe3/agents/test_review_prompt.py -v`
- [x] Type check: `uv run mypy tests/vibe3/agents/test_review_prompt.py`
- [x] Lint: `uv run ruff check tests/vibe3/agents/test_review_prompt.py`
- [x] All pre-push checks passed

Fixes #2379

---

## Contributors

claude/opus
