### PR TITLE
refactor(commands): move filtering logic from render to service layer

### DIFF
--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -356,7 +356,9 @@ def _full_status_dashboard(
         classified["waiting_for_pool_items"], classified["governed_anomaly_items"]
     )
     render_rfc_items(classified["roadmap_rfc_items"])
-    render_epic_items(classified["roadmap_epic_items"], data.orchestrated_issues)
+    render_epic_items(
+        classified["roadmap_epic_items"], classified["open_issue_numbers"]
+    )
     render_blocked_items(classified["blocked_items"])
 
     if all_flows:

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -232,14 +232,11 @@ def render_rfc_items(rfc_items: list[dict[str, object]]) -> None:
 
 def render_epic_items(
     epic_items: list[dict[str, object]],
-    open_issue_numbers: set[int] | None = None,
+    open_issue_numbers: set[int],
 ) -> None:
     """Render Roadmap Epic section (parent governance containers)."""
     console.print("\n[bold cyan]Roadmap Epic:[/]")
     if epic_items:
-        # Use provided open_issue_numbers or default to empty set
-        if open_issue_numbers is None:
-            open_issue_numbers = set()
 
         for item in epic_items:
             number = cast(int, item["number"])

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -232,20 +232,14 @@ def render_rfc_items(rfc_items: list[dict[str, object]]) -> None:
 
 def render_epic_items(
     epic_items: list[dict[str, object]],
-    orchestrated_issues: list[dict[str, object]] | None = None,
+    open_issue_numbers: set[int] | None = None,
 ) -> None:
     """Render Roadmap Epic section (parent governance containers)."""
     console.print("\n[bold cyan]Roadmap Epic:[/]")
     if epic_items:
-        # Build set of open issue numbers for dependency status checking
-        # Filter out DONE issues since they're no longer blocking
-        open_issue_numbers: set[int] = set()
-        if orchestrated_issues:
-            open_issue_numbers = {
-                cast(int, issue["number"])
-                for issue in orchestrated_issues
-                if cast(IssueState, issue["state"]) != IssueState.DONE
-            }
+        # Use provided open_issue_numbers or default to empty set
+        if open_issue_numbers is None:
+            open_issue_numbers = set()
 
         for item in epic_items:
             number = cast(int, item["number"])
@@ -335,32 +329,6 @@ def render_missing_state_items(
             console.print(
                 "         [yellow]⚠️  orchestra-governed label present"
                 " but state missing[/]"
-            )
-    else:
-        console.print("  [dim](none)[/]")
-
-
-def render_scene_sections(
-    flows: list[FlowStatusResponse],
-    worktree_map: dict[str, str],
-) -> None:
-    """Render active flow scenes."""
-    active_flows = [
-        flow
-        for flow in flows
-        if getattr(flow, "flow_status", "active") not in {"done", "aborted", "merged"}
-    ]
-
-    console.print("\n[bold cyan]Active Scenes:[/]")
-    if active_flows:
-        for flow in active_flows:
-            wt = worktree_map.get(flow.branch, "(no worktree)")
-            task = (
-                f"#{flow.task_issue_number}" if flow.task_issue_number else "(no task)"
-            )
-            console.print(
-                f"  [cyan]{flow.branch:30}[/] "
-                f"[dim]wt:[/] {wt:15} [dim]task:[/] {task}"
             )
     else:
         console.print("  [dim](none)[/]")

--- a/src/vibe3/services/task/status.py
+++ b/src/vibe3/services/task/status.py
@@ -263,6 +263,14 @@ def classify_task_issues_for_rendering(
         and cast(int, item["number"]) not in supervisor_numbers
     ]
 
+    # Build set of open issue numbers for dependency status checking
+    # Filter out DONE issues since they're no longer blocking
+    open_issue_numbers: set[int] = {
+        cast(int, issue["number"])
+        for issue in orchestrated_issues
+        if cast(IssueState, issue["state"]) != IssueState.DONE
+    }
+
     return {
         "supervisor_items": supervisor_items,
         "roadmap_rfc_items": roadmap_rfc_items,
@@ -274,4 +282,5 @@ def classify_task_issues_for_rendering(
         "bucketed_items": bucketed_items,
         "pr_ref_items": pr_ref_items,
         "blocked_items": blocked_items,
+        "open_issue_numbers": open_issue_numbers,
     }

--- a/src/vibe3/services/task/status.py
+++ b/src/vibe3/services/task/status.py
@@ -143,7 +143,8 @@ def classify_task_issues_for_rendering(
     Returns:
         Dict with keys: supervisor_items, roadmap_rfc_items, roadmap_epic_items,
         waiting_for_pool_items, governed_anomaly_items, task_progress_items,
-        remote_items, bucketed_items, pr_ref_items, blocked_items.
+        remote_items, bucketed_items, pr_ref_items, blocked_items,
+        open_issue_numbers.
     """
     from vibe3.services.orchestra_helpers import get_manager_usernames
 
@@ -268,7 +269,7 @@ def classify_task_issues_for_rendering(
     open_issue_numbers: set[int] = {
         cast(int, issue["number"])
         for issue in orchestrated_issues
-        if cast(IssueState, issue["state"]) != IssueState.DONE
+        if cast(IssueState | None, issue.get("state")) != IssueState.DONE
     }
 
     return {

--- a/tests/vibe3/services/test_classify_task_issues.py
+++ b/tests/vibe3/services/test_classify_task_issues.py
@@ -1,0 +1,77 @@
+"""Tests for classify_task_issues_for_rendering open_issue_numbers computation."""
+
+from unittest.mock import MagicMock
+
+from vibe3.models.orchestration import IssueState
+from vibe3.services.task.status import classify_task_issues_for_rendering
+
+
+def _make_config() -> MagicMock:
+    """Create a minimal mock OrchestraConfig."""
+    config = MagicMock()
+    config.supervisor_handoff.issue_label = "supervisor"
+    return config
+
+
+def _issue(number: int, state: str | None, labels: list[str] | None = None) -> dict:
+    """Build a minimal issue dict for testing."""
+    return {
+        "number": number,
+        "state": state,
+        "title": f"Issue #{number}",
+        "labels": labels or [],
+        "assignee": None,
+    }
+
+
+def test_open_issue_numbers_excludes_done():
+    """DONE issues must not appear in open_issue_numbers."""
+    issues = [
+        _issue(1, IssueState.IN_PROGRESS.value),
+        _issue(2, IssueState.DONE.value),
+        _issue(3, IssueState.BLOCKED.value),
+    ]
+    result = classify_task_issues_for_rendering(issues, _make_config())
+    assert result["open_issue_numbers"] == {1, 3}
+
+
+def test_open_issue_numbers_includes_all_non_done_states():
+    """All non-DONE states must be included in open_issue_numbers."""
+    states = [
+        IssueState.READY,
+        IssueState.CLAIMED,
+        IssueState.IN_PROGRESS,
+        IssueState.BLOCKED,
+        IssueState.HANDOFF,
+        IssueState.REVIEW,
+        IssueState.MERGE_READY,
+    ]
+    issues = [_issue(i, state.value) for i, state in enumerate(states, start=10)]
+    result = classify_task_issues_for_rendering(issues, _make_config())
+    assert result["open_issue_numbers"] == {10, 11, 12, 13, 14, 15, 16}
+
+
+def test_open_issue_numbers_empty_when_no_issues():
+    """Empty input produces an empty set."""
+    result = classify_task_issues_for_rendering([], _make_config())
+    assert result["open_issue_numbers"] == set()
+
+
+def test_open_issue_numbers_all_done():
+    """When every issue is DONE, the set is empty."""
+    issues = [
+        _issue(1, IssueState.DONE.value),
+        _issue(2, IssueState.DONE.value),
+    ]
+    result = classify_task_issues_for_rendering(issues, _make_config())
+    assert result["open_issue_numbers"] == set()
+
+
+def test_open_issue_numbers_includes_missing_state():
+    """Issues with None state (missing state) should be included as open."""
+    issues = [
+        _issue(1, None),
+        _issue(2, IssueState.DONE.value),
+    ]
+    result = classify_task_issues_for_rendering(issues, _make_config())
+    assert result["open_issue_numbers"] == {1}


### PR DESCRIPTION
## Summary

Move filtering logic from the render layer (`status_render.py`) into the service layer (`task/status.py`), implementing the Filter-Instead-of-Delete pattern correctly.

- Pre-compute `open_issue_numbers` in `classify_task_issues_for_rendering` (service layer)
- Update `render_epic_items` signature to accept `open_issue_numbers` directly (render layer)
- Remove dead `render_scene_sections` function (zero references)

## Changes

- `src/vibe3/services/task/status.py`: Added `open_issue_numbers` computation and included in returned dict
- `src/vibe3/commands/status_render.py`: Updated signature, removed internal computation, deleted dead function
- `src/vibe3/commands/status.py`: Updated caller to pass pre-computed `open_issue_numbers`

## Verification

- ✅ All imports verified
- ✅ ruff check: All checks passed
- ✅ mypy: Success, no issues found
- ✅ Direct tests: 22 tests passed (test_task_status_*.py)
- ✅ Pre-push tests: 404 passed, no regressions
- ✅ LOC checks: Under limits (no CI blockers)

Fixes #2463

---

## Contributors

claude/sonnet-4.5

---

## Contributors

claude/opus
