### PR TITLE
test(flow_status): add worktree_root verification in PR hydration failure test

### DIFF
--- a/tests/vibe3/services/test_flow_status.py
+++ b/tests/vibe3/services/test_flow_status.py
@@ -117,6 +117,7 @@ class TestFlowStatus:
         with patch("vibe3.services.pr.service.PRService") as mock_pr_class:
             mock_pr_svc = mock_pr_class.return_value
             mock_pr_svc.get_branch_pr_status.side_effect = Exception("GitHub down")
+            mock_git.find_worktree_path_for_branch.return_value = None
 
             result = service.get_flow_status("test-branch")
 
@@ -126,6 +127,7 @@ class TestFlowStatus:
         # PR hydration failure should result in default values
         assert result.pr_number is None
         assert result.pr_ready_for_review is False
+        assert result.worktree_root is None
 
     def test_get_flow_status_task_issue_number_resolution(
         self, mock_store, mock_git


### PR DESCRIPTION
Closes #2421

## Summary
Add missing mock setup and assertion to `test_get_flow_status_pr_hydration_failure` to properly verify worktree resolution failure.

## Changes
- `tests/vibe3/services/test_flow_status.py`: Added 2 lines:
  - Line 120: `mock_git.find_worktree_path_for_branch.return_value = None`
  - Line 130: `assert result.worktree_root is None`

## Why
Without explicit mock setup, `mock_git.find_worktree_path_for_branch` returns a truthy MagicMock instead of None, causing `worktree_root` to be `"<MagicMock...>"` instead of `None`. This masked an unverified code path.

## Verification
- ✅ All 10 tests in `test_flow_status.py` pass
- ✅ Ruff check passes
- ✅ No regression in sibling tests
- ✅ LOC limits satisfied (342 lines, under 400 line CI threshold)

## Test Plan
Run `uv run pytest tests/vibe3/services/test_flow_status.py -v` to verify all tests pass.

## References
- Issue: #2421
- Original PR with the test that needed this fix: #2412

---

## Contributors

claude/opus
