### PR TITLE
feat(prompts): add simple test task routing via agent judgment

### DIFF
--- a/supervisor/apply.md
+++ b/supervisor/apply.md
@@ -6,11 +6,12 @@
 
 **接收来源**：
 - 显式创建的 supervisor issue
-- 从 assignee-pool 或 manager 路由过来的简单测试任务（agent 判断只涉及测试修改、工作量小）
+- 从 assignee-pool 或 manager 路由过来的简单测试任务（agent 判断只涉及测试修改、≤ 5 文件、≤ 100 行、不涉及业务代码；路由时原 issue 会添加 `supervisor` 标签，视同 supervisor issue 处理）
 
 **允许范围**（supervisor apply 可执行）：
 - 文档治理（更新、校正、格式修复、语义对齐）
 - 测试修补治理（仅限测试文件、测试夹具、测试文案、过期测试清理）
+  - **路由任务注意**：如果执行中发现任务实际超出测试范围、需要修改业务代码，应停止并在 supervisor issue 上 comment 说明，请求转回 task issue，不得自行扩大范围
 - supervisor issue 操作：label、comment、close、recreate
 - 安排 supervisor 任务（创建 supervisor issue）
 

--- a/supervisor/apply.md
+++ b/supervisor/apply.md
@@ -4,6 +4,10 @@
 
 `supervisor/apply` 只处理 **supervisor issue**（显式立项的治理 issue，带 `supervisor` label），不处理 assignee issue。assignee issue 由 manager 主链负责推进。
 
+**接收来源**：
+- 显式创建的 supervisor issue
+- 从 assignee-pool 或 manager 路由过来的简单测试任务（agent 判断只涉及测试修改、工作量小）
+
 **允许范围**（supervisor apply 可执行）：
 - 文档治理（更新、校正、格式修复、语义对齐）
 - 测试修补治理（仅限测试文件、测试夹具、测试文案、过期测试清理）

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -375,6 +375,14 @@ Steps:
    - 若被依赖的 issue 未关闭或未处于 `state/done`，从候选中排除
    - 已有有效 flow / live dispatch 的 issue，从候选中排除
    - 被硬规则阻塞的 issue，从候选中排除
+2.5. **简单测试任务路由**：对通过依赖过滤的候选，判断是否应路由到 supervisor/apply：
+   - 阅读 issue 内容，评估完成该任务是否只需要修改测试文件、不涉及业务代码改动、且工作量小
+   - 如果判断为简单测试任务，直接执行：
+     - 添加 `supervisor` + `state/handoff` 标签
+     - 写 `[governance decide][assignee-pool]` comment 说明路由原因
+     - 打 `orchestra-governed`
+     - 跳过后续入池评估（该 issue 由 supervisor/apply 处理）
+   - 如果不确定或涉及业务代码，继续正常入池评估
 3. 对 ready candidates 按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 排序
 4. **入池评估与标签补齐**：
    - 扫描 assignee issue pool 中有 manager assignee 但缺少 `state/*` label 的 issue

--- a/supervisor/governance/assignee-pool.md
+++ b/supervisor/governance/assignee-pool.md
@@ -375,14 +375,17 @@ Steps:
    - 若被依赖的 issue 未关闭或未处于 `state/done`，从候选中排除
    - 已有有效 flow / live dispatch 的 issue，从候选中排除
    - 被硬规则阻塞的 issue，从候选中排除
-2.5. **简单测试任务路由**：对通过依赖过滤的候选，判断是否应路由到 supervisor/apply：
-   - 阅读 issue 内容，评估完成该任务是否只需要修改测试文件、不涉及业务代码改动、且工作量小
+2.5. **简单测试任务路由**：对通过依赖过滤的候选，判断是否应路由到 supervisor/apply。
+   **判断标准**（必须同时满足）：
+   - 只涉及测试文件修改（`tests/`、`test_*.py`、`*_test.py`、测试夹具、测试配置）
+   - 不涉及业务代码改动（`src/`、`lib/`、核心逻辑文件）
+   - 预估改动范围 ≤ 5 个文件、≤ 100 行
    - 如果判断为简单测试任务，直接执行：
-     - 添加 `supervisor` + `state/handoff` 标签
+     - 移除旧 `state/*` 标签，添加 `supervisor` + `state/handoff` 标签
      - 写 `[governance decide][assignee-pool]` comment 说明路由原因
      - 打 `orchestra-governed`
      - 跳过后续入池评估（该 issue 由 supervisor/apply 处理）
-   - 如果不确定或涉及业务代码，继续正常入池评估
+   - 如果不确定、超出量化标准、或涉及业务代码，继续正常入池评估
 3. 对 ready candidates 按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 排序
 4. **入池评估与标签补齐**：
    - 扫描 assignee issue pool 中有 manager assignee 但缺少 `state/*` label 的 issue

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -56,12 +56,21 @@ vibe-commit: BLOCKED - test failure in pre-push hook
 你不直接修改代码。
 你审查和评判质量，但不替代具体实现。
 
+## 简单测试任务路由（兜底）
+
+当你接收 issue 后，如果你判断这个任务只需要修改测试文件、不涉及业务代码改动、且工作量小：
+
+- 如果 flow 尚未开始执行（state 为 ready 或 blocked），直接关闭当前 issue，创建新的 supervisor issue（带 `supervisor` + `state/handoff` 标签），由 supervisor/apply 快速处理
+- 如果已有执行进度（in_progress 或有 handoff 记录），不要打断，继续正常流程
+
+这是 Phase 1（assignee-pool 层路由）的兜底。大多数简单测试任务应在 assignee-pool 层被路由，只有漏网的才由 manager 在此兜底。
+
 ## Permission Contract
 
 Allowed:
 
 - `issue`: read, write (包括编辑 title、body 以纠正事实错误，但不得修改 scope)
-- `issue.create`: allowed only when splitting the current ready issue into sub-issues before plan handoff
+- `issue.create`: allowed when splitting the current ready issue into sub-issues before plan handoff, or when routing a simple test task to supervisor/apply (close current issue + create supervisor issue)
 - `labels`: read, write
 - `comments`: read, write
 - `handoff`: read, write

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -58,10 +58,19 @@ vibe-commit: BLOCKED - test failure in pre-push hook
 
 ## 简单测试任务路由（兜底）
 
-当你接收 issue 后，如果你判断这个任务只需要修改测试文件、不涉及业务代码改动、且工作量小：
+**判断标准**（必须同时满足）：
+- 只涉及测试文件修改（`tests/`、`test_*.py`、`*_test.py`、测试夹具、测试配置）
+- 不涉及业务代码改动（`src/`、`lib/`、核心逻辑文件）
+- 预估改动范围 ≤ 5 个文件、≤ 100 行
 
-- 如果 flow 尚未开始执行（state 为 ready 或 blocked），直接关闭当前 issue，创建新的 supervisor issue（带 `supervisor` + `state/handoff` 标签），由 supervisor/apply 快速处理
+当你接收 issue 后，如果你判断该任务满足以上标准：
+
+- 如果 flow 尚未开始执行（state 为 ready 或 blocked）：
+  - 直接关闭当前 issue
+  - 创建新的 supervisor issue（带 `supervisor` + `state/handoff` 标签），由 supervisor/apply 快速处理
+  - 写 `[manager]` comment 说明路由原因，并链接新创建的 supervisor issue
 - 如果已有执行进度（in_progress 或有 handoff 记录），不要打断，继续正常流程
+- 如果不确定、超出量化标准、或涉及业务代码，继续正常流程，不要路由
 
 这是 Phase 1（assignee-pool 层路由）的兜底。大多数简单测试任务应在 assignee-pool 层被路由，只有漏网的才由 manager 在此兜底。
 


### PR DESCRIPTION
## Summary

- Add prompts-based routing for simple test tasks to supervisor/apply fast track
- Agent judges task complexity directly (test-only, small workload) — no code, no keyword matching
- Replaces the 435-line code approach from PR #2495 with 22 lines of prompts

## Changes

| File | Change |
|------|--------|
| `supervisor/governance/assignee-pool.md` | Add Step 2.5: simple test task routing during intake |
| `supervisor/manager.md` | Add fallback routing guidance + expand `issue.create` permission |
| `supervisor/apply.md` | Clarify reception scope for routed tasks |

## Test plan

- [x] Read modified prompts for consistency
- [ ] Human review of prompts wording
- [ ] Verify agent behavior with a test issue after merge

## Safety

- Agent makes the judgment (same capability as any LLM)
- PR goes through review for quality
- Human decides whether to merge
- Manager won't interrupt tasks already in progress

Closes #2472

---

## Contributors

claude/opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)