### PR TITLE
refactor(blocked-reason): add structured blocked_reason_summary field

### DIFF
--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -32,6 +32,7 @@ class SQLiteFlowStateRepo(_HasConnection):
         "initiated_by",
         "blocked_by_issue",  # NEW: Dependency issue number (INT)
         "blocked_reason",  # Block reason text (TEXT)
+        "blocked_reason_summary",  # Pre-computed display summary
         "next_step",
         "flow_status",
         "updated_at",

--- a/src/vibe3/clients/sqlite_schema.py
+++ b/src/vibe3/clients/sqlite_schema.py
@@ -261,6 +261,12 @@ def init_schema(conn: sqlite3.Connection) -> None:
             "Added blocked_reason column to flow_state"
         )
 
+    if "blocked_reason_summary" not in existing:
+        cursor.execute("ALTER TABLE flow_state ADD COLUMN blocked_reason_summary TEXT")
+        logger.bind(external="sqlite", operation="migration").info(
+            "Added blocked_reason_summary column to flow_state"
+        )
+
     # Migration: add latest_verdict field for verdict tracking
     if "latest_verdict" not in existing:
         cursor.execute("ALTER TABLE flow_state ADD COLUMN latest_verdict TEXT")

--- a/src/vibe3/commands/status_render.py
+++ b/src/vibe3/commands/status_render.py
@@ -226,7 +226,10 @@ def render_blocked_items(blocked_items: list[dict[str, object]]) -> None:
                 console.print(f"         [yellow]blocked by:[/] {blocked_by_str}")
 
             if blocked_reason:
-                reason_summary = extract_blocked_reason_summary(blocked_reason)
+                summary = flow.blocked_reason_summary if flow else None
+                reason_summary = extract_blocked_reason_summary(
+                    blocked_reason, structured_summary=summary
+                )
                 console.print(f"         [yellow]reason:[/] {reason_summary}")
     else:
         console.print("  [dim](none)[/]")

--- a/src/vibe3/commands/status_render_utils.py
+++ b/src/vibe3/commands/status_render_utils.py
@@ -14,12 +14,21 @@ from vibe3.utils import (
 )
 
 
-def extract_blocked_reason_summary(blocked_reason: str) -> str:
+def extract_blocked_reason_summary(
+    blocked_reason: str,
+    structured_summary: str | None = None,
+) -> str:
     """Extract key information from blocked_reason for status display.
+
+    Uses pre-computed structured_summary when available.
+    Falls back to string parsing for historical data.
 
     Filters out verbose runtime details (TMPDIR, Recent Errors, stdin mode).
     Preserves short status messages and error codes for quick diagnosis.
     """
+    if structured_summary:
+        return structured_summary
+
     if not blocked_reason:
         return ""
 

--- a/src/vibe3/models/flow.py
+++ b/src/vibe3/models/flow.py
@@ -89,6 +89,7 @@ class FlowState(BaseModel):
         None  # NEW: Dependency issue number (semantic clarity)
     )
     blocked_reason: str | None = None  # Block reason text
+    blocked_reason_summary: str | None = None  # Pre-computed display summary
     next_step: str | None = None
     flow_status: Literal["active", "blocked", "done", "stale", "aborted"] = "active"
     # Note: "blocked" restored for remote sync semantics.
@@ -262,6 +263,7 @@ class FlowStatusResponse(BaseModel):
     initiated_by: str | None = None
     blocked_by_issue: int | None = None  # NEW: Dependency issue number
     blocked_reason: str | None = None  # Block reason text
+    blocked_reason_summary: str | None = None  # Pre-computed display summary
     next_step: str | None = None
     issues: list[IssueLink] = Field(default_factory=list)
     planner_status: ExecutionStatus | None = None
@@ -355,6 +357,7 @@ class FlowStatusResponse(BaseModel):
             initiated_by=data.get("initiated_by"),
             blocked_by_issue=data.get("blocked_by_issue"),
             blocked_reason=data.get("blocked_reason"),
+            blocked_reason_summary=data.get("blocked_reason_summary"),
             next_step=data.get("next_step"),
             issues=issues,
             planner_status=data.get("planner_status"),

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -18,7 +18,7 @@ from vibe3.models import FlowStateProjection, IssueState
 from vibe3.services.blocked_state_types import BlockedState
 from vibe3.services.issue.body import merge_projection, parse_projection
 from vibe3.services.label_service import LabelService
-from vibe3.utils.error_message_cleaner import compute_blocked_reason_summary
+from vibe3.utils import compute_blocked_reason_summary
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient

--- a/src/vibe3/services/blocked_state_io.py
+++ b/src/vibe3/services/blocked_state_io.py
@@ -18,6 +18,7 @@ from vibe3.models import FlowStateProjection, IssueState
 from vibe3.services.blocked_state_types import BlockedState
 from vibe3.services.issue.body import merge_projection, parse_projection
 from vibe3.services.label_service import LabelService
+from vibe3.utils.error_message_cleaner import compute_blocked_reason_summary
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient
@@ -121,10 +122,12 @@ class BlockedStateIO:
         """Write blocked state to database cache."""
         if not self.store:
             return
+        summary = compute_blocked_reason_summary(reason) if reason else None
         self.store.update_flow_state(
             branch,
             flow_status="blocked",
             blocked_reason=reason,
+            blocked_reason_summary=summary,
             blocked_by_issue=blocked_by_issue,
             latest_actor=actor,
         )
@@ -143,6 +146,7 @@ class BlockedStateIO:
             branch,
             flow_status="active",
             blocked_reason=None,
+            blocked_reason_summary=None,
             blocked_by_issue=None,
             transition_count=0,  # Reset loop protection counter
             latest_actor=actor,

--- a/src/vibe3/services/flow_status_resolver.py
+++ b/src/vibe3/services/flow_status_resolver.py
@@ -9,7 +9,7 @@ from loguru import logger
 from vibe3.models import DataSource, FlowStatusResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue.body import parse_projection
-from vibe3.utils.error_message_cleaner import compute_blocked_reason_summary
+from vibe3.utils import compute_blocked_reason_summary
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient

--- a/src/vibe3/services/flow_status_resolver.py
+++ b/src/vibe3/services/flow_status_resolver.py
@@ -9,6 +9,7 @@ from loguru import logger
 from vibe3.models import DataSource, FlowStatusResponse
 from vibe3.services.flow_service import FlowService
 from vibe3.services.issue.body import parse_projection
+from vibe3.utils.error_message_cleaner import compute_blocked_reason_summary
 
 if TYPE_CHECKING:
     from vibe3.clients import SQLiteClient
@@ -161,6 +162,12 @@ class FlowStatusResolver:
         timeline = parse_timeline_from_comments(comments)
 
         # Build response with timeline
+        blocked_reason_val = projection.blocked_reason
+        blocked_summary = (
+            compute_blocked_reason_summary(blocked_reason_val)
+            if blocked_reason_val
+            else None
+        )
         return FlowStatusResponse(
             branch=branch,
             flow_slug=branch.replace("/", "-"),
@@ -168,7 +175,8 @@ class FlowStatusResolver:
             blocked_by_issue=(
                 projection.blocked_by[0] if projection.blocked_by else None
             ),
-            blocked_reason=projection.blocked_reason,
+            blocked_reason=blocked_reason_val,
+            blocked_reason_summary=blocked_summary,
             timeline=timeline,  # NEW: timeline from comments
             data_source=DataSource.ISSUE_BODY_FALLBACK,
         )

--- a/src/vibe3/utils/__init__.py
+++ b/src/vibe3/utils/__init__.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         CODEAGENT_WRAPPER_ANYWHERE_RE,
         CODEAGENT_WRAPPER_RE,
         clean_error_message,
+        compute_blocked_reason_summary,
     )
     from vibe3.utils.git_helpers import (
         find_repo_root,
@@ -65,6 +66,7 @@ _LAZY_IMPORTS = {
     "CODEAGENT_STDIN_MODE_THRESHOLD": "vibe3.utils.constants",
     "CODEAGENT_WRAPPER_ANYWHERE_RE": "vibe3.utils.error_message_cleaner",
     "CODEAGENT_WRAPPER_RE": "vibe3.utils.error_message_cleaner",
+    "compute_blocked_reason_summary": "vibe3.utils.error_message_cleaner",
     "EVENT_REQUIRED_REF_MISSING": "vibe3.utils.constants",
     "EVENT_STATE_TRANSITIONED": "vibe3.utils.constants",
     "EVENT_STATE_UNCHANGED": "vibe3.utils.constants",
@@ -129,6 +131,7 @@ __all__ = [
     "VERDICT_UNKNOWN",
     "clean_error_message",
     "check_branch_behind",
+    "compute_blocked_reason_summary",
     "diagnose_backend_error",
     "diagnose_prompt_size_issue",
     "find_parent_branch",

--- a/src/vibe3/utils/error_message_cleaner.py
+++ b/src/vibe3/utils/error_message_cleaner.py
@@ -40,3 +40,50 @@ def clean_error_message(message: str) -> str:
     cleaned = _RECENT_ERRORS_RE.split(cleaned)[0].strip()
     cleaned = _TRAILING_PIPE_RE.sub("", cleaned).strip()
     return cleaned
+
+
+def compute_blocked_reason_summary(blocked_reason: str) -> str:
+    """Compute a display-ready summary from a raw blocked_reason string.
+
+    Strips wrapper prefixes, removes TMPDIR/RecentErrors noise,
+    truncates at sentence boundary if needed.
+
+    Args:
+        blocked_reason: Raw blocked_reason string (may contain multiple lines)
+
+    Returns:
+        Cleaned, truncated summary suitable for display
+    """
+    if not blocked_reason:
+        return ""
+
+    lines = blocked_reason.strip().split("\n")
+    if not lines:
+        return ""
+
+    first_line = CODEAGENT_WRAPPER_ANYWHERE_RE.sub("", lines[0].strip())
+
+    if (not first_line or first_line.rstrip(":").startswith("E_")) and len(lines) > 1:
+        next_line = lines[1].strip()
+        if next_line:
+            first_line = next_line
+
+    if len(first_line) <= 60 and "CLAUDE_CODE_TMPDIR" not in first_line:
+        result = first_line
+    else:
+        cleaned = clean_error_message(first_line)
+        if len(cleaned) <= 80:
+            result = cleaned
+        else:
+            for sep in ["。", "."]:
+                pos = cleaned.rfind(sep, 0, 80)
+                if pos > 0:
+                    result = cleaned[: pos + 1]
+                    break
+            else:
+                result = cleaned[:80]
+
+    if result.endswith(":"):
+        result = result[:-1]
+
+    return result

--- a/tests/vibe3/domain/test_qualify_gate_remote.py
+++ b/tests/vibe3/domain/test_qualify_gate_remote.py
@@ -108,6 +108,7 @@ class TestRemoteBlockedReason:
                     "task/issue-123-test",
                     flow_status="blocked",
                     blocked_reason="Remote block from issue body",
+                    blocked_reason_summary="Remote block from issue body",
                     blocked_by_issue=None,
                     latest_actor="system:qualify_gate",
                 )
@@ -161,6 +162,7 @@ class TestRemoteBlockedReason:
                     "task/issue-123-test",
                     flow_status="blocked",
                     blocked_reason="Local block from SQLite",
+                    blocked_reason_summary="Local block from SQLite",
                     blocked_by_issue=None,
                     latest_actor="system:qualify_gate",
                 )
@@ -325,6 +327,7 @@ class TestRemoteDependencies:
                     "task/issue-123-test",
                     flow_status="blocked",
                     blocked_reason=None,
+                    blocked_reason_summary=None,
                     blocked_by_issue=456,
                     latest_actor="system:qualify_gate",
                 )
@@ -478,6 +481,7 @@ class TestE2EBlockedReconciliation:
                     "task/issue-994",
                     flow_status="blocked",
                     blocked_reason="API design pending",
+                    blocked_reason_summary="API design pending",
                     blocked_by_issue=None,
                     latest_actor="system:qualify_gate",
                 )
@@ -594,6 +598,7 @@ class TestE2EBlockedReconciliation:
                     "task/issue-994",
                     flow_status="blocked",
                     blocked_reason=None,
+                    blocked_reason_summary=None,
                     blocked_by_issue=456,
                     latest_actor="system:qualify_gate",
                 )

--- a/tests/vibe3/services/test_blocked_state_io.py
+++ b/tests/vibe3/services/test_blocked_state_io.py
@@ -1,6 +1,33 @@
 """Tests for blocked_state_io module."""
 
 
+def test_write_database_cache_stores_summary(tmp_path):
+    """write_database_cache should compute and store blocked_reason_summary."""
+    from vibe3.clients.sqlite_client import SQLiteClient
+    from vibe3.services.blocked_state_io import BlockedStateIO
+
+    db = SQLiteClient(db_path=str(tmp_path / "test.db"))
+    io = BlockedStateIO(store=db)
+
+    # Write blocked state with a reason that needs cleaning
+    io.write_database_cache(
+        "test-branch",
+        reason="codeagent-wrapper failed (code 1): Actual error message",
+        blocked_by_issue=123,
+        actor="test-actor",
+    )
+
+    # Verify both blocked_reason and blocked_reason_summary are stored
+    flow = db.get_flow_state("test-branch")
+    assert flow is not None
+    assert (
+        flow.get("blocked_reason")
+        == "codeagent-wrapper failed (code 1): Actual error message"
+    )
+    assert flow.get("blocked_reason_summary") == "Actual error message"
+    assert flow.get("flow_status") == "blocked"
+
+
 def test_clear_database_cache_resets_transition_count(tmp_path):
     """clear_database_cache should reset transition_count to 0."""
     from vibe3.clients.sqlite_client import SQLiteClient

--- a/tests/vibe3/test_rfc_epic_utils.py
+++ b/tests/vibe3/test_rfc_epic_utils.py
@@ -18,6 +18,7 @@ def make_flow(issue_number: int) -> SimpleNamespace:
         latest_verdict=None,
         pr_number=None,
         pr_ref=None,
+        blocked_reason_summary=None,
     )
 
 

--- a/tests/vibe3/utils/test_error_message_cleaner.py
+++ b/tests/vibe3/utils/test_error_message_cleaner.py
@@ -3,6 +3,7 @@
 from vibe3.utils.error_message_cleaner import (
     CODEAGENT_WRAPPER_RE,
     clean_error_message,
+    compute_blocked_reason_summary,
 )
 
 
@@ -104,3 +105,63 @@ class TestCleanErrorMessageCallerDelegation:
         message = "some error | "
         expected = re.sub(r"\s*\|\s*$", "", message).strip()
         assert clean_error_message(message) == expected
+
+
+class TestComputeBlockedReasonSummary:
+    """Test cases for compute_blocked_reason_summary function."""
+
+    def test_clean_short_reason_passes_through(self):
+        """Short, clean reason is returned as-is."""
+        result = compute_blocked_reason_summary("Simple error message")
+        assert result == "Simple error message"
+
+    def test_wrapper_prefix_stripped(self):
+        """codeagent-wrapper prefix is removed."""
+        result = compute_blocked_reason_summary(
+            "codeagent-wrapper failed (code 1): Actual error"
+        )
+        assert result == "Actual error"
+
+    def test_error_code_only_falls_back_to_next_line(self):
+        """If first line only has error code, use next line."""
+        result = compute_blocked_reason_summary("E_EXEC_NO_OUTPUT:\nActual error here")
+        assert result == "Actual error here"
+
+    def test_tmpdir_noise_filtered(self):
+        """TMPDIR noise is removed."""
+        result = compute_blocked_reason_summary(
+            "Error message CLAUDE_CODE_TMPDIR: /tmp/path with more details"
+        )
+        assert result == "Error message"
+
+    def test_long_message_truncated_at_sentence_boundary(self):
+        """Long messages are truncated at sentence boundary."""
+        long_msg = (
+            "This is a very long error message that exceeds the limit. "
+            "It should be truncated at the first sentence boundary."
+        )
+        result = compute_blocked_reason_summary(long_msg)
+        assert result == "This is a very long error message that exceeds the limit."
+        assert len(result) <= 80
+
+    def test_empty_input_returns_empty_string(self):
+        """Empty input returns empty string."""
+        result = compute_blocked_reason_summary("")
+        assert result == ""
+
+    def test_trailing_colon_removed(self):
+        """Trailing colon is removed."""
+        result = compute_blocked_reason_summary("Error message:")
+        assert result == "Error message"
+
+    def test_multiline_with_code_prefix(self):
+        """Multiline messages with code prefix are handled."""
+        result = compute_blocked_reason_summary(
+            "codeagent-wrapper failed (code 1):\nLine 1\nLine 2"
+        )
+        assert result == "Line 1"
+
+    def test_short_message_without_tmpdir_unchanged(self):
+        """Short messages without TMPDIR are not cleaned."""
+        result = compute_blocked_reason_summary("Short error")
+        assert result == "Short error"


### PR DESCRIPTION
## Summary

- Add structured `blocked_reason_summary` field to eliminate roundabout string parsing
- Compute display-ready summary at write time via `compute_blocked_reason_summary()`
- Render layer prefers structured field with fallback to legacy parsing for backward compatibility
- SQLite migration adds `blocked_reason_summary TEXT` column (additive, no data migration needed)

## Changes

**Core Utility**:
- Add `compute_blocked_reason_summary()` function to centralize summary logic extraction

**Models**:
- Add `blocked_reason_summary: str | None = None` to `FlowState` and `FlowStatusResponse`
- Update `FlowStatusResponse.from_state()` to include new field

**Database Layer**:
- Add SQLite migration for `blocked_reason_summary TEXT` column
- Add field to `VALID_FLOW_STATE_FIELDS` validation set

**Service Layer**:
- Update `BlockedStateIO` to compute and store summary at write time
- Update `FlowStatusResolver` to compute summary for remote reads

**Render Layer**:
- Update `extract_blocked_reason_summary()` to accept optional `structured_summary` parameter
- Prefer structured field when available, fallback to string parsing for historical data

**Tests**:
- Add 10 test cases for `compute_blocked_reason_summary()`
- Add 1 test case for `BlockedStateIO.write_database_cache()` summary storage
- All 35 tests pass

## Test Plan

- [x] Unit tests: 35 tests passed (10 new utility tests + 1 new IO test + 24 existing)
- [x] Type checking: mypy success on 6 modified source files
- [x] Linting: ruff check passed on 8 modified source files
- [x] Backward compatibility: Historical data without summary uses legacy parsing
- [x] Performance: Summary computed once at write time, no per-read overhead

Fixes #2464

---

## Contributors

claude/opus
