### PR TITLE
fix(base): auto-fallback to origin/main when parent branch is merged

### DIFF
--- a/src/vibe3/services/base_resolution_usecase.py
+++ b/src/vibe3/services/base_resolution_usecase.py
@@ -6,8 +6,7 @@ from typing import Callable, Literal
 from vibe3.clients import GitClient, GitClientProtocol
 from vibe3.exceptions import UserError
 from vibe3.models import BranchSource
-from vibe3.utils import find_parent_branch
-from vibe3.utils.branch_utils import is_branch_merged_to_main
+from vibe3.utils import find_parent_branch, is_branch_merged_to_main
 
 MAIN_BRANCH_NAME = "main"
 MAIN_BRANCH_REF = "origin/main"

--- a/src/vibe3/services/base_resolution_usecase.py
+++ b/src/vibe3/services/base_resolution_usecase.py
@@ -7,6 +7,7 @@ from vibe3.clients import GitClient, GitClientProtocol
 from vibe3.exceptions import UserError
 from vibe3.models import BranchSource
 from vibe3.utils import find_parent_branch
+from vibe3.utils.branch_utils import is_branch_merged_to_main
 
 MAIN_BRANCH_NAME = "main"
 MAIN_BRANCH_REF = "origin/main"
@@ -105,6 +106,9 @@ class BaseResolutionUsecase:
                     "Could not auto-detect parent branch. "
                     "Please specify base branch explicitly."
                 )
+            # If detected parent is already merged into main, use origin/main
+            if is_branch_merged_to_main(inferred):
+                return ResolvedBase(base_branch=MAIN_BRANCH_REF, auto_detected=True)
             return ResolvedBase(base_branch=inferred, auto_detected=True)
         if token == "current":
             return ResolvedBase(base_branch=current_branch, auto_detected=False)

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
         format_branch_behind_body,
         format_branch_behind_console,
     )
-    from vibe3.utils.branch_utils import find_parent_branch
+    from vibe3.utils.branch_utils import find_parent_branch, is_branch_merged_to_main
     from vibe3.utils.codeagent_helpers import (
         diagnose_backend_error,
         diagnose_prompt_size_issue,
@@ -76,6 +76,7 @@ _LAZY_IMPORTS = {
     "diagnose_backend_error": "vibe3.utils.codeagent_helpers",
     "diagnose_prompt_size_issue": "vibe3.utils.codeagent_helpers",
     "find_parent_branch": "vibe3.utils.branch_utils",
+    "is_branch_merged_to_main": "vibe3.utils.branch_utils",
     "format_age_aware_time": "vibe3.utils.time_format",
     "format_branch_behind_body": "vibe3.utils.branch_compare",
     "format_branch_behind_console": "vibe3.utils.branch_compare",
@@ -132,6 +133,7 @@ __all__ = [
     "diagnose_backend_error",
     "diagnose_prompt_size_issue",
     "find_parent_branch",
+    "is_branch_merged_to_main",
     "format_age_aware_time",
     "format_branch_behind_body",
     "format_branch_behind_console",

--- a/src/vibe3/utils/branch_utils.py
+++ b/src/vibe3/utils/branch_utils.py
@@ -112,3 +112,19 @@ def find_parent_branch(current_branch: str | None = None) -> str | None:
             error=str(e),
         ).error("Failed to find parent branch")
         return None
+
+
+def is_branch_merged_to_main(branch: str, main_ref: str = "origin/main") -> bool:
+    """Check if a branch has been merged into main.
+
+    Uses `git merge-base --is-ancestor` to check if the branch tip
+    is reachable from main_ref. Returns True if the branch is already
+    contained in main (i.e., merged).
+    """
+    try:
+        _run_git(["merge-base", "--is-ancestor", branch, main_ref])
+        return True  # exit 0 = is ancestor = merged
+    except subprocess.CalledProcessError:
+        return False  # exit 1 = not ancestor = not merged
+    except Exception:
+        return False  # git error (branch doesn't exist, etc.)

--- a/tests/vibe3/analysis/test_find_parent_branch.py
+++ b/tests/vibe3/analysis/test_find_parent_branch.py
@@ -1,8 +1,9 @@
 """Unit tests for find_parent_branch performance optimization."""
 
+import subprocess
 from unittest.mock import patch
 
-from vibe3.utils.branch_utils import find_parent_branch
+from vibe3.utils.branch_utils import find_parent_branch, is_branch_merged_to_main
 
 
 class TestFindParentBranch:
@@ -116,3 +117,43 @@ class TestFindParentBranch:
             result = find_parent_branch()
             # Should return None on error (logged but not raised)
             assert result is None
+
+
+class TestIsBranchMergedToMain:
+    """Tests for is_branch_merged_to_main function."""
+
+    def test_is_branch_merged_to_main_returns_true_when_merged(self) -> None:
+        """Test that merged branch returns True."""
+        with patch("vibe3.utils.branch_utils._run_git") as mock_git:
+            # When branch is an ancestor, _run_git returns normally (exit 0)
+            mock_git.return_value = ""
+
+            result = is_branch_merged_to_main("task/old-branch")
+
+            assert result is True
+            mock_git.assert_called_once_with(
+                ["merge-base", "--is-ancestor", "task/old-branch", "origin/main"]
+            )
+
+    def test_is_branch_merged_to_main_returns_false_when_not_merged(self) -> None:
+        """Test that unmerged branch returns False."""
+        with patch("vibe3.utils.branch_utils._run_git") as mock_git:
+            # When branch is not an ancestor, _run_git raises CalledProcessError
+            mock_git.side_effect = subprocess.CalledProcessError(1, "git")
+
+            result = is_branch_merged_to_main("task/active-branch")
+
+            assert result is False
+            mock_git.assert_called_once_with(
+                ["merge-base", "--is-ancestor", "task/active-branch", "origin/main"]
+            )
+
+    def test_is_branch_merged_to_main_returns_false_on_git_error(self) -> None:
+        """Test that git errors (e.g., branch doesn't exist) return False."""
+        with patch("vibe3.utils.branch_utils._run_git") as mock_git:
+            # Simulate other git error (e.g., branch doesn't exist)
+            mock_git.side_effect = Exception("fatal: not a valid object name")
+
+            result = is_branch_merged_to_main("nonexistent-branch")
+
+            assert result is False

--- a/tests/vibe3/services/test_base_resolution_usecase.py
+++ b/tests/vibe3/services/test_base_resolution_usecase.py
@@ -1,6 +1,6 @@
 """Tests for shared base resolution usecase."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -86,3 +86,37 @@ def test_collect_branch_material_uses_git_client() -> None:
     assert material.changed_files == ["src/vibe3/commands/pr_create.py"]
     git_client.get_commit_subjects.assert_called_once_with("origin/main", "task/demo")
     git_client.get_changed_files.assert_called_once()
+
+
+def test_resolve_inspect_base_falls_back_to_main_when_parent_merged() -> None:
+    """When auto-detected parent is already merged, should use origin/main."""
+    with patch(
+        "vibe3.services.base_resolution_usecase.is_branch_merged_to_main"
+    ) as mock_merged:
+        mock_merged.return_value = True
+        usecase = BaseResolutionUsecase(
+            parent_branch_finder=lambda branch: "task/old-branch"
+        )
+
+        resolved = usecase.resolve_inspect_base(None, current_branch="task/child")
+
+        assert resolved.base_branch == "origin/main"
+        assert resolved.auto_detected is True
+        mock_merged.assert_called_once_with("task/old-branch")
+
+
+def test_resolve_inspect_base_keeps_parent_when_not_merged() -> None:
+    """When auto-detected parent is not merged, should use it as base."""
+    with patch(
+        "vibe3.services.base_resolution_usecase.is_branch_merged_to_main"
+    ) as mock_merged:
+        mock_merged.return_value = False
+        usecase = BaseResolutionUsecase(
+            parent_branch_finder=lambda branch: "task/active-branch"
+        )
+
+        resolved = usecase.resolve_inspect_base(None, current_branch="task/child")
+
+        assert resolved.base_branch == "task/active-branch"
+        assert resolved.auto_detected is True
+        mock_merged.assert_called_once_with("task/active-branch")


### PR DESCRIPTION
## Summary
Fix bug where `inspect base` produces incorrect diff when the auto-detected parent branch has already been merged into `origin/main`.

## Problem
When `find_parent_branch` detects a parent that is already an ancestor of `origin/main`, using that parent for diff operations would include the entire parent branch's history, causing false positives in scope baseline validation.

## Solution
- Added `is_branch_merged_to_main()` to `src/vibe3/utils/branch_utils.py` to detect merged branches
- Modified `BaseResolutionUsecase.resolve_base()` to automatically fallback to `origin/main` when the auto-detected parent is already merged
- Covers all commands using `resolve_base()`: `inspect base`, `review base`, `flow create`

## Changes
- `src/vibe3/utils/branch_utils.py`: New function `is_branch_merged_to_main()` (+13 lines)
- `src/vibe3/services/base_resolution_usecase.py`: Integrated merged-branch detection (+4 lines)
- Test coverage: 5 new tests (3 for helper, 2 for integration)

## Testing
- All 25 targeted tests pass
- Type checks clean (mypy)
- Lint clean (ruff)

## Impact
Prevents false positives in diff operations when parent branches are already merged.

Fixes #2240

---

## Contributors

claude/opus
