### PR TITLE
refactor(execution): replace deep imports with public API imports (#2445)

### DIFF
--- a/src/vibe3/execution/command_adapter.py
+++ b/src/vibe3/execution/command_adapter.py
@@ -1,6 +1,6 @@
 """Command adapter registry for lazy loading of command job handlers.
 
-This module provides a registry that maps command types (from vibe3.models.job)
+This module provides a registry that maps command types (from vibe3.models)
 to import paths, resolving the actual callable only at execution time.
 
 Uses CommandType from the job contracts module (#2163) as the canonical

--- a/src/vibe3/execution/command_adapter.py
+++ b/src/vibe3/execution/command_adapter.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from vibe3.models.job import CommandType
+from vibe3.models import CommandType
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/execution/execution_lifecycle.py
+++ b/src/vibe3/execution/execution_lifecycle.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.exceptions.error_severity import ErrorHandlingContract
+from vibe3.exceptions import ErrorHandlingContract
 
 ExecutionRole = Literal[
     "planner", "executor", "reviewer", "manager", "supervisor", "governance"

--- a/src/vibe3/execution/job_executor.py
+++ b/src/vibe3/execution/job_executor.py
@@ -17,8 +17,13 @@ from loguru import logger
 from vibe3.clients import SQLiteClient
 from vibe3.execution.execution_lifecycle import ExecutionLifecycleService, ExecutionRole
 from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
-from vibe3.models.execution_request import ExecutionLaunchResult
-from vibe3.models.job import CommandType, JobContext, JobEnvelope, JobResult
+from vibe3.models import (
+    CommandType,
+    ExecutionLaunchResult,
+    JobContext,
+    JobEnvelope,
+    JobResult,
+)
 
 if TYPE_CHECKING:
     from vibe3.execution.command_adapter import CommandAdapterRegistry

--- a/tests/vibe3/execution/test_command_adapter.py
+++ b/tests/vibe3/execution/test_command_adapter.py
@@ -13,7 +13,7 @@ from vibe3.execution.command_adapter import (
     ResolvedAdapter,
     build_default_registry,
 )
-from vibe3.models.job import CommandType
+from vibe3.models import CommandType
 
 
 def test_command_type_enum():

--- a/tests/vibe3/execution/test_execution_lifecycle.py
+++ b/tests/vibe3/execution/test_execution_lifecycle.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibe3.clients.sqlite_client import SQLiteClient
+from vibe3.clients import SQLiteClient
 from vibe3.execution.execution_lifecycle import (
     ExecutionLifecycleService,
     persist_execution_lifecycle_event,
@@ -50,10 +50,7 @@ class TestExecutionLifecycleSessionCleanup:
 
     def test_runtime_error_preserves_role_status(self, mock_store: MagicMock) -> None:
         """Runtime error with record_only should NOT update ANY flow state fields."""
-        from vibe3.exceptions.error_severity import (
-            ErrorHandlingContract,
-            ErrorSeverity,
-        )
+        from vibe3.exceptions import ErrorHandlingContract, ErrorSeverity
 
         error_contract = ErrorHandlingContract(
             code="E_EXEC_TIMEOUT",

--- a/tests/vibe3/execution/test_job_executor.py
+++ b/tests/vibe3/execution/test_job_executor.py
@@ -11,8 +11,7 @@ from vibe3.execution.job_executor import (
     COMMAND_TYPE_TO_EXECUTION_ROLE,
     JobExecutor,
 )
-from vibe3.models.execution_request import ExecutionLaunchResult
-from vibe3.models.job import CommandType, JobContext, JobEnvelope
+from vibe3.models import CommandType, ExecutionLaunchResult, JobContext, JobEnvelope
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
清理 execution 模块内部的非公开 API 导入，统一改为公开 API 导入。

## Changes
- `command_adapter.py`: `vibe3.models.job` → `vibe3.models`
- `execution_lifecycle.py`: `vibe3.exceptions.error_severity` → `vibe3.exceptions`
- `job_executor.py`: 多个深层导入合并为 `vibe3.models` 统一导入
- 对应测试文件同步更新导入路径

## Test Plan
- [ ] `uv run pytest tests/vibe3/execution/ -q`
- [ ] `uv run pytest tests/vibe3/test_modularity/test_module_api_compliance.py`
- [ ] `uv run mypy src/vibe3/execution/`

## Related
- Closes #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)