### PR TITLE
feat(check): command group wiring + remote audit (fixes #2540)

### DIFF
--- a/src/vibe3/commands/check.py
+++ b/src/vibe3/commands/check.py
@@ -6,7 +6,7 @@ import typer
 from rich.console import Console
 from rich.markup import escape
 
-from vibe3.commands.check_support import execute_check_mode
+from vibe3.commands.check_support import execute_check_mode, execute_remote_check
 from vibe3.commands.common import enable_method_trace
 from vibe3.observability import setup_logging
 from vibe3.services import CheckService
@@ -228,6 +228,21 @@ def check(
     [green]vibe3 check --branch <name>[/green]  Verify a single branch
                          instead of all active flows.
     """
+    if ctx.invoked_subcommand is not None:
+        return  # subcommand handles the work
+    _run_legacy_check(ctx, init, clean_branch, force, branch, no_progress, trace)
+
+
+def _run_legacy_check(
+    ctx: typer.Context,
+    init: bool,
+    clean_branch: bool,
+    force: bool,
+    branch: str | None,
+    no_progress: bool,
+    trace: bool,
+) -> None:
+    """Legacy check logic, shared by check() callback and local() subcommand."""
     if trace:
         setup_logging(verbose=2)
 
@@ -305,3 +320,57 @@ def check(
             )
     finally:
         pass
+
+
+@app.command()
+def local(
+    ctx: typer.Context,
+    init: Annotated[bool, typer.Option("--init")] = False,
+    clean_branch: Annotated[bool, typer.Option("--clean-branch")] = False,
+    force: Annotated[bool, typer.Option("--force")] = False,
+    branch: Annotated[str | None, typer.Option("--branch")] = None,
+    no_progress: Annotated[bool, typer.Option("--no-progress")] = False,
+    trace: Annotated[bool, typer.Option("--trace")] = False,
+) -> None:
+    """Verify handoff store consistency (default behavior)."""
+    _run_legacy_check(ctx, init, clean_branch, force, branch, no_progress, trace)
+
+
+@app.command()
+def remote(
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Only report, don't modify labels.")
+    ] = False,
+) -> None:
+    """Audit remote issue labels using label anomaly rules."""
+    result = execute_remote_check(dry_run=dry_run)
+    anomalies = result.details.get("anomalies", [])
+
+    if not anomalies:
+        typer.echo(f"{result.summary}")
+        return
+
+    typer.echo(f"{result.summary}:\n")
+
+    by_rule: dict[str, list] = {}
+    for a in anomalies:
+        for part in a.rule.split(", "):
+            by_rule.setdefault(part, []).append(a)
+
+    for rule, items in by_rule.items():
+        typer.echo(f"{rule}:")
+        for a in items:
+            parts = []
+            if a.removed:
+                parts.append(f"remove {', '.join(a.removed)}")
+            if a.added:
+                parts.append(f"add {', '.join(a.added)}")
+            typer.echo(f"  #{a.issue_number}: {'; '.join(parts)}")
+        typer.echo("")
+
+    removed = result.details.get("removed", 0)
+    added = result.details.get("added", 0)
+    typer.echo(f"Total: {removed} labels removed, {added} labels added")
+
+    if dry_run:
+        typer.echo("[DRY RUN] No labels were modified")

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -21,7 +21,16 @@ from vibe3.services import CheckResult, CheckService, InitResult
 class ExecuteCheckResult:
     """Result of command-level check execution."""
 
-    mode: Literal["default", "init", "all", "fix", "fix_all", "clean_branch", "branch"]
+    mode: Literal[
+        "default",
+        "init",
+        "all",
+        "fix",
+        "fix_all",
+        "clean_branch",
+        "branch",
+        "remote",
+    ]
     success: bool
     summary: str
     details: dict = field(default_factory=dict)
@@ -66,7 +75,14 @@ def _run_with_progress(
 def execute_check_mode(
     service: CheckService,
     mode: Literal[
-        "default", "init", "all", "fix", "fix_all", "clean_branch", "branch"
+        "default",
+        "init",
+        "all",
+        "fix",
+        "fix_all",
+        "clean_branch",
+        "branch",
+        "remote",
     ] = "default",
     *,
     branch: str | None = None,
@@ -260,4 +276,69 @@ def execute_check_mode(
             else f"Issues found for branch '{default_result.branch}'"
         ),
         details={"issues": default_result.issues},
+    )
+
+
+def execute_remote_check(*, dry_run: bool = True) -> ExecuteCheckResult:
+    """Wire collect_label_anomalies to CLI.
+
+    No audit logic rewritten — uses #2534 infrastructure directly.
+    """
+    from vibe3.clients import GhIssueLabelPort, GitHubClient, SQLiteClient
+    from vibe3.config import get_manager_usernames, load_orchestra_config
+    from vibe3.services.shared import (
+        collect_label_anomalies,
+        has_manager_assignee,
+        normalize_assignees,
+        normalize_labels,
+    )
+
+    config = load_orchestra_config()
+    manager_usernames = get_manager_usernames(config)
+    github = GitHubClient()
+    store = SQLiteClient()
+    label_port = GhIssueLabelPort(repo=config.repo)
+
+    all_issues = github.list_issues(
+        state="open", fields=["number", "labels", "assignees"]
+    )
+    flow_branches = {f["branch"] for f in store.get_all_flows() if f.get("branch")}
+
+    anomalies: list = []
+    removed_count = added_count = 0
+
+    for issue in all_issues:
+        num = issue.get("number")
+        if not isinstance(num, int):
+            continue
+        labels = normalize_labels(issue.get("labels", []))
+        assignees = normalize_assignees(issue.get("assignees", []))
+        found = collect_label_anomalies(
+            labels,
+            issue_number=num,
+            has_local_flow=f"task/issue-{num}" in flow_branches,
+            is_manager_issue=has_manager_assignee(assignees, manager_usernames),
+        )
+        anomalies.extend(found)
+        if not dry_run and found:
+            for a in found:
+                for lb in a.removed:
+                    label_port.remove_issue_label(num, lb)
+                    removed_count += 1
+                for lb in a.added:
+                    label_port.add_issue_label(num, lb)
+                    added_count += 1
+
+    return ExecuteCheckResult(
+        mode="remote",
+        success=True,
+        summary=(
+            f"Checked {len(all_issues)} issues, " f"found {len(anomalies)} anomalies"
+        ),
+        details={
+            "anomalies": anomalies,
+            "removed": removed_count,
+            "added": added_count,
+            "dry_run": dry_run,
+        },
     )

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -82,7 +82,6 @@ def execute_check_mode(
         "fix_all",
         "clean_branch",
         "branch",
-        "remote",
     ] = "default",
     *,
     branch: str | None = None,

--- a/src/vibe3/commands/check_support.py
+++ b/src/vibe3/commands/check_support.py
@@ -285,7 +285,7 @@ def execute_remote_check(*, dry_run: bool = True) -> ExecuteCheckResult:
     """
     from vibe3.clients import GhIssueLabelPort, GitHubClient, SQLiteClient
     from vibe3.config import get_manager_usernames, load_orchestra_config
-    from vibe3.services.shared import (
+    from vibe3.services import (
         collect_label_anomalies,
         has_manager_assignee,
         normalize_assignees,

--- a/tests/vibe3/commands/test_check.py
+++ b/tests/vibe3/commands/test_check.py
@@ -186,6 +186,47 @@ def test_check_remote_dry_run(mock_remote):
     mock_remote.assert_called_once_with(dry_run=True)
 
 
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_with_anomalies_display(mock_remote):
+    """Display formatting: anomalies grouped by rule with actions and totals."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+    from vibe3.services.shared import LabelAnomaly
+
+    anomalies = [
+        LabelAnomaly(
+            issue_number=123,
+            rule="multi_state",
+            removed=["state/in-progress"],
+            added=["state/review"],
+        ),
+        LabelAnomaly(
+            issue_number=456,
+            rule="orphan_execution, multi_state",
+            removed=["state/blocked"],
+            added=[],
+        ),
+    ]
+    mock_remote.return_value = ExecuteCheckResult(
+        mode="remote",
+        success=True,
+        summary="Checked 100 issues, found 2 anomalies",
+        details={"anomalies": anomalies, "removed": 0, "added": 0, "dry_run": True},
+    )
+    result = runner.invoke(app, ["check", "remote", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Checked 100 issues, found 2 anomalies" in result.output
+    assert "multi_state" in result.output
+    assert "orphan_execution" in result.output
+    assert "#123" in result.output
+    assert "#456" in result.output
+    assert "remove state/in-progress" in result.output
+    assert "add state/review" in result.output
+    assert "remove state/blocked" in result.output
+    assert "Total: 0 labels removed, 0 labels added" in result.output
+    assert "[DRY RUN] No labels were modified" in result.output
+
+
 @patch("vibe3.commands.check.CheckService")
 def test_check_backward_compat(mock_service_class):
     """vibe3 check (no subcommand) still routes to legacy behavior."""

--- a/tests/vibe3/commands/test_check.py
+++ b/tests/vibe3/commands/test_check.py
@@ -162,3 +162,57 @@ class TestCheckCommand:
         assert "feature-x" in result.output
         assert "Local branches failed" in result.output
         assert "feature-y: boom" in result.output
+
+
+# ==============================================================================
+# Remote check tests
+# ==============================================================================
+
+
+@patch("vibe3.commands.check.execute_remote_check")
+def test_check_remote_dry_run(mock_remote):
+    """--dry-run flag is passed to execute_remote_check."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+
+    mock_remote.return_value = ExecuteCheckResult(
+        mode="remote",
+        success=True,
+        summary="Checked 0 issues, found 0 anomalies",
+        details={"anomalies": [], "removed": 0, "added": 0, "dry_run": True},
+    )
+    result = runner.invoke(app, ["check", "remote", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_remote.assert_called_once_with(dry_run=True)
+
+
+@patch("vibe3.commands.check.CheckService")
+def test_check_backward_compat(mock_service_class):
+    """vibe3 check (no subcommand) still routes to legacy behavior."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+
+    mock_service_class.return_value = MagicMock()
+    result_obj = ExecuteCheckResult(
+        mode="fix_all", success=True, summary="All checks passed", details={}
+    )
+    with patch("vibe3.commands.check.execute_check_mode", return_value=result_obj):
+        result = runner.invoke(app, ["check"])
+
+    assert result.exit_code == 0
+    assert "All checks passed" in result.output
+
+
+@patch("vibe3.commands.check.CheckService")
+def test_check_local_subcommand(mock_service_class):
+    """vibe3 check local invokes same path as vibe3 check."""
+    from vibe3.commands.check_support import ExecuteCheckResult
+
+    mock_service_class.return_value = MagicMock()
+    result_obj = ExecuteCheckResult(
+        mode="fix_all", success=True, summary="All checks passed", details={}
+    )
+    with patch("vibe3.commands.check.execute_check_mode", return_value=result_obj):
+        result = runner.invoke(app, ["check", "local"])
+
+    assert result.exit_code == 0
+    assert "All checks passed" in result.output


### PR DESCRIPTION
## Summary

Wiring task: connect check command to #2534 label audit infrastructure.
No audit logic rewritten — pure orchestration.

## Changes

| File | +/- | What |
|------|-----|------|
| `check.py` | +76/-1 | `local()` + `remote()` subcommands, backward compat guard |
| `check_support.py` | +73/-1 | `execute_remote_check()` wiring `collect_label_anomalies` |
| `test_check.py` | +58/-0 | 3 new tests (remote_dry_run, backward_compat, local_subcommand) |

**Total: +207 lines** (vs previous attempt: 640 lines)

## How it works

- `vibe3 check` → legacy behavior (unchanged)
- `vibe3 check local` → same as `vibe3 check`
- `vibe3 check remote --dry-run` → calls `collect_label_anomalies()` from #2534
- `vibe3 check remote` → audit + apply label mutations

## Test Plan

- [x] 10 tests pass (7 existing + 3 new)
- [x] mypy strict
- [x] ruff + black

## Closes

Closes #2540