### PR TITLE
refactor(internal): remove obsolete backfill_worktree_paths command

### DIFF
--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -169,36 +169,3 @@ def internal_bootstrap(
         dependency_issue_numbers=tuple(dependency_issue_numbers or ()),
     )
     typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
-
-
-@app.command("backfill-worktree-paths")
-def backfill_worktree_paths() -> None:
-    """Backfill worktree_path for existing active task/ flows."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.services.status_query_service import is_auto_task_branch
-
-    git = GitClient()
-    store = SQLiteClient()
-
-    worktrees = git.list_worktrees()
-    backfilled_count = 0
-
-    for wt_path, branch_ref in worktrees:
-        branch = branch_ref.removeprefix("refs/heads/")
-        if not is_auto_task_branch(branch):
-            continue
-
-        flow = store.get_flow_state(branch)
-        if not flow:
-            continue
-        if flow.get("flow_status") != "active":
-            continue
-        if flow.get("worktree_path"):
-            continue
-
-        store.update_flow_state(branch, worktree_path=str(wt_path))
-        backfilled_count += 1
-        typer.echo(f"Backfilled {branch}: {wt_path}")
-
-    typer.echo(f"\nBackfilled {backfilled_count} flows")


### PR DESCRIPTION
## Summary

Remove obsolete one-time migration command `backfill_worktree_paths` from internal.py.

## Changes

- **Deleted**: `backfill_worktree_paths` function (lines 174-205, 33 lines removed)
- **Type**: Pure deletion of dead code
- **Scope**: Minimal (1 file, -33 LOC)

## Rationale

- **Zero callers**: Command has no references in codebase
- **One-time migration**: Created 2026-05-18 for issue #1032
- **Superseded**: `flow_consistency_check` with `apply_consistency_fix()` already handles `MISSING_RECORDED_WORKTREE` detection and automatic backfill

## Testing

- ✅ **Direct tests**: `tests/vibe3/commands/test_internal.py` - 10 passed (no regressions)
- ✅ **Indirect tests**: `tests/vibe3/services/test_flow_consistency_check.py` - 5 passed (replacement system verified)
- ✅ **Type check**: `mypy src/vibe3/commands/internal.py` - Success
- ✅ **Lint**: `ruff check src/vibe3/commands/internal.py` - All checks passed

## Review

- **Verdict**: PASS ✅
- **Audit ref**: docs/reports/issue-2448-audit-report.md
- **Scope verification**: Consistent with issue and plan
- **Risk**: Low (pure deletion, replacement system tested)

Closes #2448

---

## Contributors

claude/opus
