### PR TITLE
fix(serve): create CheckService in assembly to fix verify_branch NoneType

### DIFF
--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -139,6 +139,18 @@ def _build_server_with_launch_cwd(
     # heartbeat entry point. It incorporates governance scan,
     # supervisor scan, and issue-label dispatch polling.
     # GlobalDispatchCoordinator is created internally by the facade.
+    from vibe3.services import CheckService, FlowService
+
+    shared_check_service = CheckService(
+        store=shared_store,
+        git_client=shared_flow_manager.git,
+        github_client=shared_github,
+    )
+    shared_flow_service = FlowService(
+        store=shared_store,
+        git_client=shared_flow_manager.git,
+    )
+
     facade = OrchestrationFacade(
         config=config,
         capacity=shared_capacity,
@@ -146,8 +158,8 @@ def _build_server_with_launch_cwd(
         store=shared_store,
         coordinator_factory=create_global_dispatch_coordinator,  # type: ignore[arg-type]
         coordinator_class=GlobalDispatchCoordinator,
-        check_service=None,  # created by factory
-        flow_service=None,  # created by factory
+        check_service=shared_check_service,
+        flow_service=shared_flow_service,
         queue_filter=None,  # default behavior
     )
 

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -97,7 +97,7 @@ def _build_server_with_launch_cwd(
         FailedGateProtocol,
         HeartbeatServer,
     )
-    from vibe3.services import OrchestraStatusService
+    from vibe3.services import CheckService, FlowService, OrchestraStatusService
 
     shared_github = GitHubClient()
     shared_store = SQLiteClient()
@@ -135,6 +135,17 @@ def _build_server_with_launch_cwd(
         failed_gate=failed_gate,
     )
 
+    # Create shared service instances for the assembly layer.
+    shared_check_service = CheckService(
+        store=shared_store,
+        git_client=shared_flow_manager.git,
+        github_client=shared_github,
+    )
+    shared_flow_service = FlowService(
+        store=shared_store,
+        git_client=shared_flow_manager.git,
+    )
+
     # Register OrchestrationFacade as the single domain-first
     # heartbeat entry point. It incorporates governance scan,
     # supervisor scan, and issue-label dispatch polling.
@@ -167,7 +178,7 @@ def _build_server_with_launch_cwd(
         config,
         failed_gate=cast(FailedGateProtocol | None, failed_gate),
         error_tracker=None,
-        check_service=None,
+        check_service=shared_check_service,
         cleanup_service=None,
     )
     heartbeat.register(facade)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- `registry.py` passed `check_service=None` to `OrchestrationFacade`, but `create_global_dispatch_coordinator` requires a non-None `CheckServiceProtocol`
- This caused `'NoneType' object has no attribute 'verify_branch'` on every tick when running `serve --debug`
- Fix: create `CheckService` and `FlowService` instances in the assembly layer

## Root Cause
`OrchestrationFacade.__init__` accepts `check_service: object | None = None` (default `None`). The assembly in `registry.py` relied on the comment "created by factory" but the factory signature requires `check_service: CheckServiceProtocol` (non-optional). When `None` was passed through, `DispatchHealthCheckService._check_service` was `None`, causing the `AttributeError` at `dispatch_health_check.py:87`.

## Fix
Create `CheckService` and `FlowService` in `registry.py` (the composition root) and pass them to the facade:
- `CheckService(store, git_client, github_client)` — shared instance
- `FlowService(store, git_client)` — shared instance

## Test Plan
- [x] `serve start --debug` no longer produces `verify_branch` errors
- [x] Tick #1 successfully dispatches issues (#2169, #2535)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)