### PR TITLE
perf(queue): fix N+1 query pattern in queue selection (fixes #2542)

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -46,7 +46,7 @@ code_limits:
         limit: 520
         reason: "GitHub PR 只读查询聚合，新增 CI 失败分类与检查步骤解析逻辑，包含失败分类、日志解析、状态映射等紧密耦合逻辑"
       - path: "src/vibe3/clients/sqlite_flow_state_repo.py"
-        limit: 480
+        limit: 540
         reason: |
           Repo 层职责内聚，包含：
           - 基础 CRUD 操作（10 个 get 方法）
@@ -56,13 +56,16 @@ code_limits:
           - get_task_issue_number 方法（从 flow_issue_links 查询 task issue）
           - UTC-aware datetime 写入（update_flow_state, add_issue_link）
           - Status 参数验证（get_flows_by_status 增加 VALID_FLOW_STATUSES 校验）
+          - Bulk retrieval optimization（get_flow_state_bulk、get_flows_by_issues_bulk，Issue #2542 N+1 查询优化）
 
           拆分会破坏：
           - 数据访问层完整性
           - 查询一致性（所有方法都需过滤 deleted_at）
           - 事务原子性保证
+          - Bulk optimization coherence（批量查询与单条查询语义一致性）
 
           PR #2409 新增 status 验证逻辑，提升类型安全和 fail-fast 行为（+18 行）
+          PR #2542 新增 bulk retrieval 方法，修复 N+1 查询模式，减少 100x 数据库查询（+62 行）
 
       # Commands 层 —— 允许 480-550
       - path: "src/vibe3/commands/status.py"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -316,6 +316,9 @@ code_limits:
       - path: "tests/vibe3/integration/test_session_reuse.py"
         limit: 420
         reason: "Session reuse 集成测试集，覆盖完整生命周期验证、NULL/empty 过滤、无效 ID 验证、live preference、branch/role 隔离、安全网、race condition、多 session 选择等 9 个紧密耦合场景，每个测试使用真实 SQLite 数据库（非 mock）需要完整 setup，拆分会破坏测试场景完整性（#2060）"
+      - path: "tests/vibe3/services/test_issue_flow_service.py"
+        limit: 500
+        reason: "IssueFlowService 测试集，覆盖 convention injection、branch naming、flow lookup、resolve_best_flow 优先级逻辑与 protected branch guard 等紧密耦合场景；PR #2581 新增 8 个 resolve_best_flow 测试（优先级逻辑 5 个 + protected branch guard 3 个）从 297 行增至 465 行"
       - path: "src/vibe3/commands/status_render.py"
         limit: 450
         reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -67,6 +67,34 @@ class SQLiteFlowStateRepo(_HasConnection):
             return dict(row)
         return None
 
+    def get_flow_state_bulk(self, branches: list[str]) -> dict[str, dict[str, Any]]:
+        """Batch retrieve flow states for multiple branches (excludes soft-deleted).
+
+        Args:
+            branches: List of branch names to query.
+
+        Returns:
+            Dict mapping branch -> flow_state dict. Missing branches omitted.
+        """
+        if not branches:
+            return {}
+        conn = self._get_connection()
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in branches)
+        cursor.execute(
+            f"SELECT * FROM flow_state "
+            f"WHERE branch IN ({placeholders}) AND deleted_at IS NULL",
+            tuple(branches),
+        )
+        result: dict[str, dict[str, Any]] = {}
+        for row in cursor.fetchall():
+            entry = dict(row)
+            branch = entry.get("branch")
+            if branch:
+                result[branch] = entry
+        return result
+
     def update_flow_state(self, branch: str, **kwargs: Any) -> None:
         """Update flow state fields. Raises ValueError for invalid fields."""
         if "updated_at" not in kwargs:
@@ -432,6 +460,40 @@ class SQLiteFlowStateRepo(_HasConnection):
             count=len(flows),
         ).debug("Retrieved flows by issue")
         return flows
+
+    def get_flows_by_issues_bulk(
+        self, issue_numbers: list[int], role: str
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Batch retrieve flows linked to multiple issues with specified role.
+
+        Args:
+            issue_numbers: List of issue numbers to query.
+            role: Issue role to filter by (e.g. 'task').
+
+        Returns:
+            Dict mapping issue_number -> list of flow dicts (sorted by updated_at DESC).
+        """
+        if not issue_numbers:
+            return {}
+        conn = self._get_connection()
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in issue_numbers)
+        cursor.execute(
+            f"SELECT l.issue_number, f.* FROM flow_state f "
+            f"JOIN flow_issue_links l ON f.branch = l.branch "
+            f"WHERE l.issue_number IN ({placeholders}) AND l.issue_role = ? "
+            f"AND f.deleted_at IS NULL "
+            f"ORDER BY COALESCE(f.updated_at, '') DESC, f.branch ASC",
+            (*issue_numbers, role),
+        )
+        result: dict[int, list[dict[str, Any]]] = {n: [] for n in issue_numbers}
+        for row in cursor.fetchall():
+            entry = dict(row)
+            issue_num = entry.pop("issue_number", None)
+            if issue_num is not None and issue_num in result:
+                result[issue_num].append(entry)
+        return result
 
     def get_flow_dependents(self, branch: str) -> list[str]:
         """Get dependent flows (excludes soft-deleted flows)."""

--- a/src/vibe3/domain/flow_manager.py
+++ b/src/vibe3/domain/flow_manager.py
@@ -59,6 +59,20 @@ class FlowManager:
         """
         return self.issue_flow_service.find_active_flow(issue_number)
 
+    def resolve_best_flow(self, issue_number: int, flows: list[dict]) -> dict | None:
+        """Resolve best flow from pre-fetched list.
+
+        Delegates to IssueFlowService.resolve_best_flow for bulk-path optimization.
+
+        Args:
+            issue_number: GitHub issue number
+            flows: Pre-fetched list of flow dicts
+
+        Returns:
+            Flow dict if valid flow found, None otherwise
+        """
+        return self.issue_flow_service.resolve_best_flow(issue_number, flows)
+
     def _is_reusable_auto_flow(
         self, flow: dict[str, object], issue_number: int
     ) -> bool:

--- a/src/vibe3/domain/protocols/flow_protocols.py
+++ b/src/vibe3/domain/protocols/flow_protocols.py
@@ -40,3 +40,15 @@ class FlowManagerProtocol(Protocol):
             Flow dict if created, None otherwise
         """
         ...
+
+    def resolve_best_flow(self, issue_number: int, flows: list[dict]) -> dict | None:
+        """Resolve best flow from pre-fetched list.
+
+        Args:
+            issue_number: GitHub issue number
+            flows: Pre-fetched list of flow dicts (sorted by updated_at DESC)
+
+        Returns:
+            Flow dict if valid flow found, None otherwise
+        """
+        ...

--- a/src/vibe3/orchestra/__init__.py
+++ b/src/vibe3/orchestra/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     )
     from vibe3.orchestra.issue_loader import (
         get_flow_context,
+        get_flow_context_bulk,
         is_auto_task_branch,
         load_issue,
     )
@@ -49,6 +50,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "QueuePersistenceService": "vibe3.orchestra.queue_persistence_service",
     "DispatchHealthCheckService": "vibe3.orchestra.dispatch_health_check",
     "get_flow_context": "vibe3.orchestra.issue_loader",
+    "get_flow_context_bulk": "vibe3.orchestra.issue_loader",
     "load_issue": "vibe3.orchestra.issue_loader",
     "is_auto_task_branch": "vibe3.orchestra.issue_loader",
     # Protocols (self-module re-exports only)
@@ -85,6 +87,7 @@ __all__ = [
     "QueuePersistenceService",
     "DispatchHealthCheckService",
     "get_flow_context",
+    "get_flow_context_bulk",
     "load_issue",
     "is_auto_task_branch",
     # Protocols (self-module re-exports only)

--- a/src/vibe3/orchestra/domain_types.py
+++ b/src/vibe3/orchestra/domain_types.py
@@ -177,6 +177,10 @@ class FlowManagerProtocol(Protocol):
         """Create a new flow for an issue."""
         ...
 
+    def resolve_best_flow(self, issue_number: int, flows: list[dict]) -> dict | None:
+        """Resolve best flow from pre-fetched list."""
+        ...
+
 
 class IssueCollectionServiceProtocol(Protocol):
     """Protocol for issue collection service operations."""

--- a/src/vibe3/orchestra/issue_loader.py
+++ b/src/vibe3/orchestra/issue_loader.py
@@ -53,6 +53,66 @@ def get_flow_context(
     return branch, store.get_flow_state(branch)
 
 
+def get_flow_context_bulk(
+    issue_numbers: list[int],
+    config: OrchestraConfig,
+    github: "GitHubClient",
+    store: "SQLiteClient",
+    flow_manager: "FlowManagerProtocol",
+) -> dict[int, tuple[str, dict[str, object] | None]]:
+    """Batch get flow context (branch and state) for multiple issues.
+
+    Reduces N+1 queries to 2 bulk queries by:
+    1. Bulk-fetching all flow mappings for the issue numbers
+    2. Bulk-fetching flow states for the resolved branches
+
+    Args:
+        issue_numbers: Issue numbers to look up
+        config: Orchestra configuration
+        github: GitHub client
+        store: SQLite client
+        flow_manager: Flow manager
+
+    Returns:
+        Dict mapping issue_number -> (branch, flow_state).
+        Issues with no flow get ("", None).
+    """
+    if not issue_numbers:
+        return {}
+
+    # Step 1: Bulk fetch flow mappings
+    flows_by_issue = store.get_flows_by_issues_bulk(issue_numbers, role="task")
+
+    # Resolve each issue to its best flow (replicates find_active_flow logic)
+    issue_to_flow: dict[int, dict[str, object] | None] = {}
+    branches_to_fetch: set[str] = set()
+    for issue_num, flows in flows_by_issue.items():
+        best = flow_manager.resolve_best_flow(issue_num, flows)
+        issue_to_flow[issue_num] = best
+        if best:
+            branch = str(best.get("branch") or "").strip()
+            if branch:
+                branches_to_fetch.add(branch)
+
+    # Step 2: Bulk fetch flow states for all resolved branches
+    flow_states = store.get_flow_state_bulk(list(branches_to_fetch))
+
+    # Step 3: Assemble result
+    result: dict[int, tuple[str, dict[str, object] | None]] = {}
+    for issue_num in issue_numbers:
+        flow = issue_to_flow.get(issue_num)
+        if flow is None:
+            result[issue_num] = ("", None)
+            continue
+        branch = str(flow.get("branch") or "").strip()
+        if not branch:
+            result[issue_num] = ("", None)
+            continue
+        result[issue_num] = (branch, flow_states.get(branch))
+
+    return result
+
+
 def load_issue(
     issue_number: int, config: OrchestraConfig, github: "GitHubClient"
 ) -> "IssueInfo | None":

--- a/src/vibe3/orchestra/protocols.py
+++ b/src/vibe3/orchestra/protocols.py
@@ -51,3 +51,7 @@ class FlowManagerProtocol(Protocol):
     def create_flow_for_issue(self, issue: IssueInfo) -> dict | None:
         """Create or reuse a flow for an issue."""
         ...
+
+    def resolve_best_flow(self, issue_number: int, flows: list[dict]) -> dict | None:
+        """Resolve best flow from pre-fetched list."""
+        ...

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from vibe3.config import get_manager_usernames
 from vibe3.models import IssueInfo, IssueState, OrchestraConfig, QueueEntry
 from vibe3.observability import append_orchestra_event
-from vibe3.orchestra import get_flow_context, is_auto_task_branch, load_issue
+from vibe3.orchestra import (
+    get_flow_context_bulk,
+    is_auto_task_branch,
+    load_issue,
+)
 from vibe3.utils import sort_ready_issues
 
 if TYPE_CHECKING:
@@ -52,6 +56,25 @@ def select_ready_issues_from_collected_issues(
     if role is None:
         return selected
 
+    # Collect issue numbers that pass the trigger_state and queue_filter gates
+    candidate_numbers: list[int] = []
+    for issue in issues:
+        if issue.state != trigger_state:
+            continue
+        if queue_filter is not None and queue_filter(
+            issue,
+            supervisor_label=supervisor_label,
+            manager_usernames=get_manager_usernames(config),
+            require_manager_assignee=True,
+        ):
+            continue
+        candidate_numbers.append(issue.number)
+
+    # Bulk fetch flow contexts (2 queries instead of 2N)
+    flow_contexts = get_flow_context_bulk(
+        candidate_numbers, config, github, store, flow_manager
+    )
+
     for issue in issues:
         if issue.state != trigger_state:
             continue
@@ -63,9 +86,7 @@ def select_ready_issues_from_collected_issues(
         ):
             continue
 
-        branch, flow_state = get_flow_context(
-            issue.number, config, github, store, flow_manager
-        )
+        branch, flow_state = flow_contexts.get(issue.number, ("", None))
 
         target = qualify_gate.run_qualify_gate(
             issue, branch, flow_state, issue.labels, trigger_state

--- a/src/vibe3/services/issue/flow.py
+++ b/src/vibe3/services/issue/flow.py
@@ -197,15 +197,36 @@ class IssueFlowService:
             This wraps SQLiteClient.get_flows_by_issue with priority logic.
         """
         flows = self.store.get_flows_by_issue(issue_number, role="task")
+        return self.resolve_best_flow(issue_number, flows)
+
+    def resolve_best_flow(self, issue_number: int, flows: list[dict]) -> dict | None:
+        """Resolve best flow from pre-fetched list with deterministic selection.
+
+        Priority order:
+        1. Active canonical flow (task/issue-N)
+        2. Active non-canonical flow
+        3. First available flow (fallback)
+
+        Args:
+            issue_number: GitHub issue number (for guard check and canonical branch)
+            flows: Pre-fetched list of flow dicts (sorted by updated_at DESC)
+
+        Returns:
+            Flow dict if valid flow found, None if flows is empty.
+            Raises InvalidBranchLinkError if flow points to protected branch.
+
+        Note:
+            This is the bulk-path counterpart to find_active_flow.
+            It applies the same priority logic and guard check without
+            hitting the database.
+        """
         if not flows:
             return None
 
         # Guard: detect corrupted branch links
         # Check both sources of protected branches:
         # - scene_base_ref: OrchestraConfig's configurable base branch for current scene
-        #   (e.g., 'main', 'develop', stripped of 'origin/' prefix to match DB storage)
         # - protected_branches: VibeConfig's hardcoded list of protected branches
-        #   (e.g., ['main', 'develop', 'release/*'])
         # This aligns with TaskService.link_issue() write guard for consistency.
         base_branch = self.config.scene_base_ref.replace("origin/", "")
         protected_branches = set(VibeConfig.get_defaults().flow.protected_branches)

--- a/tests/vibe3/clients/test_flow_state_repo.py
+++ b/tests/vibe3/clients/test_flow_state_repo.py
@@ -1,0 +1,148 @@
+"""Tests for SQLite flow state repository bulk operations."""
+
+import tempfile
+from pathlib import Path
+
+from vibe3.clients import SQLiteClient
+
+
+def test_get_flow_state_bulk_returns_matching() -> None:
+    """Bulk query should return matching flow states."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Insert 3 flow states
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+        store.update_flow_state(
+            "task/issue-200", flow_slug="issue-200", flow_status="active"
+        )
+        store.update_flow_state(
+            "task/issue-300", flow_slug="issue-300", flow_status="active"
+        )
+
+        # Bulk query for 2 of them
+        result = store.get_flow_state_bulk(["task/issue-100", "task/issue-300"])
+
+        assert len(result) == 2
+        assert "task/issue-100" in result
+        assert "task/issue-300" in result
+        assert result["task/issue-100"]["flow_status"] == "active"
+        assert result["task/issue-300"]["flow_status"] == "active"
+
+
+def test_get_flow_state_bulk_empty_input() -> None:
+    """Bulk query with empty list should return empty dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        result = store.get_flow_state_bulk([])
+        assert result == {}
+
+
+def test_get_flow_state_bulk_excludes_deleted() -> None:
+    """Bulk query should exclude soft-deleted flow states."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Insert and soft-delete one flow
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+        store.soft_delete_flow("task/issue-100")
+
+        # Insert another active flow
+        store.update_flow_state(
+            "task/issue-200", flow_slug="issue-200", flow_status="active"
+        )
+
+        # Bulk query both
+        result = store.get_flow_state_bulk(["task/issue-100", "task/issue-200"])
+
+        # Only active flow should be returned
+        assert len(result) == 1
+        assert "task/issue-200" in result
+        assert "task/issue-100" not in result
+
+
+def test_get_flows_by_issues_bulk_returns_grouped() -> None:
+    """Bulk query should group flows by issue number."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Create flows and issue links
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+        store.update_flow_state(
+            "task/issue-200", flow_slug="issue-200", flow_status="active"
+        )
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-100", 100, "task"),
+        )
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-200", 200, "task"),
+        )
+        conn.commit()
+
+        # Bulk query both issues
+        result = store.get_flows_by_issues_bulk([100, 200], role="task")
+
+        assert len(result) == 2
+        assert len(result[100]) == 1
+        assert len(result[200]) == 1
+        assert result[100][0]["branch"] == "task/issue-100"
+        assert result[200][0]["branch"] == "task/issue-200"
+
+
+def test_get_flows_by_issues_bulk_empty_input() -> None:
+    """Bulk query with empty list should return empty dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        result = store.get_flows_by_issues_bulk([], role="task")
+        assert result == {}
+
+
+def test_get_flows_by_issues_bulk_missing_issue() -> None:
+    """Bulk query should return empty list for missing issues."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Create one issue-flow link
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-100", 100, "task"),
+        )
+        conn.commit()
+
+        # Query for both existing and missing issue
+        result = store.get_flows_by_issues_bulk([100, 999], role="task")
+
+        assert len(result) == 2
+        assert len(result[100]) == 1
+        assert result[999] == []

--- a/tests/vibe3/orchestra/test_auto_resume_no_flow.py
+++ b/tests/vibe3/orchestra/test_auto_resume_no_flow.py
@@ -178,13 +178,13 @@ class TestAutoResumeNoFlowScene:
             make_issue_info(300, IssueState.CLAIMED),
         ]
 
-        # Mock get_flow_context to return no branch
-        def mock_get_flow_context(*args, **kwargs):
-            return (None, None)
+        # Mock get_flow_context_bulk to return no branch for issue 300
+        def mock_get_flow_context_bulk(*args, **kwargs):
+            return {300: ("", None)}
 
         monkeypatch.setattr(
-            "vibe3.orchestra.queue_operations.get_flow_context",
-            mock_get_flow_context,
+            "vibe3.orchestra.queue_operations.get_flow_context_bulk",
+            mock_get_flow_context_bulk,
         )
 
         # Mock qualify gate to return the trigger state (allow issue through)
@@ -247,13 +247,13 @@ class TestAutoResumeNoFlowScene:
             make_issue_info(301, IssueState.BLOCKED),
         ]
 
-        # Mock get_flow_context to return no branch
-        def mock_get_flow_context(*args, **kwargs):
-            return (None, None)
+        # Mock get_flow_context_bulk to return no branch for issue 301
+        def mock_get_flow_context_bulk(*args, **kwargs):
+            return {301: ("", None)}
 
         monkeypatch.setattr(
-            "vibe3.orchestra.queue_operations.get_flow_context",
-            mock_get_flow_context,
+            "vibe3.orchestra.queue_operations.get_flow_context_bulk",
+            mock_get_flow_context_bulk,
         )
 
         # Mock qualify gate to return the trigger state (allow issue through)

--- a/tests/vibe3/orchestra/test_issue_loader_bulk.py
+++ b/tests/vibe3/orchestra/test_issue_loader_bulk.py
@@ -1,0 +1,99 @@
+"""Tests for issue loader bulk operations."""
+
+from unittest.mock import MagicMock
+
+from vibe3.models import OrchestraConfig
+from vibe3.orchestra.issue_loader import get_flow_context_bulk
+
+
+def test_get_flow_context_bulk_assembles_result() -> None:
+    """Bulk context retrieval should assemble flow contexts correctly."""
+    # Mock dependencies
+    mock_store = MagicMock()
+    mock_flow_manager = MagicMock()
+    mock_config = MagicMock(spec=OrchestraConfig)
+    mock_github = MagicMock()
+
+    # Setup mock responses
+    mock_store.get_flows_by_issues_bulk.return_value = {
+        100: [{"branch": "task/issue-100", "flow_status": "active"}],
+        200: [{"branch": "task/issue-200", "flow_status": "active"}],
+    }
+
+    mock_flow_manager.resolve_best_flow.side_effect = lambda issue_num, flows: (
+        flows[0] if flows else None
+    )
+
+    mock_store.get_flow_state_bulk.return_value = {
+        "task/issue-100": {"branch": "task/issue-100", "flow_status": "active"},
+        "task/issue-200": {"branch": "task/issue-200", "flow_status": "active"},
+    }
+
+    # Execute bulk retrieval
+    result = get_flow_context_bulk(
+        [100, 200], mock_config, mock_github, mock_store, mock_flow_manager
+    )
+
+    # Verify result structure
+    assert len(result) == 2
+    assert result[100] == (
+        "task/issue-100",
+        {"branch": "task/issue-100", "flow_status": "active"},
+    )
+    assert result[200] == (
+        "task/issue-200",
+        {"branch": "task/issue-200", "flow_status": "active"},
+    )
+
+
+def test_get_flow_context_bulk_empty_input() -> None:
+    """Bulk retrieval with empty list should return empty dict."""
+    mock_store = MagicMock()
+    mock_flow_manager = MagicMock()
+    mock_config = MagicMock(spec=OrchestraConfig)
+    mock_github = MagicMock()
+
+    result = get_flow_context_bulk(
+        [], mock_config, mock_github, mock_store, mock_flow_manager
+    )
+
+    assert result == {}
+    mock_store.get_flows_by_issues_bulk.assert_not_called()
+
+
+def test_get_flow_context_bulk_issue_with_no_flow() -> None:
+    """Bulk retrieval should return empty context for issues without flows."""
+    mock_store = MagicMock()
+    mock_flow_manager = MagicMock()
+    mock_config = MagicMock(spec=OrchestraConfig)
+    mock_github = MagicMock()
+
+    # Setup mock responses - issue 100 has flow, issue 999 does not
+    mock_store.get_flows_by_issues_bulk.return_value = {
+        100: [{"branch": "task/issue-100", "flow_status": "active"}],
+        999: [],
+    }
+
+    def mock_resolve(issue_num: int, flows: list) -> dict | None:
+        if issue_num == 100:
+            return flows[0]
+        return None
+
+    mock_flow_manager.resolve_best_flow.side_effect = mock_resolve
+
+    mock_store.get_flow_state_bulk.return_value = {
+        "task/issue-100": {"branch": "task/issue-100", "flow_status": "active"},
+    }
+
+    # Execute bulk retrieval
+    result = get_flow_context_bulk(
+        [100, 999], mock_config, mock_github, mock_store, mock_flow_manager
+    )
+
+    # Verify result
+    assert len(result) == 2
+    assert result[100] == (
+        "task/issue-100",
+        {"branch": "task/issue-100", "flow_status": "active"},
+    )
+    assert result[999] == ("", None)

--- a/tests/vibe3/services/test_issue_flow_service.py
+++ b/tests/vibe3/services/test_issue_flow_service.py
@@ -4,6 +4,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
+
 from vibe3.config.profile_convention import ProfileConvention
 from vibe3.models.branch_convention import BranchConvention
 from vibe3.services.issue.flow import IssueFlowService
@@ -295,3 +297,169 @@ class TestIssueFlowServiceResolveTaskIssueNumber:
 
         result = service.resolve_task_issue_number("feature/my-branch")
         assert result is None
+
+
+class TestIssueFlowServiceResolveBestFlow:
+    """Tests for resolve_best_flow priority logic and protected branch guard.
+
+    Resolves the IMPORTANT items from PR #2581 code review:
+    1. Test priority logic (canonical > non-canonical > fallback)
+    2. Test protected branch guard (InvalidBranchLinkError)
+    """
+
+    def test_returns_none_for_empty_flows(self) -> None:
+        """Should return None when flows list is empty."""
+        service = IssueFlowService()
+        result = service.resolve_best_flow(100, [])
+        assert result is None
+
+    def test_prefers_canonical_active_over_non_canonical(self) -> None:
+        """Canonical active flow should win over non-canonical active."""
+        from unittest.mock import MagicMock
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-100"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [
+            {"branch": "task/issue-100", "flow_status": "active"},
+            {"branch": "task/issue-100-worktree", "flow_status": "active"},
+        ]
+        result = service.resolve_best_flow(100, flows)
+        assert result is not None
+        assert result["branch"] == "task/issue-100"
+
+    def test_falls_back_to_non_canonical_when_canonical_inactive(self) -> None:
+        """Non-canonical active should win when canonical is done/aborted."""
+        from unittest.mock import MagicMock
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-100"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [
+            {"branch": "task/issue-100", "flow_status": "done"},
+            {"branch": "task/issue-100-worktree", "flow_status": "active"},
+        ]
+        result = service.resolve_best_flow(100, flows)
+        assert result is not None
+        assert result["branch"] == "task/issue-100-worktree"
+
+    def test_falls_back_to_first_available_when_no_active(self) -> None:
+        """First flow should be returned when no active flows exist."""
+        from unittest.mock import MagicMock
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-100"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [
+            {"branch": "task/issue-100", "flow_status": "done"},
+            {"branch": "task/issue-100-v2", "flow_status": "aborted"},
+        ]
+        result = service.resolve_best_flow(100, flows)
+        assert result is not None
+        assert result["branch"] == "task/issue-100"
+
+    def test_raises_for_protected_branch_guard(self) -> None:
+        """Should raise InvalidBranchLinkError when flow points to protected branch."""
+        from unittest.mock import MagicMock
+
+        from vibe3.exceptions import InvalidBranchLinkError
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-100"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [{"branch": "main", "flow_status": "active"}]
+        with pytest.raises(InvalidBranchLinkError) as exc_info:
+            service.resolve_best_flow(100, flows)
+        assert exc_info.value.branch == "main"
+        assert exc_info.value.issue_number == 100
+
+    def test_raises_for_develop_as_protected_branch(self) -> None:
+        """Should raise InvalidBranchLinkError for develop (in protected_branches)."""
+        from unittest.mock import MagicMock
+
+        from vibe3.exceptions import InvalidBranchLinkError
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-200"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [{"branch": "develop", "flow_status": "active"}]
+        with pytest.raises(InvalidBranchLinkError) as exc_info:
+            service.resolve_best_flow(200, flows)
+        assert exc_info.value.branch == "develop"
+        assert exc_info.value.issue_number == 200
+
+    def test_raises_for_scene_base_ref_match(self) -> None:
+        """Should raise when branch matches scene_base_ref (non-origin prefix)."""
+        from unittest.mock import MagicMock
+
+        from vibe3.exceptions import InvalidBranchLinkError
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "develop"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-300"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [{"branch": "develop", "flow_status": "active"}]
+        with pytest.raises(InvalidBranchLinkError) as exc_info:
+            service.resolve_best_flow(300, flows)
+        assert exc_info.value.branch == "develop"
+        assert exc_info.value.issue_number == 300
+
+    def test_normal_branch_passes_guard(self) -> None:
+        """Normal task branch should not trigger guard check."""
+        from unittest.mock import MagicMock
+
+        mock_config = MagicMock()
+        mock_config.scene_base_ref = "origin/main"
+
+        mock_resolver = MagicMock()
+        convention = MagicMock()
+        convention.branch.canonical_branch.return_value = "task/issue-100"
+        mock_resolver.resolve.return_value = convention
+
+        service = IssueFlowService(config=mock_config, resolver=mock_resolver)
+
+        flows = [{"branch": "task/issue-100", "flow_status": "active"}]
+        result = service.resolve_best_flow(100, flows)
+        assert result is not None
+        assert result["branch"] == "task/issue-100"


### PR DESCRIPTION
Closes #2542

## Summary
Fix N+1 query pattern in queue selection by replacing per-issue database calls with bulk retrieval, reducing queries from 2N to 2 for N issues (100x improvement for 100 issues).

## Changes
- **Store Layer**: Added `get_flow_state_bulk` and `get_flows_by_issues_bulk` methods to SQLiteFlowStateRepo
- **Service Layer**: Added `resolve_best_flow` to IssueFlowService to enable bulk optimization
- **Orchestra Layer**: Added `get_flow_context_bulk` function for batch flow context retrieval
- **Queue Operations**: Updated `select_ready_issues_from_collected_issues` to use pre-fetched bulk lookup
- **Protocols**: Added `resolve_best_flow` to all three `FlowManagerProtocol` definitions
- **Tests**: Added 9 new tests for bulk methods + updated 2 integration tests

## Test plan
- [x] All 177 tests pass (16 direct + 161 affected)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff + black)
- [x] Pre-commit hooks pass
- [x] LOC limits checked and exception updated

## Performance Impact
- Before: 2N queries for N issues (e.g., 200 queries for 100 issues)
- After: 2 queries total regardless of issue count
- **100x reduction** for typical queue sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
