### PR TITLE
refactor(config): extract duplicate variable expansion logic to utils.py

### DIFF
--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -1,7 +1,6 @@
 """Configuration loader for Vibe Center."""
 
 import os
-import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,59 +13,10 @@ from vibe3.config.settings import VibeConfig, _vibe3_config_root
 def _expand_variables(
     config: dict[str, Any], context: dict[str, Any] | None = None
 ) -> dict[str, Any]:
-    """Expand variable references in configuration values.
+    """Expand variable references in configuration values."""
+    from vibe3.config.utils import expand_config_variables
 
-    Supports ${path.to.value} syntax for referencing other config values.
-    Performs iterative expansion to handle nested references with cycle detection.
-    Also expands ~ to home directory in path values.
-    """
-    from pathlib import Path
-
-    if context is None:
-        context = config
-
-    result: dict[str, Any] = {}
-
-    for key, value in config.items():
-        if isinstance(value, str):
-            # Expand ${...} variable references iteratively
-            expanded = value
-            max_iterations = 10  # Prevent infinite loops
-            for _ in range(max_iterations):
-                pattern = r"\$\{([^}]+)\}"
-
-                def replace_var(match: re.Match[str]) -> str:
-                    var_path = match.group(1)
-                    # Navigate to referenced value
-                    current: Any = context
-                    for part in var_path.split("."):
-                        if isinstance(current, dict) and part in current:
-                            current = current[part]
-                        else:
-                            # Variable not found, keep original reference
-                            return match.group(0)
-                    return (
-                        str(current)
-                        if not isinstance(current, dict)
-                        else match.group(0)
-                    )
-
-                new_expanded = re.sub(pattern, replace_var, expanded)
-                if new_expanded == expanded:
-                    break  # No more changes, reached fixpoint
-                expanded = new_expanded
-
-            # Expand ~ to home directory for path values
-            if expanded.startswith("~") or "/~" in expanded:
-                expanded = str(Path(expanded).expanduser())
-
-            result[key] = expanded
-        elif isinstance(value, dict):
-            result[key] = _expand_variables(value, context)
-        else:
-            result[key] = value
-
-    return result
+    return expand_config_variables(config, context)
 
 
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -425,55 +425,10 @@ class VibeConfig(BaseModel):
 
     @classmethod
     def _expand_config_variables(cls, config: dict) -> dict:
-        """Expand variable references like ${paths.policies_root} in config values.
+        """Expand variable references like ${paths.policies_root} in config values."""
+        from vibe3.config.utils import expand_config_variables
 
-        Performs iterative expansion to handle nested references with cycle detection.
-        Also expands ~ to home directory in path values.
-        """
-        import re
-        from pathlib import Path
-        from typing import Any, cast
-
-        def expand_value(value: Any, context: dict[str, Any]) -> Any:
-            if isinstance(value, str):
-                # Expand ${...} variable references iteratively
-                expanded = value
-                max_iterations = 10  # Prevent infinite loops
-                for _ in range(max_iterations):
-                    pattern = r"\$\{([^}]+)\}"
-
-                    def replace_var(match: re.Match[str]) -> str:
-                        var_path = match.group(1)
-                        # Navigate to referenced value
-                        current: Any = context
-                        for part in var_path.split("."):
-                            if isinstance(current, dict) and part in current:
-                                current = current[part]
-                            else:
-                                # Variable not found, keep original reference
-                                return match.group(0)
-                        return (
-                            str(current)
-                            if not isinstance(current, dict)
-                            else match.group(0)
-                        )
-
-                    new_expanded = re.sub(pattern, replace_var, expanded)
-                    if new_expanded == expanded:
-                        break  # No more changes, reached fixpoint
-                    expanded = new_expanded
-
-                # Expand ~ to home directory for path values
-                if expanded.startswith("~") or "/~" in expanded:
-                    expanded = str(Path(expanded).expanduser())
-
-                return expanded
-            elif isinstance(value, dict):
-                return {k: expand_value(v, context) for k, v in value.items()}
-            else:
-                return value
-
-        return cast(dict, expand_value(config, config))
+        return expand_config_variables(config)
 
     @classmethod
     def from_yaml(cls, config_path: Path) -> "VibeConfig":

--- a/src/vibe3/config/utils.py
+++ b/src/vibe3/config/utils.py
@@ -1,8 +1,11 @@
-"""Shared utilities for configuration processing."""
+"""Variable expansion utilities for YAML configuration dictionaries."""
 
 import re
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
+
+_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+_MAX_EXPANSION_ITERATIONS = 10  # Prevent infinite loops from circular ${} references
 
 
 def expand_config_variables(
@@ -25,36 +28,25 @@ def expand_config_variables(
     if context is None:
         context = config
 
+    def replace_var(match: re.Match[str]) -> str:
+        var_path = match.group(1)
+        current: Any = context
+        for part in var_path.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                return match.group(0)
+        return str(current) if not isinstance(current, dict) else match.group(0)
+
     def expand_value(value: Any, ctx: dict[str, Any]) -> Any:
         if isinstance(value, str):
-            # Expand ${...} variable references iteratively
             expanded = value
-            max_iterations = 10  # Prevent infinite loops
-            for _ in range(max_iterations):
-                pattern = r"\$\{([^}]+)\}"
-
-                def replace_var(match: re.Match[str]) -> str:
-                    var_path = match.group(1)
-                    # Navigate to referenced value
-                    current: Any = ctx
-                    for part in var_path.split("."):
-                        if isinstance(current, dict) and part in current:
-                            current = current[part]
-                        else:
-                            # Variable not found, keep original reference
-                            return match.group(0)
-                    return (
-                        str(current)
-                        if not isinstance(current, dict)
-                        else match.group(0)
-                    )
-
-                new_expanded = re.sub(pattern, replace_var, expanded)
+            for _ in range(_MAX_EXPANSION_ITERATIONS):
+                new_expanded = _VAR_PATTERN.sub(replace_var, expanded)
                 if new_expanded == expanded:
-                    break  # No more changes, reached fixpoint
+                    break
                 expanded = new_expanded
 
-            # Expand ~ to home directory for path values
             if expanded.startswith("~") or "/~" in expanded:
                 expanded = str(Path(expanded).expanduser())
 
@@ -64,4 +56,4 @@ def expand_config_variables(
         else:
             return value
 
-    return cast(dict, expand_value(config, context))
+    return expand_value(config, context)  # type: ignore[no-any-return]

--- a/src/vibe3/config/utils.py
+++ b/src/vibe3/config/utils.py
@@ -1,0 +1,67 @@
+"""Shared utilities for configuration processing."""
+
+import re
+from pathlib import Path
+from typing import Any, cast
+
+
+def expand_config_variables(
+    config: dict[str, Any], context: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Expand variable references like ${paths.policies_root} in config values.
+
+    Supports ${path.to.value} syntax for referencing other config values.
+    Performs iterative expansion to handle nested references with cycle detection.
+    Also expands ~ to home directory in path values.
+
+    Args:
+        config: Configuration dictionary to expand.
+        context: Optional context dictionary for variable resolution.
+                 If None, uses config itself as context.
+
+    Returns:
+        Expanded configuration dictionary.
+    """
+    if context is None:
+        context = config
+
+    def expand_value(value: Any, ctx: dict[str, Any]) -> Any:
+        if isinstance(value, str):
+            # Expand ${...} variable references iteratively
+            expanded = value
+            max_iterations = 10  # Prevent infinite loops
+            for _ in range(max_iterations):
+                pattern = r"\$\{([^}]+)\}"
+
+                def replace_var(match: re.Match[str]) -> str:
+                    var_path = match.group(1)
+                    # Navigate to referenced value
+                    current: Any = ctx
+                    for part in var_path.split("."):
+                        if isinstance(current, dict) and part in current:
+                            current = current[part]
+                        else:
+                            # Variable not found, keep original reference
+                            return match.group(0)
+                    return (
+                        str(current)
+                        if not isinstance(current, dict)
+                        else match.group(0)
+                    )
+
+                new_expanded = re.sub(pattern, replace_var, expanded)
+                if new_expanded == expanded:
+                    break  # No more changes, reached fixpoint
+                expanded = new_expanded
+
+            # Expand ~ to home directory for path values
+            if expanded.startswith("~") or "/~" in expanded:
+                expanded = str(Path(expanded).expanduser())
+
+            return expanded
+        elif isinstance(value, dict):
+            return {k: expand_value(v, ctx) for k, v in value.items()}
+        else:
+            return value
+
+    return cast(dict, expand_value(config, context))

--- a/tests/vibe3/config/test_loader.py
+++ b/tests/vibe3/config/test_loader.py
@@ -19,64 +19,14 @@ from vibe3.exceptions import ConfigError
 
 
 class TestExpandVariables:
-    """Tests for _expand_variables pure function."""
+    """Smoke tests: _expand_variables delegates to expand_config_variables."""
 
     def test_expand_variables_simple(self) -> None:
         config = {"paths": {"root": "/app"}, "file": "${paths.root}/data"}
         result = _expand_variables(config)
         assert result["file"] == "/app/data"
 
-    def test_expand_variables_nested(self) -> None:
-        config = {"a": {"b": "value"}, "c": "${a.b}_suffix"}
-        result = _expand_variables(config)
-        assert result["c"] == "value_suffix"
-
-    def test_expand_variables_chained(self) -> None:
-        """A refs B, B refs C — full chain resolves."""
-        config = {"base": "/tmp", "mid": "${base}/sub", "final": "${mid}/file.txt"}
-        result = _expand_variables(config)
-        assert result["final"] == "/tmp/sub/file.txt"
-
-    def test_expand_variables_cycle(self) -> None:
-        """Circular references terminate without hanging; both keys present."""
-        config = {"a": "${b}", "b": "${a}"}
-        result = _expand_variables(config)
-        assert "a" in result
-        assert "b" in result
-        # Both should be unresolved since they reference each other
-
-    def test_expand_variables_missing(self) -> None:
-        """Unresolvable references keep original string."""
-        config = {"val": "${paths.missing}"}
-        result = _expand_variables(config)
-        assert result["val"] == "${paths.missing}"
-
-    def test_expand_variables_non_string(self) -> None:
-        """Int and list values passed through unchanged."""
-        config = {"count": 42, "items": [1, 2, 3]}
-        result = _expand_variables(config)
-        assert result["count"] == 42
-        assert result["items"] == [1, 2, 3]
-
-    def test_expand_variables_dict_recursion(self) -> None:
-        """Nested dict with var refs: inner and outer both expanded."""
-        config = {
-            "root": "/app",
-            "nested": {"path": "${root}/inner", "ref": "${nested.path}/deep"},
-        }
-        result = _expand_variables(config)
-        assert result["nested"]["path"] == "/app/inner"
-        assert result["nested"]["ref"] == "/app/inner/deep"
-
-    def test_expand_variables_tilde_expansion(self) -> None:
-        """~ prefix expanded via Path.expanduser(), but /~/ embedded is not."""
-        config = {"home_path": "~/data", "embedded": "/tmp/~/data"}
-        result = _expand_variables(config)
-        assert result["home_path"] == str(Path("~/data").expanduser())
-        assert result["embedded"] == str(Path("/tmp/~/data").expanduser())
-
     def test_expand_variables_with_context(self) -> None:
-        """Explicit context param resolves against context, not config root."""
         config = {"val": "${external.key}"}
         context = {"external": {"key": "resolved"}}
         result = _expand_variables(config, context=context)

--- a/tests/vibe3/config/test_settings.py
+++ b/tests/vibe3/config/test_settings.py
@@ -10,67 +10,19 @@ from vibe3.config.settings import VibeConfig
 
 
 class TestExpandConfigVariables:
-    """Tests for VibeConfig._expand_config_variables classmethod."""
+    """Smoke tests: _expand_config_variables delegates to expand_config_variables."""
 
     def test_expand_config_variables_simple(self) -> None:
         config = {"paths": {"root": "/app"}, "file": "${paths.root}/data"}
         result = VibeConfig._expand_config_variables(config)
         assert result["file"] == "/app/data"
 
-    def test_expand_config_variables_nested(self) -> None:
-        """Chained references: A refs B, B refs C — full chain resolves."""
-        config = {"base": "/tmp", "mid": "${base}/sub", "final": "${mid}/file.txt"}
-        result = VibeConfig._expand_config_variables(config)
-        assert result["final"] == "/tmp/sub/file.txt"
-
     def test_expand_config_variables_cycle(self) -> None:
         """Circular references terminate without hanging."""
         config = {"a": "${b}", "b": "${a}"}
         result = VibeConfig._expand_config_variables(config)
-        # Should not hang; both keys should still be present
-        assert "a" in result
-        assert "b" in result
-
-    def test_expand_config_variables_missing(self) -> None:
-        """Unresolvable references keep original string."""
-        config = {"val": "${nonexistent.key}"}
-        result = VibeConfig._expand_config_variables(config)
-        assert result["val"] == "${nonexistent.key}"
-
-    def test_expand_config_variables_non_string(self) -> None:
-        """Int, bool, and list values passed through unchanged."""
-        config = {"count": 42, "enabled": True, "items": [1, 2, 3]}
-        result = VibeConfig._expand_config_variables(config)
-        assert result["count"] == 42
-        assert result["enabled"] is True
-        assert result["items"] == [1, 2, 3]
-
-    def test_expand_config_variables_tilde(self) -> None:
-        """~ prefix expanded via Path.expanduser()."""
-        config = {"home_path": "~/.vibe"}
-        result = VibeConfig._expand_config_variables(config)
-        assert result["home_path"] == str(Path("~/.vibe").expanduser())
-
-    def test_expand_config_variables_deeply_nested_dict(self) -> None:
-        """Variable references inside deeply nested dicts resolve correctly."""
-        config = {
-            "paths": {"root": "/app"},
-            "level1": {
-                "level2": {
-                    "value": "${paths.root}/deep/file.txt",
-                }
-            },
-        }
-        result = VibeConfig._expand_config_variables(config)
-        assert result["level1"]["level2"]["value"] == "/app/deep/file.txt"
-
-    def test_expand_config_variables_dict_ref_not_string(self) -> None:
-        """Reference to a dict value keeps original reference (not a dict)."""
-        config = {"section": {"a": 1}, "ref": "${section}"}
-        result = VibeConfig._expand_config_variables(config)
-        # Resolves to the dict itself, which gets str()-ed? No —
-        # the code returns match.group(0) when current is a dict
-        assert result["ref"] == "${section}"
+        assert result["a"] == "${b}"
+        assert result["b"] == "${a}"
 
 
 class TestLoadSupplementaryPromptsRoot:

--- a/tests/vibe3/config/test_utils.py
+++ b/tests/vibe3/config/test_utils.py
@@ -29,13 +29,11 @@ class TestExpandConfigVariables:
         assert result["final"] == "/tmp/sub/file.txt"
 
     def test_expand_cycle_detection(self) -> None:
-        """Circular references terminate without hanging; both keys present."""
+        """Circular references terminate without hanging; values stay unresolved."""
         config = {"a": "${b}", "b": "${a}"}
         result = expand_config_variables(config)
-        # Should not hang; both keys should still be present
-        assert "a" in result
-        assert "b" in result
-        # Both should be unresolved since they reference each other
+        assert result["a"] == "${b}"
+        assert result["b"] == "${a}"
 
     def test_expand_missing_variable(self) -> None:
         """Unresolvable references keep original string."""

--- a/tests/vibe3/config/test_utils.py
+++ b/tests/vibe3/config/test_utils.py
@@ -1,0 +1,118 @@
+"""Tests for shared expand_config_variables utility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibe3.config.utils import expand_config_variables
+
+
+class TestExpandConfigVariables:
+    """Tests for expand_config_variables shared function."""
+
+    def test_expand_simple(self) -> None:
+        """Simple variable reference resolves correctly."""
+        config = {"paths": {"root": "/app"}, "file": "${paths.root}/data"}
+        result = expand_config_variables(config)
+        assert result["file"] == "/app/data"
+
+    def test_expand_nested_path(self) -> None:
+        """Nested path references resolve correctly."""
+        config = {"a": {"b": "value"}, "c": "${a.b}_suffix"}
+        result = expand_config_variables(config)
+        assert result["c"] == "value_suffix"
+
+    def test_expand_chained_references(self) -> None:
+        """Chained references: A refs B, B refs C — full chain resolves."""
+        config = {"base": "/tmp", "mid": "${base}/sub", "final": "${mid}/file.txt"}
+        result = expand_config_variables(config)
+        assert result["final"] == "/tmp/sub/file.txt"
+
+    def test_expand_cycle_detection(self) -> None:
+        """Circular references terminate without hanging; both keys present."""
+        config = {"a": "${b}", "b": "${a}"}
+        result = expand_config_variables(config)
+        # Should not hang; both keys should still be present
+        assert "a" in result
+        assert "b" in result
+        # Both should be unresolved since they reference each other
+
+    def test_expand_missing_variable(self) -> None:
+        """Unresolvable references keep original string."""
+        config = {"val": "${nonexistent.key}"}
+        result = expand_config_variables(config)
+        assert result["val"] == "${nonexistent.key}"
+
+    def test_expand_non_string_passthrough(self) -> None:
+        """Int, bool, and list values passed through unchanged."""
+        config = {"count": 42, "enabled": True, "items": [1, 2, 3]}
+        result = expand_config_variables(config)
+        assert result["count"] == 42
+        assert result["enabled"] is True
+        assert result["items"] == [1, 2, 3]
+
+    def test_expand_dict_recursion(self) -> None:
+        """Nested dict with var refs: inner and outer both expanded."""
+        config = {
+            "root": "/app",
+            "nested": {"path": "${root}/inner", "ref": "${nested.path}/deep"},
+        }
+        result = expand_config_variables(config)
+        assert result["nested"]["path"] == "/app/inner"
+        assert result["nested"]["ref"] == "/app/inner/deep"
+
+    def test_expand_tilde_home_directory(self) -> None:
+        """~ prefix expanded via Path.expanduser()."""
+        config = {"home_path": "~/.vibe"}
+        result = expand_config_variables(config)
+        assert result["home_path"] == str(Path("~/.vibe").expanduser())
+
+    def test_expand_tilde_embedded_in_path(self) -> None:
+        """Embedded /~/ in path also expanded."""
+        config = {"embedded": "/tmp/~/data"}
+        result = expand_config_variables(config)
+        assert result["embedded"] == str(Path("/tmp/~/data").expanduser())
+
+    def test_expand_deeply_nested_dict(self) -> None:
+        """Variable references inside deeply nested dicts resolve correctly."""
+        config = {
+            "paths": {"root": "/app"},
+            "level1": {
+                "level2": {
+                    "value": "${paths.root}/deep/file.txt",
+                }
+            },
+        }
+        result = expand_config_variables(config)
+        assert result["level1"]["level2"]["value"] == "/app/deep/file.txt"
+
+    def test_expand_dict_reference_keeps_original(self) -> None:
+        """Reference to a dict value keeps original reference (not a dict)."""
+        config = {"section": {"a": 1}, "ref": "${section}"}
+        result = expand_config_variables(config)
+        # Resolves to the dict itself, which gets str()-ed? No —
+        # the code returns match.group(0) when current is a dict
+        assert result["ref"] == "${section}"
+
+    def test_expand_with_custom_context(self) -> None:
+        """Explicit context param resolves against context, not config root."""
+        config = {"val": "${external.key}"}
+        context = {"external": {"key": "resolved"}}
+        result = expand_config_variables(config, context=context)
+        assert result["val"] == "resolved"
+
+    def test_expand_context_defaults_to_config(self) -> None:
+        """When context is None, config is used as resolution context."""
+        config = {"base": "/root", "derived": "${base}/derived"}
+        result = expand_config_variables(config)
+        assert result["derived"] == "/root/derived"
+
+    def test_expand_multiple_references_in_one_value(self) -> None:
+        """Multiple ${...} references in a single string all resolve."""
+        config = {
+            "base": "/app",
+            "sub": "data",
+            "path": "${base}/${sub}/file.txt",
+        }
+        result = expand_config_variables(config)
+        assert result["path"] == "/app/data/file.txt"


### PR DESCRIPTION
## Summary

Extract the duplicated `` expansion and `~` tilde expansion logic from `settings.py` and `loader.py` into a new shared function in `src/vibe3/config/utils.py`.

## Changes

- **New**: `src/vibe3/config/utils.py` - shared `expand_config_variables()` function
- **Modified**: `src/vibe3/config/settings.py` - delegates to utils.py
- **Modified**: `src/vibe3/config/loader.py` - delegates to utils.py  
- **New**: `tests/vibe3/config/test_utils.py` - 14 comprehensive tests

Both public APIs preserved:
- `VibeConfig._expand_config_variables(config)` - classmethod API
- `_expand_variables(config, context=None)` - function API

## Code Quality

- ✅ Eliminated ~100 lines of duplicate code
- ✅ Single source of truth for variable expansion
- ✅ No API changes, all callers unchanged
- ✅ Zero regressions

## Test Results

- **New tests**: 14 passed ✅
- **Existing API tests**: 44 passed ✅  
- **Full config suite**: 171 passed ✅
- **Type check**: Success ✅
- **Lint check**: All checks passed ✅

## Verification

All pre-commit hooks passed:
- Black (Python formatter)
- Ruff (Python linter)
- MyPy (Python type checker)
- ShellCheck (bash scripts)
- Custom lint hooks

Closes #2478

---

## Contributors

claude/opus
