### PR TITLE
docs(job): clarify when JobResult.source is None

### DIFF
--- a/src/vibe3/models/job.py
+++ b/src/vibe3/models/job.py
@@ -131,6 +131,11 @@ class JobResult(BaseModel):
     Outcome of a job execution.
 
     Not frozen — downstream may update status incrementally.
+
+    Provenance tracking:
+        ``source`` is set automatically by :class:`JobExecutor` from the
+        originating ``JobEnvelope``.  When ``None``, the result was created
+        outside the standard dispatch path and trigger type is unknown.
     """
 
     command_type: CommandType
@@ -165,5 +170,9 @@ class JobResult(BaseModel):
     error_message: str | None = None
     error_code: str | None = None
 
-    # Semantic equivalence marker
+    # Semantic equivalence marker — mirrors JobEnvelope.source when the result
+    # is produced by JobExecutor.  None means the result was constructed outside
+    # the standard dispatch path (e.g. tests, legacy code, or intermediate state
+    # before source is known).  Downstream consumers that require provenance
+    # should treat None as "unknown trigger".
     source: JobSource | None = None


### PR DESCRIPTION
Closes #2325

## Summary

Add documentation to `JobResult.source` field explaining when it is `None` vs set.

**Changes**:
- Inline comment (lines 173-178 in `src/vibe3/models/job.py`): Documents that `source` is set by `JobExecutor` from `envelope.source`, and `None` means the result was constructed outside the standard dispatch path (tests, legacy code, or intermediate state)
- Class docstring (lines 135-139): Added provenance tracking section documenting automatic source setting

**Key insight**: `source` defaults to `None` but is always populated by `JobExecutor.execute()` from `envelope.source`. `None` only occurs when `JobResult` is constructed directly outside the executor path.

**Downstream impact**: Consumers (#2164, #2165) can now rely on documented behavior - `source` is set when the result comes from `JobExecutor`, `None` means unknown provenance.

## Test Plan

- ✅ mypy: Success (no type errors)
- ✅ ruff: All checks passed
- ✅ pytest: 39 tests passed (models + executor dispatch tests)
- ✅ Docs-only change: No behavioral modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
