### PR TITLE
Remove unused registry parameter from promote_progressed_entries

### DIFF
--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -14,7 +14,6 @@ from vibe3.utils import sort_ready_issues
 
 if TYPE_CHECKING:
     from vibe3.clients import GitHubClient, SQLiteClient
-    from vibe3.environment import SessionRegistryService
     from vibe3.orchestra import FlowManagerProtocol
     from vibe3.orchestra.domain_types import (
         LabelServiceProtocol,
@@ -145,7 +144,6 @@ def promote_progressed_entries(
     frozen_queue: list[QueueEntry],
     config: OrchestraConfig,
     github: "GitHubClient",
-    registry: "SessionRegistryService | None",
     supervisor_label: str,
     load_issue_func: Callable[[int], IssueInfo | None] | None = None,
     *,

--- a/src/vibe3/orchestra/queue_persistence_service.py
+++ b/src/vibe3/orchestra/queue_persistence_service.py
@@ -156,7 +156,6 @@ class QueuePersistenceService:
             self.frozen_queue,
             self.config,
             self.github,
-            self.registry,
             self.supervisor_label,
             load_issue_func=self.load_issue,
         )


### PR DESCRIPTION
## Summary
Remove unused `registry: "SessionRegistryService | None"` parameter from `promote_progressed_entries()` and its orphaned import.

Fixes #2541

## Changes
- Remove `SessionRegistryService` import from `queue_operations.py`
- Remove `registry` parameter from function signature
- Remove `self.registry` argument from call site

## Testing
- ✅ mypy: Success - no issues found
- ✅ ruff: All checks passed
- ✅ pytest orchestra: 146 passed

## Impact
- Zero behavioral change (dead code removal only)
- No API changes (parameter was unused)
- Low risk refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)