### PR TITLE
refactor(services): replace deep imports with public API imports (#2442)

### DIFF
--- a/src/vibe3/services/branch_arg.py
+++ b/src/vibe3/services/branch_arg.py
@@ -1,10 +1,7 @@
 """Backward compatibility — migrated to services.shared.branches."""
 
 # Re-export imports for test patch compatibility
-from vibe3.config.convention_resolver import (  # noqa: F401
-    ConventionResolver,
-    get_convention,
-)
+from vibe3.config import ConventionResolver, get_convention  # noqa: F401
 from vibe3.services.flow_service import FlowService  # noqa: F401
 from vibe3.services.shared.branches import (  # noqa: F401
     resolve_branch_and_issue,

--- a/src/vibe3/services/check_cleanup_service.py
+++ b/src/vibe3/services/check_cleanup_service.py
@@ -370,10 +370,10 @@ class CheckCleanupService:
             from vibe3.services.label_service import LabelService
 
             gh = self._github_client or GitHubClient()
-            from vibe3.clients.github_field_constants import GITHUB_FIELDS_STATE_ONLY
+            from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
 
             gh_issue = gh.view_issue(
-                issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)
+                issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)  # type: ignore[call-overload]
             )
             if (
                 isinstance(gh_issue, dict)

--- a/src/vibe3/services/check_pr_service.py
+++ b/src/vibe3/services/check_pr_service.py
@@ -522,10 +522,10 @@ The unresolved work continues in #{bridge_issue_number}.
             )
 
         # Check if issue already closed
-        from vibe3.clients.github_field_constants import GITHUB_FIELDS_STATE_ONLY
+        from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
 
         gh_issue = self.github_client.view_issue(
-            task_issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)
+            task_issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)  # type: ignore[call-overload]
         )
         if not isinstance(gh_issue, dict):
             # Failed to fetch issue data (network error or not found)

--- a/src/vibe3/services/check_service.py
+++ b/src/vibe3/services/check_service.py
@@ -318,13 +318,11 @@ class CheckService(CheckRemote):
             orchestration_state: IssueState | None = None
             issue_payload: dict | None = None
             if task_issue:
-                from vibe3.clients.github_field_constants import (
-                    GITHUB_DEFAULT_VIEW_FIELDS,
-                )
+                from vibe3.clients import GITHUB_DEFAULT_VIEW_FIELDS
 
                 # Need state, labels, and body for state validation
                 issue = self.github_client.view_issue(
-                    task_issue, fields=list(GITHUB_DEFAULT_VIEW_FIELDS)
+                    task_issue, fields=list(GITHUB_DEFAULT_VIEW_FIELDS)  # type: ignore[call-overload]
                 )
                 if issue == "network_error":
                     issues.append(

--- a/src/vibe3/services/comment_service.py
+++ b/src/vibe3/services/comment_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from vibe3.config import get_manager_usernames as _get_manager_usernames
 from vibe3.config import load_orchestra_config
-from vibe3.config.manager_config import get_manager_usernames as _get_manager_usernames
 from vibe3.utils.constants import AUTOMATED_MARKERS, GENERIC_AGENT_MARKER_PATTERN
 
 

--- a/src/vibe3/services/convention_resolver.py
+++ b/src/vibe3/services/convention_resolver.py
@@ -1,7 +1,3 @@
-from vibe3.config.convention_resolver import (
-    ConventionResolver,
-    get_convention,
-    get_resolver,
-)
+from vibe3.config import ConventionResolver, get_convention, get_resolver
 
 __all__ = ["ConventionResolver", "get_convention", "get_resolver"]

--- a/src/vibe3/services/flow_recovery_service.py
+++ b/src/vibe3/services/flow_recovery_service.py
@@ -257,7 +257,7 @@ class FlowRecoveryService:
         include_remote: bool = False,
     ) -> None:
         """Hard rebuild through the canonical rebuild usecase."""
-        from vibe3.config.orchestra_settings import load_orchestra_config
+        from vibe3.config import load_orchestra_config
         from vibe3.models import IssueInfo, IssueState
         from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
         from vibe3.services.issue.context import load_issue_info

--- a/src/vibe3/services/flow_transition.py
+++ b/src/vibe3/services/flow_transition.py
@@ -141,13 +141,11 @@ class FlowTransitionMixin(FlowWriteMixin):
         # Try to fetch issue title from GitHub and update cache
         if effective_issue_number:
             try:
-                from vibe3.clients.github_field_constants import (
-                    GITHUB_FIELDS_TITLE_ONLY,
-                )
+                from vibe3.clients import GITHUB_FIELDS_TITLE_ONLY
 
                 gh = GitHubClient()
                 issue_data = gh.view_issue(
-                    effective_issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)
+                    effective_issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)  # type: ignore[call-overload]
                 )
                 if isinstance(issue_data, dict):
                     issue_title = issue_data.get("title")

--- a/src/vibe3/services/issue/context.py
+++ b/src/vibe3/services/issue/context.py
@@ -25,10 +25,10 @@ def load_issue_info(
         UserError: If issue cannot be loaded or parsed
     """
     github = github or GitHubClient()
-    from vibe3.clients.github_field_constants import GITHUB_DEFAULT_VIEW_FIELDS
+    from vibe3.clients import GITHUB_DEFAULT_VIEW_FIELDS
 
     payload = github.view_issue(
-        issue_number, repo=config.repo, fields=list(GITHUB_DEFAULT_VIEW_FIELDS)
+        issue_number, repo=config.repo, fields=list(GITHUB_DEFAULT_VIEW_FIELDS)  # type: ignore[call-overload]
     )
 
     if payload == "network_error":

--- a/src/vibe3/services/issue/flow.py
+++ b/src/vibe3/services/issue/flow.py
@@ -19,7 +19,7 @@ def _default_store() -> SQLiteClient:
 
 def _default_resolver() -> "ConventionResolver":
     """Default factory for resolver."""
-    from vibe3.config.convention_resolver import get_resolver
+    from vibe3.config import get_resolver
 
     return get_resolver()
 
@@ -64,7 +64,7 @@ class IssueFlowService:
             "task/issue-372"
         """
         convention = self.resolver.resolve()
-        return convention.branch.canonical_branch(issue_number)
+        return convention.branch.canonical_branch(issue_number)  # type: ignore[no-any-return]
 
     def parse_issue_number(self, branch: str) -> int | None:
         """Extract issue number from canonical task branch.
@@ -89,7 +89,7 @@ class IssueFlowService:
         if not branch.startswith(task_prefix):
             return None
         # Delegate to convention's parsing
-        return convention.branch.parse_issue_number(branch)
+        return convention.branch.parse_issue_number(branch)  # type: ignore[no-any-return]
 
     def parse_issue_number_any(self, branch: str) -> int | None:
         """Extract issue number from task or dev issue branch.
@@ -113,7 +113,7 @@ class IssueFlowService:
             None
         """
         convention = self.resolver.resolve()
-        return convention.branch.parse_issue_number(branch)
+        return convention.branch.parse_issue_number(branch)  # type: ignore[no-any-return]
 
     def is_issue_branch(self, branch: str) -> bool:
         """Check if branch is an issue branch (task/issue-N or dev/issue-N).

--- a/src/vibe3/services/issue/title_cache.py
+++ b/src/vibe3/services/issue/title_cache.py
@@ -327,10 +327,10 @@ class IssueTitleCacheService:
             return None, False
 
         try:
-            from vibe3.clients.github_field_constants import GITHUB_FIELDS_TITLE_ONLY
+            from vibe3.clients import GITHUB_FIELDS_TITLE_ONLY
 
             issue = self.github_client.view_issue(
-                issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)
+                issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)  # type: ignore[call-overload]
             )
             if isinstance(issue, dict):
                 title = issue.get("title", f"Issue #{issue_number}")

--- a/src/vibe3/services/orchestra_helpers.py
+++ b/src/vibe3/services/orchestra_helpers.py
@@ -4,8 +4,8 @@ DEPRECATED: These functions have been moved to config/manager_config.py
 to break circular dependencies. This module re-exports them for backward
 compatibility only.
 
-For new code, import directly from config/manager_config.py:
-    from vibe3.config.manager_config import (
+For new code, import directly from config:
+    from vibe3.config import (
         get_manager_usernames,
         get_handoff_state_label,
     )

--- a/src/vibe3/services/pr/resolver.py
+++ b/src/vibe3/services/pr/resolver.py
@@ -132,7 +132,7 @@ def resolve_command_branch(
         # If unresolved and canonical_fallback enabled for issue numbers
         if canonical_fallback and branch_opt.isdigit():
             convention = get_convention()
-            return convention.branch.canonical_branch(int(branch_opt))
+            return convention.branch.canonical_branch(int(branch_opt))  # type: ignore[no-any-return]
         return branch_opt
 
     # Step 3: Priority 2 - --pr option
@@ -155,7 +155,7 @@ def resolve_command_branch(
         # If unresolved and canonical_fallback enabled for issue numbers
         if canonical_fallback and position_arg.isdigit():
             convention = get_convention()
-            return convention.branch.canonical_branch(int(position_arg))
+            return convention.branch.canonical_branch(int(position_arg))  # type: ignore[no-any-return]
         return position_arg
 
     # Step 5: Priority 4 - Current branch (fallback)

--- a/src/vibe3/services/shared/branches.py
+++ b/src/vibe3/services/shared/branches.py
@@ -67,7 +67,7 @@ def resolve_branch_and_issue(
     """
     # Import through public API for test patch compatibility
     # (cross-module import allows patching "vibe3.services.resolve_branch_arg")
-    from vibe3.config.convention_resolver import get_convention
+    from vibe3.config import get_convention
     from vibe3.services import resolve_branch_arg as resolve_via_public_api
 
     branch = resolve_via_public_api(branch_arg, flow_service=flow_service)

--- a/src/vibe3/services/task/status.py
+++ b/src/vibe3/services/task/status.py
@@ -35,7 +35,7 @@ def fetch_task_status_data(
     """
     import time
 
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.config import load_orchestra_config
     from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
     from vibe3.services.orchestra_helpers import get_manager_usernames
     from vibe3.services.orchestra_status_service import OrchestraStatusService

--- a/tests/vibe3/commands/test_task_status_dashboard.py
+++ b/tests/vibe3/commands/test_task_status_dashboard.py
@@ -236,7 +236,7 @@ def test_task_status_excludes_system_status_sections(
     assert "Vibe3 Configuration" not in result.output
 
 
-@patch("vibe3.config.orchestra_settings.load_orchestra_config")
+@patch("vibe3.config.load_orchestra_config")
 @patch(
     "vibe3.services.orchestra_status_service.OrchestraStatusService.fetch_live_snapshot"
 )
@@ -375,7 +375,7 @@ def test_task_status_shows_active_exception_for_missing_assignee(
     assert "missing assignee" in output
 
 
-@patch("vibe3.config.orchestra_settings.load_orchestra_config")
+@patch("vibe3.config.load_orchestra_config")
 @patch(
     "vibe3.services.orchestra_status_service.OrchestraStatusService.fetch_live_snapshot"
 )


### PR DESCRIPTION
## Summary

Replace non-public API imports in `src/vibe3/services/` with public API imports.

15 files in `src/vibe3/services/` were importing from deep submodules (e.g., `vibe3.config.convention_resolver`, `vibe3.clients.github_field_constants`) instead of using the public API exports (`vibe3.config`, `vibe3.clients`).

**Import changes:**
- `from vibe3.config.convention_resolver import ...` -> `from vibe3.config import ...`
- `from vibe3.config.orchestra_settings import ...` -> `from vibe3.config import ...`
- `from vibe3.config.manager_config import ...` -> `from vibe3.config import ...`
- `from vibe3.clients.github_field_constants import ...` -> `from vibe3.clients import ...`

**Type safety:** Added `# type: ignore[call-overload]` and `# type: ignore[no-any-return]` annotations where lazy `__getattr__` imports return `object`/`Any` types.

## Test plan
- [x] modularity tests pass (26 passed, 5 xfailed)
- [x] services modules import correctly (`import vibe3.services`)
- [x] mypy passes (416 source files checked)