### PR TITLE
feat(dispatch): add simple test task auto-routing to supervisor/apply

### DIFF
--- a/src/vibe3/domain/handlers/issue_state_dispatch.py
+++ b/src/vibe3/domain/handlers/issue_state_dispatch.py
@@ -160,6 +160,11 @@ def handle_manager_dispatch_intent(
             _block_for_noop("Issue info is None, cannot dispatch manager role")
             return
 
+        # Phase 2: diff-based simple test task routing
+        if _should_reroute_to_supervisor(issue_info, ctx.github_client, ctx.config):
+            _reroute_to_supervisor(issue_info, ctx.github_client, ctx.config)
+            return
+
         try:
             request = await loop.run_in_executor(
                 None,
@@ -253,3 +258,122 @@ def handle_manager_dispatch_intent(
             with get_store() as store:
                 dispatch_context = build_dispatch_context(config, store)
         asyncio.run(_do_dispatch(dispatch_context))
+
+
+def _should_reroute_to_supervisor(
+    issue: IssueInfo,
+    github: "GitHubClient",
+    config: "OrchestraConfig",
+) -> bool:
+    """Check if issue has a simple test diff that can be rerouted.
+
+    Includes flow state check to ensure safe reroute:
+    - Only reroute when flow is in safe states (ready/claimed/blocked)
+    - Never reroute when in_progress or handoff with progress
+
+    Args:
+        issue: Issue information
+        github: GitHub client for PR and flow state queries
+        config: Orchestra config for repo info
+
+    Returns:
+        True if issue should be rerouted to supervisor, False otherwise
+    """
+    from vibe3.services.label_service import LabelService
+    from vibe3.services.simple_test_task_assessor import (
+        MAX_FILES,
+        MAX_LINES,
+        is_simple_test_from_diff,
+    )
+
+    # Check issue state label first - only reroute in safe states
+    label_service = LabelService(repo=config.repo)
+    issue_state = label_service.get_state(issue.number)
+
+    # Safe states: ready, claimed, or blocked (未开始执行的状态)
+    # Unsafe states: in_progress, handoff (已开始工作的状态)
+    safe_states = {IssueState.READY, IssueState.CLAIMED, IssueState.BLOCKED, None}
+    if issue_state not in safe_states:
+        state_val = issue_state.value if issue_state else "None"
+        logger.bind(
+            domain="issue_state_dispatch_handler",
+            issue_number=issue.number,
+            issue_state=issue_state.value if issue_state else None,
+        ).warning(f"Skipping reroute: issue in unsafe state '{state_val}'")
+        return False
+
+    # Find linked PRs for this issue's branch
+    branch = f"issue-{issue.number}"
+    prs = github.list_prs_for_branch(branch, repo=config.repo)
+    if not prs:
+        return False
+
+    pr = prs[0]
+    files = github.get_pr_files(pr.number)
+    diff = github.get_pr_diff(pr.number)
+
+    if not files or not diff:
+        return False
+
+    # Count additions/deletions from diff
+    additions = sum(1 for line in diff.split("\n") if line.startswith("+"))
+    deletions = sum(1 for line in diff.split("\n") if line.startswith("-"))
+
+    is_simple = is_simple_test_from_diff(files, additions, deletions)
+    if is_simple:
+        total_lines = additions + deletions
+        logger.bind(
+            domain="issue_state_dispatch_handler",
+            issue_number=issue.number,
+            pr_number=pr.number,
+            files=len(files),
+            lines=total_lines,
+        ).info(
+            f"Simple test task detected: {len(files)} files, "
+            f"{total_lines} lines (threshold: ≤{MAX_FILES} files, ≤{MAX_LINES} lines)"
+        )
+
+    return is_simple
+
+
+def _reroute_to_supervisor(
+    issue: IssueInfo,
+    github: "GitHubClient",
+    config: "OrchestraConfig",
+) -> None:
+    """Close current issue and create new one for supervisor/apply.
+
+    Args:
+        issue: Issue information
+        github: GitHub client for issue operations
+        config: Orchestra config for repo info
+    """
+    from vibe3.services.simple_test_task_assessor import MAX_FILES, MAX_LINES
+
+    # Close original with explanation
+    github.close_issue(
+        issue.number,
+        comment=(
+            "Closed: rerouted to supervisor/apply fast track "
+            "(simple test-only change detected)."
+        ),
+    )
+
+    # Create new issue with supervisor labels
+    new_number = github.create_issue(
+        title=f"[fast-track] {issue.title}",
+        body=(
+            f"Rerouted from #{issue.number} (simple test task auto-detection).\n\n"
+            f"Original issue: #{issue.number}\n"
+            f"Reason: test-only changes within complexity threshold "
+            f"(≤{MAX_FILES} files, ≤{MAX_LINES} lines)."
+        ),
+        labels=["supervisor", "state/handoff"],
+    )
+
+    if new_number:
+        logger.bind(
+            domain="issue_state_dispatch_handler",
+            original=issue.number,
+            new=new_number,
+        ).info(f"Rerouted #{issue.number} → #{new_number} (supervisor/apply)")

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -252,6 +252,15 @@ class OrchestrationFacade(ServiceBase):
             ).debug("Skipping governance scan (min interval not reached)")
             return
 
+        # Pre-scan: tag simple test tasks for supervisor routing
+        try:
+            self._tag_simple_test_tasks()
+        except Exception as exc:
+            logger.bind(domain="orchestration_facade").warning(
+                f"Simple test task pre-scan failed: {exc}"
+            )
+            # Non-fatal: continue with normal governance dispatch
+
         # Update timestamp when actually emitting event
         self._last_governance_started_at = time.monotonic()
 
@@ -340,3 +349,46 @@ class OrchestrationFacade(ServiceBase):
             publish(event)
 
         return (total_scanned, matched_count)
+
+    def _tag_simple_test_tasks(self) -> None:
+        """Tag simple test tasks with supervisor labels for fast-track routing.
+
+        Phase 1: Pre-scan before governance agent runs.
+        Identifies simple test tasks via metadata heuristics and tags them with
+        supervisor + state/handoff + orchestra-governed labels so they bypass
+        the full manager plan→run→review cycle.
+        """
+        from vibe3.clients import GhIssueLabelPort
+        from vibe3.services import OrchestraStatusService
+        from vibe3.services.simple_test_task_assessor import (
+            is_simple_test_task_from_metadata,
+        )
+
+        status_service = OrchestraStatusService(self._config)
+        snapshot = status_service.snapshot()
+        label_port = GhIssueLabelPort(repo=self._config.repo)
+
+        for entry in snapshot.active_issues:
+            # Skip already-governed issues
+            labels = label_port.get_issue_labels(entry.number)
+            if labels is None or "orchestra-governed" in labels:
+                continue
+
+            if not is_simple_test_task_from_metadata(entry.title, labels):
+                continue
+
+            # Tag for supervisor routing
+            for label in ("supervisor", "state/handoff", "orchestra-governed"):
+                label_port.add_issue_label(entry.number, label)
+
+            self._github.add_comment(
+                entry.number,
+                "[governance decide][simple-task-router] "
+                "Routed to supervisor/apply: issue title matches simple test task "
+                "heuristic. Will be handled via fast-track path.",
+            )
+
+            logger.bind(
+                domain="orchestration_facade",
+                issue_number=entry.number,
+            ).info(f"Tagged #{entry.number} as simple test task → supervisor/apply")

--- a/src/vibe3/services/__init__.py
+++ b/src/vibe3/services/__init__.py
@@ -115,6 +115,10 @@ if TYPE_CHECKING:
         sanitize_event_detail_paths,
     )
     from vibe3.services.signature_service import SignatureService
+    from vibe3.services.simple_test_task_assessor import (
+        is_simple_test_from_diff,
+        is_simple_test_task_from_metadata,
+    )
     from vibe3.services.spec_ref_service import SpecRefService
     from vibe3.services.status_query_service import (
         StatusQueryService,
@@ -221,6 +225,8 @@ __all__ = [
     "infer_resume_label",
     "is_auto_task_branch",
     "is_running_issue",
+    "is_simple_test_from_diff",
+    "is_simple_test_task_from_metadata",
     "load_issue_info",
     "normalize_assignees",
     "normalize_labels",
@@ -325,6 +331,8 @@ _SYMBOL_MODULES = {
     "infer_resume_label": "vibe3.services.flow_resume_resolver",
     "is_auto_task_branch": "vibe3.services.status_query_service",
     "is_running_issue": "vibe3.services.orchestra_status_service",
+    "is_simple_test_from_diff": "vibe3.services.simple_test_task_assessor",
+    "is_simple_test_task_from_metadata": "vibe3.services.simple_test_task_assessor",
     "load_issue_info": "vibe3.services.issue.context",
     "normalize_assignees": "vibe3.services.shared.labels",
     "normalize_labels": "vibe3.services.shared.labels",

--- a/src/vibe3/services/simple_test_task_assessor.py
+++ b/src/vibe3/services/simple_test_task_assessor.py
@@ -1,0 +1,95 @@
+"""Simple test task assessment service.
+
+Provides heuristic and diff-based assessment functions to identify simple test tasks
+that can be routed to the supervisor/apply fast track instead of the full
+manager plan→run→review cycle.
+"""
+
+from __future__ import annotations
+
+MAX_FILES = 5
+MAX_LINES = 100
+
+# Test file path patterns
+_TEST_PATTERNS = (
+    "tests/",
+    "test_",
+    "_test.py",
+    "conftest.py",
+)
+
+# Title keywords indicating test-only tasks
+_TEST_TITLE_KEYWORDS = (
+    "test",
+    "测试",
+    "flaky",
+    "coverage",
+    "mock",
+    "fixture",
+    "conftest",
+    "pytest",
+)
+
+
+def _is_test_file(filepath: str) -> bool:
+    """Check if file path matches test file patterns.
+
+    Args:
+        filepath: File path to check
+
+    Returns:
+        True if file path matches test patterns, False otherwise
+    """
+    return any(p in filepath for p in _TEST_PATTERNS)
+
+
+def is_simple_test_task_from_metadata(title: str, labels: list[str]) -> bool:
+    """Heuristic: is this issue likely a simple test task?
+
+    Conservative assessment based on issue metadata. Only returns True when:
+    - Title clearly indicates test-only work
+    - No labels suggest complexity
+
+    Args:
+        title: Issue title
+        labels: List of issue labels
+
+    Returns:
+        True if issue is likely a simple test task, False otherwise
+    """
+    title_lower = title.lower()
+
+    # Must have test-related keyword in title
+    if not any(kw in title_lower for kw in _TEST_TITLE_KEYWORDS):
+        return False
+
+    # Exclude if labels suggest complexity
+    complex_labels = {"roadmap/epic", "roadmap/rfc", "priority/0", "priority/1"}
+    if complex_labels & set(labels):
+        return False
+
+    return True
+
+
+def is_simple_test_from_diff(
+    changed_files: list[str],
+    additions: int,
+    deletions: int,
+) -> bool:
+    """Diff-based assessment: is this a simple test-only change?
+
+    Args:
+        changed_files: List of changed file paths
+        additions: Total lines added
+        deletions: Total lines deleted
+
+    Returns:
+        True if change is simple test-only, False otherwise
+    """
+    if not changed_files:
+        return False
+    if len(changed_files) > MAX_FILES:
+        return False
+    if (additions + deletions) > MAX_LINES:
+        return False
+    return all(_is_test_file(f) for f in changed_files)

--- a/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
+++ b/tests/vibe3/domain/handlers/test_issue_state_dispatch.py
@@ -287,6 +287,7 @@ class TestIssueStateDispatchHandler:
         mock_ctx.capacity.can_dispatch.return_value = True
         mock_ctx.registry = MagicMock()
         mock_ctx.coordinator = MagicMock()
+        mock_ctx.github_client.list_prs_for_branch.return_value = None
 
         # Mock build_manager_request to return None
         with patch(
@@ -403,6 +404,7 @@ class TestIssueStateDispatchHandler:
         mock_ctx.coordinator.dispatch_execution.return_value = MagicMock(
             launched=True, reason=None
         )
+        mock_ctx.github_client.list_prs_for_branch.return_value = None
 
         # Mock build_dispatch_context to return our mock context
         mock_build_context.return_value = mock_ctx

--- a/tests/vibe3/services/test_simple_test_task_assessor.py
+++ b/tests/vibe3/services/test_simple_test_task_assessor.py
@@ -1,0 +1,154 @@
+"""Unit tests for simple_test_task_assessor service."""
+
+from __future__ import annotations
+
+from vibe3.services.simple_test_task_assessor import (
+    MAX_FILES,
+    MAX_LINES,
+    is_simple_test_from_diff,
+    is_simple_test_task_from_metadata,
+)
+
+
+class TestIsSimpleTestTaskFromMetadata:
+    """Tests for is_simple_test_task_from_metadata function."""
+
+    def test_title_with_test_keyword(self) -> None:
+        """Title with test keyword should return True."""
+        assert is_simple_test_task_from_metadata("fix flaky test_something", []) is True
+
+    def test_title_without_test_keyword(self) -> None:
+        """Title without test keyword should return False."""
+        assert is_simple_test_task_from_metadata("add new feature X", []) is False
+
+    def test_title_with_complex_label(self) -> None:
+        """Title with complex label should return False."""
+        assert (
+            is_simple_test_task_from_metadata(
+                "improve test coverage for Y", ["roadmap/epic"]
+            )
+            is False
+        )
+
+    def test_title_with_chinese_keyword(self) -> None:
+        """Title with Chinese test keyword should return True."""
+        assert is_simple_test_task_from_metadata("修复测试", []) is True
+
+    def test_empty_title(self) -> None:
+        """Empty title should return False."""
+        assert is_simple_test_task_from_metadata("", []) is False
+
+    def test_title_with_coverage_keyword(self) -> None:
+        """Title with coverage keyword should return True."""
+        assert (
+            is_simple_test_task_from_metadata("add coverage for module X", []) is True
+        )
+
+    def test_title_with_priority_0_label(self) -> None:
+        """Title with priority/0 label should return False."""
+        assert (
+            is_simple_test_task_from_metadata("fix test failure", ["priority/0"])
+            is False
+        )
+
+    def test_title_with_priority_1_label(self) -> None:
+        """Title with priority/1 label should return False."""
+        assert (
+            is_simple_test_task_from_metadata("fix test failure", ["priority/1"])
+            is False
+        )
+
+    def test_title_with_multiple_labels(self) -> None:
+        """Title with multiple labels, none complex, should return True."""
+        assert (
+            is_simple_test_task_from_metadata(
+                "fix flaky test", ["bug", "component/test"]
+            )
+            is True
+        )
+
+    def test_title_with_flaky_keyword(self) -> None:
+        """Title with flaky keyword should return True."""
+        assert is_simple_test_task_from_metadata("flaky test needs fixing", []) is True
+
+
+class TestIsSimpleTestFromDiff:
+    """Tests for is_simple_test_from_diff function."""
+
+    def test_small_test_change(self) -> None:
+        """Small test change should return True."""
+        files = ["tests/test_one.py", "tests/test_two.py", "tests/test_three.py"]
+        assert is_simple_test_from_diff(files, 30, 20) is True
+
+    def test_exceeds_max_files(self) -> None:
+        """Change exceeding MAX_FILES should return False."""
+        files = [f"tests/test_{i}.py" for i in range(MAX_FILES + 1)]
+        assert is_simple_test_from_diff(files, 10, 10) is False
+
+    def test_exceeds_max_lines(self) -> None:
+        """Change exceeding MAX_LINES should return False."""
+        files = ["tests/test_one.py", "tests/test_two.py"]
+        assert is_simple_test_from_diff(files, 80, 30) is False
+
+    def test_mixed_files(self) -> None:
+        """Mixed test and source files should return False."""
+        files = ["tests/test_one.py", "tests/test_two.py", "src/module.py"]
+        assert is_simple_test_from_diff(files, 10, 10) is False
+
+    def test_conftest_only(self) -> None:
+        """Conftest.py only should return True."""
+        files = ["tests/conftest.py"]
+        assert is_simple_test_from_diff(files, 10, 5) is True
+
+    def test_empty_file_list(self) -> None:
+        """Empty file list should return False."""
+        assert is_simple_test_from_diff([], 0, 0) is False
+
+    def test_test_underscore_pattern(self) -> None:
+        """Files with test_ prefix should be recognized."""
+        files = ["tests/test_module.py"]
+        assert is_simple_test_from_diff(files, 10, 10) is True
+
+    def test_test_suffix_pattern(self) -> None:
+        """Files with _test.py suffix should be recognized."""
+        files = ["tests/module_test.py"]
+        assert is_simple_test_from_diff(files, 10, 10) is True
+
+    def test_exactly_max_files(self) -> None:
+        """Exactly MAX_FILES should return True."""
+        files = [f"tests/test_{i}.py" for i in range(MAX_FILES)]
+        assert is_simple_test_from_diff(files, 10, 10) is True
+
+    def test_exactly_max_lines(self) -> None:
+        """Exactly MAX_LINES should return True."""
+        files = ["tests/test_one.py"]
+        total_lines = MAX_LINES
+        assert is_simple_test_from_diff(files, total_lines, 0) is True
+
+    def test_large_diff_in_test_files(self) -> None:
+        """Large diff even in test files should return False."""
+        files = ["tests/test_one.py"]
+        assert is_simple_test_from_diff(files, 100, 100) is False
+
+    def test_non_test_file_pattern(self) -> None:
+        """Non-test files should return False."""
+        files = ["src/module.py", "docs/readme.md"]
+        assert is_simple_test_from_diff(files, 10, 10) is False
+
+    def test_pytest_keyword_in_title(self) -> None:
+        """Title with pytest keyword should return True."""
+        assert (
+            is_simple_test_task_from_metadata("update pytest configuration", []) is True
+        )
+
+    def test_mock_keyword_in_title(self) -> None:
+        """Title with mock keyword should return True."""
+        assert (
+            is_simple_test_task_from_metadata("add mock for external API", []) is True
+        )
+
+    def test_fixture_keyword_in_title(self) -> None:
+        """Title with fixture keyword should return True."""
+        assert (
+            is_simple_test_task_from_metadata("create fixture for database", []) is True
+        )


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2472` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2472
```


---

## Summary

Implements two-phase interception to route simple test tasks away from the full manager plan→run→review cycle into the supervisor/apply fast path.

**Phase 1 (Governance Pre-scan)**:
- Code-level heuristic check before governance LLM agent runs
- Tags qualifying issues with supervisor + state/handoff + orchestra-governed labels
- Uses title/label metadata for conservative assessment

**Phase 2 (Manager Fallback)**:
- Diff-based complexity check (≤5 files, ≤100 lines)
- Flow state validation: only reroutes when issue in safe states (ready/claimed/blocked)
- Never reroutes when in_progress or handoff with progress
- Closes original issue and creates new one with supervisor labels

## Changes

- Add `simple_test_task_assessor` service with pure functions
- Integrate Phase 1 into `OrchestrationFacade._tag_simple_test_tasks()`
- Integrate Phase 2 into `IssueStateDispatchHandler` with flow state validation
- Add 25 comprehensive unit tests
- Update 2 existing tests to mock Phase 2 GitHub calls

## Test Plan

- [x] All 44 tests pass (25 new + 19 existing)
- [x] Type checks pass (mypy)
- [x] Lint checks pass (ruff)
- [x] Pre-commit hooks pass
- [x] User constraint satisfied (flow state validation implemented)

## User Constraint Compliance

From issue #2472 comment:
- ✅ Check issue state before rerouting
- ✅ Only reroute in safe states (ready/claimed/blocked)
- ✅ Never reroute when in_progress or handoff with progress
- ✅ Warning logs when skipping reroute

Closes #2472

---

## Contributors

claude/opus
