### PR TITLE
refactor(orchestra): remove redundant git branch_exists check from dispatcher loop

### DIFF
--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -78,12 +78,6 @@ def select_ready_issues_from_collected_issues(
                 if issue.state not in {IssueState.READY, IssueState.BLOCKED}:
                     _auto_resume_to_ready(issue, config, label_service=label_service)
                 continue
-            if not flow_manager.git.branch_exists(branch):
-                append_orchestra_event(
-                    "dispatcher",
-                    f"skip #{issue.number}: branch '{branch}' not found in git",
-                )
-                continue
 
         selected.append(issue)
 

--- a/tests/vibe3/orchestra/conftest.py
+++ b/tests/vibe3/orchestra/conftest.py
@@ -97,7 +97,6 @@ def make_coordinator() -> callable:
 
         flow_manager = MagicMock()
         flow_manager.get_flow_for_issue = MagicMock(return_value=None)
-        flow_manager.git.branch_exists = MagicMock(return_value=True)
 
         health_check_service = MagicMock()
 


### PR DESCRIPTION
Closes #2544

## Summary

Remove the inline `flow_manager.git.branch_exists(branch)` call from the `select_ready_issues_from_collected_issues` hot loop. The DB-backed `get_flow_context` already determines flow validity by querying SQLite with `deleted_at IS NULL` filter.

The git subprocess call (`git rev-parse --verify <branch>`) per issue was redundant overhead that violated the principle of using the orchestration database as the primary source of truth.

## Changes

- **src/vibe3/orchestra/queue_operations.py**: Removed `branch_exists` guard (lines 81-86) from the dispatcher loop
- **tests/vibe3/orchestra/conftest.py**: Removed dead mock configuration that was no longer in the call path

## Background: Why the check is redundant

The caller already resolves flow context via `get_flow_context()`, which:
1. Calls `flow_manager.get_flow_for_issue(issue_number)` → queries the DB for the active flow record
2. Calls `store.get_flow_state(branch)` → queries the DB with `deleted_at IS NULL` filter

If no flow exists in the DB, `get_flow_context` returns `("", None)` — an empty branch. The code already handles this at line 77: `if not branch or not is_auto_task_branch(branch):` → auto-resume path.

The git check on line 81 was a redundant filesystem-level re-validation that only catches the edge case of a branch deleted outside the orchestration system. That edge case belongs to background cleanup, not the hot dispatch loop.

## Test Plan

- ✅ All 146 orchestra tests pass
- ✅ Type check: mypy passes (no issues in 1 source file)
- ✅ Pre-commit hooks: All passed (ShellCheck, Ruff, Black, MyPy)
- ✅ No remaining references to `branch_exists` in orchestra module
- ✅ Direct test file `test_auto_resume_no_flow.py` (7 tests) exercises the affected code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
