### PR TITLE
refactor(commands): replace deep imports with public API imports (#2444)

### DIFF
--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -104,7 +104,7 @@ def execute_check_mode(
 
     if mode == "clean_branch":
         # Use dedicated cleanup service for --clean-branch
-        from vibe3.services.check_cleanup_service import CheckCleanupService
+        from vibe3.services import CheckCleanupService
 
         cleanup_service = CheckCleanupService(
             store=service.store,

--- a/src/vibe3/commands/command_options.py
+++ b/src/vibe3/commands/command_options.py
@@ -6,7 +6,7 @@ import typer
 
 if TYPE_CHECKING:
     from vibe3.config import VibeConfig
-    from vibe3.services.flow_service import FlowService
+    from vibe3.services import FlowService
 
 _TRACE_OPT = Annotated[
     bool, typer.Option("--trace", help="Enable call tracing (set VIBE3_TRACE=1)")
@@ -88,8 +88,7 @@ def load_config_and_validate_model(
         typer.Exit: If config loading fails or --model used without backend
         ConfigError: If config loading fails
     """
-    from vibe3.config import load_runtime_config
-    from vibe3.config.cli_overrides import build_role_cli_overrides
+    from vibe3.config import build_role_cli_overrides, load_runtime_config
     from vibe3.exceptions import ConfigError
 
     cli_overrides = build_role_cli_overrides(role, agent, backend, model)
@@ -180,7 +179,7 @@ def ensure_flow_for_current_branch() -> tuple["FlowService", str]:
         typer.Exit: If on main branch or flow creation fails
     """
     from vibe3.models.flow import MainBranchProtectedError
-    from vibe3.services.flow_service import FlowService
+    from vibe3.services import FlowService
 
     flow_service = FlowService()
     branch = flow_service.get_current_branch()

--- a/src/vibe3/commands/common.py
+++ b/src/vibe3/commands/common.py
@@ -51,7 +51,7 @@ def run_full_check_shortcut() -> None:
     The status dashboard should still render even if the full check reports
     unfixable issues or raises unexpectedly, but users must see a warning.
     """
-    from vibe3.services.check_service import CheckService
+    from vibe3.services import CheckService
 
     try:
         result = execute_check_mode(CheckService(), "fix_all", show_progress=False)

--- a/src/vibe3/commands/flow_lifecycle.py
+++ b/src/vibe3/commands/flow_lifecycle.py
@@ -8,12 +8,12 @@ from loguru import logger
 from vibe3.commands.common import enable_method_trace
 from vibe3.config import load_orchestra_config
 from vibe3.services import (
+    FlowRebuildUsecase,
     FlowService,
     load_issue_info,
     resolve_branch_and_issue,
     resolve_branch_arg,
 )
-from vibe3.services.flow_rebuild_usecase import FlowRebuildUsecase
 
 
 def blocked(
@@ -177,7 +177,7 @@ def rebuild(
         )
         return
 
-    from vibe3.clients.github_client import GitHubClient
+    from vibe3.clients import GitHubClient
 
     config = load_orchestra_config()
     issue = load_issue_info(issue_number, config=config, github=GitHubClient())

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -169,8 +169,8 @@ def update(
             err=True,
         )
         output_format = "json"
-    from vibe3.clients.git_client import GitClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.clients import GitClient
+    from vibe3.config import load_orchestra_config
     from vibe3.services import resolve_branch_arg
     from vibe3.utils.issue_ref import try_parse_issue_number
 

--- a/src/vibe3/commands/flow_status.py
+++ b/src/vibe3/commands/flow_status.py
@@ -103,13 +103,13 @@ def show(
             raise typer.Exit(1) from error
 
         # Get task issue number for remote fallback
-        from vibe3.services.issue.flow import IssueFlowService
+        from vibe3.services import IssueFlowService
 
         issue_flow_service = IssueFlowService(store=service.store)
         task_issue_number = issue_flow_service.resolve_task_issue_number(target_branch)
 
     # Use resolver for source-aware read
-    from vibe3.services.flow_status_resolver import FlowStatusResolver
+    from vibe3.services import FlowStatusResolver
 
     resolver = FlowStatusResolver(store=service.store, flow_service=service)
     flow_status = resolver.resolve(
@@ -121,7 +121,7 @@ def show(
     # Handle non-registered flow or special branches
     if not flow_status or flow_status.flow_status == "aborted":
         if output_format == "table":
-            from vibe3.services.flow_service import FlowService as FlowService_
+            from vibe3.services import FlowService as FlowService_
 
             is_safe = target_branch.startswith(FlowService_.SAFE_BRANCH_PREFIX)
             is_aborted = flow_status and flow_status.flow_status == "aborted"
@@ -187,7 +187,7 @@ def show(
     if snapshot:
         # Use resolver's flow_status directly (already source-aware)
         # Do NOT re-read from local via FlowProjectionService.get_projection
-        from vibe3.services.flow_projection_service import FlowProjection
+        from vibe3.services import FlowProjection
 
         projection = FlowProjection.from_flow_status(flow_status)
 
@@ -324,7 +324,7 @@ def status(
         raise typer.Exit(0)
 
     # Try to fetch cached issue titles from orchestra server first
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     config = load_orchestra_config()
     orch_snapshot = OrchestraStatusService.fetch_live_snapshot(config)

--- a/src/vibe3/commands/flow_status_helpers.py
+++ b/src/vibe3/commands/flow_status_helpers.py
@@ -113,7 +113,7 @@ def _fetch_worktree_map() -> dict[str, str]:
     """Fetch worktree mapping from git worktree list."""
     worktree_map: dict[str, str] = {}
     try:
-        from vibe3.clients.git_client import GitClient
+        from vibe3.clients import GitClient
 
         git = GitClient()
         worktree_output = git._run(["worktree", "list", "--porcelain"])
@@ -178,7 +178,7 @@ def _fetch_issue_titles_for_status(
         return titles, False
 
     # Server not running, use cache service with real branches
-    from vibe3.services.issue.title_cache import IssueTitleCacheService
+    from vibe3.services import IssueTitleCacheService
 
     branches = [flow.branch for flow in flows if flow.branch]
     title_cache = IssueTitleCacheService(

--- a/src/vibe3/commands/inspect_base.py
+++ b/src/vibe3/commands/inspect_base.py
@@ -56,9 +56,8 @@ def register(app: typer.Typer) -> None:
             vibe inspect base origin/develop # Compare current branch vs origin/develop
             vibe inspect base main           # Compare current branch vs origin/main
         """
-        from vibe3.clients.git_client import GitClient
-        from vibe3.clients.github_client import GitHubClient
-        from vibe3.config.loader import get_config
+        from vibe3.clients import GitClient, GitHubClient
+        from vibe3.config import get_config
         from vibe3.models.change_source import BranchSource
         from vibe3.utils.git_helpers import get_current_branch
 

--- a/src/vibe3/commands/inspect_base_helpers.py
+++ b/src/vibe3/commands/inspect_base_helpers.py
@@ -13,7 +13,7 @@ from vibe3.clients import GitClient
 from vibe3.config import get_config
 from vibe3.exceptions import GitError, UserError
 from vibe3.models import BranchSource
-from vibe3.services.pr.scoring import PRDimensions, generate_score_report
+from vibe3.services import PRDimensions, generate_score_report
 
 
 def _code_paths() -> list[str]:

--- a/src/vibe3/commands/inspect_helpers.py
+++ b/src/vibe3/commands/inspect_helpers.py
@@ -18,7 +18,7 @@ from vibe3.models.pr_analysis import (  # noqa: F401
     CriticalFileInfo,
     PRCriticalAnalysis,
 )
-from vibe3.services.pr.analysis import (  # noqa: F401 - backward compat re-exports
+from vibe3.services import (  # noqa: F401 - backward compat re-exports
     analyze_critical_files,
     calculate_pr_risk_score,
     filter_critical_files,

--- a/src/vibe3/commands/inspect_pr_helpers.py
+++ b/src/vibe3/commands/inspect_pr_helpers.py
@@ -11,6 +11,6 @@ from vibe3.models.pr_analysis import (  # noqa: F401
     CriticalFileInfo,
     PRCriticalAnalysis,
 )
-from vibe3.services.pr.analysis import build_pr_analysis  # noqa: F401
+from vibe3.services import build_pr_analysis  # noqa: F401
 
 __all__ = ["build_pr_analysis", "CommitInfo", "CriticalFileInfo", "PRCriticalAnalysis"]

--- a/src/vibe3/commands/internal.py
+++ b/src/vibe3/commands/internal.py
@@ -41,7 +41,7 @@ def internal_manager_dispatch(
         run_issue_role_async,
         run_issue_role_sync,
     )
-    from vibe3.roles.manager import MANAGER_SYNC_SPEC
+    from vibe3.roles import MANAGER_SYNC_SPEC
 
     if no_async:
         run_issue_role_sync(
@@ -73,7 +73,7 @@ def internal_apply_dispatch(
     ] = False,
 ) -> None:
     """L2: Dispatch the Supervisor/Apply agent for a governance issue."""
-    from vibe3.roles.scan_service import dispatch_supervisor_execution
+    from vibe3.roles import dispatch_supervisor_execution
 
     dispatch_supervisor_execution(issue_number=issue, no_async=no_async)
 
@@ -104,7 +104,7 @@ def internal_governance_dispatch(
     Note: This command is only called via CLI self-invocation (internal governance)
     from the tmux wrapper launched by governance_scan handler. It always runs sync.
     """
-    from vibe3.roles.scan_service import dispatch_governance_execution
+    from vibe3.roles import dispatch_governance_execution
 
     dispatch_governance_execution(
         tick_count=tick, execution_count=execution_count, material_override=material
@@ -146,10 +146,8 @@ def internal_bootstrap(
     ] = False,
 ) -> None:
     """Bootstrap a standardized flow scene through the shared service path."""
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
+    from vibe3.services import FlowOrchestratorService
 
     config = load_orchestra_config()
     store = SQLiteClient()

--- a/src/vibe3/commands/mcp.py
+++ b/src/vibe3/commands/mcp.py
@@ -35,12 +35,10 @@ def run() -> None:
       - orchestra://issues: List of managed issues
       - orchestra://circuit-breaker: Circuit breaker state
     """
-    from vibe3.clients.git_client import GitClient
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.clients.sqlite_client import SQLiteClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.clients import GitClient, GitHubClient, SQLiteClient
+    from vibe3.config import load_orchestra_config
     from vibe3.domain import FlowManager
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import OrchestraStatusService
 
     config = load_orchestra_config()
 

--- a/src/vibe3/commands/plan.py
+++ b/src/vibe3/commands/plan.py
@@ -19,9 +19,9 @@ from vibe3.commands.command_options import (
     validate_show_prompt_dependency,
 )
 from vibe3.commands.common import enable_method_trace
-from vibe3.config.cli_overrides import RoleCliOverrides
+from vibe3.config import RoleCliOverrides
 from vibe3.execution import CodeagentExecutionService
-from vibe3.roles.plan import (
+from vibe3.roles import (
     execute_spec_plan_async,
     execute_spec_plan_sync,
     resolve_spec_plan_input,

--- a/src/vibe3/commands/pr_query.py
+++ b/src/vibe3/commands/pr_query.py
@@ -66,7 +66,7 @@ def _resolve_task_from_flow(pr_svc: PRService, branch: str) -> list[int]:
 
         # Fallback: use unified method if no DB link exists
         if not task_issues:
-            from vibe3.services.issue.flow import IssueFlowService
+            from vibe3.services import IssueFlowService
 
             issue_flow_service = IssueFlowService(store=pr_svc.store)
             task_issue_number = issue_flow_service.resolve_task_issue_number(branch)

--- a/src/vibe3/commands/review.py
+++ b/src/vibe3/commands/review.py
@@ -25,7 +25,7 @@ from vibe3.execution.issue_role_sync_runner import (
     run_issue_role_async,
     run_issue_role_sync,
 )
-from vibe3.roles.review import (
+from vibe3.roles import (
     REVIEW_SYNC_SPEC,
     build_base_review_request,
     execute_manual_review_async,

--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -20,11 +20,11 @@ from vibe3.commands.command_options import (
 )
 from vibe3.commands.common import enable_method_trace
 from vibe3.exceptions import UserError
-from vibe3.roles import resolve_skill_path
-from vibe3.roles.run import (
+from vibe3.roles import (
     ensure_plan_file_exists,
     execute_manual_run,
     resolve_run_mode,
+    resolve_skill_path,
     validate_run_prerequisites,
 )
 from vibe3.services import FlowService, resolve_branch_arg, resolve_handoff_target

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -27,7 +27,7 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
     Args:
         material_override: Optional governance role to override material rotation
     """
-    from vibe3.roles.scan_service import dispatch_governance_execution
+    from vibe3.roles import dispatch_governance_execution
 
     dispatch_governance_execution(material_override=material_override)
 
@@ -49,7 +49,7 @@ def _run_governance_scan(
         logger.bind(domain="orchestra").info("Governance scan completed")
     else:
         from vibe3.execution.governance_sync_runner import run_governance_async
-        from vibe3.roles.governance import build_governance_execution_name
+        from vibe3.roles import build_governance_execution_name
 
         run_governance_async(
             tick_count=0,
@@ -69,7 +69,7 @@ def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
     """
     from vibe3.execution.governance_sync_runner import run_governance_sync
     from vibe3.observability import append_governance_event
-    from vibe3.roles.governance_factory import build_default_governance_fns
+    from vibe3.roles import build_default_governance_fns
 
     # Call internal governance runner with dry_run=True
     # This uses real snapshot instead of synthetic dry-run context
@@ -93,7 +93,7 @@ def _run_supervisor_scan() -> tuple[int, int]:
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
-    from vibe3.roles.scan_service import (
+    from vibe3.roles import (
         dispatch_supervisor_execution,
         fetch_supervisor_candidates,
     )
@@ -120,9 +120,9 @@ def _run_supervisor_scan_dry_run() -> None:
     """
     from rich.console import Console
 
-    from vibe3.clients.github_client import GitHubClient
-    from vibe3.config.orchestra_settings import load_orchestra_config
-    from vibe3.roles.scan_service import fetch_supervisor_candidates
+    from vibe3.clients import GitHubClient
+    from vibe3.config import load_orchestra_config
+    from vibe3.roles import fetch_supervisor_candidates
     from vibe3.ui.scan_display import display_supervisor_dry_run
 
     console = Console()
@@ -175,7 +175,7 @@ def governance(
     """
     from rich.console import Console
 
-    from vibe3.roles.scan_service import (
+    from vibe3.roles import (
         get_available_governance_materials,
         governance_material_exists,
         list_governance_materials,

--- a/src/vibe3/commands/snapshot.py
+++ b/src/vibe3/commands/snapshot.py
@@ -106,7 +106,7 @@ def save(
         vibe3 snapshot save --as-baseline
         vibe3 snapshot save --json
     """
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     if trace:
         enable_method_trace()
@@ -274,7 +274,7 @@ def diff(
         vibe3 snapshot diff <snapshot-id>    # Compare with specific snapshot
         vibe3 snapshot diff latest           # Compare with latest snapshot
     """
-    from vibe3.clients.git_client import GitClient
+    from vibe3.clients import GitClient
 
     if trace:
         enable_method_trace()

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -20,7 +20,7 @@ from vibe3.commands.common import (
     run_full_check_shortcut,
     validate_trace_options,
 )
-from vibe3.config.env_override import OVERRIDE_RULES
+from vibe3.config import OVERRIDE_RULES
 from vibe3.models import OrchestraConfig
 from vibe3.observability import orchestra_events_log_path
 from vibe3.server import validate_pid_file
@@ -29,7 +29,7 @@ from vibe3.ui import console
 from vibe3.utils import format_age_aware_time
 
 if TYPE_CHECKING:
-    from vibe3.services.orchestra_status_service import OrchestraSnapshot
+    from vibe3.services import OrchestraSnapshot
 
 
 def _resolve_server_label(
@@ -219,8 +219,7 @@ def _fetch_system_snapshot(
     import time
     from dataclasses import replace
 
-    from vibe3.services.flow_orchestrator_service import FlowOrchestratorService
-    from vibe3.services.orchestra_status_service import OrchestraStatusService
+    from vibe3.services import FlowOrchestratorService, OrchestraStatusService
 
     snapshot = OrchestraStatusService.fetch_live_snapshot(config)
     if snapshot is None:
@@ -307,7 +306,7 @@ def _full_status_dashboard(
         render_rfc_items,
         render_supervisor_issues,
     )
-    from vibe3.services.task import (
+    from vibe3.services import (
         classify_task_issues_for_rendering,
         fetch_task_status_data,
     )
@@ -400,7 +399,7 @@ def status(
     if check:
         run_full_check_shortcut()
 
-    from vibe3.config.orchestra_settings import load_orchestra_config
+    from vibe3.config import load_orchestra_config
 
     config = load_orchestra_config()
     orch_snapshot, snapshot_found = _fetch_system_snapshot(config)

--- a/src/vibe3/commands/task.py
+++ b/src/vibe3/commands/task.py
@@ -10,8 +10,11 @@ import typer
 from vibe3.clients import GitHubClient
 from vibe3.commands.command_options import FormatOption
 from vibe3.commands.common import enable_method_trace
-from vibe3.config import get_convention, get_manager_usernames
-from vibe3.config.loader import get_config_with_env_override
+from vibe3.config import (
+    get_config_with_env_override,
+    get_convention,
+    get_manager_usernames,
+)
 from vibe3.exceptions import SystemError, UserError
 from vibe3.models import IssueState
 from vibe3.observability import setup_logging

--- a/src/vibe3/roles/__init__.py
+++ b/src/vibe3/roles/__init__.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     # For type checkers, import all symbols
@@ -205,7 +205,7 @@ _LAZY_IMPORTS: dict[str, str] = {
 }
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> Any:
     """Lazy import for role symbols to avoid circular imports."""
     if name in _LAZY_IMPORTS:
         module = importlib.import_module(_LAZY_IMPORTS[name])

--- a/tests/vibe3/commands/test_flow_show_auto_ensure.py
+++ b/tests/vibe3/commands/test_flow_show_auto_ensure.py
@@ -30,7 +30,7 @@ def test_flow_show_hint_when_not_registered(mock_service_cls, _render_timeline) 
 
 
 @patch("vibe3.commands.flow_status.render_flow_timeline")
-@patch("vibe3.services.flow_status_resolver.FlowStatusResolver")
+@patch("vibe3.services.FlowStatusResolver")
 @patch("vibe3.commands.flow_status.find_parent_branch", return_value=None)
 @patch("vibe3.commands.flow_status.FlowService")
 def test_flow_show_timeline_when_registered(
@@ -78,7 +78,7 @@ def test_flow_show_timeline_when_registered(
 
 
 @patch("vibe3.commands.flow_status.render_flow_timeline")
-@patch("vibe3.services.flow_status_resolver.FlowStatusResolver")
+@patch("vibe3.services.FlowStatusResolver")
 @patch("vibe3.commands.flow_status.find_parent_branch", return_value=None)
 @patch("vibe3.commands.flow_status.FlowService")
 def test_flow_show_numeric_issue_resolves_branch(

--- a/tests/vibe3/commands/test_flow_status.py
+++ b/tests/vibe3/commands/test_flow_status.py
@@ -30,9 +30,7 @@ def test_flow_show_format_json() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -69,9 +67,7 @@ def test_flow_show_format_yaml() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -208,9 +204,7 @@ def test_flow_show_default_format() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:

--- a/tests/vibe3/commands/test_flow_status_remote_timeline.py
+++ b/tests/vibe3/commands/test_flow_status_remote_timeline.py
@@ -42,9 +42,7 @@ def test_remote_no_local_db_uses_remote_timeline() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -108,9 +106,7 @@ def test_remote_ignores_stale_local_events() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -169,9 +165,7 @@ def test_non_remote_uses_local_events() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -244,9 +238,7 @@ def test_remote_json_output_includes_timeline() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:
@@ -300,9 +292,7 @@ def test_remote_yaml_output_includes_timeline() -> None:
     )
 
     with patch("vibe3.commands.flow_status.FlowService") as mock_service_class:
-        with patch(
-            "vibe3.services.flow_status_resolver.FlowStatusResolver"
-        ) as mock_resolver_class:
+        with patch("vibe3.services.FlowStatusResolver") as mock_resolver_class:
             with patch(
                 "vibe3.commands.flow_status.FlowProjectionService"
             ) as mock_projection_class:

--- a/tests/vibe3/commands/test_inspect_base.py
+++ b/tests/vibe3/commands/test_inspect_base.py
@@ -22,7 +22,7 @@ def test_inspect_base_default_parent():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 with patch(
@@ -45,7 +45,7 @@ def test_inspect_base_custom_base_branch():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
 
@@ -72,7 +72,7 @@ def test_inspect_base_with_core_files():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 dag_mod = "vibe3.analysis.dag_service"
@@ -104,7 +104,7 @@ def test_inspect_base_json_output():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = []
                 dag_mod = "vibe3.analysis.dag_service"
@@ -150,7 +150,7 @@ def test_inspect_base_json_custom_branch():
         mock_git_client.return_value = mock_git
         with patch("vibe3.utils.git_helpers.get_current_branch") as mock_branch:
             mock_branch.return_value = "feature/test"
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = []
                 dag_mod = "vibe3.analysis.dag_service"
@@ -192,7 +192,7 @@ def test_inspect_base_uses_shared_base_resolver():
         with patch(
             "vibe3.utils.git_helpers.get_current_branch", return_value="feature/test"
         ):
-            with patch("vibe3.config.loader.get_config") as mock_config:
+            with patch("vibe3.config.get_config") as mock_config:
                 mock_config.return_value.review_scope.critical_paths = ["src/core/"]
                 mock_config.return_value.review_scope.public_api_paths = ["src/api/"]
                 with patch(

--- a/tests/vibe3/commands/test_internal.py
+++ b/tests/vibe3/commands/test_internal.py
@@ -167,9 +167,7 @@ def test_internal_bootstrap_dispatch() -> None:
         with patch("vibe3.clients.sqlite_client.SQLiteClient"):
             with patch("vibe3.clients.git_client.GitClient"):
                 with patch("vibe3.clients.github_client.GitHubClient") as github_cls:
-                    with patch(
-                        "vibe3.services.flow_orchestrator_service.FlowOrchestratorService"
-                    ) as service_cls:
+                    with patch("vibe3.services.FlowOrchestratorService") as service_cls:
                         github = MagicMock()
                         github.view_issue.return_value = issue_payload
                         github_cls.return_value = github

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -64,9 +64,7 @@ class TestGovernanceScan:
 
     def test_governance_scan_does_not_call_on_heartbeat_tick(self):
         """Sync path (--no-async) calls service layer directly, not through facade."""
-        with patch(
-            "vibe3.roles.scan_service.dispatch_governance_execution"
-        ) as mock_service_run:
+        with patch("vibe3.roles.dispatch_governance_execution") as mock_service_run:
             with patch(
                 "vibe3.domain.orchestration_facade.OrchestrationFacade"
             ) as mock_facade:
@@ -112,9 +110,7 @@ class TestCombinedScan:
 class TestScanIntegration:
     def test_governance_scan_registers_handlers(self):
         """Sync governance scan calls service layer directly, not facade."""
-        with patch(
-            "vibe3.roles.scan_service.dispatch_governance_execution"
-        ) as mock_service:
+        with patch("vibe3.roles.dispatch_governance_execution") as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan(no_async=True)
@@ -123,10 +119,8 @@ class TestScanIntegration:
     def test_supervisor_scan_registers_handlers(self):
         """Supervisor scan calls service layer directly, not facade."""
         with (
-            patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
-            patch(
-                "vibe3.roles.scan_service.dispatch_supervisor_execution"
-            ) as mock_apply,
+            patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
+            patch("vibe3.roles.dispatch_supervisor_execution") as mock_apply,
         ):
             mock_fetch.return_value = (
                 1,
@@ -149,9 +143,7 @@ class TestScanIntegration:
 class TestFailedGateBlocking:
     def test_governance_scan_blocked_by_failed_gate(self):
         """Sync governance scan ignores FailedGate (only for heartbeat)."""
-        with patch(
-            "vibe3.roles.scan_service.dispatch_governance_execution"
-        ) as mock_service:
+        with patch("vibe3.roles.dispatch_governance_execution") as mock_service:
             from vibe3.commands.scan import _run_governance_scan
 
             _run_governance_scan(no_async=True)
@@ -159,9 +151,7 @@ class TestFailedGateBlocking:
 
     def test_supervisor_scan_blocked_by_failed_gate(self):
         """Manual supervisor scan ignores FailedGate (only for heartbeat)."""
-        with patch(
-            "vibe3.roles.scan_service.fetch_supervisor_candidates"
-        ) as mock_fetch:
+        with patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch:
             mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_supervisor_scan
@@ -173,11 +163,9 @@ class TestFailedGateBlocking:
     async def test_combined_scan_blocked_by_failed_gate(self):
         """Combined scan bypasses FailedGate for both governance and supervisor."""
         with (
-            patch(
-                "vibe3.roles.scan_service.dispatch_governance_execution"
-            ) as mock_governance,
-            patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
-            patch("vibe3.roles.scan_service.dispatch_supervisor_execution"),
+            patch("vibe3.roles.dispatch_governance_execution") as mock_governance,
+            patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
+            patch("vibe3.roles.dispatch_supervisor_execution"),
         ):
             mock_fetch.return_value = (0, [])
 
@@ -191,8 +179,8 @@ class TestFailedGateBlocking:
 def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
     """Manual supervisor scan fetches candidates and dispatches each."""
     with (
-        patch("vibe3.roles.scan_service.fetch_supervisor_candidates") as mock_fetch,
-        patch("vibe3.roles.scan_service.dispatch_supervisor_execution") as mock_apply,
+        patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
+        patch("vibe3.roles.dispatch_supervisor_execution") as mock_apply,
     ):
         mock_fetch.return_value = (
             2,


### PR DESCRIPTION
Closes #2444

## Summary

Replace all deep cross-module imports in `src/vibe3/commands/*.py` with top-level public API imports. The change is mechanical: `from vibe3.<module>.<submodule> import <symbol>` → `from vibe3.<module> import <symbol>`.

### Changes
- **54 import lines** updated across **21 command files**
- **28 test patch paths** updated in **6 test files** (lazy import caching breaks submodule-level mock patches)
- **1 ancillary fix**: `roles/__init__.py` `__getattr__` return type `object`→`Any` (mypy compatibility with lazy imports)

### Files affected
- `src/vibe3/commands/*.py` (all 21 files)
- `src/vibe3/roles/__init__.py` (type annotation fix)
- `tests/vibe3/commands/test_*.py` (6 test files)

### Verification
- ✅ All tests pass (403/404, 1 pre-existing env-dependent failure)
- ✅ mypy: 0 errors
- ✅ ruff: 0 errors
- ✅ black: clean
- ✅ Modularity API compliance: passed
- ✅ No deep imports remain in commands/

## Test plan
- `uv run pytest tests/vibe3/commands/ -q`
- `uv run mypy src/vibe3/commands/`
- `rg 'from vibe3\\.(services|clients|config|roles)\\.' src/vibe3/commands/` (should return no results)

---

## Contributors

claude/opus
