### PR TITLE
refactor(check): consolidate check local logic, eliminate redundancy (#2380)

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -235,6 +235,9 @@ code_limits:
       - path: "tests/vibe3/clients/test_github_client_prs.py"
         limit: 540
         reason: "GitHub client PR 测试集，覆盖 auth check、PR create/update、review operations、CI 失败分类与检查步骤解析等多个场景，新增 failure category 测试后略微超标"
+      - path: "tests/vibe3/clients/test_github_client_issues.py"
+        limit: 440
+        reason: "GitHub client Issues 测试集，覆盖 24 个紧密耦合场景（list issues with assignees、close issue、remove/add assignees、add comment、view issue with custom/default fields、create issue with labels/assignees、list issue comments 等），共享 mock setup 和 GitHub client fixture，拆分收益低"
       - path: "tests/vibe3/orchestra/test_dispatch_health_checks.py"
         limit: 520
         reason: "Health check failure 测试集，7 个独立测试用例验证 coordinator 对 CheckService 结果的处理逻辑，每个测试需要完整 mock setup，拆分会降低可读性；新增 mock_flow_blocker 注入对齐测试模式（#1723）；新增 _make_mock_coordinator_dependencies helper function 后略微超标（#1887）"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -286,6 +286,9 @@ code_limits:
       - path: "tests/vibe3/services/test_check_service.py"
         limit: 540
         reason: "Check service bridge issue 测试集，覆盖 9 个关键场景（bridge 创建、idempotency、API 失败保护、PR 编号精确匹配等），共享 mock setup，新增边缘情况测试后略微超标（#1895）；Issue #2329 rename handle_closed_pr → handle_pr_terminal_state 增加行数（长方法名需换行，2个超长函数名需 noqa 注释）"
+      - path: "tests/vibe3/services/test_check_service_verify_branch.py"
+        limit: 420
+        reason: "CheckService.verify_branch 测试集，覆盖 9 个紧密耦合场景（正常返回、缺失 flow、protected branch、merged/closed PR、missing worktree、runtime ownership warnings 回归、closed issue、stale blocked flow 解锁），共享 mock setup 和 SQLite fixture，拆分收益低"
       - path: "tests/vibe3/services/test_handoff_service.py"
         limit: 500
         reason: "Handoff service 测试集，覆盖 plan/report/audit/indicate 记录、artifact 解析、verdict 处理、next step 管理、passive artifact 记录等紧密耦合场景，共享 fixture 和 mock setup，拆分收益低；架构重构后新增 ref_field 参数验证测试略微超标（#1908）"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -192,8 +192,8 @@ code_limits:
         limit: 580
         reason: "Orchestra 状态查询服务，包含状态快照和格式化逻辑、IssueState 反序列化类型安全处理、HTTP fetch 集成、live snapshot 解析、pr_number 类型强制转换防御逻辑等紧密耦合逻辑；新增 get_manager_usernames 静态方法提供统一的服务层 API 供 governance.py 和 status.py 使用（#1783）；新增 create() 工厂方法使用动态导入避免循环依赖（#2001），职责单一但方法较多"
       - path: "src/vibe3/services/check_pr_service.py"
-        limit: 700
-        reason: "Check PR 状态服务聚合，包含 PR 状态查询、closed 状态检测、terminal 状态判断、bridge issue 创建工作流（5个辅助函数 + idempotency 检查）、label 继承、GitHub API 失败保护（network/auth/timeout）、retry-safe cleanup 逻辑等紧密耦合功能，替代 rebuild 逻辑避免 check-rebuild 循环（#1895）"
+        limit: 720
+        reason: "Check PR 状态服务聚合，包含 PR 状态查询、closed 状态检测、terminal 状态判断、bridge issue 创建工作流（5个辅助函数 + idempotency 检查）、label 继承、GitHub API 失败保护（network/auth/timeout）、retry-safe cleanup 逻辑、dependency transfer（PR closed 时将依赖从旧 issue 转移到 bridge issue）等紧密耦合功能，替代 rebuild 逻辑避免 check-rebuild 循环（#1895）；Issue #2380 新增 _transfer_dependencies 方法支持依赖转移（+35 行）"
 
       # 强耦合测试例外
       - path: "tests/vibe3/models/test_job.py"

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -160,6 +160,50 @@ class CheckPRService:
             ).warning(warning_msg)
             return (None, [warning_msg])
 
+    def _transfer_dependencies(
+        self,
+        old_branch: str,
+        old_issue_number: int,
+        bridge_issue_number: int,
+    ) -> int:
+        """Transfer dependency links from old issue to bridge issue.
+
+        Args:
+            old_branch: Branch name of the old issue
+            old_issue_number: Issue number of the old (closed) issue
+            bridge_issue_number: Issue number of the new bridge issue
+
+        Returns:
+            Number of dependent flows updated
+        """
+        dependents = self.store.get_flow_dependents(old_branch)
+        if not dependents:
+            return 0
+
+        transferred = 0
+        for dep_branch in dependents:
+            try:
+                self.store.add_issue_link(dep_branch, bridge_issue_number, "dependency")
+                transferred += 1
+                logger.bind(
+                    domain="check",
+                    action="transfer_dependency",
+                    branch=dep_branch,
+                    old_issue=old_issue_number,
+                    new_issue=bridge_issue_number,
+                ).info(
+                    f"Transferred dependency from #{old_issue_number} "
+                    f"to #{bridge_issue_number} for branch {dep_branch}"
+                )
+            except Exception as exc:
+                logger.bind(
+                    domain="check",
+                    action="transfer_dependency",
+                    branch=dep_branch,
+                ).warning(f"Failed to transfer dependency: {exc}")
+
+        return transferred
+
     def handle_pr_terminal_state(
         self,
         branch: str,
@@ -620,6 +664,9 @@ The unresolved work continues in #{bridge_issue_number}.
             )
 
         # Success - abort and cleanup old flow
+        # Transfer dependencies from old issue to bridge issue
+        self._transfer_dependencies(branch, task_issue_number, bridge_number)
+
         assignee_names = [
             a.get("login", "")
             for a in gh_issue.get("assignees", [])

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -394,6 +394,19 @@ class CheckService(CheckRemote):
             flow_status = flow_data.get("flow_status", "active")
             is_active_flow = flow_status not in self.INACTIVE_FLOW_STATUSES
 
+            # Instantiate FlowRecoveryService early for use in blocked state recovery
+            # and flow consistency check
+            from vibe3.services.flow_recovery_service import (
+                FlowRecoveryService,
+                RecoveryAction,
+            )
+
+            recovery_svc = FlowRecoveryService(
+                store=self.store,
+                git_client=self.git_client,
+                github_client=self.github_client,
+            )
+
             if task_issue_closed:
                 if is_active_flow:
                     # Active flow with closed issue and no open PR = anomaly
@@ -415,10 +428,28 @@ class CheckService(CheckRemote):
                 and orchestration_state is not None
                 and orchestration_state != IssueState.BLOCKED
             ):
-                self._flow_status_service.mark_flow_unblocked(
-                    branch, "Remote state/blocked label removed"
-                )
-                return CheckResult(is_valid=True, branch=branch, issues=[])
+                try:
+                    result = recovery_svc.recover(
+                        branch=branch,
+                        issue_number=task_issue,
+                        reason="Remote state/blocked label removed",
+                        auto=True,
+                        ensure_worktree=True,
+                    )
+                    logger.info(
+                        "Auto-resumed stale blocked flow",
+                        branch=branch,
+                        action=result.action.value,
+                        detail=result.detail,
+                    )
+                    return CheckResult(is_valid=True, branch=branch, issues=[])
+                except Exception as e:
+                    logger.error(
+                        "Failed to auto-resume blocked flow",
+                        branch=branch,
+                        error=str(e),
+                    )
+                    issues.append(f"Blocked flow auto-resume failed: {e}")
 
             # Handle stale ready flow rebuild
             if (
@@ -490,16 +521,6 @@ class CheckService(CheckRemote):
 
             # Flow consistency check and auto-recovery
             if flow_status not in self.INACTIVE_FLOW_STATUSES:
-                from vibe3.services.flow_recovery_service import (
-                    FlowRecoveryService,
-                    RecoveryAction,
-                )
-
-                recovery_svc = FlowRecoveryService(
-                    store=self.store,
-                    git_client=self.git_client,
-                    github_client=self.github_client,
-                )
                 action, consistency = recovery_svc.classify(branch)
 
                 if action != RecoveryAction.RESUME_ONLY:
@@ -534,6 +555,27 @@ class CheckService(CheckRemote):
                             f"{consistency_error}. "
                             f"Auto-recovery failed: {e}. "
                             f"Manual fix: vibe3 flow rebuild {task_issue} --yes"
+                        )
+
+            # Read-only dependency check
+            if task_issue and flow_status not in self.INACTIVE_FLOW_STATUSES:
+                from vibe3.services.coordination_resolver import CoordinationResolver
+
+                resolver = CoordinationResolver(store=self.store)
+                truth = resolver.resolve_coordination(branch, task_issue)
+                if truth.dependencies:
+                    unresolved = []
+                    for dep in truth.dependencies:
+                        dep_issue = self.github_client.view_issue(dep)
+                        if (
+                            not isinstance(dep_issue, dict)
+                            or dep_issue.get("state") != "closed"
+                        ):
+                            unresolved.append(dep)
+                    if unresolved:
+                        warnings.append(
+                            f"Unresolved dependencies: "
+                            f"{', '.join(f'#{d}' for d in unresolved)}"
                         )
 
             is_valid = len(issues) == 0

--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -190,6 +190,10 @@ class FlowStatusService:
         Clears blocked_by_issue and blocked_reason in addition to flow_status,
         matching what BlockedStateIO.clear_database_cache() does.
         Only updates local state — GitHub label sync is left to qualify_gate.
+
+        .. deprecated::
+            Use FlowRecoveryService.recover() or BlockedStateService.unblock() instead.
+            Will be removed in a future version.
         """
         logger.bind(
             domain="check",

--- a/tests/vibe3/services/test_check_service_verify_branch.py
+++ b/tests/vibe3/services/test_check_service_verify_branch.py
@@ -384,16 +384,33 @@ def test_verify_branch_unblocks_stale_blocked_flow(tmp_path: Path) -> None:
     }
     mock_github.list_all_prs.return_value = []
     mock_github.list_prs_for_branch.return_value = []
+    # Mock issue body operations for BlockedStateService
+    mock_github.get_issue_body.return_value = ""
+    mock_github.update_issue_body.return_value = True
+    mock_github.add_issue_labels.return_value = True
+    mock_github.remove_issue_labels.return_value = True
 
-    service = CheckService(store=store, git_client=mock_git, github_client=mock_github)
-    service._initialize_pr_cache()
-    result = service.verify_branch(branch)
+    # Mock LabelService to avoid gh CLI calls
+    from unittest.mock import patch
 
-    assert result.is_valid is True
+    with patch(
+        "vibe3.services.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        mock_label_service = MagicMock()
+        mock_label_service.confirm_issue_state.return_value = "confirmed"
+        mock_label_service_cls.return_value = mock_label_service
 
-    # DB blocked state must be cleared
-    flow = store.get_flow_state(branch)
-    assert flow is not None
-    assert flow.get("flow_status") == "active"
-    assert flow.get("blocked_by_issue") is None
-    assert flow.get("blocked_reason") is None
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is True
+
+        # DB blocked state must be cleared
+        flow = store.get_flow_state(branch)
+        assert flow is not None
+        assert flow.get("flow_status") == "active"
+        assert flow.get("blocked_by_issue") is None
+        assert flow.get("blocked_reason") is None


### PR DESCRIPTION
Closes #2380

## Summary

Refactoring to consolidate check local logic and eliminate redundancy across check service files. This implements issue #2380 by:

1. **Replacing `mark_flow_unblocked` with full recovery** - Changed from DB-only state clearing to full 3-source recovery (DB + GitHub label + issue body), preventing flows from getting stuck on stale `state/blocked` labels.

2. **Added read-only dependency checking** - Implemented dependency validation that reports unresolved dependencies as warnings during health checks, improving observability without auto-blocking.

3. **Implemented dependency transfer** - Added automatic dependency link transfer from closed issues to bridge issues when PR closes without merge, preventing dependent flows from remaining blocked.

4. **Deprecated legacy method** - Added deprecation notice to `mark_flow_unblocked` directing callers to use the full recovery path.

## Test plan

- [x] Unit tests: 737 tests passed in services test suite
- [x] Type checks: mypy clean on all modified files
- [x] Lint checks: ruff passed on all modified files
- [x] Pre-commit hooks: all checks passed
- [x] Pre-push checks: all checks passed (124 tests in 20.06s)
- [x] Manual verification: tested blocked state recovery with mocked LabelService

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
