### PR TITLE
refactor(config): remove unused PolicyResolverMixin class

### DIFF
--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -257,17 +257,7 @@ class AgentConfig(BaseModel):
     timeout_seconds: int = Field(default=3600, ge=1)
 
 
-class PolicyResolverMixin:
-    """Mixin providing a common base type for policy config classes.
-
-    Used by ReviewConfig, PlanConfig, RunConfig to share type identity.
-    Subclasses declare policy_file and common_rules as their own Pydantic fields.
-    """
-
-    __slots__ = ()
-
-
-class ReviewConfig(BaseModel, PolicyResolverMixin):
+class ReviewConfig(BaseModel):
     """Review configuration."""
 
     policy_file: str | None = Field(
@@ -284,7 +274,7 @@ class ReviewConfig(BaseModel, PolicyResolverMixin):
     review_prompt: str = Field(default="")
 
 
-class PlanConfig(BaseModel, PolicyResolverMixin):
+class PlanConfig(BaseModel):
     """Plan command configuration."""
 
     policy_file: str | None = Field(
@@ -300,7 +290,7 @@ class PlanConfig(BaseModel, PolicyResolverMixin):
     plan_prompt: str = Field(default="")
 
 
-class RunConfig(BaseModel, PolicyResolverMixin):
+class RunConfig(BaseModel):
     """Run command configuration."""
 
     policy_file: str | None = Field(


### PR DESCRIPTION
## Summary

Remove the unused `PolicyResolverMixin` class from `src/vibe3/config/settings.py` and drop it from the MRO of its three subclasses. The class had no methods, no fields (only `__slots__ = ()`), and was never referenced in any isinstance check, type hint, or export outside of settings.py.

## Changes

- **src/vibe3/config/settings.py**:
  - Deleted the `PolicyResolverMixin` class definition (lines 260-267)
  - Changed `ReviewConfig(BaseModel, PolicyResolverMixin)` → `ReviewConfig(BaseModel)`
  - Changed `PlanConfig(BaseModel, PolicyResolverMixin)` → `PlanConfig(BaseModel)`
  - Changed `RunConfig(BaseModel, PolicyResolverMixin)` → `RunConfig(BaseModel)`

## Verification

✅ **Type-check**: mypy passed - no issues found  
✅ **Lint**: ruff passed - all checks passed  
✅ **Tests**: 381 tests passed (157 config + 224 execution)  
✅ **LOC check**: All files under CI block threshold

## Test Plan

- **Direct tests**: `tests/vibe3/config/` - 157 tests passed
- **Integration tests**: `tests/vibe3/execution/` - 224 tests passed
- All tests pass, confirming zero behavioral change
- This is a safe structural cleanup with no functional impact

Fixes #2480

---

## Contributors

claude/opus
