### PR TITLE
feat(run): enforce mandatory plan requirements verification

### DIFF
--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -360,15 +360,35 @@ run:
     - Then run module-level tests: `tests/vibe3/<module>/`
 
     ## Plan Requirements Verification
-    **REQUIRED if plan contains explicit Verification requirements**
+    **MANDATORY SECTION — must appear in every execution report**
 
-    For each "Verification:" or verification requirement found in the plan:
+    Extract ALL verification requirements from the plan (not just "Verification:" lines):
+
+    1. Scan the plan for:
+       - Lines starting with "Verification:" or "验证："
+       - Verification requirements in "Risks & Considerations" section
+       - Requirements in "Success Criteria" / "验收标准" / "验证清单" section
+       - Test file creation/modification steps in "Implementation Steps"
+       - Explicit test commands mentioned in the plan
+       - Integration test requirements (for multi-module or lifecycle changes)
+
+    2. For each requirement found:
 
     | Requirement | Status | Evidence |
     |-------------|--------|----------|
     | [requirement text or reference] | ✅/❌ | [code location, test output, or manual verification steps] |
 
-    If no explicit verification requirements in plan, write: "No explicit Verification requirements in plan."
+    **If no explicit verification requirements in plan**, write: "No explicit Verification requirements in plan."
+
+    ### Deviation Declaration (if any requirement is ❌)
+    If any requirement cannot be satisfied, explicitly document:
+
+    **Deviation**: [Which requirement is not satisfied]
+    **Reason**: [Why it cannot be satisfied]
+    **Risk Impact**: [What risk this deviation introduces]
+    **Mitigation**: [If applicable, how the risk is mitigated]
+
+    **DO NOT claim "no deviations from plan" if any requirement is ❌**
 
     ## Verification
     - [ ] All changes committed (git status clean)
@@ -514,6 +534,38 @@ run:
     # Direct test: uv run pytest tests/vibe3/agents/test_run_prompt.py -v
     # Module tests: uv run pytest tests/vibe3/agents/ -q
     ```
+
+    ### MANDATORY Plan Requirements Verification (before claiming "no deviations")
+    **CRITICAL**: You MUST complete this verification before writing your execution report.
+
+    The supervisor policy (`supervisor/policies/run.md`) already requires extracting Verification requirements from the plan. This section elevates that guidance to a **MANDATORY, non-skippable step**.
+
+    #### Step-by-Step Verification Process
+
+    1. **Re-read the plan**: Run `uv run python src/vibe3/cli.py handoff show <plan_ref>` to extract ALL verification requirements.
+
+    2. **Extract ALL verification requirements** from the plan:
+       - Find all lines starting with "Verification:" or "验证："
+       - Find verification requirements in "Risks & Considerations" section (each Risk's Verification item)
+       - Find verification requirements in "Success Criteria" / "验收标准" / "验证清单" section
+       - Find test file creation/modification steps mentioned in Implementation Steps
+       - Find explicit test commands mentioned in the plan
+       - **If plan involves multi-module changes, lifecycle management, or complex flows**: Require at least one integration test covering the integration point
+
+    3. **Form a Requirements Checklist**:
+       - Each requirement as an independent checklist item
+       - Mark source location (e.g., "Risk 4", "验收标准 #3", "Step 2")
+       - Track verification status for each item
+
+    4. **Verify against checklist**:
+       - For each requirement, verify it is satisfied
+       - Document evidence (code location, test output, manual verification)
+       - If any requirement cannot be satisfied, document reason and impact
+
+    5. **Tie "no deviations" claim to checklist completion**:
+       - Claiming "no deviations from plan" without completing this checklist is a **report accuracy failure**
+       - If any requirement is ❌, you MUST document deviation in your report
+       - Do NOT skip this verification step
 
     Follow plan steps strictly, verify each step before proceeding.
     Write clean code with tests, run verification after changes.

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -135,3 +135,39 @@ def test_build_run_prompt_body_includes_pre_coding_validation(tmp_path: Path) ->
     context = build_run_prompt_body(str(plan_file), config)
     assert "REQUIRED:BEFORE_CODING" in context
     assert "Pre-Coding Plan Validation" in context
+
+
+def test_build_run_prompt_body_includes_plan_requirements_verification(
+    tmp_path: Path,
+) -> None:
+    """Run prompt must contain MANDATORY plan requirements verification section."""
+    config = VibeConfig.get_defaults()
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("## Summary\nTest plan\n", encoding="utf-8")
+
+    context = build_run_prompt_body(str(plan_file), config)
+
+    # Verify mandatory section appears
+    assert "Plan Requirements Verification" in context
+    assert "MANDATORY" in context
+
+    # Verify instruction to extract requirements from plan
+    assert "Extract ALL verification requirements" in context
+    assert "handoff show <plan_ref>" in context
+
+    # Verify instruction to form checklist
+    assert "Requirements Checklist" in context or "checklist" in context.lower()
+
+
+def test_build_run_prompt_body_includes_deviation_declaration(tmp_path: Path) -> None:
+    """Run prompt must instruct executor to document deviations."""
+    config = VibeConfig.get_defaults()
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("## Summary\nTest plan\n", encoding="utf-8")
+
+    context = build_run_prompt_body(str(plan_file), config)
+
+    # Verify deviation declaration enforcement
+    assert "Deviation Declaration" in context
+    assert "❌" in context
+    assert "DO NOT claim" in context or "report accuracy failure" in context


### PR DESCRIPTION
Closes #2300

## Summary

Reinforce executor prompt to make plan requirement verification a MANDATORY, non-skippable step before claiming "no deviations from plan." The executor policy already describes checklist formation; this PR adds enforcement hooks in the coding task and output contract.

## Changes

- **config/prompts/prompts.yaml**: 
  - Added MANDATORY verification block to `run.coding_task` (lines 517-566) requiring:
    - Re-reading plan via `handoff show <plan_ref>`
    - Extracting ALL verification requirements (Verification lines, test commands, integration tests)
    - Forming checklist with status and evidence for each requirement
    - Tying "no deviations" claim to checklist completion
    - Integration test enforcement for multi-module changes
  
  - Enhanced `run.output_format` (lines 356-398) with:
    - Explicit MANDATORY section requirement for every execution report
    - Expanded scope to include test files, test commands, and integration tests
    - Deviation Declaration subsection requiring explicit documentation when requirements cannot be satisfied

- **tests/vibe3/agents/test_run_prompt.py**:
  - Added `test_build_run_prompt_body_includes_plan_requirements_verification()`
  - Added `test_build_run_prompt_body_includes_deviation_declaration()`

## Testing

- Direct tests: 12/12 passed (test_run_prompt.py)
- Module tests: 135/135 passed (tests/vibe3/agents/)
- All pre-commit hooks pass: Ruff, Black, MyPy
- LOC checks pass (no files exceed 400 line CI block threshold)

## Implementation Details

The implementation successfully elevates the existing supervisor/policies/run.md guidance to a MANDATORY, non-skippable step by:
- Making the verification step explicit in the coding task instructions
- Requiring checklist formation before claiming "no deviations"
- Adding deviation declaration requirements to the output format
- Providing test coverage to ensure the new content appears in executor prompts

All changes are within the specified scope (prompts.yaml and test_run_prompt.py) with no cross-module symbol changes or API modifications.

## Verification Evidence

- Commit: 558c0286 feat(run): enforce mandatory plan requirements verification
- Report: docs/reports/issue-2300-execution-report.md
- Review: PASS (verified by claude/opus)

---

## Contributors

claude/opus
