### PR TITLE
perf: cache PromptManifest.load_default() to eliminate repeated I/O

### DIFF
--- a/src/vibe3/prompts/manifest.py
+++ b/src/vibe3/prompts/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,6 +65,7 @@ class PromptManifest:
     recipes: dict[str, PromptRecipeDefinition]
 
     @classmethod
+    @functools.lru_cache(maxsize=1)
     def load_default(cls) -> "PromptManifest":
         """Load prompt recipes from the repository config directory."""
         return cls.load(_resolve_repo_path(DEFAULT_PROMPT_RECIPES_PATH))

--- a/tests/vibe3/conftest.py
+++ b/tests/vibe3/conftest.py
@@ -43,6 +43,22 @@ def clear_find_repo_root_cache():
 
 
 @pytest.fixture(autouse=True)
+def clear_prompt_manifest_cache():
+    """Clear PromptManifest.load_default cache before each test to ensure isolation.
+
+    The load_default() function uses @functools.lru_cache(maxsize=1) for
+    performance, but this can leak across tests when DEFAULT_PROMPT_RECIPES_PATH
+    is monkeypatched. This autouse fixture ensures each test starts with a clean cache.
+    """
+    from vibe3.prompts.manifest import PromptManifest
+
+    PromptManifest.load_default.cache_clear()
+    yield
+    # Clear again after test to clean up for subsequent tests
+    PromptManifest.load_default.cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def isolate_database(request):
     """Use temporary database for tests to prevent production DB contamination.
 


### PR DESCRIPTION
## Summary

Add `@functools.lru_cache(maxsize=1)` to `PromptManifest.load_default()` to eliminate repeated file I/O and YAML parsing. This performance optimization benefits 12+ call sites across 7 modules.

## Changes

- **src/vibe3/prompts/manifest.py**: Added `functools` import and decorated `load_default()` with `@lru_cache(maxsize=1)`
- **tests/vibe3/conftest.py**: Added autouse fixture to clear cache before each test for test isolation

## Performance Impact

**Before**: Each call to `PromptManifest.load_default()` performs file I/O + YAML parsing.

**After**: First call performs I/O + parsing, subsequent calls return cached instance (O(1) lookup).

**Beneficiaries**: 12+ call sites across 7 modules:
- `roles/review.py` (2-3 calls per review request)
- `agents/plan_prompt.py` (2 calls)
- `agents/run_prompt.py` (4 calls)
- `roles/governance.py`
- `roles/manager.py`
- `roles/supervisor.py`
- `services/scan_service.py`

## Test Plan

- ✅ All 3114 tests pass
- ✅ mypy: Success (no type errors)
- ✅ ruff: All checks passed
- ✅ Full test suite: 3114 PASS, 4 xfailed, 1 xpassed
- ✅ LOC checks: No files exceed 400-line CI block threshold

## Technical Details

**Why `lru_cache(maxsize=1)` on a classmethod?**
- Python 3.12 supports `@classmethod @lru_cache` correctly
- Cache key is `(cls,)`, which is always `PromptManifest` — effectively a singleton
- `PromptManifest` is `frozen=True`, so the cached instance is immutable
- Safe to cache: prompt recipes YAML is static read-only config

**Test Isolation**: Added autouse fixture to clear cache before each test ensures tests that monkeypatch `DEFAULT_PROMPT_RECIPES_PATH` get fresh manifests.

Fixes #2377

🤖 Generated with [Claude Code](https://claude.ai/code)