### PR TITLE
refactor(config): replace deep imports with public API imports (#2443)

### DIFF
--- a/src/vibe3/config/convention_resolver.py
+++ b/src/vibe3/config/convention_resolver.py
@@ -17,7 +17,7 @@ from vibe3.config.env_override import get_env_override
 from vibe3.config.profile_convention import ProfileConvention
 
 if TYPE_CHECKING:
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
     from vibe3.config.profile_config import ProfileConfig
     from vibe3.models.adapter_manifest import AdapterManifest
 
@@ -65,7 +65,7 @@ class ConventionResolver:
             GitClient instance (injected or lazy-loaded)
         """
         if self._git_client is None:
-            from vibe3.clients.git_client import GitClient
+            from vibe3.clients import GitClient
 
             self._git_client = GitClient()
         return self._git_client

--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -419,7 +419,7 @@ def load_keys_env_fallback() -> None:
     # (git_client imports from config module)
     repo_root: Path | None = None
     try:
-        from vibe3.clients.git_client import find_repo_root
+        from vibe3.clients import find_repo_root
 
         repo_root = find_repo_root()
     except SystemError:


### PR DESCRIPTION
## Summary
Replace non-public API imports in `src/vibe3/config/` with public API imports from parent `__init__.py`:

- `from vibe3.clients.git_client import GitClient` -> `from vibe3.clients import GitClient` (2 occurrences in convention_resolver.py: TYPE_CHECKING block + lazy runtime import)
- `from vibe3.clients.git_client import find_repo_root` -> `from vibe3.clients import find_repo_root` (1 occurrence in loader.py)

## Test plan
- [x] modularity tests pass (26 passed, 5 xfailed)
- [x] config modules import correctly (`import vibe3.config`)
- [x] all pre-commit hooks pass (ruff, black, mypy, shellcheck)
- [x] only files in `src/vibe3/config/` modified