### PR TITLE
feat(clients): add field validation for view_issue fields parameter

### DIFF
--- a/src/vibe3/clients/github_field_constants.py
+++ b/src/vibe3/clients/github_field_constants.py
@@ -46,3 +46,29 @@ GITHUB_FIELDS_FULL_WITH_COMMENTS: Final[tuple[str, ...]] = (
     "milestone",
     "assignees",
 )
+
+# Complete set of all valid GitHub Issue API fields (for validation)
+# Sourced from `gh issue view --help` and `gh issue list --help` JSON FIELDS sections
+GITHUB_KNOWN_ISSUE_FIELDS: Final[tuple[str, ...]] = (
+    "assignees",
+    "author",
+    "body",
+    "closed",
+    "closedAt",
+    "closedByPullRequestsReferences",
+    "comments",
+    "createdAt",
+    "id",
+    "isPinned",
+    "labels",
+    "milestone",
+    "number",
+    "projectCards",
+    "projectItems",
+    "reactionGroups",
+    "state",
+    "stateReason",
+    "title",
+    "updatedAt",
+    "url",
+)

--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -1,12 +1,17 @@
 """GitHub client issues operations."""
 
+import difflib
 import json
+import os
 import re
 from typing import Any, cast
 
 from loguru import logger
 
-from vibe3.clients.github_field_constants import GITHUB_DEFAULT_VIEW_FIELDS
+from vibe3.clients.github_field_constants import (
+    GITHUB_DEFAULT_VIEW_FIELDS,
+    GITHUB_KNOWN_ISSUE_FIELDS,
+)
 from vibe3.clients.github_issue_admin_ops import IssueAdminMixin
 
 # Patterns GitHub uses to auto-close issues via PR body
@@ -22,6 +27,36 @@ _BLOCKED_BY_RE = re.compile(
 )
 
 _DEFAULT_LIST_FIELDS = "number,title,state,updatedAt,labels,assignees,milestone"
+
+# Pre-computed set for O(1) field validation lookups
+_KNOWN_FIELDS_SET: frozenset[str] = frozenset(GITHUB_KNOWN_ISSUE_FIELDS)
+
+
+def _validate_issue_fields(fields: list[str]) -> None:
+    """Validate that all field names are known GitHub issue API fields.
+
+    Raises ValueError with typo suggestions for unknown fields.
+
+    Args:
+        fields: List of field names to validate
+
+    Raises:
+        ValueError: If any unknown fields are found, with suggestions for typos
+    """
+    invalid = [f for f in fields if f not in _KNOWN_FIELDS_SET]
+    if not invalid:
+        return
+    suggestions = []
+    for f in invalid:
+        matches = difflib.get_close_matches(f, _KNOWN_FIELDS_SET, n=1, cutoff=0.6)
+        if matches:
+            suggestions.append(f"'{f}' (did you mean '{matches[0]}'?)")
+        else:
+            suggestions.append(f"'{f}'")
+    raise ValueError(
+        f"Unknown GitHub issue field(s): {', '.join(suggestions)}. "
+        f"Known fields: {', '.join(sorted(_KNOWN_FIELDS_SET))}"
+    )
 
 
 def parse_blocked_by(body: str) -> list[int]:
@@ -248,6 +283,10 @@ class IssuesMixin(IssueAdminMixin):
             operation="view_issue",
             issue_number=issue_number,
         ).debug("Calling GitHub API: view_issue")
+
+        # Validate fields if provided and validation is not skipped
+        if fields is not None and not os.environ.get("VIBE_SKIP_FIELD_VALIDATION"):
+            _validate_issue_fields(fields)
 
         fields_str = (
             ",".join(fields)

--- a/tests/vibe3/clients/test_github_field_validation.py
+++ b/tests/vibe3/clients/test_github_field_validation.py
@@ -1,0 +1,104 @@
+"""Tests for GitHub issue field validation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibe3.clients.github_field_constants import GITHUB_KNOWN_ISSUE_FIELDS
+from vibe3.clients.github_issues_ops import _validate_issue_fields
+
+
+class TestFieldValidation:
+    """Tests for _validate_issue_fields function."""
+
+    def test_validate_all_known_fields_pass(self) -> None:
+        """All 21 known fields should pass validation without error."""
+        # This should not raise any exception
+        _validate_issue_fields(list(GITHUB_KNOWN_ISSUE_FIELDS))
+
+    def test_validate_empty_fields_pass(self) -> None:
+        """Empty list should pass validation (edge case)."""
+        # This should not raise any exception
+        _validate_issue_fields([])
+
+    def test_validate_typo_detected_with_suggestion(self) -> None:
+        """Typo 'commnts' should raise ValueError suggesting 'comments'."""
+        with pytest.raises(ValueError) as exc_info:
+            _validate_issue_fields(["commnts"])
+
+        error_msg = str(exc_info.value)
+        assert "Unknown GitHub issue field(s)" in error_msg
+        assert "'commnts'" in error_msg
+        assert "'comments'" in error_msg
+        assert "did you mean" in error_msg
+
+    def test_validate_multiple_invalid_fields(self) -> None:
+        """Multiple invalid fields should all be listed in error."""
+        with pytest.raises(ValueError) as exc_info:
+            _validate_issue_fields(["bad1", "bad2"])
+
+        error_msg = str(exc_info.value)
+        assert "'bad1'" in error_msg
+        assert "'bad2'" in error_msg
+
+    def test_validate_mixed_valid_invalid(self) -> None:
+        """Mixed valid/invalid fields should raise error for invalid only."""
+        with pytest.raises(ValueError) as exc_info:
+            _validate_issue_fields(["number", "bad"])
+
+        error_msg = str(exc_info.value)
+        assert "'bad'" in error_msg
+        assert "'number'" not in error_msg  # Valid field should not be listed
+
+    def test_view_issue_validates_fields(self) -> None:
+        """view_issue should call validation for invalid fields."""
+        from vibe3.clients.github_issues_ops import IssuesMixin
+
+        # Create a mock instance with necessary attributes
+        mock_instance = MagicMock(spec=IssuesMixin)
+        mock_instance._run_gh_command = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="{}", stderr="")
+        )
+
+        # Call view_issue with invalid fields
+        with pytest.raises(ValueError) as exc_info:
+            IssuesMixin.view_issue(mock_instance, 123, fields=["commnts"])
+
+        error_msg = str(exc_info.value)
+        assert "commnts" in error_msg
+        assert "comments" in error_msg
+
+    def test_view_issue_skips_validation_with_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """view_issue should skip validation when VIBE_SKIP_FIELD_VALIDATION is set."""
+        from vibe3.clients.github_issues_ops import IssuesMixin
+
+        # Set environment variable
+        monkeypatch.setenv("VIBE_SKIP_FIELD_VALIDATION", "1")
+
+        # Create a mock instance with necessary attributes
+        mock_instance = MagicMock(spec=IssuesMixin)
+        mock_instance._run_gh_command = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="{}", stderr="")
+        )
+
+        # This should NOT raise ValueError because validation is skipped
+        result = IssuesMixin.view_issue(mock_instance, 123, fields=["commnts"])
+        # The function will return empty dict due to mock, but no ValueError
+        assert result is not None or result == {} or isinstance(result, dict)
+
+    def test_view_issue_no_fields_no_validation(self) -> None:
+        """view_issue should not validate when fields=None (default)."""
+        from vibe3.clients.github_issues_ops import IssuesMixin
+
+        # Create a mock instance with necessary attributes
+        mock_instance = MagicMock(spec=IssuesMixin)
+        mock_instance._run_gh_command = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="{}", stderr="")
+        )
+
+        # This should NOT raise ValueError because fields=None uses default set
+        result = IssuesMixin.view_issue(mock_instance, 123)
+        # The function will return empty dict due to mock, but no ValueError
+        assert result is not None or result == {} or isinstance(result, dict)

--- a/tests/vibe3/clients/test_github_field_validation.py
+++ b/tests/vibe3/clients/test_github_field_validation.py
@@ -86,7 +86,7 @@ class TestFieldValidation:
         # This should NOT raise ValueError because validation is skipped
         result = IssuesMixin.view_issue(mock_instance, 123, fields=["commnts"])
         # The function will return empty dict due to mock, but no ValueError
-        assert result is not None or result == {} or isinstance(result, dict)
+        assert isinstance(result, dict)
 
     def test_view_issue_no_fields_no_validation(self) -> None:
         """view_issue should not validate when fields=None (default)."""
@@ -101,4 +101,4 @@ class TestFieldValidation:
         # This should NOT raise ValueError because fields=None uses default set
         result = IssuesMixin.view_issue(mock_instance, 123)
         # The function will return empty dict due to mock, but no ValueError
-        assert result is not None or result == {} or isinstance(result, dict)
+        assert isinstance(result, dict)


### PR DESCRIPTION
Closes #2426

## Summary

Add comprehensive field name validation for GitHub issue API calls to prevent silent typos and provide helpful suggestions using fuzzy matching.

## Changes

- Added `GITHUB_KNOWN_ISSUE_FIELDS` constant (21 valid fields verified from gh CLI)
- Implemented `_validate_issue_fields()` helper with difflib typo suggestions
- Wired validation into `view_issue()` with opt-out via `VIBE_SKIP_FIELD_VALIDATION` env var
- Comprehensive test suite: 8 test cases covering valid/invalid fields, edge cases, env bypass

## Test Results

- New tests: 8 passed (test_github_field_validation.py)
- Regression tests: 35 passed (test_github_client_issues.py, test_github_issue_body_ops.py)
- Type check: mypy SUCCESS
- Lint check: ruff PASS

## Key Features

- Validates field names against 21 known GitHub issue API fields
- Provides typo suggestions using fuzzy matching (e.g., "commnts" → "comments")
- Opt-out via `VIBE_SKIP_FIELD_VALIDATION` environment variable
- Default fields bypass validation intentionally (already known-correct)

Ref: #2426

---

## Contributors

claude/opus
