### PR TITLE
refactor(execution): remove dead code from ExecutionRolePolicyService

### DIFF
--- a/docs/v3/architecture/infrastructure-guide.md
+++ b/docs/v3/architecture/infrastructure-guide.md
@@ -80,14 +80,6 @@ policy_service = ExecutionRolePolicyService(config)
 # 解析 backend
 backend = policy_service.resolve_backend("planner")  # "claude" 或 "openai"
 
-# 解析 prompt contract
-prompt_contract = policy_service.resolve_prompt_contract("planner")
-# 返回 PromptContract(template="orchestra.plan", supervisor_file="...")
-
-# 解析 session 策略
-session_strategy = policy_service.resolve_session_strategy("planner")
-# 返回 SessionStrategy(mode="tmux", timeout=1800)
-
 # 解析 agent options（完整配置）
 agent_options = policy_service.resolve_agent_options("planner")
 # 返回 AgentOptions(agent=..., backend=..., model=..., timeout_seconds=...)
@@ -144,7 +136,6 @@ def run_command():
 
     agent_options = policy_service.resolve_agent_options("executor")
     backend = policy_service.resolve_backend("executor")
-    prompt_contract = policy_service.resolve_prompt_contract("executor")
 
     # 使用解析的配置执行 agent
     ...

--- a/src/vibe3/execution/execution_role_policy.py
+++ b/src/vibe3/execution/execution_role_policy.py
@@ -1,38 +1,13 @@
 """Execution role policy service."""
 
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Literal
-
 from loguru import logger
 
 from vibe3.agents import sync_models_json
-from vibe3.config import (
-    diagnose_profile,
-    load_orchestra_config,
-)
+from vibe3.config import load_orchestra_config
 from vibe3.config import (
     resolve_effective_agent_options as resolve_backend_effective_agent_options,
 )
-from vibe3.exceptions import DiagnosticContext, MissingResourceError
 from vibe3.models import AgentOptions, OrchestraConfig
-
-
-@dataclass(frozen=True)
-class PromptContract:
-    template: str
-
-
-@dataclass(frozen=True)
-class SessionStrategy:
-    mode: Literal["tmux", "inline", "async"]
-    timeout: int | None = None
-
-
-@dataclass(frozen=True)
-class ConcurrencyClass:
-    max_concurrent: int = 3
-    semaphore_key: str = "default"
 
 
 class ExecutionRolePolicyService:
@@ -124,74 +99,3 @@ class ExecutionRolePolicyService:
         )
         sync_models_json(effective)
         return effective
-
-    def resolve_prompt_contract(self, role: str) -> PromptContract:
-        section_name = self._ROLE_CONFIG_MAP.get(role)
-        if not section_name:
-            raise ValueError(f"Unknown role: {role}")
-
-        section = getattr(self._config, section_name, None)
-        if not section:
-            raise MissingResourceError(
-                resource=f"config section for role '{role}'",
-                context=DiagnosticContext(
-                    resource_type="role-config",
-                    search_paths=[str(Path("config/v3/settings.yaml"))],
-                    profile=diagnose_profile(),
-                    remediation=(
-                        f"Add {section_name} configuration to config/v3/settings.yaml"
-                    ),
-                    ref_issue=1925,
-                ),
-            )
-
-        template = getattr(section, "prompt_template", None)
-        if not template:
-            raise MissingResourceError(
-                resource=f"prompt_template for role '{role}'",
-                context=DiagnosticContext(
-                    resource_type="role-config",
-                    search_paths=[str(Path("config/v3/settings.yaml"))],
-                    profile=diagnose_profile(),
-                    remediation=(
-                        f"Add prompt_template to {section_name} in "
-                        "config/v3/settings.yaml"
-                    ),
-                    ref_issue=1907,
-                ),
-            )
-
-        return PromptContract(template=template)
-
-    def resolve_session_strategy(self, role: str) -> SessionStrategy:
-        section_name = self._ROLE_CONFIG_MAP.get(role)
-        if not section_name:
-            return SessionStrategy(mode="async")
-
-        section = getattr(self._config, section_name, None)
-        if not section:
-            return SessionStrategy(mode="async")
-
-        use_worktree = getattr(section, "use_worktree", True)
-        async_mode = getattr(section, "async_mode", True)
-        timeout = getattr(section, "timeout_seconds", None)
-
-        mode: Literal["tmux", "inline", "async"] = "async"
-        if use_worktree and async_mode:
-            mode = "tmux"
-        elif not async_mode:
-            mode = "inline"
-
-        return SessionStrategy(mode=mode, timeout=timeout)
-
-    def resolve_concurrency_class(self, role: str) -> ConcurrencyClass:
-        if role == "manager":
-            return ConcurrencyClass(
-                max_concurrent=self._config.max_concurrent_flows,
-                semaphore_key="manager",
-            )
-
-        return ConcurrencyClass(
-            max_concurrent=10,
-            semaphore_key=role,
-        )

--- a/tests/vibe3/execution/test_execution_role_policy.py
+++ b/tests/vibe3/execution/test_execution_role_policy.py
@@ -60,59 +60,6 @@ def test_resolve_backend_unknown_role(sample_config: OrchestraConfig) -> None:
         service.resolve_backend("unknown_role")
 
 
-def test_resolve_prompt_contract_manager(sample_config: OrchestraConfig) -> None:
-    """Test prompt contract resolution for manager role."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    contract = service.resolve_prompt_contract("manager")
-
-    assert contract.template == "orchestra.assignee_dispatch.manager"
-
-
-def test_resolve_prompt_contract_supervisor(sample_config: OrchestraConfig) -> None:
-    """Test prompt contract resolution for supervisor role."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    contract = service.resolve_prompt_contract("supervisor")
-
-    assert contract.template == "orchestra.supervisor.apply"
-
-
-def test_resolve_session_strategy_manager(sample_config: OrchestraConfig) -> None:
-    """Test session strategy resolution for manager role."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    strategy = service.resolve_session_strategy("manager")
-
-    # Manager with use_worktree=True and async_mode=True should use tmux
-    assert strategy.mode == "tmux"
-    assert strategy.timeout == 3600
-
-
-def test_resolve_session_strategy_unknown_role(sample_config: OrchestraConfig) -> None:
-    """Test session strategy for unknown role defaults to async."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    strategy = service.resolve_session_strategy("unknown_role")
-
-    assert strategy.mode == "async"
-    assert strategy.timeout is None
-
-
-def test_resolve_concurrency_class_manager(sample_config: OrchestraConfig) -> None:
-    """Test concurrency class resolution for manager role."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    concurrency = service.resolve_concurrency_class("manager")
-
-    assert concurrency.max_concurrent == 3  # From max_concurrent_flows
-    assert concurrency.semaphore_key == "manager"
-
-
-def test_resolve_concurrency_class_other_role(sample_config: OrchestraConfig) -> None:
-    """Test concurrency class resolution for non-manager role."""
-    service = ExecutionRolePolicyService(config=sample_config)
-    concurrency = service.resolve_concurrency_class("planner")
-
-    assert concurrency.max_concurrent == 10  # Default for agents
-    assert concurrency.semaphore_key == "planner"
-
-
 def test_all_roles_resolve_backend(sample_config: OrchestraConfig) -> None:
     """Test that all valid orchestra roles can resolve backend."""
     service = ExecutionRolePolicyService(config=sample_config)
@@ -125,20 +72,6 @@ def test_all_roles_resolve_backend(sample_config: OrchestraConfig) -> None:
     for role, expected_backend in expected_backends.items():
         backend = service.resolve_backend(role)
         assert backend == expected_backend
-
-
-def test_all_roles_resolve_prompt_contract(sample_config: OrchestraConfig) -> None:
-    """Test that all valid orchestra roles can resolve prompt contract."""
-    service = ExecutionRolePolicyService(config=sample_config)
-
-    expected_templates = {
-        "manager": "orchestra.assignee_dispatch.manager",
-        "supervisor": "orchestra.supervisor.apply",
-        "governance": "orchestra.governance.plan",
-    }
-    for role, expected_template in expected_templates.items():
-        contract = service.resolve_prompt_contract(role)
-        assert contract.template == expected_template
 
 
 @patch("vibe3.execution.execution_role_policy.sync_models_json")


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2271` is behind `main` by **4 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2271
```


---

## Summary

Remove unused dataclasses and methods from `ExecutionRolePolicyService`:
- 3 unused dataclasses: `PromptContract`, `SessionStrategy`, `ConcurrencyClass`
- 3 unused methods: `resolve_prompt_contract`, `resolve_session_strategy`, `resolve_concurrency_class`
- 6 now-unused imports: `dataclass`, `Path`, `Literal`, `diagnose_profile`, `DiagnosticContext`, `MissingResourceError`
- 7 test functions for removed methods
- Documentation references to removed APIs

All removed symbols confirmed unused in production via `inspect symbols` analysis. No re-exports in `src/vibe3/execution/__init__.py`.

## Changes

- `src/vibe3/execution/execution_role_policy.py`: Removed dead code
- `tests/vibe3/execution/test_execution_role_policy.py`: Removed tests for dead code
- `docs/v3/architecture/infrastructure-guide.md`: Removed documentation references

## Test Results

- Direct tests: 5/5 PASS
- Module tests: 217 PASS
- Type check: mypy PASS
- Lint: ruff PASS
- LOC: All files under CI block threshold

Fixes #2271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
