### PR TITLE
feat(runtime): record resolved adapter and policy versions in JobResult/status

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -66,8 +66,8 @@ code_limits:
 
       # Commands 层 —— 允许 480-550
       - path: "src/vibe3/commands/status.py"
-        limit: 450
-        reason: "Status 命令聚合，包含 Orchestra/Configuration/Flows/Tasks 多维度显示，新增 Vibe3 Configuration section（repo name, manager agents, polling interval 等）后略微超标"
+        limit: 490
+        reason: "Status 命令聚合，包含 Orchestra/Configuration/Flows/Tasks 多维度显示，新增 Vibe3 Configuration section（repo name, manager agents, polling interval 等）；#2177 新增 Runtime Versions section 显示 policy/material hashes（+53 行）"
       - path: "src/vibe3/commands/task.py"
         limit: 500
         reason: "Task 命令聚合，包含 show/status/intake/resume 多个子命令入口；新增 vibe3 task intake 命令（issue assignee 分配 + guard 逻辑）后超标"
@@ -189,8 +189,8 @@ code_limits:
         limit: 650
         reason: "No-op gate 聚合，包含 verdict-aware ref 检查（PASS 可省略 audit_ref，MINOR/MAJOR/BLOCK 仍需）、单步转换限制检查、全局转换计数检查、state 验证、GitHub API 错误处理、retry counter 机制（3次重试 + 即时持久化）、error/block 分离（GitHub API 失败记录 error_log 不触发 flow block）等多层防御机制，职责单一但紧密耦合"
       - path: "src/vibe3/execution/job_executor.py"
-        limit: 650
-        reason: "JobExecutor 聚合服务，包含 command dispatch 路由、sync/async 执行模式、governance dispatch、envelope 解析、adapter resolution、lifecycle 事件记录、actor 生命周期管理（实时监控层，与 ExecutionLifecycleService 持久记录层互补）等紧密耦合的统一调度入口逻辑；#2172 集成 actor supervision（+60 行），作为 aggregation layer 保持内聚性优于拆分"
+        limit: 750
+        reason: "JobExecutor 聚合服务，包含 command dispatch 路由、sync/async 执行模式、governance dispatch、envelope 解析、adapter resolution、lifecycle 事件记录、actor 生命周期管理（实时监控层，与 ExecutionLifecycleService 持久记录层互补）等紧密耦合的统一调度入口逻辑；#2172 集成 actor supervision（+60 行），#2177 新增版本元数据追踪（adapter_hash/policy_hash/material_hash 计算与持久化，+130 行），作为 aggregation layer 保持内聚性优于拆分"
       - path: "src/vibe3/execution/codeagent_runner.py"
         limit: 600
         reason: "Sync execution runner 聚合，包含 supervisor label cleanup、planner commit detection（cwd-aware GitClient）、context preparation、finalize、retry counter 持久化、before_issue_is_closed 检测（PR closed 阻塞逻辑）等紧密耦合的执行生命周期逻辑；rebase 后新增 tick_id 参数传递和 before_issue_is_closed 检测逻辑，#2265 follow-up 将 AgentExecutionError metadata 写入 error_log 和 lifecycle refs 后略微超标；Issue #2435 新增 model 输出显示（+4 行）"
@@ -203,8 +203,8 @@ code_limits:
 
       # 强耦合测试例外
       - path: "tests/vibe3/models/test_job.py"
-        limit: 500
-        reason: "Job contract models 测试集，覆盖 JobEnvelope/JobContext/JobResult 构造、序列化、frozen 约束、semantic equivalence、dispatch intent 表示、actor_id 字段等紧密耦合场景；#2172 新增 TestJobResult.test_actor_id_field 和 test_actor_id_defaults_to_none 测试后略微超标"
+        limit: 510
+        reason: "Job contract models 测试集，覆盖 JobEnvelope/JobContext/JobResult 构造、序列化、frozen 约束、semantic equivalence、dispatch intent 表示、actor_id 字段等紧密耦合场景；#2172 新增 TestJobResult.test_actor_id_field 和 test_actor_id_defaults_to_none 测试后略微超标；#2177 新增 adapter_hash 字段测试（+27 行）"
       - path: "tests/vibe3/agents/test_codeagent_backend.py"
         limit: 680
         reason: "Codeagent backend 核心测试，覆盖 sync/async 执行、tmux 管理、命令构建、preset 传递（新增 preset 执行路径保留测试）等紧密耦合逻辑；#2265 follow-up 新增实际 prompt file payload 长度诊断回归测试后略微超标"
@@ -230,8 +230,8 @@ code_limits:
         limit: 520
         reason: "Gate 集成测试，包含完整的 mock 设置和断言场景，拆分会破坏测试逻辑完整性；#2265 follow-up 新增 AgentExecutionError metadata 写入 error_log/lifecycle refs 回归测试后略微超标"
       - path: "tests/vibe3/execution/test_job_executor.py"
-        limit: 550
-        reason: "JobExecutor 核心服务测试集，覆盖 10 个紧密耦合场景（映射正确性、context 构建、success/failure/skip 路径、governance dispatch、equivalence regression、lifecycle 事件、adapter resolution error），共享 mock setup（registry/store/lifecycle），拆分收益低；测试覆盖 JobEnvelope → JobResult 完整执行流程与生命周期事件记录"
+        limit: 560
+        reason: "JobExecutor 核心服务测试集，覆盖 10 个紧密耦合场景（映射正确性、context 构建、success/failure/skip 路径、governance dispatch、equivalence regression、lifecycle 事件、adapter resolution error），共享 mock setup（registry/store/lifecycle），拆分收益低；测试覆盖 JobEnvelope → JobResult 完整执行流程与生命周期事件记录；#2177 新增 TestVersionHashComputation 测试类（6 个测试方法，+152 行）验证版本元数据计算"
       - path: "tests/vibe3/execution/test_noop_gate_transition_count.py"
         limit: 480
         reason: "Transition count 测试集，14 个测试围绕 transition_count 功能（全局计数、pair 追踪、事件记录），共享 fixture，拆分收益低"

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -74,6 +74,63 @@ def _resolve_repo_name(config_repo: str | None) -> str:
     return "(unknown)"
 
 
+def _render_runtime_versions() -> None:
+    """Render Runtime Versions section showing current versions.
+
+    Displays the current policy and material hashes computed from the
+    governance directory contents.
+    """
+    import hashlib
+    from pathlib import Path
+
+    from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+    from vibe3.services import material_loader, policy_loader
+
+    console.print("[bold]Runtime Versions[/] [dim](current)[/]")
+
+    try:
+        repo_root = resolve_orchestra_repo_root()
+        if hasattr(repo_root, "repo"):
+            base_path = Path(repo_root.repo)
+        else:
+            base_path = Path(str(repo_root))
+
+        # Compute policy hash
+        policies_dir = base_path / ".vibe" / "governance" / "policies"
+        policy_loader_instance = policy_loader(policies_dir)
+        policy_entries = policy_loader_instance.load_all()
+        if policy_entries:
+            hash_parts = sorted(
+                [f"{entry.name}|{entry.content_hash}" for entry in policy_entries]
+            )
+            concatenated = "|".join(hash_parts)
+            policy_hash = hashlib.sha256(concatenated.encode("utf-8")).hexdigest()[:16]
+            console.print(f"  Policy hash:  {policy_hash}")
+        else:
+            console.print("  Policy hash:  [dim](no policies found)[/]")
+
+        # Compute material hash
+        materials_dir = base_path / ".vibe" / "governance" / "materials"
+        material_loader_instance = material_loader(materials_dir)
+        material_entries = material_loader_instance.load_all()
+        if material_entries:
+            hash_parts = sorted(
+                [f"{entry.name}|{entry.content_hash}" for entry in material_entries]
+            )
+            concatenated = "|".join(hash_parts)
+            material_hash = hashlib.sha256(concatenated.encode("utf-8")).hexdigest()[
+                :16
+            ]
+            console.print(f"  Material hash: {material_hash}")
+        else:
+            console.print("  Material hash: [dim](no materials found)[/]")
+
+    except Exception as e:
+        console.print(f"  [dim]Error computing versions: {e}[/]")
+
+    console.print()
+
+
 def _analyze_orchestra_config_sources(config: OrchestraConfig) -> dict[str, str]:
     """Determine the source of each displayed orchestra config value.
 
@@ -423,6 +480,7 @@ def status(
         return
 
     _render_system_status(config, orch_snapshot, snapshot_found)
+    _render_runtime_versions()
     typer.echo(
         "Use 'vibe3 task status' to view issue progress and ready queue",
         err=True,

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -82,7 +82,7 @@ def _render_runtime_versions() -> None:
     """
     import hashlib
 
-    from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
+    from vibe3.execution import resolve_orchestra_repo_root
     from vibe3.services import material_loader, policy_loader
 
     console.print("[bold]Runtime Versions[/] [dim](current)[/]")

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -81,7 +81,6 @@ def _render_runtime_versions() -> None:
     governance directory contents.
     """
     import hashlib
-    from pathlib import Path
 
     from vibe3.execution.issue_role_support import resolve_orchestra_repo_root
     from vibe3.services import material_loader, policy_loader
@@ -90,13 +89,9 @@ def _render_runtime_versions() -> None:
 
     try:
         repo_root = resolve_orchestra_repo_root()
-        if hasattr(repo_root, "repo"):
-            base_path = Path(repo_root.repo)
-        else:
-            base_path = Path(str(repo_root))
 
         # Compute policy hash
-        policies_dir = base_path / ".vibe" / "governance" / "policies"
+        policies_dir = repo_root / ".vibe" / "governance" / "policies"
         policy_loader_instance = policy_loader(policies_dir)
         policy_entries = policy_loader_instance.load_all()
         if policy_entries:
@@ -110,7 +105,7 @@ def _render_runtime_versions() -> None:
             console.print("  Policy hash:  [dim](no policies found)[/]")
 
         # Compute material hash
-        materials_dir = base_path / ".vibe" / "governance" / "materials"
+        materials_dir = repo_root / ".vibe" / "governance" / "materials"
         material_loader_instance = material_loader(materials_dir)
         material_entries = material_loader_instance.load_all()
         if material_entries:

--- a/src/vibe3/execution/job_executor.py
+++ b/src/vibe3/execution/job_executor.py
@@ -184,6 +184,8 @@ class JobExecutor:
             # Resolve adapter
             resolved = self._registry.resolve(envelope.command_type)
             adapter_path = resolved.entry.import_path
+            # Compute adapter hash
+            adapter_hash = self._compute_adapter_hash(resolved)
         except Exception as e:
             # Pre-launch failure: actor still QUEUED, just clean up
             registry.remove_actor(actor_obj.actor_id)
@@ -202,6 +204,11 @@ class JobExecutor:
         # Build context (no premature session ID loading —
         # session metadata comes from ExecutionLaunchResult after dispatch)
         context = self._build_context(envelope)
+
+        # Compute version hashes
+        repo_root = resolve_orchestra_repo_root()
+        policy_hash = self._compute_policy_hash(repo_root)
+        material_hash = self._compute_material_hash(repo_root)
 
         # Record lifecycle started event
         role = COMMAND_TYPE_TO_EXECUTION_ROLE.get(envelope.command_type)
@@ -222,12 +229,24 @@ class JobExecutor:
 
         # Record actor launch and lifecycle started
         actor_obj.record_launch()
+
+        # Prepare version refs for lifecycle events
+        version_refs = {
+            "adapter_hash": adapter_hash or "",
+            "policy_hash": policy_hash or "",
+            "material_hash": material_hash or "",
+        }
+
         self._lifecycle.record_started(
             role=role,
             target=envelope.branch,
             actor=envelope.actor,
             session_id=context.session_id,
-            refs={**(envelope.refs or {}), "actor_id": actor_obj.actor_id},
+            refs={
+                **(envelope.refs or {}),
+                "actor_id": actor_obj.actor_id,
+                **version_refs,
+            },
         )
 
         try:
@@ -261,7 +280,7 @@ class JobExecutor:
                     target=envelope.branch,
                     actor=envelope.actor,
                     error=job_result.error_message,
-                    refs=envelope.refs,
+                    refs={**(envelope.refs or {}), **version_refs},
                 )
             elif job_result.status == "skipped":
                 actor_obj.record_completion(detail=f"{envelope.command_type} skipped")
@@ -270,7 +289,7 @@ class JobExecutor:
                     target=envelope.branch,
                     actor=envelope.actor,
                     detail="Execution skipped",
-                    refs=envelope.refs,
+                    refs={**(envelope.refs or {}), **version_refs},
                 )
             else:
                 # launched or completed
@@ -282,12 +301,15 @@ class JobExecutor:
                     target=envelope.branch,
                     actor=envelope.actor,
                     detail=f"{envelope.command_type} {job_result.status}",
-                    refs=envelope.refs,
+                    refs={**(envelope.refs or {}), **version_refs},
                 )
 
             # Fill in execution metadata
             job_result.started_at = started_at
             job_result.adapter_path = adapter_path
+            job_result.policy_hash = policy_hash
+            job_result.material_hash = material_hash
+            job_result.adapter_hash = adapter_hash
             job_result.actor_id = actor_obj.actor_id
 
             # Actor stays in registry for TTL-based monitoring;
@@ -304,7 +326,7 @@ class JobExecutor:
                 target=envelope.branch,
                 actor=envelope.actor,
                 error=str(e),
-                refs=envelope.refs,
+                refs={**(envelope.refs or {}), **version_refs},
             )
 
             # Actor stays in registry for TTL-based monitoring
@@ -626,3 +648,124 @@ class JobExecutor:
             job_result.payload_summary = {"stdout": result.stdout[:1000]}  # Truncate
 
         return job_result
+
+    def _compute_adapter_hash(self, resolved: object) -> str | None:
+        """Compute SHA-256 hash of the resolved adapter's source file.
+
+        Args:
+            resolved: The resolved adapter object from registry.resolve()
+
+        Returns:
+            First 16 hex chars of SHA-256 hash, or None if module file cannot be found
+        """
+        import hashlib
+        import importlib
+
+        try:
+            # Get the module name from the resolved adapter
+            if not hasattr(resolved, "entry") or not hasattr(
+                resolved.entry, "import_path"
+            ):
+                return None
+
+            import_path = resolved.entry.import_path
+            # Extract module path
+            # e.g., "vibe3.roles.plan.PLAN_SYNC_SPEC" → "vibe3.roles.plan"
+            module_name = import_path.rsplit(".", 1)[0]
+
+            module = importlib.import_module(module_name)
+            if not hasattr(module, "__file__") or module.__file__ is None:
+                return None
+
+            source_path = module.__file__
+            if hasattr(source_path, "read_text"):
+                content = source_path.read_text(encoding="utf-8")
+            else:
+                content = open(source_path).read()
+            content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+            return content_hash
+        except Exception as e:
+            logger.warning(f"Failed to compute adapter hash: {e}")
+            return None
+
+    def _compute_policy_hash(self, repo_root: object) -> str | None:
+        """Compute aggregate hash of all policy files.
+
+        Args:
+            repo_root: The repository root path
+
+        Returns:
+            First 16 hex chars of aggregate SHA-256 hash, or None if no policies found
+        """
+        import hashlib
+        from pathlib import Path
+
+        try:
+            from vibe3.services import policy_loader
+
+            # Convert repo_root to Path if needed
+            if hasattr(repo_root, "repo"):
+                base_path = Path(repo_root.repo)
+            else:
+                base_path = Path(str(repo_root))
+
+            policies_dir = base_path / ".vibe" / "governance" / "policies"
+            loader = policy_loader(policies_dir)
+            entries = loader.load_all()
+
+            if not entries:
+                return None
+
+            # Aggregate all content_hash values sorted by name
+            hash_parts = sorted(
+                [f"{entry.name}|{entry.content_hash}" for entry in entries]
+            )
+            concatenated = "|".join(hash_parts)
+            aggregate_hash = hashlib.sha256(concatenated.encode("utf-8")).hexdigest()[
+                :16
+            ]
+            return aggregate_hash
+        except Exception as e:
+            logger.warning(f"Failed to compute policy hash: {e}")
+            return None
+
+    def _compute_material_hash(self, repo_root: object) -> str | None:
+        """Compute aggregate hash of all material files.
+
+        Args:
+            repo_root: The repository root path
+
+        Returns:
+            First 16 hex chars of aggregate SHA-256 hash, or None if no materials found
+        """
+        import hashlib
+        from pathlib import Path
+
+        try:
+            from vibe3.services import material_loader
+
+            # Convert repo_root to Path if needed
+            if hasattr(repo_root, "repo"):
+                base_path = Path(repo_root.repo)
+            else:
+                base_path = Path(str(repo_root))
+
+            materials_dir = base_path / ".vibe" / "governance" / "materials"
+            loader = material_loader(materials_dir)
+            entries = loader.load_all()
+
+            if not entries:
+                return None
+
+            # Aggregate all content_hash values sorted by name
+            hash_parts = sorted(
+                [f"{entry.name}|{entry.content_hash}" for entry in entries]
+            )
+            concatenated = "|".join(hash_parts)
+            aggregate_hash = hashlib.sha256(concatenated.encode("utf-8")).hexdigest()[
+                :16
+            ]
+            return aggregate_hash
+        except Exception as e:
+            logger.warning(f"Failed to compute material hash: {e}")
+            return None

--- a/src/vibe3/execution/job_executor.py
+++ b/src/vibe3/execution/job_executor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
@@ -26,7 +27,7 @@ from vibe3.models import (
 )
 
 if TYPE_CHECKING:
-    from vibe3.execution.command_adapter import CommandAdapterRegistry
+    from vibe3.execution.command_adapter import CommandAdapterRegistry, ResolvedAdapter
     from vibe3.execution.coordinator import ExecutionCoordinator
     from vibe3.execution.role_interfaces import IssueRoleSyncSpec
 
@@ -649,7 +650,7 @@ class JobExecutor:
 
         return job_result
 
-    def _compute_adapter_hash(self, resolved: object) -> str | None:
+    def _compute_adapter_hash(self, resolved: "ResolvedAdapter") -> str | None:
         """Compute SHA-256 hash of the resolved adapter's source file.
 
         Args:
@@ -660,35 +661,27 @@ class JobExecutor:
         """
         import hashlib
         import importlib
+        from pathlib import Path
 
         try:
             # Get the module name from the resolved adapter
-            if not hasattr(resolved, "entry") or not hasattr(
-                resolved.entry, "import_path"
-            ):
+            if not hasattr(resolved, "module_name"):
                 return None
 
-            import_path = resolved.entry.import_path
-            # Extract module path
-            # e.g., "vibe3.roles.plan.PLAN_SYNC_SPEC" → "vibe3.roles.plan"
-            module_name = import_path.rsplit(".", 1)[0]
-
+            module_name = resolved.module_name
             module = importlib.import_module(module_name)
             if not hasattr(module, "__file__") or module.__file__ is None:
                 return None
 
-            source_path = module.__file__
-            if hasattr(source_path, "read_text"):
-                content = source_path.read_text(encoding="utf-8")
-            else:
-                content = open(source_path).read()
+            source_path = Path(module.__file__)
+            content = source_path.read_text(encoding="utf-8")
             content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
             return content_hash
         except Exception as e:
             logger.warning(f"Failed to compute adapter hash: {e}")
             return None
 
-    def _compute_policy_hash(self, repo_root: object) -> str | None:
+    def _compute_policy_hash(self, repo_root: Path) -> str | None:
         """Compute aggregate hash of all policy files.
 
         Args:
@@ -698,18 +691,11 @@ class JobExecutor:
             First 16 hex chars of aggregate SHA-256 hash, or None if no policies found
         """
         import hashlib
-        from pathlib import Path
 
         try:
             from vibe3.services import policy_loader
 
-            # Convert repo_root to Path if needed
-            if hasattr(repo_root, "repo"):
-                base_path = Path(repo_root.repo)
-            else:
-                base_path = Path(str(repo_root))
-
-            policies_dir = base_path / ".vibe" / "governance" / "policies"
+            policies_dir = repo_root / ".vibe" / "governance" / "policies"
             loader = policy_loader(policies_dir)
             entries = loader.load_all()
 
@@ -729,7 +715,7 @@ class JobExecutor:
             logger.warning(f"Failed to compute policy hash: {e}")
             return None
 
-    def _compute_material_hash(self, repo_root: object) -> str | None:
+    def _compute_material_hash(self, repo_root: Path) -> str | None:
         """Compute aggregate hash of all material files.
 
         Args:
@@ -739,18 +725,11 @@ class JobExecutor:
             First 16 hex chars of aggregate SHA-256 hash, or None if no materials found
         """
         import hashlib
-        from pathlib import Path
 
         try:
             from vibe3.services import material_loader
 
-            # Convert repo_root to Path if needed
-            if hasattr(repo_root, "repo"):
-                base_path = Path(repo_root.repo)
-            else:
-                base_path = Path(str(repo_root))
-
-            materials_dir = base_path / ".vibe" / "governance" / "materials"
+            materials_dir = repo_root / ".vibe" / "governance" / "materials"
             loader = material_loader(materials_dir)
             entries = loader.load_all()
 

--- a/src/vibe3/models/job.py
+++ b/src/vibe3/models/job.py
@@ -136,6 +136,12 @@ class JobResult(BaseModel):
         ``source`` is set automatically by :class:`JobExecutor` from the
         originating ``JobEnvelope``.  When ``None``, the result was created
         outside the standard dispatch path and trigger type is unknown.
+
+    Version metadata:
+        ``adapter_hash``, ``policy_hash``, and ``material_hash`` track the
+        content versions of the resolved adapter, policies, and materials
+        used at dispatch time. These enable explainability and reproducibility
+        by capturing the runtime versions that influenced the job execution.
     """
 
     command_type: CommandType
@@ -150,6 +156,7 @@ class JobResult(BaseModel):
 
     # Resolved adapter
     adapter_path: str | None = None
+    adapter_hash: str | None = None
 
     # Execution metadata
     context: JobContext | None = None

--- a/tests/vibe3/execution/test_job_executor.py
+++ b/tests/vibe3/execution/test_job_executor.py
@@ -437,8 +437,7 @@ class TestVersionHashComputation:
             # Create mock resolved object
             from types import SimpleNamespace
 
-            mock_entry = SimpleNamespace(import_path="test_module.adapter.Adapter")
-            mock_resolved = SimpleNamespace(entry=mock_entry)
+            mock_resolved = SimpleNamespace(module_name="test_module.adapter")
 
             # Compute hash
             registry = CommandAdapterRegistry()
@@ -535,3 +534,26 @@ class TestVersionHashComputation:
 
         # Verify hashes are different
         assert hash1 != hash2
+
+    def test_adapter_hash_none_when_module_file_missing(
+        self, mock_store: SQLiteClient
+    ) -> None:
+        """Adapter hash should return None when module.__file__ is None."""
+        from types import SimpleNamespace
+        from unittest.mock import Mock, patch
+
+        registry = CommandAdapterRegistry()
+        executor = JobExecutor(registry, mock_store)
+
+        # Create mock resolved adapter
+        mock_resolved = SimpleNamespace(module_name="namespace_package")
+
+        # Mock module with __file__ = None (namespace package)
+        mock_module = Mock()
+        mock_module.__file__ = None
+
+        with patch("importlib.import_module", return_value=mock_module):
+            adapter_hash = executor._compute_adapter_hash(mock_resolved)
+
+        # Verify hash is None
+        assert adapter_hash is None

--- a/tests/vibe3/execution/test_job_executor.py
+++ b/tests/vibe3/execution/test_job_executor.py
@@ -405,3 +405,133 @@ class TestMapLaunchResult:
         assert result.context.session_id == "session-123"
         assert result.context.tmux_session == "tmux-456"
         assert result.context.log_path == "/path/to/log"
+
+
+class TestVersionHashComputation:
+    """Tests for version hash computation helpers."""
+
+    def test_adapter_hash_computed_from_module_source(
+        self, mock_store: SQLiteClient, tmp_path
+    ) -> None:
+        """Adapter hash should be computed from module source file."""
+        import hashlib
+
+        # Create a temporary module file
+        module_dir = tmp_path / "test_module"
+        module_dir.mkdir()
+        module_file = module_dir / "adapter.py"
+        module_content = "# Test adapter module\nprint('hello')\n"
+        module_file.write_text(module_content)
+
+        # Create a mock resolved adapter
+        import sys
+
+        sys.path.insert(0, str(tmp_path))
+
+        try:
+            # Import the module
+            import importlib
+
+            importlib.import_module("test_module.adapter")
+
+            # Create mock resolved object
+            from types import SimpleNamespace
+
+            mock_entry = SimpleNamespace(import_path="test_module.adapter.Adapter")
+            mock_resolved = SimpleNamespace(entry=mock_entry)
+
+            # Compute hash
+            registry = CommandAdapterRegistry()
+            executor = JobExecutor(registry, mock_store)
+            adapter_hash = executor._compute_adapter_hash(mock_resolved)
+
+            # Verify hash
+            expected_hash = hashlib.sha256(module_content.encode("utf-8")).hexdigest()[
+                :16
+            ]
+            assert adapter_hash == expected_hash
+        finally:
+            sys.path.remove(str(tmp_path))
+
+    def test_policy_hash_aggregates_all_policy_files(
+        self, mock_store: SQLiteClient, tmp_path
+    ) -> None:
+        """Policy hash should aggregate all policy files."""
+
+        # Create policy directory and files
+        policy_dir = tmp_path / ".vibe" / "governance" / "policies"
+        policy_dir.mkdir(parents=True)
+
+        policy1 = policy_dir / "policy1.yaml"
+        policy1.write_text("name: policy1\nversion: '1.0'\n")
+        policy2 = policy_dir / "policy2.yaml"
+        policy2.write_text("name: policy2\nversion: '2.0'\n")
+
+        # Compute hash
+        registry = CommandAdapterRegistry()
+        executor = JobExecutor(registry, mock_store)
+        policy_hash = executor._compute_policy_hash(tmp_path)
+
+        # Verify hash is computed (not None)
+        assert policy_hash is not None
+        assert len(policy_hash) == 16
+
+    def test_material_hash_aggregates_all_material_files(
+        self, mock_store: SQLiteClient, tmp_path
+    ) -> None:
+        """Material hash should aggregate all material files."""
+
+        # Create material directory and files
+        material_dir = tmp_path / ".vibe" / "governance" / "materials"
+        material_dir.mkdir(parents=True)
+
+        material1 = material_dir / "material1.md"
+        material1.write_text("# Material 1\nContent 1\n")
+        material2 = material_dir / "material2.md"
+        material2.write_text("# Material 2\nContent 2\n")
+
+        # Compute hash
+        registry = CommandAdapterRegistry()
+        executor = JobExecutor(registry, mock_store)
+        material_hash = executor._compute_material_hash(tmp_path)
+
+        # Verify hash is computed (not None)
+        assert material_hash is not None
+        assert len(material_hash) == 16
+
+    def test_hash_none_when_directory_missing(
+        self, mock_store: SQLiteClient, tmp_path
+    ) -> None:
+        """Hash should return None when directory is missing."""
+        registry = CommandAdapterRegistry()
+        executor = JobExecutor(registry, mock_store)
+
+        # No governance directory exists
+        policy_hash = executor._compute_policy_hash(tmp_path)
+        material_hash = executor._compute_material_hash(tmp_path)
+
+        assert policy_hash is None
+        assert material_hash is None
+
+    def test_hash_changes_when_file_changes(
+        self, mock_store: SQLiteClient, tmp_path
+    ) -> None:
+        """Hash should change when file content changes."""
+        # Create policy directory and file
+        policy_dir = tmp_path / ".vibe" / "governance" / "policies"
+        policy_dir.mkdir(parents=True)
+
+        policy1 = policy_dir / "policy1.yaml"
+        policy1.write_text("name: policy1\nversion: '1.0'\n")
+
+        # Compute initial hash
+        registry = CommandAdapterRegistry()
+        executor = JobExecutor(registry, mock_store)
+        hash1 = executor._compute_policy_hash(tmp_path)
+
+        # Change file content
+        policy1.write_text("name: policy1\nversion: '2.0'\n")
+        hash2 = executor._compute_policy_hash(tmp_path)
+
+        # Verify hashes are different
+        assert hash1 != hash2

--- a/tests/vibe3/models/test_job.py
+++ b/tests/vibe3/models/test_job.py
@@ -209,6 +209,7 @@ class TestJobResult:
             "status": "launched",
             "exit_code": None,
             "adapter_path": None,
+            "adapter_hash": None,
             "context": None,
             "policy_hash": None,
             "material_hash": None,
@@ -221,6 +222,32 @@ class TestJobResult:
             "actor_id": None,
         }.items():  # noqa: E501
             assert getattr(result, field) == expected
+
+    def test_adapter_hash_defaults_to_none(self):
+        """Verify adapter_hash defaults to None for backward compatibility."""
+        result = JobResult(
+            command_type=CommandType.PLAN,
+            issue_number=1,
+            branch="main",
+        )
+        assert result.adapter_hash is None
+
+    def test_version_fields_serialization_round_trip(self):
+        """Verify version metadata fields serialize/deserialize correctly."""
+        original = JobResult(
+            command_type=CommandType.RUN,
+            issue_number=123,
+            branch="main",
+            adapter_hash="a1b2c3d4e5f6a7b8",
+            policy_hash="0123456789abcdef",
+            material_hash="fedcba9876543210",
+        )
+        data = original.model_dump()
+        restored = JobResult.model_validate(data)
+
+        assert restored.adapter_hash == "a1b2c3d4e5f6a7b8"
+        assert restored.policy_hash == "0123456789abcdef"
+        assert restored.material_hash == "fedcba9876543210"
 
     def test_mutability(self):
         """Verify result is mutable (not frozen)."""


### PR DESCRIPTION
## Summary

Add version metadata tracking for runtime explainability by recording the content versions of adapters, policies, and materials used at dispatch time.

Closes #2177

## Key Changes

### 1. JobResult Model
- Added `adapter_hash: str | None` field to track resolved adapter's source version
- Updated docstring to document version metadata fields

### 2. JobExecutor
- Added `_compute_adapter_hash()`: Computes SHA-256 hash of resolved adapter's source file
- Added `_compute_policy_hash()`: Computes aggregate hash of all policy files
- Added `_compute_material_hash()`: Computes aggregate hash of all material files
- Modified `execute()` to compute hashes after adapter resolution and context building
- Persisted version hashes in event_log refs for status command

### 3. Status Command
- Added `_render_runtime_versions()` to display current policy/material hashes
- Shows graceful messages when governance directories don't exist

### 4. Tests
- Added `TestVersionHashComputation` class with 6 test methods
- Added test for `module.__file__ == None` case (namespace packages)
- All 61 tests pass

## Implementation Details

**Hash Computation**:
- Adapter hash: SHA-256 of module source file (first 16 hex chars)
- Policy/Material hash: Aggregate SHA-256 of sorted "name|content_hash" concatenations (first 16 hex chars)
- All hashes return None when files/directories don't exist (graceful degradation)

**File Handle Leak Fix**:
- Used `Path.read_text()` instead of `open().read()` to ensure proper resource management
- Eliminated potential file descriptor leak in hot path

**Type Safety Improvements**:
- Changed parameter types from `object` to concrete types (`ResolvedAdapter`, `Path`)
- Used `resolved.module_name` directly instead of deriving from `import_path`
- Removed dead `hasattr(repo_root, "repo")` branches

## Verification

✅ All 61 tests pass
✅ Type checking: mypy Success
✅ Lint: ruff All checks passed
✅ Status command verified: Runtime Versions section displays correctly
✅ LOC limits: All files within exception limits

## Test Coverage

- `test_adapter_hash_computed_from_module_source`: Verifies adapter hash computation
- `test_policy_hash_aggregates_all_policy_files`: Verifies policy hash aggregation
- `test_material_hash_aggregates_all_material_files`: Verifies material hash aggregation
- `test_hash_none_when_directory_missing`: Verifies graceful degradation
- `test_hash_changes_when_file_changes`: Verifies determinism and sensitivity
- `test_adapter_hash_none_when_module_file_missing`: Verifies namespace package handling

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
