### PR TITLE
refactor(roles): replace deep imports with public API imports (#2441)

### DIFF
--- a/src/vibe3/roles/governance_factory.py
+++ b/src/vibe3/roles/governance_factory.py
@@ -12,7 +12,7 @@ from vibe3.roles.governance import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.execution.role_interfaces import GovernanceFunctions
+    from vibe3.execution import GovernanceFunctions
 
 
 def build_default_governance_fns() -> GovernanceFunctions:

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -7,18 +7,16 @@ from typing import Any
 
 from vibe3.clients import GitHubClient
 from vibe3.models import OrchestraConfig
-from vibe3.services import (
-    get_manager_usernames,
-    normalize_assignees,
-    normalize_labels,
-)
 
 # public-api: pending upstream export
-from vibe3.services.orchestra_status_service import (
+from vibe3.services import (
     IssueStatusEntry,
     format_issue_runtime_line,
     format_issue_summary_line,
+    get_manager_usernames,
     is_running_issue,
+    normalize_assignees,
+    normalize_labels,
 )
 
 

--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -9,14 +9,16 @@ from typing import Any
 import yaml
 from loguru import logger
 
-from vibe3.clients import runtime_assets_root
+# public-api: pending upstream export
+from vibe3.clients import check_runtime_asset, runtime_assets_root
 
 # public-api: pending upstream export
-from vibe3.clients.runtime_assets import check_runtime_asset
-from vibe3.config import MANAGER_GATE_CONFIG, get_convention, get_resolver
-
-# public-api: pending upstream export
-from vibe3.config.convention_resolver import diagnose_profile
+from vibe3.config import (
+    MANAGER_GATE_CONFIG,
+    diagnose_profile,
+    get_convention,
+    get_resolver,
+)
 from vibe3.environment import SessionRegistryService
 
 # public-api: pending upstream export
@@ -122,7 +124,7 @@ def resolve_manager_token(config: OrchestraConfig) -> str | None:
 
     # 2. Fallback to config/keys.env
     try:
-        from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+        from vibe3.execution import resolve_orchestra_repo_root
 
         keys_path = resolve_orchestra_repo_root() / "config" / "keys.env"
         if keys_path.exists():

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -97,8 +97,7 @@ def _build_plan_task_guidance(
     branch: str,
 ) -> str | None:
     """Build plan task guidance from flow and issue context."""
-    from vibe3.services.flow_service import FlowService
-    from vibe3.services.spec_ref_service import SpecRefService
+    from vibe3.services import FlowService, SpecRefService
 
     flow_service = FlowService()
     flow = flow_service.get_flow_status(branch)
@@ -108,10 +107,10 @@ def _build_plan_task_guidance(
     sections: list[str] = []
 
     # Issue context
-    from vibe3.clients.github_field_constants import GITHUB_FIELDS_BODY_COMMENTS
+    from vibe3.clients import GITHUB_FIELDS_BODY_COMMENTS
 
     issue_payload = GitHubClient().view_issue(
-        issue.number, repo=config.repo, fields=list(GITHUB_FIELDS_BODY_COMMENTS)
+        issue.number, repo=config.repo, fields=list(GITHUB_FIELDS_BODY_COMMENTS)  # type: ignore[call-overload]
     )
     if isinstance(issue_payload, dict):
         title = issue_payload.get("title")
@@ -223,7 +222,7 @@ def build_plan_sync_request(
     tick_id: int = 0,
 ) -> ExecutionRequest:
     """Build the planner sync execution request."""
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     flow_state = SQLiteClient().get_flow_state(branch) if branch else None
     (
@@ -286,8 +285,7 @@ def resolve_spec_plan_input(
     2. Flow's existing spec_ref (if available)
     3. Error if none available
     """
-    from vibe3.services.flow_service import FlowService
-    from vibe3.services.spec_ref_service import SpecRefService
+    from vibe3.services import FlowService, SpecRefService
 
     # Case 1: Explicit file provided
     if file:
@@ -382,10 +380,10 @@ def execute_spec_plan_async(
     because they should already be included in ``cli_args`` by the caller.
     """
     _ = request, config, agent, backend, model, fresh_session
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     # Resolve repo path from git common dir (main repo root)
-    from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+    from vibe3.execution import resolve_orchestra_repo_root
 
     repo_root = resolve_orchestra_repo_root()
 
@@ -442,7 +440,7 @@ def execute_spec_plan_sync(
     show_prompt: bool = False,
 ) -> CodeagentResult:
     """Execute spec plan in sync mode (direct execution)."""
-    from vibe3.execution.session_service import load_session_id
+    from vibe3.execution import load_session_id
 
     cfg = config or VibeConfig.get_defaults()
     session_id = None if fresh_session else load_session_id("planner", branch)

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -17,16 +17,16 @@ from vibe3.agents import (
     run_inspect_json,
 )
 from vibe3.analysis import changed_symbols
+
+# public-api: pending upstream export
 from vibe3.config import (
     REVIEWER_GATE_CONFIG,
+    RoleCliOverrides,
     VibeConfig,
     get_convention,
     load_orchestra_config,
     load_runtime_config,
 )
-
-# public-api: pending upstream export
-from vibe3.config.cli_overrides import RoleCliOverrides
 from vibe3.execution import (
     CodeagentExecutionService,
     ExecutionCoordinator,
@@ -264,7 +264,7 @@ def build_review_sync_request(
     dry_run: bool,
     show_prompt: bool,
 ) -> ExecutionRequest:
-    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.clients import SQLiteClient
 
     flow_state = SQLiteClient().get_flow_state(branch) if branch else None
     return build_issue_review_request(
@@ -407,7 +407,7 @@ def execute_manual_review_sync(
     show_prompt: bool = False,
 ) -> ReviewRunResult:
     """Execute manual review in sync mode (direct execution)."""
-    from vibe3.execution.session_service import load_session_id
+    from vibe3.execution import load_session_id
 
     _ = flow_service
     cfg = config or VibeConfig.get_defaults()
@@ -463,8 +463,8 @@ def _dispatch_async_manual_review(
         if issue_number is not None
         else f"vibe3-reviewer-{request.scope.kind}-{target_id or 'adhoc'}"
     )
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+    from vibe3.clients import SQLiteClient
+    from vibe3.execution import resolve_orchestra_repo_root
 
     repo_root = resolve_orchestra_repo_root()
 

--- a/src/vibe3/roles/run_command.py
+++ b/src/vibe3/roles/run_command.py
@@ -21,8 +21,12 @@ from vibe3.agents import (
     make_skill_context_builder,
 )
 from vibe3.clients import SQLiteClient, resolve_runtime_asset
-from vibe3.config import VibeConfig, get_resolver, load_orchestra_config
-from vibe3.config.cli_overrides import RoleCliOverrides
+from vibe3.config import (
+    RoleCliOverrides,
+    VibeConfig,
+    get_resolver,
+    load_orchestra_config,
+)
 from vibe3.exceptions import SkillNotAvailableError
 from vibe3.execution import (
     CodeagentExecutionService,
@@ -71,7 +75,7 @@ def dispatch_run_command_async(
     handoff_metadata: dict[str, object] | None,
 ) -> None:
     """Dispatch manual run command asynchronously through execution."""
-    from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+    from vibe3.execution import resolve_orchestra_repo_root
 
     refs: dict[str, str] = {}
     if issue_number is not None:
@@ -131,7 +135,7 @@ def execute_manual_run(
     if skill:
         skill_path = resolve_skill_path(skill)
         if not skill_path:
-            from vibe3.config.convention_resolver import diagnose_profile
+            from vibe3.config import diagnose_profile
 
             detected_profile = diagnose_profile()
             raise SkillNotAvailableError(skill, profile=detected_profile)
@@ -273,7 +277,7 @@ def execute_manual_run(
             }.items()
             if v
         }
-        from vibe3.execution.prompt_meta import PromptMeta
+        from vibe3.execution import PromptMeta
 
         meta = PromptMeta(
             prompt_mode=prompt_mode,

--- a/tests/vibe3/roles/test_plan.py
+++ b/tests/vibe3/roles/test_plan.py
@@ -140,8 +140,8 @@ class TestResolveSpecPlanInputDefaultSpecRef:
 
         # Patch at the source module, not where it's imported
         with (
-            patch("vibe3.services.flow_service.FlowService") as mock_fs,
-            patch("vibe3.services.spec_ref_service.SpecRefService") as mock_ss,
+            patch("vibe3.services.FlowService") as mock_fs,
+            patch("vibe3.services.SpecRefService") as mock_ss,
         ):
             mock_fs.return_value.get_flow_status.return_value = mock_flow
             mock_ss.return_value.parse_spec_ref.return_value = mock_spec_info
@@ -169,8 +169,8 @@ class TestResolveSpecPlanInputDefaultSpecRef:
 
         # Patch at the source module
         with (
-            patch("vibe3.services.flow_service.FlowService") as mock_fs,
-            patch("vibe3.services.spec_ref_service.SpecRefService") as mock_ss,
+            patch("vibe3.services.FlowService") as mock_fs,
+            patch("vibe3.services.SpecRefService") as mock_ss,
         ):
             mock_fs.return_value.get_flow_status.return_value = mock_flow
             mock_ss.return_value.parse_spec_ref.return_value = mock_spec_info
@@ -189,7 +189,7 @@ class TestResolveSpecPlanInputDefaultSpecRef:
         mock_flow.spec_ref = None
 
         # Patch at the source module
-        with patch("vibe3.services.flow_service.FlowService") as mock_fs:
+        with patch("vibe3.services.FlowService") as mock_fs:
             mock_fs.return_value.get_flow_status.return_value = mock_flow
 
             with pytest.raises(ValueError) as exc_info:
@@ -200,7 +200,7 @@ class TestResolveSpecPlanInputDefaultSpecRef:
     def test_no_explicit_input_raises_when_no_flow(self) -> None:
         """Raise ValueError when flow does not exist."""
         # Patch at the source module
-        with patch("vibe3.services.flow_service.FlowService") as mock_fs:
+        with patch("vibe3.services.FlowService") as mock_fs:
             mock_fs.return_value.get_flow_status.return_value = None
 
             with pytest.raises(ValueError) as exc_info:
@@ -215,8 +215,8 @@ class TestResolveSpecPlanInputDefaultSpecRef:
 
         # Patch at the source module
         with (
-            patch("vibe3.services.flow_service.FlowService") as mock_fs,
-            patch("vibe3.services.spec_ref_service.SpecRefService") as mock_ss,
+            patch("vibe3.services.FlowService") as mock_fs,
+            patch("vibe3.services.SpecRefService") as mock_ss,
         ):
             mock_fs.return_value.get_flow_status.return_value = mock_flow
             mock_ss.return_value.validate_spec_ref.return_value = (
@@ -236,8 +236,8 @@ class TestResolveSpecPlanInputDefaultSpecRef:
 
         # Patch at the source module
         with (
-            patch("vibe3.services.flow_service.FlowService") as mock_fs,
-            patch("vibe3.services.spec_ref_service.SpecRefService") as mock_ss,
+            patch("vibe3.services.FlowService") as mock_fs,
+            patch("vibe3.services.SpecRefService") as mock_ss,
         ):
             mock_fs.return_value.get_flow_status.return_value = mock_flow
             mock_ss.return_value.validate_spec_ref.return_value = (True, "")


### PR DESCRIPTION
## Summary

Replace 20 non-public API imports in `src/vibe3/roles/` with public API imports from parent modules.

Changes: `config.cli_overrides` → `config`, `services.flow_service` → `services`, `clients.sqlite_client` → `clients`, `execution.issue_role_support` → `execution`, etc.

## Test plan

- [x] 13 role tests pass
- [x] 25 modularity tests pass
- [x] All roles modules import correctly