### PR TITLE
feat(actor): add lightweight actor abstraction for job supervision

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -189,8 +189,8 @@ code_limits:
         limit: 650
         reason: "No-op gate 聚合，包含 verdict-aware ref 检查（PASS 可省略 audit_ref，MINOR/MAJOR/BLOCK 仍需）、单步转换限制检查、全局转换计数检查、state 验证、GitHub API 错误处理、retry counter 机制（3次重试 + 即时持久化）、error/block 分离（GitHub API 失败记录 error_log 不触发 flow block）等多层防御机制，职责单一但紧密耦合"
       - path: "src/vibe3/execution/job_executor.py"
-        limit: 600
-        reason: "JobExecutor 聚合服务，包含 command dispatch 路由、sync/async 执行模式、governance dispatch、envelope 解析、adapter resolution、lifecycle 事件记录等紧密耦合的统一调度入口逻辑；Issue #2430 扩展支持 sync 和 governance dispatch 后略微超标（+65 行），作为 aggregation layer 保持内聚性优于拆分"
+        limit: 650
+        reason: "JobExecutor 聚合服务，包含 command dispatch 路由、sync/async 执行模式、governance dispatch、envelope 解析、adapter resolution、lifecycle 事件记录、actor 生命周期管理（实时监控层，与 ExecutionLifecycleService 持久记录层互补）等紧密耦合的统一调度入口逻辑；#2172 集成 actor supervision（+60 行），作为 aggregation layer 保持内聚性优于拆分"
       - path: "src/vibe3/execution/codeagent_runner.py"
         limit: 600
         reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；rebase 后新增 tick_id 参数传递和 before_issue_is_closed 检测逻辑，#2265 follow-up 将 AgentExecutionError metadata 写入 error_log 和 lifecycle refs 后略微超标；Issue #2435 新增 model 输出显示（+4 行）"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -203,8 +203,8 @@ code_limits:
 
       # 强耦合测试例外
       - path: "tests/vibe3/models/test_job.py"
-        limit: 460
-        reason: "Job contract models 测试集，覆盖 JobEnvelope/JobContext/JobResult 构造、序列化、frozen 约束、semantic equivalence、dispatch intent 表示等紧密耦合场景；新增 TestNegativeValidation 负面验证测试（7 个 parametrized cases）覆盖无效 literal、缺失字段、无效状态等 Pydantic validation 场景，Black auto-formatting 后略微超标"
+        limit: 500
+        reason: "Job contract models 测试集，覆盖 JobEnvelope/JobContext/JobResult 构造、序列化、frozen 约束、semantic equivalence、dispatch intent 表示、actor_id 字段等紧密耦合场景；#2172 新增 TestJobResult.test_actor_id_field 和 test_actor_id_defaults_to_none 测试后略微超标"
       - path: "tests/vibe3/agents/test_codeagent_backend.py"
         limit: 680
         reason: "Codeagent backend 核心测试，覆盖 sync/async 执行、tmux 管理、命令构建、preset 传递（新增 preset 执行路径保留测试）等紧密耦合逻辑；#2265 follow-up 新增实际 prompt file payload 长度诊断回归测试后略微超标"

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -19,7 +19,7 @@ from vibe3.domain.events.flow_lifecycle import (
     ReviewerDispatchIntent,
 )
 from vibe3.domain.handler_registry import register_handler
-from vibe3.execution.actor import JobType, get_actor_registry
+from vibe3.execution import JobType, get_actor_registry
 from vibe3.models import ExecutionRequest
 from vibe3.services import load_issue_info
 

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -19,7 +19,6 @@ from vibe3.domain.events.flow_lifecycle import (
     ReviewerDispatchIntent,
 )
 from vibe3.domain.handler_registry import register_handler
-from vibe3.execution import JobType, get_actor_registry
 from vibe3.models import ExecutionRequest
 from vibe3.services import load_issue_info
 
@@ -44,150 +43,118 @@ def _dispatch_role_intent(
     with get_store() as store:
         issue = load_issue_info(issue_number, config=config)
 
-        # Resolve branch for actor creation
-        branch_arg = builder_kwargs.get("branch")
-        branch = str(branch_arg) if branch_arg else ""
-
-        # Create actor for supervision tracking
-        registry = get_actor_registry()
-        actor_obj = registry.create_actor(
-            job_type=JobType.DISPATCH,
-            issue_number=issue_number,
-            branch=branch,
-            store=store,
-        )
-
         logger.bind(
             domain=handler_domain,
             issue_number=issue_number,
         ).debug(f"Building {role} request")
 
-        try:
-            # Build request
-            request = request_builder(config, issue, **builder_kwargs)
+        request = request_builder(config, issue, **builder_kwargs)
 
-            # Inject actor_id into request refs for tracking
-            if request.refs is None:
-                request.refs = {}
-            request.refs["actor_id"] = actor_obj.actor_id
+        coordinator = ExecutionCoordinator(config, store)
 
-            coordinator = ExecutionCoordinator(config, store)
+        # Record dispatch intent BEFORE execution (correct chronological order)
+        branch_arg = builder_kwargs.get("branch")
+        branch = str(branch_arg) if branch_arg else ""
+        if branch:
+            store.add_event(
+                branch,
+                f"{role}_dispatched",
+                actor,
+                detail=f"{role.capitalize()} dispatched",
+                refs={
+                    "issue": str(issue_number),
+                    "role": role,
+                },
+            )
 
-            # Record dispatch intent BEFORE execution (correct chronological order)
-            if branch:
-                store.add_event(
-                    branch,
-                    f"{role}_dispatched",
-                    actor,
-                    detail=f"{role.capitalize()} dispatched",
-                    refs={
-                        "issue": str(issue_number),
-                        "role": role,
-                        "actor_id": actor_obj.actor_id,
-                    },
-                )
+        result = coordinator.dispatch_execution(request)
 
-            # Record actor launch
-            actor_obj.record_launch()
+        if result.launched:
 
-            result = coordinator.dispatch_execution(request)
+            logger.bind(
+                domain=handler_domain,
+                issue_number=issue_number,
+                tmux_session=result.tmux_session,
+            ).success(f"{role.capitalize()} dispatch completed")
+            return
 
-            if result.launched:
-                actor_obj.record_completion(detail=f"{role} launched")
+        if result.skipped:
+            logger.bind(
+                domain=handler_domain,
+                issue_number=issue_number,
+            ).info(f"{role.capitalize()} dispatch skipped: {result.reason}")
+            return
 
-                logger.bind(
-                    domain=handler_domain,
-                    issue_number=issue_number,
-                    tmux_session=result.tmux_session,
-                ).success(f"{role.capitalize()} dispatch completed")
-                return
+        # Not launched, not skipped:
+        # - capacity_full / duplicate_dispatch → normal throttling (info)
+        # - all other failures → warning (FailedGate will control)
+        # Dispatch failures do NOT trigger flow block.
+        # Flow block is determined by business logic only
+        # (noop_gate, dependencies, loops).
+        # FailedGate controls dispatch based on error severity.
+        reason_code = result.reason_code or "unknown"
 
-            if result.skipped:
-                actor_obj.record_dead(detail=f"{role} skipped: {result.reason}")
+        if reason_code in ("capacity_full", "duplicate_dispatch"):
+            # Normal throttling/dedup - log at info level
+            logger.bind(
+                domain=handler_domain,
+                issue_number=issue_number,
+                reason_code=reason_code,
+            ).info(f"{role.capitalize()} dispatch deferred: {result.reason}")
+        elif reason_code == "launch_failed":
+            # Check if bottom layer already recorded a specific error
+            # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
+            # If no, record E_DISPATCH_FAILURE for infrastructure visibility
+            from vibe3.services import has_recent_specific_error
 
-                logger.bind(
-                    domain=handler_domain,
-                    issue_number=issue_number,
-                ).info(f"{role.capitalize()} dispatch skipped: {result.reason}")
-                return
-
-            # Not launched, not skipped - record failure
-            actor_obj.record_failure(error=result.reason or "dispatch failed")
-
-            # - capacity_full / duplicate_dispatch → normal throttling (info)
-            # - all other failures → warning (FailedGate will control)
-            # Dispatch failures do NOT trigger flow block.
-            # Flow block is determined by business logic only
-            # (noop_gate, dependencies, loops).
-            # FailedGate controls dispatch based on error severity.
-            reason_code = result.reason_code or "unknown"
-
-            if reason_code in ("capacity_full", "duplicate_dispatch"):
-                # Normal throttling/dedup - log at info level
+            if has_recent_specific_error(
+                issue_number=issue_number,
+                branch=branch,
+                within_seconds=60,
+                store=store,
+            ):
+                # Bottom layer recorded specific error - skip duplicate
                 logger.bind(
                     domain=handler_domain,
                     issue_number=issue_number,
                     reason_code=reason_code,
-                ).info(f"{role.capitalize()} dispatch deferred: {result.reason}")
-            elif reason_code == "launch_failed":
-                # Check if bottom layer already recorded a specific error
-                # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
-                # If no, record E_DISPATCH_FAILURE for infrastructure visibility
-                from vibe3.services import has_recent_specific_error
+                ).info(
+                    f"{role.capitalize()} dispatch failed (bottom layer recorded): "
+                    f"{result.reason}"
+                )
+            else:
+                # No prior error - this is an infrastructure failure
+                # Fall through to record E_DISPATCH_FAILURE
+                pass
+        else:
+            # Dispatch-level infrastructure failure - record to error_log
+            # FailedGate will control dispatch based on threshold
+            from vibe3.services import record_error
 
-                if has_recent_specific_error(
+            error_message = f"{role} dispatch failed: {result.reason}"
+            try:
+                record_error(
+                    error_code="E_DISPATCH_FAILURE",
+                    error_message=error_message,
+                    tick_id=tick_id,
                     issue_number=issue_number,
                     branch=branch,
-                    within_seconds=60,
                     store=store,
-                ):
-                    # Bottom layer recorded specific error - skip duplicate
-                    logger.bind(
-                        domain=handler_domain,
-                        issue_number=issue_number,
-                        reason_code=reason_code,
-                    ).info(
-                        f"{role.capitalize()} dispatch failed (bottom layer recorded): "
-                        f"{result.reason}"
-                    )
-                else:
-                    # No prior error - this is an infrastructure failure
-                    # Fall through to record E_DISPATCH_FAILURE
-                    pass
-            else:
-                # Dispatch-level infrastructure failure - record to error_log
-                # FailedGate will control dispatch based on threshold
-                from vibe3.services import record_error
-
-                error_message = f"{role} dispatch failed: {result.reason}"
-                try:
-                    record_error(
-                        error_code="E_DISPATCH_FAILURE",
-                        error_message=error_message,
-                        tick_id=tick_id,
-                        issue_number=issue_number,
-                        branch=branch,
-                        store=store,
-                    )
-                except Exception as exc:
-                    logger.bind(
-                        domain=handler_domain,
-                        issue_number=issue_number,
-                    ).warning(f"Failed to record dispatch error: {exc}")
-
+                )
+            except Exception as exc:
                 logger.bind(
                     domain=handler_domain,
                     issue_number=issue_number,
-                    reason_code=reason_code,
-                ).warning(
-                    f"{role.capitalize()} dispatch failed: {result.reason} - "
-                    "FailedGate will control dispatch"
-                )
+                ).warning(f"Failed to record dispatch error: {exc}")
 
-        except Exception as exc:
-            # Record actor failure on exception
-            actor_obj.record_failure(error=str(exc))
-            raise
+            logger.bind(
+                domain=handler_domain,
+                issue_number=issue_number,
+                reason_code=reason_code,
+            ).warning(
+                f"{role.capitalize()} dispatch failed: {result.reason} - "
+                "FailedGate will control dispatch"
+            )
 
 
 @register_handler("PlannerDispatchIntent")

--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -19,6 +19,7 @@ from vibe3.domain.events.flow_lifecycle import (
     ReviewerDispatchIntent,
 )
 from vibe3.domain.handler_registry import register_handler
+from vibe3.execution.actor import JobType, get_actor_registry
 from vibe3.models import ExecutionRequest
 from vibe3.services import load_issue_info
 
@@ -43,118 +44,150 @@ def _dispatch_role_intent(
     with get_store() as store:
         issue = load_issue_info(issue_number, config=config)
 
+        # Resolve branch for actor creation
+        branch_arg = builder_kwargs.get("branch")
+        branch = str(branch_arg) if branch_arg else ""
+
+        # Create actor for supervision tracking
+        registry = get_actor_registry()
+        actor_obj = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=issue_number,
+            branch=branch,
+            store=store,
+        )
+
         logger.bind(
             domain=handler_domain,
             issue_number=issue_number,
         ).debug(f"Building {role} request")
 
-        request = request_builder(config, issue, **builder_kwargs)
+        try:
+            # Build request
+            request = request_builder(config, issue, **builder_kwargs)
 
-        coordinator = ExecutionCoordinator(config, store)
+            # Inject actor_id into request refs for tracking
+            if request.refs is None:
+                request.refs = {}
+            request.refs["actor_id"] = actor_obj.actor_id
 
-        # Record dispatch intent BEFORE execution (correct chronological order)
-        branch_arg = builder_kwargs.get("branch")
-        branch = str(branch_arg) if branch_arg else ""
-        if branch:
-            store.add_event(
-                branch,
-                f"{role}_dispatched",
-                actor,
-                detail=f"{role.capitalize()} dispatched",
-                refs={
-                    "issue": str(issue_number),
-                    "role": role,
-                },
-            )
+            coordinator = ExecutionCoordinator(config, store)
 
-        result = coordinator.dispatch_execution(request)
+            # Record dispatch intent BEFORE execution (correct chronological order)
+            if branch:
+                store.add_event(
+                    branch,
+                    f"{role}_dispatched",
+                    actor,
+                    detail=f"{role.capitalize()} dispatched",
+                    refs={
+                        "issue": str(issue_number),
+                        "role": role,
+                        "actor_id": actor_obj.actor_id,
+                    },
+                )
 
-        if result.launched:
+            # Record actor launch
+            actor_obj.record_launch()
 
-            logger.bind(
-                domain=handler_domain,
-                issue_number=issue_number,
-                tmux_session=result.tmux_session,
-            ).success(f"{role.capitalize()} dispatch completed")
-            return
+            result = coordinator.dispatch_execution(request)
 
-        if result.skipped:
-            logger.bind(
-                domain=handler_domain,
-                issue_number=issue_number,
-            ).info(f"{role.capitalize()} dispatch skipped: {result.reason}")
-            return
+            if result.launched:
+                actor_obj.record_completion(detail=f"{role} launched")
 
-        # Not launched, not skipped:
-        # - capacity_full / duplicate_dispatch → normal throttling (info)
-        # - all other failures → warning (FailedGate will control)
-        # Dispatch failures do NOT trigger flow block.
-        # Flow block is determined by business logic only
-        # (noop_gate, dependencies, loops).
-        # FailedGate controls dispatch based on error severity.
-        reason_code = result.reason_code or "unknown"
+                logger.bind(
+                    domain=handler_domain,
+                    issue_number=issue_number,
+                    tmux_session=result.tmux_session,
+                ).success(f"{role.capitalize()} dispatch completed")
+                return
 
-        if reason_code in ("capacity_full", "duplicate_dispatch"):
-            # Normal throttling/dedup - log at info level
-            logger.bind(
-                domain=handler_domain,
-                issue_number=issue_number,
-                reason_code=reason_code,
-            ).info(f"{role.capitalize()} dispatch deferred: {result.reason}")
-        elif reason_code == "launch_failed":
-            # Check if bottom layer already recorded a specific error
-            # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
-            # If no, record E_DISPATCH_FAILURE for infrastructure visibility
-            from vibe3.services import has_recent_specific_error
+            if result.skipped:
+                actor_obj.record_dead(detail=f"{role} skipped: {result.reason}")
 
-            if has_recent_specific_error(
-                issue_number=issue_number,
-                branch=branch,
-                within_seconds=60,
-                store=store,
-            ):
-                # Bottom layer recorded specific error - skip duplicate
+                logger.bind(
+                    domain=handler_domain,
+                    issue_number=issue_number,
+                ).info(f"{role.capitalize()} dispatch skipped: {result.reason}")
+                return
+
+            # Not launched, not skipped - record failure
+            actor_obj.record_failure(error=result.reason or "dispatch failed")
+
+            # - capacity_full / duplicate_dispatch → normal throttling (info)
+            # - all other failures → warning (FailedGate will control)
+            # Dispatch failures do NOT trigger flow block.
+            # Flow block is determined by business logic only
+            # (noop_gate, dependencies, loops).
+            # FailedGate controls dispatch based on error severity.
+            reason_code = result.reason_code or "unknown"
+
+            if reason_code in ("capacity_full", "duplicate_dispatch"):
+                # Normal throttling/dedup - log at info level
                 logger.bind(
                     domain=handler_domain,
                     issue_number=issue_number,
                     reason_code=reason_code,
-                ).info(
-                    f"{role.capitalize()} dispatch failed (bottom layer recorded): "
-                    f"{result.reason}"
-                )
-            else:
-                # No prior error - this is an infrastructure failure
-                # Fall through to record E_DISPATCH_FAILURE
-                pass
-        else:
-            # Dispatch-level infrastructure failure - record to error_log
-            # FailedGate will control dispatch based on threshold
-            from vibe3.services import record_error
+                ).info(f"{role.capitalize()} dispatch deferred: {result.reason}")
+            elif reason_code == "launch_failed":
+                # Check if bottom layer already recorded a specific error
+                # If yes, skip E_DISPATCH_FAILURE to avoid duplicate
+                # If no, record E_DISPATCH_FAILURE for infrastructure visibility
+                from vibe3.services import has_recent_specific_error
 
-            error_message = f"{role} dispatch failed: {result.reason}"
-            try:
-                record_error(
-                    error_code="E_DISPATCH_FAILURE",
-                    error_message=error_message,
-                    tick_id=tick_id,
+                if has_recent_specific_error(
                     issue_number=issue_number,
                     branch=branch,
+                    within_seconds=60,
                     store=store,
-                )
-            except Exception as exc:
+                ):
+                    # Bottom layer recorded specific error - skip duplicate
+                    logger.bind(
+                        domain=handler_domain,
+                        issue_number=issue_number,
+                        reason_code=reason_code,
+                    ).info(
+                        f"{role.capitalize()} dispatch failed (bottom layer recorded): "
+                        f"{result.reason}"
+                    )
+                else:
+                    # No prior error - this is an infrastructure failure
+                    # Fall through to record E_DISPATCH_FAILURE
+                    pass
+            else:
+                # Dispatch-level infrastructure failure - record to error_log
+                # FailedGate will control dispatch based on threshold
+                from vibe3.services import record_error
+
+                error_message = f"{role} dispatch failed: {result.reason}"
+                try:
+                    record_error(
+                        error_code="E_DISPATCH_FAILURE",
+                        error_message=error_message,
+                        tick_id=tick_id,
+                        issue_number=issue_number,
+                        branch=branch,
+                        store=store,
+                    )
+                except Exception as exc:
+                    logger.bind(
+                        domain=handler_domain,
+                        issue_number=issue_number,
+                    ).warning(f"Failed to record dispatch error: {exc}")
+
                 logger.bind(
                     domain=handler_domain,
                     issue_number=issue_number,
-                ).warning(f"Failed to record dispatch error: {exc}")
+                    reason_code=reason_code,
+                ).warning(
+                    f"{role.capitalize()} dispatch failed: {result.reason} - "
+                    "FailedGate will control dispatch"
+                )
 
-            logger.bind(
-                domain=handler_domain,
-                issue_number=issue_number,
-                reason_code=reason_code,
-            ).warning(
-                f"{role.capitalize()} dispatch failed: {result.reason} - "
-                "FailedGate will control dispatch"
-            )
+        except Exception as exc:
+            # Record actor failure on exception
+            actor_obj.record_failure(error=str(exc))
+            raise
 
 
 @register_handler("PlannerDispatchIntent")

--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from vibe3.execution.actor import ActorRegistry, ActorStatus, JobActor, JobType
+    from vibe3.execution.actor import (
+        ActorRegistry,
+        ActorStatus,
+        JobActor,
+        JobType,
+        get_actor_registry,
+    )
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.execution.codeagent_runner import CodeagentExecutionService
     from vibe3.execution.codeagent_support import build_self_invocation
@@ -58,6 +64,7 @@ _LAZY_IMPORTS = {
     "ActorStatus": "vibe3.execution.actor",
     "JobActor": "vibe3.execution.actor",
     "JobType": "vibe3.execution.actor",
+    "get_actor_registry": "vibe3.execution.actor",
     "CapacityService": "vibe3.execution.capacity_service",
     "CodeagentExecutionService": "vibe3.execution.codeagent_runner",
     "CommandAdapterEntry": "vibe3.execution.command_adapter",
@@ -116,6 +123,7 @@ __all__ = [
     "ActorStatus",
     "JobActor",
     "JobType",
+    "get_actor_registry",
     # Core services
     "ExecutionCoordinator",
     "CodeagentExecutionService",

--- a/src/vibe3/execution/__init__.py
+++ b/src/vibe3/execution/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from vibe3.execution.actor import ActorRegistry, ActorStatus, JobActor, JobType
     from vibe3.execution.capacity_service import CapacityService
     from vibe3.execution.codeagent_runner import CodeagentExecutionService
     from vibe3.execution.codeagent_support import build_self_invocation
@@ -53,6 +54,10 @@ if TYPE_CHECKING:
 
 # Lazy imports for self-references (avoid circular init dependencies)
 _LAZY_IMPORTS = {
+    "ActorRegistry": "vibe3.execution.actor",
+    "ActorStatus": "vibe3.execution.actor",
+    "JobActor": "vibe3.execution.actor",
+    "JobType": "vibe3.execution.actor",
     "CapacityService": "vibe3.execution.capacity_service",
     "CodeagentExecutionService": "vibe3.execution.codeagent_runner",
     "CommandAdapterEntry": "vibe3.execution.command_adapter",
@@ -106,6 +111,11 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    # Actor supervision
+    "ActorRegistry",
+    "ActorStatus",
+    "JobActor",
+    "JobType",
     # Core services
     "ExecutionCoordinator",
     "CodeagentExecutionService",

--- a/src/vibe3/execution/actor.py
+++ b/src/vibe3/execution/actor.py
@@ -118,8 +118,7 @@ class JobActor:
             detail: Optional detail string
             refs: Optional refs dict (will include actor_id)
         """
-        event_refs = refs or {}
-        event_refs["actor_id"] = self.actor_id
+        event_refs = {**(refs or {}), "actor_id": self.actor_id}
 
         try:
             self._store.add_event(

--- a/src/vibe3/execution/actor.py
+++ b/src/vibe3/execution/actor.py
@@ -1,0 +1,318 @@
+"""Lightweight actor abstraction for command-job supervision.
+
+This module provides in-memory tracking of job lifecycle (queued → running →
+done | failed | dead) with event recording to the existing event_log.
+
+Design notes:
+- In-memory only (no SQLite schema change) — matches the spec's "lightweight" intent
+- Singleton pattern avoids passing registry through call chains
+- The existing runtime_session table remains the durable session store; actor
+  complements it with in-process supervision
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
+
+
+class ActorStatus(str, Enum):
+    """Lifecycle status for a JobActor.
+
+    Status transitions:
+        queued → running → done | failed | dead
+
+    Note:
+        The 'dead' status indicates asyncio task cancellation or unexpected
+        termination, distinct from 'aborted' in runtime_session which indicates
+        explicit user abort.
+    """
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    DEAD = "dead"
+
+
+class JobType(str, Enum):
+    """Type of job being supervised by the actor."""
+
+    DISPATCH = "dispatch"
+    GOVERNANCE = "governance"
+    FLOW = "flow"
+
+
+# Valid status transitions
+_VALID_TRANSITIONS: dict[ActorStatus, set[ActorStatus]] = {
+    ActorStatus.QUEUED: {ActorStatus.RUNNING},
+    ActorStatus.RUNNING: {ActorStatus.DONE, ActorStatus.FAILED, ActorStatus.DEAD},
+    ActorStatus.DONE: set(),  # Terminal
+    ActorStatus.FAILED: set(),  # Terminal
+    ActorStatus.DEAD: set(),  # Terminal
+}
+
+
+@dataclass
+class JobActor:
+    """In-memory state tracker for a supervised job.
+
+    Each mutation (record_launch, record_completion, record_failure, record_dead)
+    writes to the event_log via the store reference.
+
+    Attributes:
+        actor_id: Unique identifier for this actor
+        job_type: Type of job being supervised
+        status: Current lifecycle status
+        issue_number: Issue number (0 for governance)
+        branch: Target branch
+        _store: Reference to SQLiteClient for event recording (internal)
+        started_at: ISO 8601 timestamp when launched (None if queued)
+        completed_at: ISO 8601 timestamp when terminated (None if not terminal)
+        pid: Process ID if available (None if not launched or not applicable)
+    """
+
+    actor_id: str
+    job_type: JobType
+    status: ActorStatus
+    issue_number: int
+    branch: str
+    _store: SQLiteClient = field(repr=False, compare=False)
+    started_at: str | None = None
+    completed_at: str | None = None
+    pid: int | None = None
+
+    def _validate_transition(self, new_status: ActorStatus) -> None:
+        """Validate that the transition is allowed.
+
+        Args:
+            new_status: Target status
+
+        Raises:
+            ValueError: If transition is not valid
+        """
+        allowed = _VALID_TRANSITIONS.get(self.status, set())
+        if new_status not in allowed:
+            raise ValueError(
+                f"Invalid status transition: {self.status.value} → {new_status.value}"
+            )
+
+    def _record_event(
+        self,
+        event_type: str,
+        detail: str | None = None,
+        refs: dict[str, str] | None = None,
+    ) -> None:
+        """Record an event to the event_log.
+
+        Args:
+            event_type: Event type (e.g., "actor_started", "actor_done")
+            detail: Optional detail string
+            refs: Optional refs dict (will include actor_id)
+        """
+        event_refs = refs or {}
+        event_refs["actor_id"] = self.actor_id
+
+        try:
+            self._store.add_event(
+                branch=self.branch,
+                event_type=event_type,
+                actor=f"actor:{self.job_type.value}",
+                detail=detail,
+                refs=event_refs,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to record actor event {event_type}: {e}")
+
+    def record_launch(self, pid: int | None = None) -> None:
+        """Record that the job has launched.
+
+        Args:
+            pid: Optional process ID
+
+        Raises:
+            ValueError: If not in QUEUED status
+        """
+        self._validate_transition(ActorStatus.RUNNING)
+
+        self.status = ActorStatus.RUNNING
+        self.started_at = datetime.now(tz=timezone.utc).isoformat()
+        self.pid = pid
+
+        detail = f"Actor launched (pid={pid})" if pid else "Actor launched"
+        self._record_event("actor_started", detail=detail)
+
+    def record_completion(self, detail: str | None = None) -> None:
+        """Record that the job has completed successfully.
+
+        Args:
+            detail: Optional detail string
+
+        Raises:
+            ValueError: If not in RUNNING status
+        """
+        self._validate_transition(ActorStatus.DONE)
+
+        self.status = ActorStatus.DONE
+        self.completed_at = datetime.now(tz=timezone.utc).isoformat()
+
+        event_detail = detail or "Actor completed"
+        self._record_event("actor_done", detail=event_detail)
+
+    def record_failure(self, error: str) -> None:
+        """Record that the job has failed.
+
+        Args:
+            error: Error message
+
+        Raises:
+            ValueError: If not in RUNNING status
+        """
+        self._validate_transition(ActorStatus.FAILED)
+
+        self.status = ActorStatus.FAILED
+        self.completed_at = datetime.now(tz=timezone.utc).isoformat()
+
+        self._record_event("actor_failed", detail=error)
+
+    def record_dead(self, detail: str | None = None) -> None:
+        """Record that the job has died (cancelled or unexpected termination).
+
+        Args:
+            detail: Optional detail string
+
+        Raises:
+            ValueError: If not in RUNNING status
+        """
+        self._validate_transition(ActorStatus.DEAD)
+
+        self.status = ActorStatus.DEAD
+        self.completed_at = datetime.now(tz=timezone.utc).isoformat()
+
+        event_detail = detail or "Actor died"
+        self._record_event("actor_dead", detail=event_detail)
+
+
+class ActorRegistry:
+    """Registry for tracking active actors.
+
+    This is a module-level singleton accessed via get_actor_registry().
+
+    Note:
+        The registry is in-memory only. Actors are lost if the orchestrator
+        process exits. This matches the "lightweight" design intent — the
+        runtime_session table remains the durable session store.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the registry."""
+        self._actors: dict[str, JobActor] = {}
+
+    def create_actor(
+        self,
+        job_type: JobType,
+        issue_number: int,
+        branch: str,
+        store: SQLiteClient,
+    ) -> JobActor:
+        """Create a new actor in QUEUED state.
+
+        Args:
+            job_type: Type of job
+            issue_number: Issue number (0 for governance)
+            branch: Target branch
+            store: SQLite client for event recording
+
+        Returns:
+            The created actor
+        """
+        actor_id = f"actor-{uuid.uuid4().hex[:12]}"
+
+        actor = JobActor(
+            actor_id=actor_id,
+            job_type=job_type,
+            status=ActorStatus.QUEUED,
+            issue_number=issue_number,
+            branch=branch,
+            _store=store,
+        )
+
+        self._actors[actor_id] = actor
+
+        # Record creation event
+        try:
+            store.add_event(
+                branch=branch,
+                event_type="actor_created",
+                actor=f"actor:{job_type.value}",
+                detail=f"Actor created for {job_type.value}",
+                refs={"actor_id": actor_id, "issue": str(issue_number)},
+            )
+        except Exception as e:
+            logger.warning(f"Failed to record actor_created event: {e}")
+
+        return actor
+
+    def get_actor(self, actor_id: str) -> JobActor | None:
+        """Get an actor by ID.
+
+        Args:
+            actor_id: Actor ID
+
+        Returns:
+            The actor if found, None otherwise
+        """
+        return self._actors.get(actor_id)
+
+    def get_active_actors(self) -> list[JobActor]:
+        """Get all non-terminal actors.
+
+        Returns:
+            List of actors in QUEUED or RUNNING status
+        """
+        return [
+            actor
+            for actor in self._actors.values()
+            if actor.status in (ActorStatus.QUEUED, ActorStatus.RUNNING)
+        ]
+
+    def remove_actor(self, actor_id: str) -> None:
+        """Remove an actor from the registry.
+
+        Args:
+            actor_id: Actor ID
+        """
+        self._actors.pop(actor_id, None)
+
+
+# Module-level singleton
+_REGISTRY: ActorRegistry | None = None
+
+
+def get_actor_registry() -> ActorRegistry:
+    """Get the module-level actor registry singleton.
+
+    Returns:
+        The singleton ActorRegistry instance
+    """
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = ActorRegistry()
+    return _REGISTRY
+
+
+def _reset_registry() -> None:
+    """Reset the module-level registry singleton.
+
+    This is for test use only.
+    """
+    global _REGISTRY
+    _REGISTRY = None

--- a/src/vibe3/execution/job_executor.py
+++ b/src/vibe3/execution/job_executor.py
@@ -26,7 +26,6 @@ from vibe3.models import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.execution.actor import ActorRegistry
     from vibe3.execution.command_adapter import CommandAdapterRegistry
     from vibe3.execution.coordinator import ExecutionCoordinator
     from vibe3.execution.role_interfaces import IssueRoleSyncSpec
@@ -107,7 +106,6 @@ class JobExecutor:
         registry: CommandAdapterRegistry,
         store: SQLiteClient,
         coordinator: ExecutionCoordinator | None = None,
-        actor_registry: ActorRegistry | None = None,
     ) -> None:
         """Initialize executor with adapter registry and store.
 
@@ -118,14 +116,11 @@ class JobExecutor:
                 When provided, _execute_issue_role uses it instead of creating
                 a new one per invocation. When None, a coordinator is created
                 on each call (preserving the original behavior).
-            actor_registry: Optional actor registry for supervision tracking.
-                When provided, actor_id from envelope.refs is propagated to
-                JobResult for cross-referencing.
         """
         self._registry = registry
         self._lifecycle = ExecutionLifecycleService(store)
         self._coordinator = coordinator
-        self._actor_registry = actor_registry
+        self._store = store
 
     def _resolve_coordinator(self, config: object) -> ExecutionCoordinator:
         """Resolve or create an ExecutionCoordinator.
@@ -152,6 +147,10 @@ class JobExecutor:
     def execute(self, envelope: JobEnvelope) -> JobResult:
         """Execute a job from its envelope.
 
+        Manages actor lifecycle (create → launch → complete/fail/die) as a
+        lightweight supervision wrapper around the existing execution path.
+        Actor state is tracked in-memory and written to event_log.
+
         Args:
             envelope: The job envelope containing all execution parameters
 
@@ -162,13 +161,32 @@ class JobExecutor:
             For async commands, status will be "launched" not "completed".
             The executor returns immediately after tmux launch.
         """
+        from vibe3.execution.actor import JobType, get_actor_registry
+
         started_at = datetime.now(tz=timezone.utc).isoformat()
+
+        # Map CommandType to actor JobType
+        _command_to_job_type: dict[CommandType, JobType] = {
+            CommandType.GOVERNANCE_SCAN: JobType.GOVERNANCE,
+        }
+        job_type = _command_to_job_type.get(envelope.command_type, JobType.DISPATCH)
+
+        # Create actor for supervision tracking
+        registry = get_actor_registry()
+        actor_obj = registry.create_actor(
+            job_type=job_type,
+            issue_number=envelope.issue_number,
+            branch=envelope.branch,
+            store=self._store,
+        )
 
         try:
             # Resolve adapter
             resolved = self._registry.resolve(envelope.command_type)
             adapter_path = resolved.entry.import_path
         except Exception as e:
+            # Pre-launch failure: actor still QUEUED, just clean up
+            registry.remove_actor(actor_obj.actor_id)
             logger.error(f"Failed to resolve adapter for {envelope.command_type}: {e}")
             return JobResult(
                 command_type=envelope.command_type,
@@ -188,6 +206,8 @@ class JobExecutor:
         # Record lifecycle started event
         role = COMMAND_TYPE_TO_EXECUTION_ROLE.get(envelope.command_type)
         if role is None:
+            # Pre-launch failure: actor still QUEUED, just clean up
+            registry.remove_actor(actor_obj.actor_id)
             logger.error(f"No execution role mapping for {envelope.command_type}")
             return JobResult(
                 command_type=envelope.command_type,
@@ -200,12 +220,14 @@ class JobExecutor:
                 source=envelope.source,
             )
 
+        # Record actor launch and lifecycle started
+        actor_obj.record_launch()
         self._lifecycle.record_started(
             role=role,
             target=envelope.branch,
             actor=envelope.actor,
             session_id=context.session_id,
-            refs=envelope.refs,
+            refs={**(envelope.refs or {}), "actor_id": actor_obj.actor_id},
         )
 
         try:
@@ -229,8 +251,11 @@ class JobExecutor:
             # Map to JobResult
             job_result = self._map_launch_result(result, envelope, context)
 
-            # Record lifecycle completion
+            # Record lifecycle completion and actor terminal state
             if job_result.status == "failed":
+                actor_obj.record_failure(
+                    error=job_result.error_message or "dispatch failed"
+                )
                 self._lifecycle.record_failed(
                     role=role,
                     target=envelope.branch,
@@ -239,7 +264,7 @@ class JobExecutor:
                     refs=envelope.refs,
                 )
             elif job_result.status == "skipped":
-                # Skipped is treated as a successful no-op
+                actor_obj.record_completion(detail=f"{envelope.command_type} skipped")
                 self._lifecycle.record_completed(
                     role=role,
                     target=envelope.branch,
@@ -249,6 +274,9 @@ class JobExecutor:
                 )
             else:
                 # launched or completed
+                actor_obj.record_completion(
+                    detail=f"{envelope.command_type} {job_result.status}"
+                )
                 self._lifecycle.record_completed(
                     role=role,
                     target=envelope.branch,
@@ -260,18 +288,18 @@ class JobExecutor:
             # Fill in execution metadata
             job_result.started_at = started_at
             job_result.adapter_path = adapter_path
+            job_result.actor_id = actor_obj.actor_id
 
-            # Propagate actor_id from envelope if present
-            actor_id = envelope.refs.get("actor_id")
-            if actor_id:
-                job_result.actor_id = actor_id
+            # Clean up actor from registry (terminal state reached)
+            registry.remove_actor(actor_obj.actor_id)
 
             return job_result
 
         except Exception as e:
             logger.exception(f"Job execution failed: {e}")
 
-            # Record lifecycle failure
+            # Record actor failure and lifecycle failure
+            actor_obj.record_failure(error=str(e))
             self._lifecycle.record_failed(
                 role=role,
                 target=envelope.branch,
@@ -279,6 +307,9 @@ class JobExecutor:
                 error=str(e),
                 refs=envelope.refs,
             )
+
+            # Clean up actor from registry
+            registry.remove_actor(actor_obj.actor_id)
 
             return JobResult(
                 command_type=envelope.command_type,

--- a/src/vibe3/execution/job_executor.py
+++ b/src/vibe3/execution/job_executor.py
@@ -26,6 +26,7 @@ from vibe3.models import (
 )
 
 if TYPE_CHECKING:
+    from vibe3.execution.actor import ActorRegistry
     from vibe3.execution.command_adapter import CommandAdapterRegistry
     from vibe3.execution.coordinator import ExecutionCoordinator
     from vibe3.execution.role_interfaces import IssueRoleSyncSpec
@@ -106,6 +107,7 @@ class JobExecutor:
         registry: CommandAdapterRegistry,
         store: SQLiteClient,
         coordinator: ExecutionCoordinator | None = None,
+        actor_registry: ActorRegistry | None = None,
     ) -> None:
         """Initialize executor with adapter registry and store.
 
@@ -116,10 +118,14 @@ class JobExecutor:
                 When provided, _execute_issue_role uses it instead of creating
                 a new one per invocation. When None, a coordinator is created
                 on each call (preserving the original behavior).
+            actor_registry: Optional actor registry for supervision tracking.
+                When provided, actor_id from envelope.refs is propagated to
+                JobResult for cross-referencing.
         """
         self._registry = registry
         self._lifecycle = ExecutionLifecycleService(store)
         self._coordinator = coordinator
+        self._actor_registry = actor_registry
 
     def _resolve_coordinator(self, config: object) -> ExecutionCoordinator:
         """Resolve or create an ExecutionCoordinator.
@@ -254,6 +260,11 @@ class JobExecutor:
             # Fill in execution metadata
             job_result.started_at = started_at
             job_result.adapter_path = adapter_path
+
+            # Propagate actor_id from envelope if present
+            actor_id = envelope.refs.get("actor_id")
+            if actor_id:
+                job_result.actor_id = actor_id
 
             return job_result
 

--- a/src/vibe3/models/job.py
+++ b/src/vibe3/models/job.py
@@ -176,3 +176,6 @@ class JobResult(BaseModel):
     # before source is known).  Downstream consumers that require provenance
     # should treat None as "unknown trigger".
     source: JobSource | None = None
+
+    # Actor supervision link
+    actor_id: str | None = None

--- a/tests/vibe3/execution/test_actor.py
+++ b/tests/vibe3/execution/test_actor.py
@@ -1,0 +1,399 @@
+"""Tests for actor supervision tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibe3.clients import SQLiteClient
+from vibe3.execution.actor import (
+    ActorRegistry,
+    ActorStatus,
+    JobActor,
+    JobType,
+    _reset_registry,
+    get_actor_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_registry() -> None:
+    """Reset the singleton registry before each test."""
+    _reset_registry()
+
+
+class TestActorStatusTransitions:
+    """Test ActorStatus transition validation."""
+
+    def test_queued_to_running(self) -> None:
+        """Valid transition: queued → running."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        actor.record_launch()
+
+        assert actor.status == ActorStatus.RUNNING
+        assert actor.started_at is not None
+        assert actor.pid is None
+
+    def test_running_to_done(self) -> None:
+        """Valid transition: running → done."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_completion(detail="Success")
+
+        assert actor.status == ActorStatus.DONE
+        assert actor.completed_at is not None
+
+    def test_running_to_failed(self) -> None:
+        """Valid transition: running → failed."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_failure(error="Something went wrong")
+
+        assert actor.status == ActorStatus.FAILED
+        assert actor.completed_at is not None
+
+    def test_running_to_dead(self) -> None:
+        """Valid transition: running → dead."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_dead(detail="Cancelled")
+
+        assert actor.status == ActorStatus.DEAD
+        assert actor.completed_at is not None
+
+    def test_invalid_transition_done_to_running(self) -> None:
+        """Invalid transition: done → running raises ValueError."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.DONE,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            completed_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            actor.record_launch()
+
+    def test_invalid_transition_queued_to_done(self) -> None:
+        """Invalid transition: queued → done raises ValueError."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            actor.record_completion()
+
+
+class TestJobActorMethods:
+    """Test JobActor methods."""
+
+    def test_record_launch_sets_pid(self) -> None:
+        """record_launch() sets pid when provided."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        actor.record_launch(pid=12345)
+
+        assert actor.pid == 12345
+        assert actor.status == ActorStatus.RUNNING
+
+    def test_record_launch_writes_event(self) -> None:
+        """record_launch() writes actor_started event."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        actor.record_launch()
+
+        store.add_event.assert_called_once()
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["event_type"] == "actor_started"
+        assert call_kwargs["branch"] == "test-branch"
+        assert call_kwargs["refs"]["actor_id"] == "test-1"
+
+    def test_record_completion_writes_event(self) -> None:
+        """record_completion() writes actor_done event."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_completion(detail="planner launched")
+
+        store.add_event.assert_called_once()
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["event_type"] == "actor_done"
+        assert call_kwargs["detail"] == "planner launched"
+
+    def test_record_failure_writes_event(self) -> None:
+        """record_failure() writes actor_failed event."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_failure(error="Dispatch failed")
+
+        store.add_event.assert_called_once()
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["event_type"] == "actor_failed"
+        assert call_kwargs["detail"] == "Dispatch failed"
+
+    def test_record_dead_writes_event(self) -> None:
+        """record_dead() writes actor_dead event."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-1",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.RUNNING,
+            issue_number=123,
+            branch="test-branch",
+            started_at=datetime.now(tz=timezone.utc).isoformat(),
+            _store=store,
+        )
+
+        actor.record_dead(detail="planner skipped: already planned")
+
+        store.add_event.assert_called_once()
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["event_type"] == "actor_dead"
+        assert call_kwargs["detail"] == "planner skipped: already planned"
+
+
+class TestActorRegistry:
+    """Test ActorRegistry methods."""
+
+    def test_create_actor_returns_actor(self) -> None:
+        """create_actor() returns a new actor in QUEUED state."""
+        store = MagicMock(spec=SQLiteClient)
+        registry = ActorRegistry()
+
+        actor = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=123,
+            branch="test-branch",
+            store=store,
+        )
+
+        assert actor.status == ActorStatus.QUEUED
+        assert actor.job_type == JobType.DISPATCH
+        assert actor.issue_number == 123
+        assert actor.branch == "test-branch"
+        assert actor.actor_id.startswith("actor-")
+
+    def test_create_actor_records_event(self) -> None:
+        """create_actor() records actor_created event."""
+        store = MagicMock(spec=SQLiteClient)
+        registry = ActorRegistry()
+
+        actor = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=123,
+            branch="test-branch",
+            store=store,
+        )
+
+        store.add_event.assert_called_once()
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["event_type"] == "actor_created"
+        assert call_kwargs["refs"]["actor_id"] == actor.actor_id
+        assert call_kwargs["refs"]["issue"] == "123"
+
+    def test_get_actor_returns_existing(self) -> None:
+        """get_actor() returns existing actor."""
+        store = MagicMock(spec=SQLiteClient)
+        registry = ActorRegistry()
+
+        created = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=123,
+            branch="test-branch",
+            store=store,
+        )
+
+        retrieved = registry.get_actor(created.actor_id)
+        assert retrieved is created
+
+    def test_get_actor_returns_none_for_missing(self) -> None:
+        """get_actor() returns None for missing actor."""
+        registry = ActorRegistry()
+        assert registry.get_actor("nonexistent") is None
+
+    def test_get_active_actors_returns_non_terminal(self) -> None:
+        """get_active_actors() returns only QUEUED and RUNNING actors."""
+        store = MagicMock(spec=SQLiteClient)
+        registry = ActorRegistry()
+
+        actor1 = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=123,
+            branch="test-branch-1",
+            store=store,
+        )
+        actor2 = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=124,
+            branch="test-branch-2",
+            store=store,
+        )
+        actor2.record_launch()  # RUNNING
+
+        actor3 = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=125,
+            branch="test-branch-3",
+            store=store,
+        )
+        actor3.record_launch()
+        actor3.record_completion()  # DONE (terminal)
+
+        active = registry.get_active_actors()
+        assert len(active) == 2
+        assert actor1 in active
+        assert actor2 in active
+        assert actor3 not in active
+
+    def test_remove_actor(self) -> None:
+        """remove_actor() removes actor from registry."""
+        store = MagicMock(spec=SQLiteClient)
+        registry = ActorRegistry()
+
+        actor = registry.create_actor(
+            job_type=JobType.DISPATCH,
+            issue_number=123,
+            branch="test-branch",
+            store=store,
+        )
+
+        assert registry.get_actor(actor.actor_id) is actor
+        registry.remove_actor(actor.actor_id)
+        assert registry.get_actor(actor.actor_id) is None
+
+
+class TestGetActorRegistry:
+    """Test get_actor_registry singleton."""
+
+    def test_returns_singleton(self) -> None:
+        """get_actor_registry() returns the same instance."""
+        registry1 = get_actor_registry()
+        registry2 = get_actor_registry()
+        assert registry1 is registry2
+
+    def test_reset_creates_new_instance(self) -> None:
+        """_reset_registry() creates a new instance."""
+        registry1 = get_actor_registry()
+        _reset_registry()
+        registry2 = get_actor_registry()
+        assert registry1 is not registry2
+
+
+class TestEventRecording:
+    """Test event recording to store."""
+
+    def test_event_refs_include_actor_id(self) -> None:
+        """All actor events include actor_id in refs."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-actor-id",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        actor.record_launch()
+
+        call_kwargs = store.add_event.call_args[1]
+        assert "actor_id" in call_kwargs["refs"]
+        assert call_kwargs["refs"]["actor_id"] == "test-actor-id"
+
+    def test_event_actor_format(self) -> None:
+        """Actor events use 'actor:<job_type>' format."""
+        store = MagicMock(spec=SQLiteClient)
+        actor = JobActor(
+            actor_id="test-actor-id",
+            job_type=JobType.DISPATCH,
+            status=ActorStatus.QUEUED,
+            issue_number=123,
+            branch="test-branch",
+            _store=store,
+        )
+
+        actor.record_launch()
+
+        call_kwargs = store.add_event.call_args[1]
+        assert call_kwargs["actor"] == "actor:dispatch"

--- a/tests/vibe3/models/test_job.py
+++ b/tests/vibe3/models/test_job.py
@@ -218,6 +218,7 @@ class TestJobResult:
             "error_message": None,
             "error_code": None,
             "source": None,
+            "actor_id": None,
         }.items():  # noqa: E501
             assert getattr(result, field) == expected
 
@@ -249,6 +250,7 @@ class TestJobResult:
             started_at="2026-06-06T10:00:00Z",
             finished_at="2026-06-06T10:30:00Z",
             source="cli-manual",
+            actor_id="actor-abc123def456",
         )
         data = original.model_dump()
         restored = JobResult.model_validate(data)
@@ -263,6 +265,7 @@ class TestJobResult:
         assert restored.started_at == "2026-06-06T10:00:00Z"
         assert restored.finished_at == "2026-06-06T10:30:00Z"
         assert restored.source == "cli-manual"
+        assert restored.actor_id == "actor-abc123def456"
 
     def test_status_transitions(self):
         """Verify status can transition from launched to completed/failed."""
@@ -285,6 +288,29 @@ class TestJobResult:
         failed_result.status = "failed"
         failed_result.error_message = "Test failure"
         assert failed_result.status == "failed"
+
+    def test_actor_id_field(self):
+        """Verify actor_id field can be set and updated."""
+        result = JobResult(
+            command_type=CommandType.PLAN,
+            issue_number=123,
+            branch="task/issue-123",
+            actor_id="actor-test-123",
+        )
+        assert result.actor_id == "actor-test-123"
+
+        # Can be updated (result is mutable)
+        result.actor_id = "actor-updated-456"
+        assert result.actor_id == "actor-updated-456"
+
+    def test_actor_id_defaults_to_none(self):
+        """Verify actor_id defaults to None."""
+        result = JobResult(
+            command_type=CommandType.RUN,
+            issue_number=123,
+            branch="main",
+        )
+        assert result.actor_id is None
 
 
 class TestSemanticEquivalence:


### PR DESCRIPTION
Closes #2172

## Summary

Add in-memory actor tracking for dispatch job lifecycle (queued → running → done | failed | dead).

## Changes

- **actor module** (NEW): ActorStatus, JobActor, ActorRegistry for lifecycle tracking
- **JobResult enhancement**: Added actor_id field for cross-referencing
- **JobExecutor integration**: Propagates actor_id from envelope refs
- **dispatch handler integration**: Wraps dispatch path with actor lifecycle

## Event Recording

Actor events written to event_log:
- actor_created (status=queued)
- actor_started (status=running)
- actor_done / actor_failed / actor_dead (terminal states)

## Design

- In-memory only (no SQLite schema change)
- Singleton pattern for registry
- Backward-compatible (actor_id defaults to None)
- Module API compliant (get_actor_registry exported)

## Tests

All 3175 tests pass:
- 21 actor lifecycle tests
- 3 JobResult actor_id tests
- Module API compliance tests pass
- No regressions

## Verification

- ✅ All changes committed
- ✅ Type checking clean (mypy)
- ✅ Linting clean (ruff)
- ✅ Module API compliance verified
- ✅ Full test suite passes (3175 passed, 1 xpassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
