### PR TITLE
refactor(comment): move is_human_comment from utils to services (#2428)

### DIFF
--- a/src/vibe3/services/comment_service.py
+++ b/src/vibe3/services/comment_service.py
@@ -1,32 +1,13 @@
-"""Comment filtering utilities for identifying human vs automated comments."""
+"""Comment filtering service for identifying human vs automated comments."""
+
+from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from vibe3.utils import AUTOMATED_MARKERS, GENERIC_AGENT_MARKER_PATTERN
-
-# Delayed import to avoid utils → config circular dependency
-# from vibe3.config import load_orchestra_config, get_manager_usernames
-
-if TYPE_CHECKING:
-    from vibe3.models.orchestra_config import OrchestraConfig
-
-
-def get_manager_usernames() -> list[str]:
-    """Get manager usernames with delayed import."""
-    from vibe3.config.manager_config import (
-        get_manager_usernames as _get_manager_usernames,
-    )
-
-    config = load_orchestra_config()
-    return list(_get_manager_usernames(config))
-
-
-def load_orchestra_config() -> "OrchestraConfig":
-    """Load orchestra config with delayed import."""
-    from vibe3.config import load_orchestra_config as _load_orchestra_config
-
-    return _load_orchestra_config()
+from vibe3.config import load_orchestra_config
+from vibe3.config.manager_config import get_manager_usernames as _get_manager_usernames
+from vibe3.utils.constants import AUTOMATED_MARKERS, GENERIC_AGENT_MARKER_PATTERN
 
 
 def is_human_comment(comment: dict[str, Any]) -> bool:
@@ -93,7 +74,7 @@ def is_human_comment(comment: dict[str, Any]) -> bool:
             return False
 
         # Check manager_usernames list
-        manager_usernames = get_manager_usernames()
+        manager_usernames = _get_manager_usernames(config)
         if manager_usernames:
             manager_logins = [u.lower() for u in manager_usernames]
             if login in manager_logins:

--- a/src/vibe3/services/task/service.py
+++ b/src/vibe3/services/task/service.py
@@ -30,7 +30,6 @@ from vibe3.services.task.show import (
     TaskRefSummary,
     TaskShowResult,
     TaskShowService,
-    is_human_comment,
 )
 
 __all__ = [
@@ -40,7 +39,6 @@ __all__ = [
     "TaskRefSummary",
     "TaskCommentSummary",
     "TaskPRSummary",
-    "is_human_comment",
 ]
 
 

--- a/src/vibe3/services/task/show.py
+++ b/src/vibe3/services/task/show.py
@@ -11,10 +11,10 @@ from typing import Any, cast
 from vibe3.clients import GitHubClient, GitHubClientProtocol, SQLiteClient
 from vibe3.models import FlowStatusResponse, PRResponse
 from vibe3.services.artifact_parser import ArtifactParser
+from vibe3.services.comment_service import is_human_comment
 from vibe3.services.flow_service import FlowService
 from vibe3.services.pr.service import PRService
 from vibe3.services.shared.paths import resolve_ref_path
-from vibe3.utils import is_human_comment
 
 
 @dataclass

--- a/src/vibe3/utils/README.md
+++ b/src/vibe3/utils/README.md
@@ -10,7 +10,6 @@
 | branch_utils.py | 109 | Branch 父分支查找算法 |
 | git_helpers.py | 104 | Handoff 目录计算、commit message、current branch |
 | constants.py | 105 | 常量定义（默认路径、后缀等） |
-| comment_utils.py | 80 | Comment 格式化工具 |
 | issue_branch_resolver.py | 41 | Issue 到分支的解析和转换 |
 | trace.py | 36 | Trace 工具函数 |
 | issue_ref.py | 14 | Issue 引用解析（#123, owner/repo#123） |
@@ -27,13 +26,12 @@
 ### 其他工具
 - **codeagent_helpers.py**: Codeagent 后端辅助
 - **constants.py**: 常量定义
-- **comment_utils.py**: Comment 格式化
 
 ## 依赖关系
 
 ```
 utils/
-├── 无外部依赖：branch_utils, git_helpers, constants, comment_utils, trace, issue_ref, actor_utils, time_format, error_message_cleaner
+├── 无外部依赖：branch_utils, git_helpers, constants, trace, issue_ref, actor_utils, time_format, error_message_cleaner
 └── 独立配置：codeagent_helpers (依赖 VibeConfig)
 ```
 

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
         stream_reader,
         summarize_backend_output,
     )
-    from vibe3.utils.comment_utils import is_human_comment
     from vibe3.utils.constants import (
         AUTOMATED_MARKERS,
         CODEAGENT_STDIN_MODE_THRESHOLD,
@@ -78,7 +77,6 @@ _LAZY_IMPORTS = {
     "get_branch_handoff_dir": "vibe3.utils.git_helpers",
     "get_commit_message": "vibe3.utils.git_helpers",
     "get_current_branch": "vibe3.utils.git_helpers",
-    "is_human_comment": "vibe3.utils.comment_utils",
     "normalize_actor": "vibe3.utils.actor_utils",
     "OrchestraInstanceInfo": "vibe3.utils.orchestra_instance",
     "parse_issue_number": "vibe3.utils.issue_ref",
@@ -134,7 +132,6 @@ __all__ = [
     "get_branch_handoff_dir",
     "get_commit_message",
     "get_current_branch",
-    "is_human_comment",
     "normalize_actor",
     "OrchestraInstanceInfo",
     "parse_issue_number",

--- a/tests/vibe3/services/test_comment_service.py
+++ b/tests/vibe3/services/test_comment_service.py
@@ -1,0 +1,96 @@
+"""Tests for comment_service — human vs automated comment filtering."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from vibe3.services.comment_service import is_human_comment
+
+
+def _make_comment(login: str = "alice", body: str = "") -> dict:
+    return {"author": {"login": login}, "body": body}
+
+
+class TestIsHumanComment:
+    """Unit tests for is_human_comment."""
+
+    def test_human_comment_returns_true(self) -> None:
+        assert is_human_comment(_make_comment("alice", "Thanks for the PR!")) is True
+
+    def test_empty_login_returns_true(self) -> None:
+        assert is_human_comment(_make_comment("", "")) is True
+
+    def test_missing_author_returns_true(self) -> None:
+        assert is_human_comment({"body": "hello"}) is True
+
+    def test_linear_bot_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("linear", "Status update")) is False
+
+    def test_bot_login_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("dependabot[bot]", "Bump foo")) is False
+
+    def test_manager_marker_returns_false(self) -> None:
+        assert (
+            is_human_comment(_make_comment("alice", "[manager] Status: done")) is False
+        )
+
+    def test_plan_marker_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("bob", "[plan] Scope defined")) is False
+
+    def test_run_marker_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("bob", "[run] Complete")) is False
+
+    def test_review_marker_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("bob", "[review] LGTM")) is False
+
+    def test_resume_marker_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("bob", "[resume] Continuing")) is False
+
+    def test_generic_agent_marker_returns_false(self) -> None:
+        assert is_human_comment(_make_comment("bob", "[agent:planner] Done")) is False
+
+    def test_heading_with_marker_returns_false(self) -> None:
+        assert (
+            is_human_comment(_make_comment("bob", "### [manager] Status report"))
+            is False
+        )
+
+    def test_marker_not_at_start_of_line_is_human(self) -> None:
+        assert (
+            is_human_comment(_make_comment("alice", "See [manager] docs for details"))
+            is True
+        )
+
+    @patch("vibe3.services.comment_service.load_orchestra_config")
+    def test_bot_username_from_config(self, mock_config: MagicMock) -> None:
+        config = MagicMock()
+        config.bot_username = "mybot"
+        mock_config.return_value = config
+        assert is_human_comment(_make_comment("mybot", "hi")) is False
+
+    @patch("vibe3.services.comment_service._get_manager_usernames")
+    @patch("vibe3.services.comment_service.load_orchestra_config")
+    def test_manager_username_from_config(
+        self, mock_config: MagicMock, mock_usernames: MagicMock
+    ) -> None:
+        config = MagicMock()
+        config.bot_username = None
+        mock_config.return_value = config
+        mock_usernames.return_value = ("manager-user",)
+        assert is_human_comment(_make_comment("manager-user", "hi")) is False
+
+    @patch("vibe3.services.comment_service.load_orchestra_config")
+    def test_config_load_failure_falls_through(self, mock_config: MagicMock) -> None:
+        mock_config.side_effect = RuntimeError("config unavailable")
+        assert is_human_comment(_make_comment("alice", "hello")) is True
+
+    @patch("vibe3.services.comment_service._get_manager_usernames")
+    @patch("vibe3.services.comment_service.load_orchestra_config")
+    def test_empty_manager_usernames_list(
+        self, mock_config: MagicMock, mock_usernames: MagicMock
+    ) -> None:
+        config = MagicMock()
+        config.bot_username = None
+        mock_config.return_value = config
+        mock_usernames.return_value = ()
+        assert is_human_comment(_make_comment("alice", "hi")) is True


### PR DESCRIPTION
## Summary
- Move `is_human_comment()` from `utils/comment_utils.py` to new `services/comment_service.py`, eliminating the `utils → config` dependency cycle
- Delete `comment_utils.py` entirely — all imports updated to `services.comment_service`
- Add 96-line unit test for the new service module

## Changes
| File | Change |
|------|--------|
| `services/comment_service.py` | New — receives `is_human_comment()` + helpers |
| `utils/comment_utils.py` | Deleted (105 lines) |
| `utils/__init__.py` | Remove `comment_utils` re-export |
| `utils/README.md` | Update module listing |
| `services/task/service.py` | Remove unused `comment_utils` import |
| `services/task/show.py` | Update import path |
| `tests/.../test_comment_service.py` | New — 17 tests |

## Why
`is_human_comment()` depends on `config.manager_config` and `config.orchestra_config`, making it a service-layer function, not a utility. This eliminates the delayed-import cycle: `clients → utils → config → adapters → clients`.

Closes #2428

## Test plan
- [x] 17 unit tests for `comment_service.py` pass
- [x] 25 modularity tests pass (no violations)
- [x] 14 task service tests pass
- [ ] CI green