### PR TITLE
refactor(roles): slim __init__.py by removing 49 unused symbols (Phase 3 step 1)

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -235,6 +235,9 @@ code_limits:
       - path: "tests/vibe3/clients/test_github_client_prs.py"
         limit: 540
         reason: "GitHub client PR 测试集，覆盖 auth check、PR create/update、review operations、CI 失败分类与检查步骤解析等多个场景，新增 failure category 测试后略微超标"
+      - path: "tests/vibe3/clients/test_github_client_issues.py"
+        limit: 450
+        reason: "GitHub client issues 测试集，覆盖 issue 查询、fields 参数优化、list_issues 过滤、状态转换等多个场景，共享 fixture，拆分收益低；新增 fields 参数测试验证 body over-fetching 优化后略微超标（#2425）"
       - path: "tests/vibe3/orchestra/test_dispatch_health_checks.py"
         limit: 520
         reason: "Health check failure 测试集，7 个独立测试用例验证 coordinator 对 CheckService 结果的处理逻辑，每个测试需要完整 mock setup，拆分会降低可读性；新增 mock_flow_blocker 注入对齐测试模式（#1723）；新增 _make_mock_coordinator_dependencies helper function 后略微超标（#1887）"

--- a/src/vibe3/roles/__init__.py
+++ b/src/vibe3/roles/__init__.py
@@ -15,193 +15,58 @@ import importlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    # For type checkers, import all symbols
-    from vibe3.roles.definitions import (
-        IssueRoleSyncSpec,
-        RoleDefinition,
-        RoleOutputContract,
-        TriggerableRoleDefinition,
-        TriggerName,
-    )
+    # For type checkers, import all symbols that are externally used
+    from vibe3.roles.definitions import TriggerableRoleDefinition
     from vibe3.roles.governance import (
-        GOVERNANCE_ROLE,
-        GOVERNANCE_TASK_PROMPT,
         build_governance_execution_name,
-        build_governance_recipe,
-        build_governance_request,
-        build_governance_snapshot_context,
         load_governance_material_catalog,
-        render_governance_prompt,
-        resolve_governance_options,
     )
     from vibe3.roles.governance_factory import build_default_governance_fns
-    from vibe3.roles.governance_utils import (
-        find_material_in_catalog,
-        normalize_material_name,
-    )
-    from vibe3.roles.manager import (
-        HANDOFF_MANAGER_ROLE,
-        MANAGER_BRANCH_RESOLVER,
-        MANAGER_ROLE,
-        MANAGER_SYNC_SPEC,
-        build_manager_request,
-        build_manager_sync_request,
-        resolve_manager_options,
-        resolve_manager_token,
-    )
-    from vibe3.roles.plan import (
-        PLAN_BRANCH_RESOLVER,
-        PLAN_SYNC_SPEC,
-        PLANNER_ROLE,
-        build_plan_prompt,
-        build_plan_request,
-        build_plan_sync_request,
-        execute_spec_plan_async,
-        execute_spec_plan_sync,
-        resolve_plan_options,
-        resolve_spec_plan_input,
-    )
+    from vibe3.roles.governance_utils import find_material_in_catalog
+    from vibe3.roles.manager import build_manager_request
+    from vibe3.roles.plan import build_plan_request
     from vibe3.roles.registry import (
         LABEL_DISPATCH_ROLES,
         build_label_dispatch_event,
     )
-    from vibe3.roles.review import (
-        REVIEW_BRANCH_RESOLVER,
-        REVIEW_SYNC_SPEC,
-        REVIEWER_ROLE,
-        build_base_review_request,
-        build_issue_review_request,
-        build_manual_review_request_payload,
-        build_review_request,
-        build_review_sync_request,
-        execute_manual_review_async,
-        execute_manual_review_sync,
-        resolve_review_options,
-        validate_review_prerequisites,
-    )
+    from vibe3.roles.review import build_review_request
     from vibe3.roles.run import (
-        EXECUTOR_PUBLISH_ROLE,
-        EXECUTOR_ROLE,
-        RUN_BRANCH_RESOLVER,
-        RUN_SYNC_SPEC,
         build_run_request,
-        build_run_sync_request,
-        dispatch_run_command_async,
-        ensure_plan_file_exists,
-        execute_manual_run,
-        publish_run_command_failure,
-        publish_run_command_success,
-        resolve_run_mode,
-        resolve_run_options,
         resolve_skill_path,
-        validate_run_prerequisites,
     )
     from vibe3.roles.supervisor import (
         SUPERVISOR_APPLY_ROLE,
         SUPERVISOR_CLI_SYNC_SPEC,
-        SUPERVISOR_IDENTIFY_ROLE,
-        build_supervisor_apply_request,
-        build_supervisor_cli_request,
-        build_supervisor_cli_sync_request,
-        build_supervisor_handoff_payload,
-        build_supervisor_task_string,
-        get_supervisor_prompt_path,
         iter_supervisor_identified_events,
     )
 
 # Lazy import mapping: symbol_name -> module_path
 # Symbol name is the same in both this module and the source module
 _LAZY_IMPORTS: dict[str, str] = {
-    # definitions (no circular dependency risk, but moved to lazy per modularity test)
-    "IssueRoleSyncSpec": "vibe3.roles.definitions",
-    "RoleDefinition": "vibe3.roles.definitions",
-    "RoleOutputContract": "vibe3.roles.definitions",
-    "TriggerName": "vibe3.roles.definitions",
+    # definitions
     "TriggerableRoleDefinition": "vibe3.roles.definitions",
-    # registry (imports from manager, so must be lazy)
+    # registry
     "LABEL_DISPATCH_ROLES": "vibe3.roles.registry",
     "build_label_dispatch_event": "vibe3.roles.registry",
     # manager
-    "HANDOFF_MANAGER_ROLE": "vibe3.roles.manager",
-    "MANAGER_BRANCH_RESOLVER": "vibe3.roles.manager",
-    "MANAGER_ROLE": "vibe3.roles.manager",
-    "MANAGER_SYNC_SPEC": "vibe3.roles.manager",
     "build_manager_request": "vibe3.roles.manager",
-    "build_manager_sync_request": "vibe3.roles.manager",
-    "resolve_manager_token": "vibe3.roles.manager",
-    "resolve_manager_options": "vibe3.roles.manager",
     # planner
-    "PLAN_BRANCH_RESOLVER": "vibe3.roles.plan",
-    "PLAN_SYNC_SPEC": "vibe3.roles.plan",
-    "PLANNER_ROLE": "vibe3.roles.plan",
-    "build_plan_prompt": "vibe3.roles.plan",
     "build_plan_request": "vibe3.roles.plan",
-    "build_plan_sync_request": "vibe3.roles.plan",
-    "execute_spec_plan_async": "vibe3.roles.plan",
-    "execute_spec_plan_sync": "vibe3.roles.plan",
-    "resolve_plan_options": "vibe3.roles.plan",
-    "resolve_spec_plan_input": "vibe3.roles.plan",
     # executor
-    "EXECUTOR_PUBLISH_ROLE": "vibe3.roles.run",
-    "EXECUTOR_ROLE": "vibe3.roles.run",
-    "RUN_BRANCH_RESOLVER": "vibe3.roles.run",
-    "RUN_SYNC_SPEC": "vibe3.roles.run",
     "build_run_request": "vibe3.roles.run",
-    "build_run_sync_request": "vibe3.roles.run",
-    "dispatch_run_command_async": "vibe3.roles.run",
-    "ensure_plan_file_exists": "vibe3.roles.run",
-    "execute_manual_run": "vibe3.roles.run",
-    "publish_run_command_failure": "vibe3.roles.run",
-    "publish_run_command_success": "vibe3.roles.run",
-    "resolve_run_mode": "vibe3.roles.run",
-    "resolve_run_options": "vibe3.roles.run",
     "resolve_skill_path": "vibe3.roles.run",
-    "validate_run_prerequisites": "vibe3.roles.run",
     # reviewer
-    "REVIEW_BRANCH_RESOLVER": "vibe3.roles.review",
-    "REVIEW_SYNC_SPEC": "vibe3.roles.review",
-    "REVIEWER_ROLE": "vibe3.roles.review",
-    "build_base_review_request": "vibe3.roles.review",
-    "build_issue_review_request": "vibe3.roles.review",
-    "build_manual_review_request_payload": "vibe3.roles.review",
     "build_review_request": "vibe3.roles.review",
-    "build_review_sync_request": "vibe3.roles.review",
-    "execute_manual_review_async": "vibe3.roles.review",
-    "execute_manual_review_sync": "vibe3.roles.review",
-    "resolve_review_options": "vibe3.roles.review",
-    "validate_review_prerequisites": "vibe3.roles.review",
     # supervisor
     "SUPERVISOR_APPLY_ROLE": "vibe3.roles.supervisor",
     "SUPERVISOR_CLI_SYNC_SPEC": "vibe3.roles.supervisor",
-    "SUPERVISOR_IDENTIFY_ROLE": "vibe3.roles.supervisor",
-    "build_supervisor_apply_request": "vibe3.roles.supervisor",
-    "build_supervisor_cli_request": "vibe3.roles.supervisor",
-    "build_supervisor_cli_sync_request": "vibe3.roles.supervisor",
-    "build_supervisor_handoff_payload": "vibe3.roles.supervisor",
-    "build_supervisor_task_string": "vibe3.roles.supervisor",
-    "get_supervisor_prompt_path": "vibe3.roles.supervisor",
     "iter_supervisor_identified_events": "vibe3.roles.supervisor",
     # governance
-    "GOVERNANCE_ROLE": "vibe3.roles.governance",
-    "GOVERNANCE_TASK_PROMPT": "vibe3.roles.governance",
     "build_governance_execution_name": "vibe3.roles.governance",
-    "build_governance_recipe": "vibe3.roles.governance",
-    "build_governance_request": "vibe3.roles.governance",
-    "build_governance_snapshot_context": "vibe3.roles.governance",
     "load_governance_material_catalog": "vibe3.roles.governance",
-    "render_governance_prompt": "vibe3.roles.governance",
-    "resolve_governance_options": "vibe3.roles.governance",
     # governance factory & utils
     "build_default_governance_fns": "vibe3.roles.governance_factory",
     "find_material_in_catalog": "vibe3.roles.governance_utils",
-    "normalize_material_name": "vibe3.roles.governance_utils",
-    # scan service
-    "dispatch_governance_execution": "vibe3.roles.scan_service",
-    "dispatch_supervisor_execution": "vibe3.roles.scan_service",
-    "fetch_supervisor_candidates": "vibe3.roles.scan_service",
-    "get_available_governance_materials": "vibe3.roles.scan_service",
-    "governance_material_exists": "vibe3.roles.scan_service",
-    "list_governance_materials": "vibe3.roles.scan_service",
 }
 
 
@@ -217,96 +82,30 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
-    # definitions (lazy)
-    "IssueRoleSyncSpec",
-    "RoleDefinition",
-    "RoleOutputContract",
-    "TriggerName",
+    # definitions
     "TriggerableRoleDefinition",
-    # registry (lazy)
+    # registry
     "LABEL_DISPATCH_ROLES",
     "build_label_dispatch_event",
-    # manager (lazy)
-    "HANDOFF_MANAGER_ROLE",
-    "MANAGER_BRANCH_RESOLVER",
-    "MANAGER_SYNC_SPEC",
-    "MANAGER_ROLE",
+    # manager
     "build_manager_request",
-    "build_manager_sync_request",
-    "resolve_manager_token",
-    "resolve_manager_options",
-    # planner (lazy)
-    "PLAN_BRANCH_RESOLVER",
-    "PLAN_SYNC_SPEC",
-    "PLANNER_ROLE",
-    "build_plan_prompt",
+    # planner
     "build_plan_request",
-    "build_plan_sync_request",
-    "resolve_plan_options",
-    "resolve_spec_plan_input",
-    "execute_spec_plan_async",
-    "execute_spec_plan_sync",
-    # executor (lazy)
-    "EXECUTOR_PUBLISH_ROLE",
-    "EXECUTOR_ROLE",
-    "RUN_BRANCH_RESOLVER",
-    "RUN_SYNC_SPEC",
+    # executor
     "build_run_request",
-    "build_run_sync_request",
-    "dispatch_run_command_async",
-    "ensure_plan_file_exists",
-    "execute_manual_run",
-    "publish_run_command_failure",
-    "publish_run_command_success",
-    "resolve_run_mode",
-    "resolve_run_options",
     "resolve_skill_path",
-    "validate_run_prerequisites",
-    # reviewer (lazy)
-    "REVIEW_BRANCH_RESOLVER",
-    "REVIEW_SYNC_SPEC",
-    "REVIEWER_ROLE",
-    "build_base_review_request",
-    "build_issue_review_request",
-    "build_manual_review_request_payload",
+    # reviewer
     "build_review_request",
-    "build_review_sync_request",
-    "execute_manual_review_async",
-    "execute_manual_review_sync",
-    "resolve_review_options",
-    "validate_review_prerequisites",
-    # supervisor (lazy)
+    # supervisor
     "SUPERVISOR_APPLY_ROLE",
     "SUPERVISOR_CLI_SYNC_SPEC",
-    "SUPERVISOR_IDENTIFY_ROLE",
-    "build_supervisor_apply_request",
-    "build_supervisor_cli_request",
-    "build_supervisor_cli_sync_request",
-    "build_supervisor_handoff_payload",
-    "build_supervisor_task_string",
-    "get_supervisor_prompt_path",
     "iter_supervisor_identified_events",
-    # governance (lazy)
-    "GOVERNANCE_ROLE",
-    "GOVERNANCE_TASK_PROMPT",
+    # governance
     "build_governance_execution_name",
-    "build_governance_recipe",
-    "build_governance_request",
-    "build_governance_snapshot_context",
     "load_governance_material_catalog",
-    "render_governance_prompt",
-    "resolve_governance_options",
-    # governance factory & utils (lazy)
+    # governance factory & utils
     "build_default_governance_fns",
     "find_material_in_catalog",
-    "normalize_material_name",
-    # scan service
-    "dispatch_governance_execution",
-    "dispatch_supervisor_execution",
-    "fetch_supervisor_candidates",
-    "get_available_governance_materials",
-    "governance_material_exists",
-    "list_governance_materials",
 ]
 
 # Consistency check: ensure __all__ matches lazy symbols

--- a/src/vibe3/roles/__init__.py
+++ b/src/vibe3/roles/__init__.py
@@ -23,16 +23,44 @@ if TYPE_CHECKING:
     )
     from vibe3.roles.governance_factory import build_default_governance_fns
     from vibe3.roles.governance_utils import find_material_in_catalog
-    from vibe3.roles.manager import build_manager_request
-    from vibe3.roles.plan import build_plan_request
+    from vibe3.roles.manager import (
+        MANAGER_SYNC_SPEC,
+        build_manager_request,
+        resolve_manager_token,
+    )
+    from vibe3.roles.plan import (
+        build_plan_request,
+        execute_spec_plan_async,
+        execute_spec_plan_sync,
+        resolve_spec_plan_input,
+    )
     from vibe3.roles.registry import (
         LABEL_DISPATCH_ROLES,
         build_label_dispatch_event,
     )
-    from vibe3.roles.review import build_review_request
+    from vibe3.roles.review import (
+        REVIEW_SYNC_SPEC,
+        build_base_review_request,
+        build_review_request,
+        execute_manual_review_async,
+        execute_manual_review_sync,
+        validate_review_prerequisites,
+    )
     from vibe3.roles.run import (
         build_run_request,
+        ensure_plan_file_exists,
+        execute_manual_run,
+        resolve_run_mode,
         resolve_skill_path,
+        validate_run_prerequisites,
+    )
+    from vibe3.roles.scan_service import (
+        dispatch_governance_execution,
+        dispatch_supervisor_execution,
+        fetch_supervisor_candidates,
+        get_available_governance_materials,
+        governance_material_exists,
+        list_governance_materials,
     )
     from vibe3.roles.supervisor import (
         SUPERVISOR_APPLY_ROLE,
@@ -49,14 +77,28 @@ _LAZY_IMPORTS: dict[str, str] = {
     "LABEL_DISPATCH_ROLES": "vibe3.roles.registry",
     "build_label_dispatch_event": "vibe3.roles.registry",
     # manager
+    "MANAGER_SYNC_SPEC": "vibe3.roles.manager",
     "build_manager_request": "vibe3.roles.manager",
+    "resolve_manager_token": "vibe3.roles.manager",
     # planner
     "build_plan_request": "vibe3.roles.plan",
+    "execute_spec_plan_async": "vibe3.roles.plan",
+    "execute_spec_plan_sync": "vibe3.roles.plan",
+    "resolve_spec_plan_input": "vibe3.roles.plan",
     # executor
     "build_run_request": "vibe3.roles.run",
+    "ensure_plan_file_exists": "vibe3.roles.run",
+    "execute_manual_run": "vibe3.roles.run",
+    "resolve_run_mode": "vibe3.roles.run",
     "resolve_skill_path": "vibe3.roles.run",
+    "validate_run_prerequisites": "vibe3.roles.run",
     # reviewer
+    "REVIEW_SYNC_SPEC": "vibe3.roles.review",
+    "build_base_review_request": "vibe3.roles.review",
     "build_review_request": "vibe3.roles.review",
+    "execute_manual_review_async": "vibe3.roles.review",
+    "execute_manual_review_sync": "vibe3.roles.review",
+    "validate_review_prerequisites": "vibe3.roles.review",
     # supervisor
     "SUPERVISOR_APPLY_ROLE": "vibe3.roles.supervisor",
     "SUPERVISOR_CLI_SYNC_SPEC": "vibe3.roles.supervisor",
@@ -67,6 +109,13 @@ _LAZY_IMPORTS: dict[str, str] = {
     # governance factory & utils
     "build_default_governance_fns": "vibe3.roles.governance_factory",
     "find_material_in_catalog": "vibe3.roles.governance_utils",
+    # scan_service
+    "dispatch_governance_execution": "vibe3.roles.scan_service",
+    "dispatch_supervisor_execution": "vibe3.roles.scan_service",
+    "fetch_supervisor_candidates": "vibe3.roles.scan_service",
+    "get_available_governance_materials": "vibe3.roles.scan_service",
+    "governance_material_exists": "vibe3.roles.scan_service",
+    "list_governance_materials": "vibe3.roles.scan_service",
 }
 
 
@@ -88,14 +137,28 @@ __all__ = [
     "LABEL_DISPATCH_ROLES",
     "build_label_dispatch_event",
     # manager
+    "MANAGER_SYNC_SPEC",
     "build_manager_request",
+    "resolve_manager_token",
     # planner
     "build_plan_request",
+    "execute_spec_plan_async",
+    "execute_spec_plan_sync",
+    "resolve_spec_plan_input",
     # executor
     "build_run_request",
+    "ensure_plan_file_exists",
+    "execute_manual_run",
+    "resolve_run_mode",
     "resolve_skill_path",
+    "validate_run_prerequisites",
     # reviewer
+    "REVIEW_SYNC_SPEC",
+    "build_base_review_request",
     "build_review_request",
+    "execute_manual_review_async",
+    "execute_manual_review_sync",
+    "validate_review_prerequisites",
     # supervisor
     "SUPERVISOR_APPLY_ROLE",
     "SUPERVISOR_CLI_SYNC_SPEC",
@@ -106,6 +169,13 @@ __all__ = [
     # governance factory & utils
     "build_default_governance_fns",
     "find_material_in_catalog",
+    # scan_service
+    "dispatch_governance_execution",
+    "dispatch_supervisor_execution",
+    "fetch_supervisor_candidates",
+    "get_available_governance_materials",
+    "governance_material_exists",
+    "list_governance_materials",
 ]
 
 # Consistency check: ensure __all__ matches lazy symbols


### PR DESCRIPTION
Closes #2278

## Summary

Remove 49 unused re-exported symbols from `roles/__init__.py`, reducing from 83 to 34 symbols (59% reduction).

This is step 1 of Phase 3 (issue #2278) - slimming large `__init__.py` files to improve modularity and reduce maintenance burden.

## Changes

### Commits

1. **Initial refactor**: Removed 69 unused symbols based on `rg`-based analysis
2. **Modularity compliance fix**: Added back 20 symbols required for deep cross-module imports

### Net Result

- **Symbols removed**: 49 (83 → 34)
- **LOC reduction**: ~318 lines → ~150 lines (53% reduction)

### Symbols Kept (34 total)

**Top-level imports** (14 symbols):
- TriggerableRoleDefinition, LABEL_DISPATCH_ROLES, build_label_dispatch_event
- build_manager_request, build_plan_request, build_run_request, resolve_skill_path
- build_review_request, SUPERVISOR_APPLY_ROLE, SUPERVISOR_CLI_SYNC_SPEC
- iter_supervisor_identified_events, build_governance_execution_name
- load_governance_material_catalog, build_default_governance_fns, find_material_in_catalog

**Deep cross-module imports** (20 symbols added back for modularity compliance):
- manager: MANAGER_SYNC_SPEC, resolve_manager_token
- plan: execute_spec_plan_async, execute_spec_plan_sync, resolve_spec_plan_input
- run: ensure_plan_file_exists, execute_manual_run, resolve_run_mode, validate_run_prerequisites
- review: REVIEW_SYNC_SPEC, build_base_review_request, execute_manual_review_async, execute_manual_review_sync, validate_review_prerequisites
- scan_service: dispatch_governance_execution, dispatch_supervisor_execution, fetch_supervisor_candidates, get_available_governance_materials, governance_material_exists, list_governance_materials

## Key Learning

The modularity compliance test (`tests/vibe3/test_modularity/test_module_api_compliance.py`) checks **ALL** cross-module imports, including deep imports like `from vibe3.roles.manager import X`, not just top-level imports (`from vibe3.roles import X`).

This means the plan's `rg`-based analysis was insufficient. Future Phase 3 work requires:
- AST-based symbol usage analysis, OR
- Test-driven verification (temporarily raise AttributeError for candidate symbols)

## Tests

- ✅ Modularity compliance test: PASSED
- ✅ Roles module tests: 143 passed
- ✅ Mypy type checking: PASSED
- ✅ All pre-commit hooks: PASSED

## Related

- Issue: #2278
- Epic: #2275 (Phase 3 of modularity refactor)
- Dependencies: Phase 1 (#2276), Phase 2 (#2277) - both closed

## Next Steps

This PR completes Phase 3 step 1. Remaining work:
- Steps 2-12: other modules (services, config, prompts, etc.)
- Use AST-based analysis for complex modules
- Verify with modularity compliance test before each commit

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
