### PR TITLE
test(commands): strengthen weak .called assertions in test_command_params_unified.py

### DIFF
--- a/tests/vibe3/commands/test_command_params_unified.py
+++ b/tests/vibe3/commands/test_command_params_unified.py
@@ -210,7 +210,7 @@ def test_run_dry_run_forwards_to_execution(
 
     runner.invoke(run_app, ["--dry-run", "--no-async", "test instructions"])
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("dry_run") is True
 
 
@@ -246,7 +246,7 @@ def test_review_base_dry_run_returns_dry_run_verdict(
     result = runner.invoke(review_app, ["base", "main", "--dry-run", "--no-async"])
 
     assert result.exit_code == 0
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("dry_run") is True
 
 
@@ -261,7 +261,7 @@ def test_internal_manager_dry_run_forwards_param(
 
     runner.invoke(internal_app, ["manager", "123", "--no-async", "--dry-run"])
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("dry_run") is True
 
 
@@ -317,7 +317,7 @@ def test_run_show_prompt_forwarded(
         run_app, ["--dry-run", "--show-prompt", "--no-async", "test instructions"]
     )
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("dry_run") is True
     assert mock_execute.call_args.kwargs.get("show_prompt") is True
 
@@ -331,7 +331,7 @@ def test_review_show_prompt_forwarded(
 
     runner.invoke(review_app, ["--branch", "42", "--dry-run", "--show-prompt"])
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("show_prompt") is True
 
 
@@ -348,7 +348,7 @@ def test_internal_manager_show_prompt_forwarded(
         internal_app, ["manager", "123", "--no-async", "--dry-run", "--show-prompt"]
     )
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("show_prompt") is True
 
 
@@ -368,7 +368,7 @@ def test_run_cli_agent_overrides_config(
         run_app, ["--agent", "override-agent", "--no-async", "test instructions"]
     )
 
-    assert mock_execute.called
+    mock_execute.assert_called_once()
     assert mock_execute.call_args.kwargs.get("agent") == "override-agent"
 
 


### PR DESCRIPTION
Fixes #2450

## Summary
Replace 7 weak \`assert mock_execute.called\` assertions with \`mock_execute.assert_called_once()\` to eliminate self-checking code anti-pattern.

## Changes
- **tests/vibe3/commands/test_command_params_unified.py**: Replaced 7 weak assertions
  - \`test_run_dry_run_forwards_to_execution\` (line 213)
  - \`test_review_base_dry_run_returns_dry_run_verdict\` (line 249)
  - \`test_internal_manager_dry_run_forwards_param\` (line 264)
  - \`test_run_show_prompt_forwarded\` (line 320)
  - \`test_review_show_prompt_forwarded\` (line 334)
  - \`test_internal_manager_show_prompt_forwarded\` (line 351)
  - \`test_run_cli_agent_overrides_config\` (line 371)

## Verification
- ✅ All 17 direct tests pass
- ✅ All 403 module tests pass (no regressions)
- ✅ No remaining weak assertions
- ✅ Pre-commit hooks passed
- ✅ Pre-push checks passed (type check, tests, LOC)

## Scope
- Test-only changes, no production code impact
- Low risk refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
