### PR TITLE
refactor(sqlite): centralize DB path resolution in from_repo_path classmethod

### DIFF
--- a/src/vibe3/clients/sqlite_base.py
+++ b/src/vibe3/clients/sqlite_base.py
@@ -5,7 +5,7 @@ import datetime
 import sqlite3
 import threading
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 from loguru import logger
 
@@ -93,6 +93,9 @@ def _utcnow_iso() -> str:
 atexit.register(_close_global_connection)
 
 
+T = TypeVar("T", bound="SQLiteClientBase")
+
+
 class SQLiteClientBase:
     """Connection/bootstrap layer shared by focused SQLite repositories."""
 
@@ -108,14 +111,31 @@ class SQLiteClientBase:
                     "rev-parse --git-common-dir",
                     f"returned non-absolute path: {git_dir}",
                 )
-            db_path = str(get_vibe3_db_path(git_dir))
             git_dir.joinpath("vibe3").mkdir(parents=True, exist_ok=True)
+            db_path = str(get_vibe3_db_path(git_dir))
 
         self.db_path = db_path
         self._init_db()
         logger.bind(external="sqlite", operation="init", db_path=db_path).debug(
             "SQLite client initialized"
         )
+
+    @classmethod
+    def from_repo_path(cls: type[T], repo_path: Path) -> T:
+        """Create a SQLiteClient resolved from a repository root path.
+
+        Centralizes the handoff.db path resolution to avoid duplication
+        across worktree environment modules.
+
+        Args:
+            repo_path: Path to the main repository root
+
+        Returns:
+            New SQLiteClient instance with the resolved db path
+        """
+        git_dir = repo_path / ".git"
+        db_path = str(get_vibe3_db_path(git_dir))
+        return cls(db_path=db_path)
 
     def _init_db(self) -> None:
         """Initialize schema and run migrations (idempotent).

--- a/src/vibe3/clients/sqlite_base.py
+++ b/src/vibe3/clients/sqlite_base.py
@@ -111,8 +111,8 @@ class SQLiteClientBase:
                     "rev-parse --git-common-dir",
                     f"returned non-absolute path: {git_dir}",
                 )
-            git_dir.joinpath("vibe3").mkdir(parents=True, exist_ok=True)
             db_path = str(get_vibe3_db_path(git_dir))
+            git_dir.joinpath("vibe3").mkdir(parents=True, exist_ok=True)
 
         self.db_path = db_path
         self._init_db()

--- a/src/vibe3/environment/worktree.py
+++ b/src/vibe3/environment/worktree.py
@@ -17,7 +17,6 @@ from vibe3.environment.worktree_support import (
     recycle_worktree_path,
 )
 from vibe3.exceptions import SystemError
-from vibe3.utils import get_vibe3_db_path
 
 if TYPE_CHECKING:
     from vibe3.clients import FlowStatePort
@@ -122,9 +121,7 @@ class WorktreeManager(WorktreePRMixin):
             # Record fallback event
             try:
                 # Calculate db path directly from repo_path without git command
-                git_common_dir = self.repo_path / ".git"
-                db_path = str(get_vibe3_db_path(git_common_dir))
-                store = SQLiteClient(db_path=db_path)
+                store = SQLiteClient.from_repo_path(self.repo_path)
                 store.add_event(
                     branch,
                     "dependency_branch_fallback",

--- a/src/vibe3/environment/worktree_pr_mixin.py
+++ b/src/vibe3/environment/worktree_pr_mixin.py
@@ -13,7 +13,6 @@ from loguru import logger
 
 from vibe3.clients import GitHubClient, SQLiteClient
 from vibe3.environment.worktree_context import WorktreeContext
-from vibe3.utils import get_vibe3_db_path
 
 if TYPE_CHECKING:
     from vibe3.models import OrchestraConfig
@@ -43,9 +42,7 @@ class WorktreePRMixin:
         try:
             # Calculate db path directly from repo_path without git command
             # This avoids extra git invocation in unit tests
-            git_common_dir = self.repo_path / ".git"
-            db_path = str(get_vibe3_db_path(git_common_dir))
-            store = SQLiteClient(db_path=db_path)
+            store = SQLiteClient.from_repo_path(self.repo_path)
             events = store.get_events(flow_branch, event_type="flow_unblocked")
         except Exception:
             # Failed to access SQLite store (e.g. in test temp directory)

--- a/tests/vibe3/clients/test_sqlite_client_fresh_db.py
+++ b/tests/vibe3/clients/test_sqlite_client_fresh_db.py
@@ -124,3 +124,14 @@ def test_default_db_path_reopens_closed_singleton_connection(tmp_path, monkeypat
     state = second.get_flow_state("task/reopen")
     assert state is not None
     assert state["branch"] == "task/reopen"
+
+
+class TestFromRepoPath:
+    """Test SQLiteClient.from_repo_path classmethod."""
+
+    def test_resolves_db_path_from_repo_path(self, tmp_path):
+        """from_repo_path should resolve handoff.db from .git/vibe3/."""
+        git_dir = tmp_path / ".git" / "vibe3"
+        git_dir.mkdir(parents=True)
+        store = SQLiteClient.from_repo_path(tmp_path)
+        assert store.db_path == str(tmp_path / ".git" / "vibe3" / "handoff.db")

--- a/tests/vibe3/clients/test_sqlite_client_fresh_db.py
+++ b/tests/vibe3/clients/test_sqlite_client_fresh_db.py
@@ -135,3 +135,10 @@ class TestFromRepoPath:
         git_dir.mkdir(parents=True)
         store = SQLiteClient.from_repo_path(tmp_path)
         assert store.db_path == str(tmp_path / ".git" / "vibe3" / "handoff.db")
+
+    def test_returns_correct_subclass_type(self, tmp_path):
+        """from_repo_path should return SQLiteClient, not SQLiteClientBase."""
+        git_dir = tmp_path / ".git" / "vibe3"
+        git_dir.mkdir(parents=True)
+        store = SQLiteClient.from_repo_path(tmp_path)
+        assert type(store).__name__ == "SQLiteClient"

--- a/tests/vibe3/environment/test_worktree_branch_from_pr.py
+++ b/tests/vibe3/environment/test_worktree_branch_from_pr.py
@@ -33,7 +33,7 @@ class TestFindDependencyWakeupPR:
         manager = WorktreeManager(config=config, repo_path=repo_path)
 
         with patch(
-            "vibe3.environment.worktree_pr_mixin.SQLiteClient",
+            "vibe3.environment.worktree_pr_mixin.SQLiteClient.from_repo_path",
             return_value=store,
         ):
             # Execute
@@ -61,7 +61,7 @@ class TestFindDependencyWakeupPR:
         manager = WorktreeManager(config=config, repo_path=repo_path)
 
         with patch(
-            "vibe3.environment.worktree_pr_mixin.SQLiteClient",
+            "vibe3.environment.worktree_pr_mixin.SQLiteClient.from_repo_path",
             return_value=store,
         ):
             # Execute
@@ -103,7 +103,7 @@ class TestFindDependencyWakeupPR:
         manager = WorktreeManager(config=config, repo_path=repo_path)
 
         with patch(
-            "vibe3.environment.worktree_pr_mixin.SQLiteClient",
+            "vibe3.environment.worktree_pr_mixin.SQLiteClient.from_repo_path",
             return_value=store,
         ):
             # Execute
@@ -136,7 +136,7 @@ class TestFindDependencyWakeupPR:
         manager = WorktreeManager(config=config, repo_path=repo_path)
 
         with patch(
-            "vibe3.environment.worktree_pr_mixin.SQLiteClient",
+            "vibe3.environment.worktree_pr_mixin.SQLiteClient.from_repo_path",
             return_value=store,
         ):
             # Execute


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2496` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2496
```


---

Closes #2496

## Summary

Add `SQLiteClientBase.from_repo_path()` as single source of truth for resolving `handoff.db` from a repository path, leveraging the `get_vibe3_db_path` utility function for centralized path resolution.

## Changes

- Add `paths.py` module with `get_vibe3_db_path` utility (aligned with main)
- Add `from_repo_path()` classmethod to `SQLiteClientBase` using `get_vibe3_db_path`
- Update `__init__` in `sqlite_base.py` to use `get_vibe3_db_path`
- Replace duplicated path constructions in worktree modules:
  - `worktree_pr_mixin.py`: `_find_dependency_wakeup_pr()`
  - `worktree.py`: `acquire_issue_worktree()`
  - `worktree_lifecycle.py`: now uses FlowService (aligned with main)
- Update protocols and models from main for type compatibility
- Add unit test for `from_repo_path()` classmethod
- Update test mocks to patch `from_repo_path()` instead of constructor

## Benefits

This refactoring combines two improvements:
1. Utility function for path resolution (from main)
2. Classmethod for convenient client creation (this PR)

Eliminates 2 duplicated path constructions across worktree environment modules, centralizing DB path resolution for easier maintenance and consistency.

## Test Plan

- ✅ Unit test added: `TestFromRepoPath::test_resolves_db_path_from_repo_path`
- ✅ All affected tests pass (29 tests)
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff)
- ✅ LOC limits checked
- ✅ Pre-push checks passed (284 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
