### PR TITLE
refactor(services): remove deprecated mark_flow_unblocked method (#2447)

### DIFF
--- a/src/vibe3/services/flow_status_service.py
+++ b/src/vibe3/services/flow_status_service.py
@@ -183,33 +183,3 @@ class FlowStatusService:
         self.mark_flow_status(
             branch, "stale", reason, "flow_auto_staled", "auto_stale_flow"
         )
-
-    def mark_flow_unblocked(self, branch: str, reason: str) -> None:
-        """Clear stale blocked state from local DB and mark flow as active.
-
-        Clears blocked_by_issue and blocked_reason in addition to flow_status,
-        matching what BlockedStateIO.clear_database_cache() does.
-        Only updates local state — GitHub label sync is left to qualify_gate.
-
-        .. deprecated::
-            Use FlowRecoveryService.recover() or BlockedStateService.unblock() instead.
-            Will be removed in a future version.
-        """
-        logger.bind(
-            domain="check",
-            action="auto_unblock_flow",
-            branch=branch,
-        ).info(f"auto_unblock_flow: {reason}")
-        self.store.update_flow_state(
-            branch,
-            flow_status="active",
-            blocked_reason=None,
-            blocked_by_issue=None,
-            transition_count=0,
-        )
-        self.store.add_event(
-            branch,
-            "flow_auto_unblocked",
-            "system",
-            f"Flow auto-unblocked: {reason}",
-        )


### PR DESCRIPTION
## Summary
- Delete deprecated `mark_flow_unblocked` method from `FlowStatusService` (29 lines, lines 187-215)
- Method has 0 callers, replacement path `FlowRecoveryService.recover()` has test coverage
- Event name `flow_auto_unblocked` fully eliminated from codebase

## Changes
- `src/vibe3/services/flow_status_service.py`: Removed deprecated method (30 deletions)

## Test Plan
- [x] `uv run pytest tests/vibe3/services/test_flow_status.py` - 11 tests passed
- [x] `uv run pytest tests/vibe3/services/test_check_service_verify_branch.py::test_verify_branch_unblocks_stale_blocked_flow` - replacement path verified
- [x] `uv run mypy src/vibe3/services/flow_status_service.py` - clean
- [x] Pre-commit hooks (Ruff, Black, MyPy, custom lint) - passed
- [x] Pre-push checks - 124 tests passed, type check clean
- [x] `vibe3 inspect symbols` - confirmed 0 references
- [x] `rg 'flow_auto_unblocked'` - confirmed event name only in method body

## Verification
- File parses clean (AST validation)
- No type errors
- No lint errors
- No residual references to deleted code

## Related
- Follow-up to PR #2473 (Phase 2c backward compatibility bridge removal)
- Issue #2380 (check command refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)