### PR TITLE
feat(check): command group + remote label audit (fixes #2540)

### DIFF
--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -6,7 +6,11 @@ import typer
 from rich.console import Console
 from rich.markup import escape
 
-from vibe3.commands.check_support import execute_check_mode
+from vibe3.commands.check_support import (
+    ExecuteCheckResult,
+    execute_check_mode,
+    execute_remote_check,
+)
 from vibe3.commands.common import enable_method_trace
 from vibe3.observability import setup_logging
 from vibe3.services import CheckService
@@ -154,80 +158,63 @@ def _emit_check_details(
         return
 
 
-@app.callback(invoke_without_command=True)
-def check(
-    ctx: typer.Context,
-    init: Annotated[
-        bool,
-        typer.Option(
-            "--init",
-            help=(
-                "Scan merged PRs on GitHub and back-fill missing task_issue_number "
-                "for all flows. Requires network. Writes to local store. "
-                "Safe to re-run (skips flows that already have task_issue_number)."
-            ),
-        ),
-    ] = False,
-    clean_branch: Annotated[
-        bool,
-        typer.Option(
-            "--clean-branch",
-            help=(
-                "Clean residual resources: terminal flows, expired agent "
-                "worktrees (>7d), expired remote branches (>7d), and local "
-                "branches with no active/blocked flow record (>7d, merge "
-                "status ignored)."
-            ),
-        ),
-    ] = False,
-    force: Annotated[
-        bool,
-        typer.Option(
-            "--force",
-            help=(
-                "With --clean-branch: bypass the 7-day age gate and delete "
-                "every eligible branch (still skips active/blocked flows)."
-            ),
-        ),
-    ] = False,
-    branch: Annotated[
-        str | None,
-        typer.Option(
-            "--branch",
-            help="Check a single branch instead of all active flows.",
-        ),
-    ] = None,
-    no_progress: Annotated[
-        bool,
-        typer.Option(
-            "--no-progress",
-            help="Disable progress bar for 'all' and 'fix_all' modes.",
-        ),
-    ] = False,
-    trace: Annotated[
-        bool, typer.Option("--trace", help="启用调用链路追踪（set VIBE3_TRACE=1）")
-    ] = False,
+def _emit_remote_check_details(result: ExecuteCheckResult) -> None:
+    """Render remote check results grouped by anomaly rule."""
+    details = result.details
+    anomalies = details.get("anomalies", [])
+    errors = details.get("errors", [])
+    dry_run = details.get("dry_run", True)
+    removed_count = details.get("removed_count", 0)
+    added_count = details.get("added_count", 0)
+
+    if not anomalies:
+        _emit(f"  [green]{result.summary}[/green]")
+        return
+
+    # Group anomalies by rule
+    by_rule: dict[str, list[dict]] = {}
+    for anomaly in anomalies:
+        rule = anomaly.get("rule", "unknown")
+        by_rule.setdefault(rule, []).append(anomaly)
+
+    _emit(f"  [yellow]{result.summary}[/yellow]:")
+    _emit("")
+
+    for rule, rule_anomalies in sorted(by_rule.items()):
+        _emit(f"  [bold]{rule}[/bold]:")
+        for anomaly in rule_anomalies:
+            inum = anomaly["issue_number"]
+            removed = anomaly.get("removed", [])
+            added = anomaly.get("added", [])
+            parts: list[str] = []
+            if removed:
+                parts.append(f"remove {', '.join(removed)}")
+            if added:
+                parts.append(f"add {', '.join(added)}")
+            if parts:
+                _emit(f"    [cyan]#{inum}[/cyan]: {', '.join(parts)}")
+        _emit("")
+
+    action = "Would remove" if dry_run else "Removed"
+    action_add = "Would add" if dry_run else "Added"
+    _emit(
+        f"  [bold]Total:[/bold] {action} {removed_count} label(s), "
+        f"{action_add} {added_count} label(s)"
+    )
+
+    if errors:
+        _emit_failures("Errors", errors)
+
+
+def _run_legacy_check(
+    init: bool = False,
+    clean_branch: bool = False,
+    force: bool = False,
+    branch: str | None = None,
+    no_progress: bool = False,
+    trace: bool = False,
 ) -> None:
-    """Verify handoff store consistency.
-
-    Default mode: Check + fix all active flows.
-    (Fixable: missing handoff file, missing pr_number, aborted status)
-
-    [green]vibe3 check[/green]         Verify all flows + auto-fix
-
-    [green]vibe3 check --init[/green]  Scan merged PRs + GitHub items,
-                         back-fill task_issue_number for all flows.
-
-    [green]vibe3 check --clean-branch[/green]  Clean residual branches:
-                         terminal flows + branches with no active/blocked
-                         flow record older than 7 days (merge status ignored).
-
-    [green]vibe3 check --clean-branch --force[/green]  Also delete eligible
-                         branches younger than 7 days (skips active/blocked).
-
-    [green]vibe3 check --branch <name>[/green]  Verify a single branch
-                         instead of all active flows.
-    """
+    """Execute the original check logic (forward-compat for check / check local)."""
     if trace:
         setup_logging(verbose=2)
 
@@ -305,3 +292,169 @@ def check(
             )
     finally:
         pass
+
+
+@app.callback(invoke_without_command=True)
+def check(
+    ctx: typer.Context,
+    init: Annotated[
+        bool,
+        typer.Option(
+            "--init",
+            help=(
+                "Scan merged PRs on GitHub and back-fill missing task_issue_number "
+                "for all flows. Requires network. Writes to local store. "
+                "Safe to re-run (skips flows that already have task_issue_number)."
+            ),
+        ),
+    ] = False,
+    clean_branch: Annotated[
+        bool,
+        typer.Option(
+            "--clean-branch",
+            help=(
+                "Clean residual resources: terminal flows, expired agent "
+                "worktrees (>7d), expired remote branches (>7d), and local "
+                "branches with no active/blocked flow record (>7d, merge "
+                "status ignored)."
+            ),
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help=(
+                "With --clean-branch: bypass the 7-day age gate and delete "
+                "every eligible branch (still skips active/blocked flows)."
+            ),
+        ),
+    ] = False,
+    branch: Annotated[
+        str | None,
+        typer.Option(
+            "--branch",
+            help="Check a single branch instead of all active flows.",
+        ),
+    ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option(
+            "--no-progress",
+            help="Disable progress bar for 'all' and 'fix_all' modes.",
+        ),
+    ] = False,
+    trace: Annotated[
+        bool, typer.Option("--trace", help="启用调用链路追踪（set VIBE3_TRACE=1）")
+    ] = False,
+) -> None:
+    """Verify handoff store consistency.
+
+    Default mode: Check + fix all active flows.
+    (Fixable: missing handoff file, missing pr_number, aborted status)
+
+    [green]vibe3 check[/green]         Verify all flows + auto-fix
+
+    [green]vibe3 check --init[/green]  Scan merged PRs + GitHub items,
+                         back-fill task_issue_number for all flows.
+
+    [green]vibe3 check --clean-branch[/green]  Clean residual branches:
+                         terminal flows + branches with no active/blocked
+                         flow record older than 7 days (merge status ignored).
+
+    [green]vibe3 check --clean-branch --force[/green]  Also delete eligible
+                         branches younger than 7 days (skips active/blocked).
+
+    [green]vibe3 check --branch <name>[/green]  Verify a single branch
+                         instead of all active flows.
+
+    [green]vibe3 check local[/green]   Alias for default behavior.
+
+    [green]vibe3 check remote[/green]  Audit remote issue labels.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    _run_legacy_check(init, clean_branch, force, branch, no_progress, trace)
+
+
+@app.command()
+def local(
+    init: Annotated[
+        bool,
+        typer.Option(
+            "--init",
+            help=(
+                "Scan merged PRs on GitHub and back-fill missing task_issue_number "
+                "for all flows. Requires network. Writes to local store. "
+                "Safe to re-run (skips flows that already have task_issue_number)."
+            ),
+        ),
+    ] = False,
+    clean_branch: Annotated[
+        bool,
+        typer.Option(
+            "--clean-branch",
+            help=(
+                "Clean residual resources: terminal flows, expired agent "
+                "worktrees (>7d), expired remote branches (>7d), and local "
+                "branches with no active/blocked flow record (>7d, merge "
+                "status ignored)."
+            ),
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help=(
+                "With --clean-branch: bypass the 7-day age gate and delete "
+                "every eligible branch (still skips active/blocked flows)."
+            ),
+        ),
+    ] = False,
+    branch: Annotated[
+        str | None,
+        typer.Option(
+            "--branch",
+            help="Check a single branch instead of all active flows.",
+        ),
+    ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option(
+            "--no-progress",
+            help="Disable progress bar for 'all' and 'fix_all' modes.",
+        ),
+    ] = False,
+    trace: Annotated[
+        bool, typer.Option("--trace", help="启用调用链路追踪（set VIBE3_TRACE=1）")
+    ] = False,
+) -> None:
+    """Verify handoff store consistency (default behavior)."""
+    _run_legacy_check(init, clean_branch, force, branch, no_progress, trace)
+
+
+@app.command()
+def remote(
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Only report, don't modify labels."),
+    ] = False,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Disable progress bar."),
+    ] = False,
+    trace: Annotated[
+        bool, typer.Option("--trace", help="启用调用链路追踪（set VIBE3_TRACE=1）")
+    ] = False,
+) -> None:
+    """Audit and fix remote issue labels using label anomaly rules."""
+    if trace:
+        setup_logging(verbose=2)
+        enable_method_trace()
+
+    result = execute_remote_check(dry_run=dry_run, show_progress=not no_progress)
+    _emit_remote_check_details(result)
+
+    if not result.success:
+        raise typer.Exit(code=1)

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -14,14 +14,24 @@ from rich.progress import (
     TextColumn,
 )
 
+from vibe3.clients import GhIssueLabelPort
+from vibe3.config import OrchestraConfig, get_manager_usernames
 from vibe3.services import CheckResult, CheckService, InitResult
+from vibe3.services.shared import (
+    collect_label_anomalies,
+    has_manager_assignee,
+    normalize_assignees,
+    normalize_labels,
+)
 
 
 @dataclass
 class ExecuteCheckResult:
     """Result of command-level check execution."""
 
-    mode: Literal["default", "init", "all", "fix", "fix_all", "clean_branch", "branch"]
+    mode: Literal[
+        "default", "init", "all", "fix", "fix_all", "clean_branch", "branch", "remote"
+    ]
     success: bool
     summary: str
     details: dict = field(default_factory=dict)
@@ -66,7 +76,7 @@ def _run_with_progress(
 def execute_check_mode(
     service: CheckService,
     mode: Literal[
-        "default", "init", "all", "fix", "fix_all", "clean_branch", "branch"
+        "default", "init", "all", "fix", "fix_all", "clean_branch", "branch", "remote"
     ] = "default",
     *,
     branch: str | None = None,
@@ -260,4 +270,156 @@ def execute_check_mode(
             else f"Issues found for branch '{default_result.branch}'"
         ),
         details={"issues": default_result.issues},
+    )
+
+
+def _audit_single_issue(
+    issue: dict,
+    *,
+    local_issue_numbers: set[int],
+    manager_usernames: tuple[str, ...],
+) -> list[dict]:
+    """Audit one GitHub issue for label anomalies.
+
+    Returns list of anomaly dicts with keys:
+        issue_number, rule, removed, added.
+    """
+    issue_number = issue.get("number")
+    if not issue_number:
+        return []
+
+    raw_labels = issue.get("labels", [])
+    labels = normalize_labels(raw_labels)
+
+    raw_assignees = issue.get("assignees", [])
+    assignees = normalize_assignees(raw_assignees)
+
+    has_local_flow = issue_number in local_issue_numbers
+    is_manager_issue = has_manager_assignee(assignees, manager_usernames)
+
+    anomalies = collect_label_anomalies(
+        labels,
+        issue_number=issue_number,
+        has_local_flow=has_local_flow,
+        is_manager_issue=is_manager_issue,
+    )
+
+    return [
+        {
+            "issue_number": a.issue_number,
+            "rule": a.rule,
+            "removed": a.removed,
+            "added": a.added,
+        }
+        for a in anomalies
+    ]
+
+
+def execute_remote_check(
+    *,
+    dry_run: bool = True,
+    show_progress: bool = True,
+) -> ExecuteCheckResult:
+    """Audit remote issue labels for anomalies and optionally fix them.
+
+    Args:
+        dry_run: Only report, don't modify labels.
+        show_progress: Show progress bar while checking issues.
+
+    Returns:
+        ExecuteCheckResult with mode="remote" and grouped anomaly details.
+    """
+    service = CheckService()
+    store = service.store
+    gh_client = service.github_client
+    label_port = GhIssueLabelPort()
+
+    config = OrchestraConfig()
+    manager_usernames = get_manager_usernames(config)
+
+    # Fetch all open issues
+    issues = gh_client.list_issues(
+        state="open",
+        fields=["labels", "assignees", "number"],
+    )
+
+    # Build set of locally-tracked issue numbers
+    all_flows = store.get_all_flows()
+    local_issue_numbers: set[int] = set()
+    for flow in all_flows:
+        branch = flow.get("branch", "")
+        if branch:
+            issue_num = store.get_task_issue_number(branch)
+            if issue_num is not None:
+                local_issue_numbers.add(issue_num)
+
+    all_anomalies: list[dict] = []
+    errors: list[str] = []
+
+    if show_progress:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+        ) as progress:
+            task_id = progress.add_task("Checking remote issues", total=len(issues))
+            for issue in issues:
+                progress.update(
+                    task_id,
+                    advance=1,
+                    description=f"Checking issue #{issue.get('number', '?')}",
+                )
+                anomalies = _audit_single_issue(
+                    issue,
+                    local_issue_numbers=local_issue_numbers,
+                    manager_usernames=manager_usernames,
+                )
+                all_anomalies.extend(anomalies)
+    else:
+        for issue in issues:
+            anomalies = _audit_single_issue(
+                issue,
+                local_issue_numbers=local_issue_numbers,
+                manager_usernames=manager_usernames,
+            )
+            all_anomalies.extend(anomalies)
+
+    # Apply fixes if not dry-run
+    if not dry_run:
+        for anomaly in all_anomalies:
+            inum = anomaly["issue_number"]
+            for label in anomaly["removed"]:
+                try:
+                    label_port.remove_issue_label(inum, label)
+                except Exception as e:
+                    errors.append(f"#{inum}: failed to remove {label}: {e}")
+            for label in anomaly["added"]:
+                try:
+                    label_port.add_issue_label(inum, label)
+                except Exception as e:
+                    errors.append(f"#{inum}: failed to add {label}: {e}")
+
+    checked_count = len(issues)
+    anomaly_count = len(all_anomalies)
+    total_removed = sum(len(a["removed"]) for a in all_anomalies)
+    total_added = sum(len(a["added"]) for a in all_anomalies)
+
+    if anomaly_count == 0:
+        summary = f"Checked {checked_count} issues, no anomalies found"
+    else:
+        summary = f"Checked {checked_count} issues, found {anomaly_count} anomalies"
+
+    return ExecuteCheckResult(
+        mode="remote",
+        success=anomaly_count == 0,
+        summary=summary,
+        details={
+            "checked_count": checked_count,
+            "anomalies": all_anomalies,
+            "removed_count": total_removed,
+            "added_count": total_added,
+            "errors": errors,
+            "dry_run": dry_run,
+        },
     )

--- a/tests/vibe3/commands/test_check.py
+++ b/tests/vibe3/commands/test_check.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 
 from vibe3.cli import app
 from vibe3.commands.check import app as check_app
+from vibe3.commands.check_support import ExecuteCheckResult
 
 runner = CliRunner()
 
@@ -162,3 +163,255 @@ class TestCheckCommand:
         assert "feature-x" in result.output
         assert "Local branches failed" in result.output
         assert "feature-y: boom" in result.output
+
+
+# ==============================================================================
+# Remote check tests
+# ==============================================================================
+
+
+def _make_remote_result(
+    *,
+    success: bool,
+    summary: str,
+    checked_count: int = 0,
+    anomalies: list | None = None,
+    removed_count: int = 0,
+    added_count: int = 0,
+    dry_run: bool = True,
+) -> ExecuteCheckResult:
+    """Helper to create an ExecuteCheckResult for remote check tests."""
+    return ExecuteCheckResult(
+        mode="remote",
+        success=success,
+        summary=summary,
+        details={
+            "checked_count": checked_count,
+            "anomalies": anomalies or [],
+            "removed_count": removed_count,
+            "added_count": added_count,
+            "errors": [],
+            "dry_run": dry_run,
+        },
+    )
+
+
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_dry_run(mock_check):
+    """--dry-run flag is passed to execute_remote_check."""
+    mock_check.return_value = _make_remote_result(
+        success=True,
+        summary="Checked 0 issues, no anomalies found",
+        checked_count=0,
+    )
+    result = runner.invoke(app, ["check", "remote", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_check.assert_called_once_with(dry_run=True, show_progress=True)
+
+
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_applies_fixes(mock_check):
+    """Without --dry-run, execute_remote_check is called with dry_run=False."""
+    mock_check.return_value = _make_remote_result(
+        success=True,
+        summary="Checked 0 issues, no anomalies found",
+        checked_count=0,
+        dry_run=False,
+    )
+    result = runner.invoke(app, ["check", "remote"])
+
+    assert result.exit_code == 0
+    mock_check.assert_called_once_with(dry_run=False, show_progress=True)
+
+
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_with_anomalies(mock_check):
+    """Output groups anomalies by rule when anomalies are found."""
+    mock_check.return_value = _make_remote_result(
+        success=False,
+        summary="Checked 342 issues, found 2 anomalies",
+        checked_count=342,
+        anomalies=[
+            {
+                "issue_number": 123,
+                "rule": "roadmap_conflict",
+                "removed": ["state/claimed"],
+                "added": [],
+            },
+            {
+                "issue_number": 456,
+                "rule": "roadmap_conflict",
+                "removed": ["state/in-progress", "state/blocked"],
+                "added": [],
+            },
+            {
+                "issue_number": 789,
+                "rule": "multi_state",
+                "removed": ["state/review"],
+                "added": [],
+            },
+        ],
+        removed_count=4,
+        added_count=0,
+        dry_run=True,
+    )
+    result = runner.invoke(app, ["check", "remote", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert "roadmap_conflict" in result.output
+    assert "multi_state" in result.output
+    assert "#123" in result.output
+    assert "#456" in result.output
+    assert "#789" in result.output
+    assert "state/claimed" in result.output
+    assert "state/in-progress" in result.output
+    assert "state/blocked" in result.output
+    assert "state/review" in result.output
+    assert "Would remove" in result.output
+    assert "4 label(s)" in result.output
+    # No literal Rich markup tags
+    assert "[green]" not in result.output
+    assert "[bold]" not in result.output
+
+
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_no_anomalies(mock_check):
+    """Clean result shows 'no anomalies' message."""
+    mock_check.return_value = _make_remote_result(
+        success=True,
+        summary="Checked 342 issues, no anomalies found",
+        checked_count=342,
+    )
+    result = runner.invoke(app, ["check", "remote", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "no anomalies" in result.output
+
+
+@patch("vibe3.commands.check.CheckService")
+def test_check_backward_compat(mock_service_class):
+    """vibe3 check (no subcommand) still routes to legacy behavior."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+
+    mock_service = MagicMock()
+    result_obj = ExecuteCheckResult(
+        mode="fix_all", success=True, summary="All checks passed", details={}
+    )
+    mock_service_class.return_value = mock_service
+    with patch("vibe3.commands.check.execute_check_mode", return_value=result_obj):
+        result = runner.invoke(app, ["check"])
+
+    assert result.exit_code == 0
+    assert "All checks passed" in result.output
+
+
+@patch("vibe3.commands.check.CheckService")
+def test_check_local_subcommand(mock_service_class):
+    """vibe3 check local invokes same path as vibe3 check."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+
+    mock_service = MagicMock()
+    result_obj = ExecuteCheckResult(
+        mode="fix_all", success=True, summary="All checks passed", details={}
+    )
+    mock_service_class.return_value = mock_service
+    with patch("vibe3.commands.check.execute_check_mode", return_value=result_obj):
+        result = runner.invoke(app, ["check", "local"])
+
+    assert result.exit_code == 0
+    assert "All checks passed" in result.output
+
+
+# ==============================================================================
+# _audit_single_issue integration tests
+# ==============================================================================
+
+
+class TestAuditSingleIssue:
+    """Direct tests for _audit_single_issue composition logic."""
+
+    def test_manager_assignee_triggers_rules(self) -> None:
+        """Manager-assigned issue with execution state triggers Rule 3."""
+        from vibe3.commands.check_support import _audit_single_issue
+
+        issue = {
+            "number": 42,
+            "labels": [{"name": "state/in-progress"}],
+            "assignees": [{"login": "vibe-manager-agent"}],
+        }
+        result = _audit_single_issue(
+            issue=issue,
+            local_issue_numbers=set(),  # no local flow
+            manager_usernames=("vibe-manager-agent",),
+        )
+
+        assert len(result) == 1
+        assert result[0]["rule"] == "orphan_execution"
+        assert result[0]["issue_number"] == 42
+
+    def test_non_manager_assignee_skips_rules_3_4(self) -> None:
+        """Non-manager issue does NOT trigger Rule 3."""
+        from vibe3.commands.check_support import _audit_single_issue
+
+        issue = {
+            "number": 43,
+            "labels": [{"name": "state/in-progress"}],
+            "assignees": [{"login": "stranger"}],
+        }
+        result = _audit_single_issue(
+            issue=issue,
+            local_issue_numbers=set(),
+            manager_usernames=("vibe-manager-agent",),
+        )
+
+        assert result == []  # no anomalies for non-manager
+
+    def test_orchestra_governed_without_manager_assignee_no_rule_3(self) -> None:
+        """orchestra-governed label alone does NOT make is_manager_issue=True."""
+        from vibe3.commands.check_support import _audit_single_issue
+
+        issue = {
+            "number": 44,
+            "labels": [{"name": "orchestra-governed"}, {"name": "state/in-progress"}],
+            "assignees": [],  # no manager assignee
+        }
+        result = _audit_single_issue(
+            issue=issue,
+            local_issue_numbers=set(),
+            manager_usernames=("vibe-manager-agent",),
+        )
+
+        # Rule 3 should NOT fire (not a manager issue)
+        rules = [r["rule"] for r in result]
+        assert "orphan_execution" not in rules
+
+    def test_has_local_flow_prevents_rule_3(self) -> None:
+        """Issue with local flow does NOT trigger orphan execution."""
+        from vibe3.commands.check_support import _audit_single_issue
+
+        issue = {
+            "number": 42,
+            "labels": [{"name": "state/in-progress"}],
+            "assignees": [{"login": "vibe-manager-agent"}],
+        }
+        result = _audit_single_issue(
+            issue=issue,
+            local_issue_numbers={42},  # has local flow
+            manager_usernames=("vibe-manager-agent",),
+        )
+
+        assert result == []
+
+    def test_no_number_returns_empty(self) -> None:
+        """Issue without number returns empty list."""
+        from vibe3.commands.check_support import _audit_single_issue
+
+        issue = {"labels": [{"name": "state/ready"}], "assignees": []}
+        result = _audit_single_issue(
+            issue=issue,
+            local_issue_numbers=set(),
+            manager_usernames=(),
+        )
+
+        assert result == []


### PR DESCRIPTION
## Summary

- Restructure `vibe3 check` into command group with `local` / `remote` subcommands
- Add `check remote [--dry-run]` for batch remote label audit using #2534 infrastructure
- Backward compatible: `vibe3 check` (no args) routes to legacy behavior

## Changes

| File | Lines | What |
|------|-------|------|
| `check.py` | +221/-72 | Command group: `local()` + `remote()` subcommands |
| `check_support.py` | +166 | `execute_remote_check()` + `_audit_single_issue()` |
| `test_check.py` | +253 | 18 tests (5 direct _audit_single_issue + 13 CLI) |

## Key Fix

`is_manager_issue` uses only `has_manager_assignee` — NOT `has_orchestra_governed`. The plan incorrectly included `has_orchestra_governed`, which would have made Rule 3 fire for orchestra-governed issues without a manager assignee.

## Test Plan

- [x] 18 tests pass
- [x] mypy strict
- [x] ruff clean

## Closes

Closes #2540