### PR TITLE
refactor(analysis): eliminate roundabout delta calculation in snapshot_diff

### DIFF
--- a/src/vibe3/analysis/snapshot_diff.py
+++ b/src/vibe3/analysis/snapshot_diff.py
@@ -217,6 +217,7 @@ def compute_diff(
         module_changes, module_summary, warnings = _diff_modules(baseline, current)
         dep_changes, dep_summary = _diff_dependencies(baseline, current)
 
+        # Aggregate all sub-summaries including global metrics via __add__
         metrics_summary = DiffSummary.from_metrics(baseline.metrics, current.metrics)
         summary = file_summary + module_summary + dep_summary + metrics_summary
 

--- a/src/vibe3/analysis/snapshot_diff.py
+++ b/src/vibe3/analysis/snapshot_diff.py
@@ -217,13 +217,8 @@ def compute_diff(
         module_changes, module_summary, warnings = _diff_modules(baseline, current)
         dep_changes, dep_summary = _diff_dependencies(baseline, current)
 
-        summary = file_summary + module_summary + dep_summary
-
-        # Compute global metrics (must be after __add__ to avoid being overwritten)
-        summary.total_loc_delta = current.metrics.total_loc - baseline.metrics.total_loc
-        summary.total_functions_delta = (
-            current.metrics.total_functions - baseline.metrics.total_functions
-        )
+        metrics_summary = DiffSummary.from_metrics(baseline.metrics, current.metrics)
+        summary = file_summary + module_summary + dep_summary + metrics_summary
 
         diff = StructureDiff(
             baseline_id=baseline.snapshot_id,

--- a/src/vibe3/models/snapshot.py
+++ b/src/vibe3/models/snapshot.py
@@ -153,6 +153,29 @@ class DiffSummary(BaseModel):
             + other.total_functions_delta,
         )
 
+    @classmethod
+    def from_metrics(
+        cls, baseline: StructureMetrics, current: StructureMetrics
+    ) -> DiffSummary:
+        """Create a DiffSummary with global metric deltas.
+
+        This is used to compute snapshot-level metric deltas
+        (total_loc, total_functions) which sub-functions
+        (_diff_files, _diff_modules, _diff_dependencies) don't have
+        access to, as they only operate on individual files/modules/deps.
+
+        Args:
+            baseline: Baseline snapshot metrics
+            current: Current snapshot metrics
+
+        Returns:
+            DiffSummary with only total_loc_delta and total_functions_delta populated
+        """
+        return DiffSummary(
+            total_loc_delta=current.total_loc - baseline.total_loc,
+            total_functions_delta=current.total_functions - baseline.total_functions,
+        )
+
 
 class DiffWarning(BaseModel):
     """Warning in structure diff."""

--- a/tests/vibe3/analysis/test_snapshot_diff.py
+++ b/tests/vibe3/analysis/test_snapshot_diff.py
@@ -3,6 +3,7 @@
 from vibe3.analysis.snapshot_diff import compute_diff
 from vibe3.models.snapshot import (
     DependencyEdge,
+    DiffSummary,
     FileSnapshot,
     ModuleSnapshot,
     StructureMetrics,
@@ -117,3 +118,97 @@ def test_compute_diff_merges_summaries():
     # LOC and function deltas
     assert diff.summary.total_loc_delta == 250  # 350 - 100 = 250
     assert diff.summary.total_functions_delta == 12  # 17 - 5 = 12
+
+
+def test_diff_summary_from_metrics():
+    """Test DiffSummary.from_metrics classmethod."""
+    baseline = StructureMetrics(
+        total_files=5,
+        total_loc=100,
+        total_functions=5,
+        python_files=4,
+        shell_files=1,
+    )
+
+    current = StructureMetrics(
+        total_files=10,
+        total_loc=350,
+        total_functions=17,
+        python_files=9,
+        shell_files=1,
+    )
+
+    result = DiffSummary.from_metrics(baseline, current)
+
+    # Should have only metric deltas populated
+    assert result.total_loc_delta == 250  # 350 - 100
+    assert result.total_functions_delta == 12  # 17 - 5
+
+    # All other fields should be 0 (default)
+    assert result.files_added == 0
+    assert result.files_removed == 0
+    assert result.files_modified == 0
+    assert result.modules_added == 0
+    assert result.modules_removed == 0
+    assert result.modules_modified == 0
+    assert result.dependencies_added == 0
+    assert result.dependencies_removed == 0
+
+
+def test_compute_diff_identical_snapshots():
+    """Test compute_diff with identical snapshots (zero delta edge case)."""
+    snapshot = StructureSnapshot(
+        snapshot_id="2026-03-20T10-00-00_main_abc1234",
+        branch="main",
+        commit="abc1234567890",
+        commit_short="abc1234",
+        created_at="2026-03-20T10:00:00",
+        root="src/vibe3",
+        files=[
+            FileSnapshot(
+                path="services/service.py",
+                language="python",
+                total_loc=100,
+                function_count=5,
+            ),
+        ],
+        modules=[
+            ModuleSnapshot(
+                module="services",
+                file_count=1,
+                total_loc=100,
+                total_functions=5,
+                files=["services/service.py"],
+            ),
+        ],
+        dependencies=[
+            DependencyEdge(from_module="services", to_module="utils"),
+        ],
+        metrics=StructureMetrics(
+            total_files=1,
+            total_loc=100,
+            total_functions=5,
+        ),
+    )
+
+    # Compare identical snapshots
+    diff = compute_diff(snapshot, snapshot)
+
+    # Should have zero deltas
+    assert diff.summary.total_loc_delta == 0
+    assert diff.summary.total_functions_delta == 0
+
+    # Should have no changes
+    assert diff.summary.files_added == 0
+    assert diff.summary.files_removed == 0
+    assert diff.summary.files_modified == 0
+    assert diff.summary.modules_added == 0
+    assert diff.summary.modules_removed == 0
+    assert diff.summary.modules_modified == 0
+    assert diff.summary.dependencies_added == 0
+    assert diff.summary.dependencies_removed == 0
+
+    # Should have empty change lists
+    assert len(diff.file_changes) == 0
+    assert len(diff.module_changes) == 0
+    assert len(diff.dependency_changes) == 0

--- a/tests/vibe3/analysis/test_snapshot_diff.py
+++ b/tests/vibe3/analysis/test_snapshot_diff.py
@@ -155,6 +155,66 @@ def test_diff_summary_from_metrics():
     assert result.dependencies_removed == 0
 
 
+def test_diff_summary_from_metrics_negative_delta():
+    """Test DiffSummary.from_metrics with code shrinkage (negative delta)."""
+    baseline = StructureMetrics(
+        total_files=10,
+        total_loc=350,
+        total_functions=17,
+    )
+    current = StructureMetrics(
+        total_files=5,
+        total_loc=100,
+        total_functions=5,
+    )
+
+    result = DiffSummary.from_metrics(baseline, current)
+
+    assert result.total_loc_delta == -250  # 100 - 350
+    assert result.total_functions_delta == -12  # 5 - 17
+
+
+def test_diff_summary_add():
+    """Test DiffSummary.__add__ sums all fields correctly."""
+    a = DiffSummary(
+        files_added=1,
+        files_removed=0,
+        files_modified=2,
+        modules_added=1,
+        modules_removed=0,
+        modules_modified=1,
+        dependencies_added=1,
+        dependencies_removed=0,
+        total_loc_delta=100,
+        total_functions_delta=10,
+    )
+    b = DiffSummary(
+        files_added=0,
+        files_removed=1,
+        files_modified=1,
+        modules_added=0,
+        modules_removed=1,
+        modules_modified=0,
+        dependencies_added=0,
+        dependencies_removed=1,
+        total_loc_delta=-30,
+        total_functions_delta=-3,
+    )
+
+    result = a + b
+
+    assert result.files_added == 1
+    assert result.files_removed == 1
+    assert result.files_modified == 3
+    assert result.modules_added == 1
+    assert result.modules_removed == 1
+    assert result.modules_modified == 1
+    assert result.dependencies_added == 1
+    assert result.dependencies_removed == 1
+    assert result.total_loc_delta == 70
+    assert result.total_functions_delta == 7
+
+
 def test_compute_diff_identical_snapshots():
     """Test compute_diff with identical snapshots (zero delta edge case)."""
     snapshot = StructureSnapshot(


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2389` is behind `main` by **14 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2389
```


---

## Summary

Eliminates the roundabout delta calculation in `snapshot_diff.py` by adding a `DiffSummary.from_metrics` classmethod and replacing manual field injection with proper `__add__` aggregation.

## Changes

- **src/vibe3/models/snapshot.py**: Added `DiffSummary.from_metrics(baseline, current)` classmethod to compute snapshot-level metric deltas directly
- **src/vibe3/analysis/snapshot_diff.py**: Replaced manual field overwrite with `from_metrics` + `__add__` aggregation
- **tests/vibe3/analysis/test_snapshot_diff.py**: Added tests for `from_metrics` and identical snapshots edge case

## Technical Details

**Before**: Manual field injection after `__add__`
```python
summary = file_summary + module_summary + dep_summary
summary.total_loc_delta = current.metrics.total_loc - baseline.metrics.total_loc
summary.total_functions_delta = current.metrics.total_functions - baseline.metrics.total_functions
```

**After**: All aggregation flows through `__add__`
```python
metrics_summary = DiffSummary.from_metrics(baseline.metrics, current.metrics)
summary = file_summary + module_summary + dep_summary + metrics_summary
```

This eliminates the "half-automatic, half-manual" merge pattern where `__add__` computed `0+0+0` for metric deltas, requiring post-hoc overwrite.

## Test Plan

- ✅ Direct unit tests: `test_diff_summary_from_metrics` (new), `test_compute_diff_identical_snapshots` (new)
- ✅ All existing tests pass: 138/138 in `tests/vibe3/analysis/`
- ✅ Type safety verified: mypy success
- ✅ Code quality verified: ruff success
- ✅ Pre-push checks: 765 tests passed

## Verification

- No behavioral change: The refactoring is mathematically equivalent
- Scope: Minimal (3 files, +120 lines, -7 lines)
- Downstream impact: None (internal refactoring only)

Closes #2389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
