### PR TITLE
feat(event-rules): add configurable event→command routing engine

### DIFF
--- a/config/policies/event-rules.yaml
+++ b/config/policies/event-rules.yaml
@@ -1,0 +1,40 @@
+# Event routing rules for orchestration
+#
+# Rules are evaluated for every published domain event.
+# Each rule specifies:
+#   - event: DomainEvent class name to match
+#   - action: Action identifier (e.g., "log", "enqueue_command_job")
+#   - params: Template parameters with {{ event.field }} syntax
+#   - enabled: Whether the rule is active (default: true)
+#
+# Template expansion:
+#   - {{ event.field }} is replaced with the event's attribute value
+#   - Unknown fields are replaced with empty string
+#
+# This file is loaded at server startup via EventPublisher.on_publish hook.
+
+rules:
+  # Governance scan started → log for observability
+  - event: GovernanceScanStarted
+    action: log
+    params:
+      message: "governance scan started (tick={{ event.tick_count }})"
+
+  # Manager dispatch → queue manager command
+  - event: ManagerDispatchIntent
+    action: enqueue_command_job
+    params:
+      command: "vibe3 internal manager {{ event.issue_number }}"
+      actor: "{{ event.actor }}"
+
+  # Supervisor issue identified → log for tracking
+  - event: SupervisorIssueIdentified
+    action: log
+    params:
+      message: "supervisor candidate: issue #{{ event.issue_number }}"
+
+  # Issue failed → record for error tracking
+  - event: IssueFailed
+    action: log
+    params:
+      message: "issue #{{ event.issue_number }} failed: {{ event.reason }}"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -144,8 +144,8 @@ code_limits:
         limit: 620
         reason: "Orchestra CLI 入口聚合，包含 FailedGate/ErrorTracking status 显示、密钥加载 fallback 检查、全局单例实例管理、serve start/stop/status 增强；#2174 新增 Active Jobs 面板显示运行态 job 监控数据（+83 行）"
       - path: "src/vibe3/server/registry.py"
-        limit: 510
-        reason: "Orchestra 服务注册与启动聚合，包含 serve 命令构建、async child process 启动、FastAPI 路由注册；#2174 新增 /status jobs 字段和 / 路由重定向（+46 行）"
+        limit: 540
+        reason: "Orchestra 服务注册与启动聚合，包含 serve 命令构建、async child process 启动、FastAPI 路由注册；#2174 新增 /status jobs 字段和 / 路由重定向（+46 行）；#2169 新增 event rules engine 初始化与 EventPublisher hook 注册（+24 行）"
 
       # Shell / 脚本兼容入口
       - path: "scripts/install.sh"

--- a/src/vibe3/domain/__init__.py
+++ b/src/vibe3/domain/__init__.py
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
         MAX_INTENTS_PER_TICK,
         GlobalDispatchCoordinator,
     )
+    from vibe3.domain.event_rules import (
+        EventRule,
+        build_action_handlers,
+        evaluate_rules,
+        expand_template,
+        load_rules,
+    )
     from vibe3.domain.events.base import DomainEvent
     from vibe3.domain.events.flow_lifecycle import (
         ExecutorDispatchIntent,
@@ -91,6 +98,12 @@ _LAZY_IMPORTS: dict[str, str] = {
     "find_role_for_state": "vibe3.domain.role_resolver",
     # Publisher
     "EventPublisher": "vibe3.domain.publisher",
+    # Event rules
+    "EventRule": "vibe3.domain.event_rules",
+    "build_action_handlers": "vibe3.domain.event_rules",
+    "evaluate_rules": "vibe3.domain.event_rules",
+    "expand_template": "vibe3.domain.event_rules",
+    "load_rules": "vibe3.domain.event_rules",
 }
 
 
@@ -171,6 +184,12 @@ __all__ = [
     "get_publisher",
     "publish",
     "subscribe",
+    # Event rules
+    "EventRule",
+    "build_action_handlers",
+    "evaluate_rules",
+    "expand_template",
+    "load_rules",
     # Handlers
     "register_event_handlers",
 ]

--- a/src/vibe3/domain/event_rules.py
+++ b/src/vibe3/domain/event_rules.py
@@ -15,7 +15,7 @@ import yaml
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.models.domain_events import DomainEvent
+    from vibe3.models import DomainEvent
 
 
 @dataclass(frozen=True)

--- a/src/vibe3/domain/event_rules.py
+++ b/src/vibe3/domain/event_rules.py
@@ -1,0 +1,208 @@
+"""Event routing rule engine.
+
+Loads declarative event→action rules from YAML and evaluates them
+on every published domain event via EventPublisher.on_publish hook.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import yaml
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vibe3.models.domain_events import DomainEvent
+
+
+@dataclass(frozen=True)
+class EventRule:
+    """Single event routing rule."""
+
+    event: str  # DomainEvent class name (e.g. "ManagerDispatchIntent")
+    action: str  # Action identifier (e.g. "log", "enqueue_command_job")
+    params: dict[str, str]  # Template parameters with {{ event.field }} syntax
+    enabled: bool = True
+    scope: tuple[str, ...] = ()  # Optional scope filter
+
+
+def load_rules(policy_dir: Path) -> tuple[EventRule, ...]:
+    """Load rules from YAML files in policy_dir.
+
+    Args:
+        policy_dir: Directory containing event-rules.yaml
+
+    Returns:
+        Tuple of EventRule objects. Empty tuple if directory or file missing.
+    """
+    rules_file = policy_dir / "event-rules.yaml"
+    if not rules_file.exists():
+        logger.bind(domain="event_rules").debug(
+            f"Event rules file not found: {rules_file}, using empty ruleset"
+        )
+        return ()
+
+    try:
+        content = yaml.safe_load(rules_file.read_text())
+    except Exception as exc:
+        logger.bind(domain="event_rules").warning(
+            f"Failed to load event rules from {rules_file}: {exc}"
+        )
+        return ()
+
+    if not content or "rules" not in content:
+        return ()
+
+    rules: list[EventRule] = []
+    for idx, rule_data in enumerate(content["rules"]):
+        if not isinstance(rule_data, dict):
+            logger.bind(domain="event_rules").warning(
+                f"Rule #{idx} is not a dict, skipping"
+            )
+            continue
+
+        # Validate required fields
+        if "event" not in rule_data or "action" not in rule_data:
+            logger.bind(domain="event_rules").warning(
+                f"Rule #{idx} missing required field (event/action), skipping"
+            )
+            continue
+
+        try:
+            rule = EventRule(
+                event=str(rule_data["event"]),
+                action=str(rule_data["action"]),
+                params=rule_data.get("params", {}),
+                enabled=rule_data.get("enabled", True),
+                scope=tuple(rule_data.get("scope", [])),
+            )
+            rules.append(rule)
+        except Exception as exc:
+            logger.bind(domain="event_rules").warning(
+                f"Failed to create rule #{idx}: {exc}, skipping"
+            )
+            continue
+
+    logger.bind(domain="event_rules").info(
+        f"Loaded {len(rules)} event rules from {rules_file}"
+    )
+    return tuple(rules)
+
+
+def expand_template(template: str, event: DomainEvent) -> str:
+    """Expand {{ event.field }} placeholders using event attribute values.
+
+    Args:
+        template: String with {{ event.field }} placeholders
+        event: DomainEvent instance to extract values from
+
+    Returns:
+        String with placeholders replaced by attribute values.
+        Unknown attributes are replaced with empty string.
+    """
+
+    def replace_match(match: re.Match[str]) -> str:
+        field_path = match.group(1).strip()
+        # Handle dot-path for nested attributes (e.g., event.issue.number)
+        parts = field_path.split(".")
+        if not parts or parts[0] != "event":
+            return match.group(0)  # Return original if not event.*
+
+        value: object = event
+        for part in parts[1:]:
+            try:
+                value = getattr(value, part)
+            except AttributeError:
+                logger.bind(domain="event_rules").warning(
+                    f"Event missing attribute '{field_path}', preserving placeholder"
+                )
+                return match.group(0)
+
+        return str(value)
+
+    return re.sub(r"\{\{\s*([^}]+)\s*\}\}", replace_match, template)
+
+
+def evaluate_rules(
+    event: DomainEvent,
+    rules: tuple[EventRule, ...],
+    action_handlers: dict[str, Callable[[dict[str, str]], None]],
+) -> None:
+    """Evaluate all matching rules for an event and execute their actions.
+
+    Args:
+        event: DomainEvent instance to evaluate
+        rules: Tuple of EventRule objects to check
+        action_handlers: Dict mapping action names to handler functions
+    """
+    event_type = type(event).__name__
+
+    for rule in rules:
+        if not rule.enabled:
+            continue
+
+        if rule.event != event_type:
+            continue
+
+        # Expand template parameters
+        expanded_params: dict[str, str] = {}
+        for key, value in rule.params.items():
+            if isinstance(value, str):
+                expanded_params[key] = expand_template(value, event)
+            else:
+                expanded_params[key] = str(value)
+
+        # Scope filter: if rule has scope, check against params
+        if rule.scope:
+            # For now, scope is informational; can be extended for filtering
+            pass
+
+        # Execute action
+        handler = action_handlers.get(rule.action)
+        if not handler:
+            logger.bind(domain="event_rules").warning(
+                f"No handler registered for action '{rule.action}', skipping"
+            )
+            continue
+
+        try:
+            handler(expanded_params)
+        except Exception as exc:
+            logger.bind(domain="event_rules").error(
+                f"Action handler '{rule.action}' failed: {exc}"
+            )
+
+
+def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
+    """Build action handlers dict for rule evaluation.
+
+    Returns:
+        Dict mapping action names to handler functions.
+        Currently supports: log, enqueue_command_job
+    """
+
+    def log_action(params: dict[str, str]) -> None:
+        """Log action handler."""
+        message = params.get("message", "")
+        logger.bind(domain="event_rules").info(message)
+
+    def enqueue_command_job_action(params: dict[str, str]) -> None:
+        """Enqueue command job action handler.
+
+        NOTE: This is a placeholder for now. Full implementation
+        requires integration with the job queue system.
+        """
+        command = params.get("command", "")
+        actor = params.get("actor", "system")
+        logger.bind(domain="event_rules").info(
+            f"Would enqueue command: {command} (actor={actor})"
+        )
+        # TODO: Integrate with actual job queue when available
+
+    return {
+        "log": log_action,
+        "enqueue_command_job": enqueue_command_job_action,
+    }

--- a/src/vibe3/models/__init__.py
+++ b/src/vibe3/models/__init__.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from vibe3.models.event_bus import (
         EventHandler,
         EventPublisher,
+        PublishHook,
         get_publisher,
         publish,
         subscribe,
@@ -218,6 +219,7 @@ _LAZY_IMPORTS = {
     "DISPLAY_PLACEHOLDER_ACTORS": "vibe3.models.actor_utils",
     "EventHandler": "vibe3.models.event_bus",
     "EventPublisher": "vibe3.models.event_bus",
+    "PublishHook": "vibe3.models.event_bus",
     "format_result_entries": "vibe3.models.trace",
     "get_publisher": "vibe3.models.event_bus",
     "GovernanceConfig": "vibe3.models.orchestra_config",
@@ -342,6 +344,7 @@ __all__: list[str] = [
     "DISPLAY_PLACEHOLDER_ACTORS",
     "EventHandler",
     "EventPublisher",
+    "PublishHook",
     "format_result_entries",
     "get_publisher",
     "GovernanceConfig",

--- a/src/vibe3/models/event_bus.py
+++ b/src/vibe3/models/event_bus.py
@@ -14,6 +14,7 @@ from vibe3.models.domain_events import DomainEvent
 
 E = TypeVar("E", bound=DomainEvent)
 EventHandler = Callable[[E], None]
+PublishHook = Callable[[DomainEvent], None]
 
 
 class EventPublisher:
@@ -21,16 +22,20 @@ class EventPublisher:
 
     _instance: EventPublisher | None = None
     _handlers: dict[str, list[Callable[[DomainEvent], None]]]
+    _hooks: list[PublishHook]
 
     def __new__(cls) -> EventPublisher:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._handlers = {}
+            cls._instance._hooks = []
         return cls._instance
 
     @classmethod
     def reset(cls) -> None:
         """Reset the singleton instance (for testing)."""
+        if cls._instance is not None:
+            cls._instance._hooks.clear()
         cls._instance = None
 
     def subscribe(
@@ -42,9 +47,27 @@ class EventPublisher:
         if handler not in self._handlers[event_type]:
             self._handlers[event_type].append(handler)
 
+    def add_publish_hook(self, hook: PublishHook) -> None:
+        """Register a hook that fires for every published event."""
+        if hook not in self._hooks:
+            self._hooks.append(hook)
+
+    def remove_publish_hook(self, hook: PublishHook) -> None:
+        """Remove a previously registered publish hook."""
+        if hook in self._hooks:
+            self._hooks.remove(hook)
+
     def publish(self, event: DomainEvent) -> None:
         """Publish an event to all subscribed handlers."""
         event_type = type(event).__name__
+
+        # Fire publish hooks before type-specific dispatch
+        for hook in self._hooks:
+            try:
+                hook(event)
+            except Exception as e:
+                logger.bind(domain="events").error(f"Publish hook failed: {e}")
+
         handlers = self._handlers.get(event_type, [])
 
         if not handlers:

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -88,16 +88,13 @@ def _build_server_with_launch_cwd(
         FlowManager,
         GlobalDispatchCoordinator,
         OrchestrationFacade,
-    )
-    from vibe3.domain.event_rules import (
         build_action_handlers,
         evaluate_rules,
         load_rules,
     )
     from vibe3.environment import SessionRegistryService
     from vibe3.execution import CapacityService
-    from vibe3.models.domain_events import DomainEvent
-    from vibe3.models.event_bus import get_publisher
+    from vibe3.models import DomainEvent, get_publisher
     from vibe3.orchestra import create_global_dispatch_coordinator
     from vibe3.runtime import (
         CircuitBreaker,
@@ -192,9 +189,9 @@ def _build_server_with_launch_cwd(
 
     # Wire event rules engine into EventPublisher
     try:
-        from vibe3.config.settings import _vibe3_config_root
+        from vibe3.utils import find_repo_root
 
-        rules_dir = _vibe3_config_root() / "config" / "policies"
+        rules_dir = find_repo_root() / "config" / "policies"
         rules = load_rules(rules_dir)
         action_handlers = build_action_handlers()
         publisher = get_publisher()

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -89,8 +89,15 @@ def _build_server_with_launch_cwd(
         GlobalDispatchCoordinator,
         OrchestrationFacade,
     )
+    from vibe3.domain.event_rules import (
+        build_action_handlers,
+        evaluate_rules,
+        load_rules,
+    )
     from vibe3.environment import SessionRegistryService
     from vibe3.execution import CapacityService
+    from vibe3.models.domain_events import DomainEvent
+    from vibe3.models.event_bus import get_publisher
     from vibe3.orchestra import create_global_dispatch_coordinator
     from vibe3.runtime import (
         CircuitBreaker,
@@ -182,6 +189,27 @@ def _build_server_with_launch_cwd(
         cleanup_service=None,
     )
     heartbeat.register(facade)  # type: ignore[arg-type]
+
+    # Wire event rules engine into EventPublisher
+    try:
+        from vibe3.config.settings import _vibe3_config_root
+
+        rules_dir = _vibe3_config_root() / "config" / "policies"
+        rules = load_rules(rules_dir)
+        action_handlers = build_action_handlers()
+        publisher = get_publisher()
+
+        def rule_engine_hook(event: DomainEvent) -> None:  # type: ignore[valid-type]
+            evaluate_rules(event, rules, action_handlers)
+
+        publisher.add_publish_hook(rule_engine_hook)
+        logger.bind(domain="orchestra").info(
+            f"Event rules engine initialized with {len(rules)} rules"
+        )
+    except Exception as exc:
+        logger.bind(domain="orchestra").warning(
+            f"Event rules engine initialization failed (non-fatal): {exc}"
+        )
 
     # Combined shutdown callback for all services
     def shutdown_all() -> None:

--- a/tests/vibe3/domain/test_event_rules.py
+++ b/tests/vibe3/domain/test_event_rules.py
@@ -1,0 +1,277 @@
+"""Tests for event routing rule engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from vibe3.domain.event_rules import (
+    EventRule,
+    build_action_handlers,
+    evaluate_rules,
+    expand_template,
+    load_rules,
+)
+from vibe3.models.domain_events import DomainEvent
+
+
+@dataclass(frozen=True)
+class _TestEvent(DomainEvent):
+    """Test event for rule tests."""
+
+    issue_number: int = 123
+    reason: str = "test reason"
+    actor: str = "test_actor"
+
+
+class TestLoadRules:
+    """Test load_rules function."""
+
+    def test_load_rules_parses_yaml(self, tmp_path: Path) -> None:
+        """Valid YAML → correct EventRule tuples."""
+        rules_file = tmp_path / "event-rules.yaml"
+        rules_file.write_text("""
+rules:
+  - event: TestEvent
+    action: log
+    params:
+      message: "test message"
+  - event: AnotherEvent
+    action: enqueue
+    params:
+      command: "test command"
+    enabled: false
+""")
+
+        rules = load_rules(tmp_path)
+
+        assert len(rules) == 2
+        assert rules[0].event == "TestEvent"
+        assert rules[0].action == "log"
+        assert rules[0].params == {"message": "test message"}
+        assert rules[0].enabled is True
+        assert rules[1].enabled is False
+
+    def test_load_rules_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        """Graceful degradation when directory missing."""
+        missing_dir = tmp_path / "nonexistent"
+        rules = load_rules(missing_dir)
+
+        assert rules == ()
+
+    def test_load_rules_skips_invalid_yaml(self, tmp_path: Path) -> None:
+        """No crash on bad YAML."""
+        rules_file = tmp_path / "event-rules.yaml"
+        rules_file.write_text("invalid: yaml: ::")
+
+        rules = load_rules(tmp_path)
+        assert rules == ()
+
+    def test_load_rules_skips_missing_required_fields(self, tmp_path: Path) -> None:
+        """Rules missing event/action are skipped."""
+        rules_file = tmp_path / "event-rules.yaml"
+        rules_file.write_text("""
+rules:
+  - event: TestEvent
+    # missing action
+  - action: log
+    # missing event
+  - event: GoodEvent
+    action: log
+    params:
+      message: "good"
+""")
+
+        rules = load_rules(tmp_path)
+
+        assert len(rules) == 1
+        assert rules[0].event == "GoodEvent"
+
+    def test_load_rules_missing_rules_key(self, tmp_path: Path) -> None:
+        """YAML without rules key returns empty."""
+        rules_file = tmp_path / "event-rules.yaml"
+        rules_file.write_text("other: data")
+
+        rules = load_rules(tmp_path)
+        assert rules == ()
+
+
+class TestExpandTemplate:
+    """Test expand_template function."""
+
+    def test_expand_template_substitutes_fields(self) -> None:
+        """{{ event.field }} → actual value."""
+        event = _TestEvent(issue_number=456, reason="testing")
+        template = "issue #{{ event.issue_number }}: {{ event.reason }}"
+
+        result = expand_template(template, event)
+
+        assert result == "issue #456: testing"
+
+    def test_expand_template_unknown_field_preserves_placeholder(self) -> None:
+        """No crash on missing attr, preserves placeholder."""
+        event = _TestEvent()
+        template = "missing: {{ event.nonexistent }}"
+
+        result = expand_template(template, event)
+
+        assert result == "missing: {{ event.nonexistent }}"
+
+    def test_expand_template_with_whitespace(self) -> None:
+        """Template handles whitespace in placeholders."""
+        event = _TestEvent(issue_number=789)
+        template = "issue {{  event.issue_number  }}"
+
+        result = expand_template(template, event)
+
+        assert result == "issue 789"
+
+    def test_expand_template_multiple_placeholders(self) -> None:
+        """Multiple placeholders in one template."""
+        event = _TestEvent(issue_number=100, actor="alice")
+        template = "{{ event.actor }} reported issue #{{ event.issue_number }}"
+
+        result = expand_template(template, event)
+
+        assert result == "alice reported issue #100"
+
+
+class TestEvaluateRules:
+    """Test evaluate_rules function."""
+
+    def test_evaluate_rules_matches_event_type(self) -> None:
+        """Correct handler called for matching event."""
+        event = _TestEvent()
+        rules = (
+            EventRule(
+                event="_TestEvent",
+                action="test_action",
+                params={"value": "{{ event.issue_number }}"},
+            ),
+        )
+        handler_calls: list[dict[str, str]] = []
+
+        def test_handler(params: dict[str, str]) -> None:
+            handler_calls.append(params)
+
+        action_handlers = {"test_action": test_handler}
+        evaluate_rules(event, rules, action_handlers)
+
+        assert len(handler_calls) == 1
+        assert handler_calls[0] == {"value": "123"}
+
+    def test_evaluate_rules_no_match(self) -> None:
+        """Handler NOT called when event type doesn't match."""
+        event = _TestEvent()
+        rules = (
+            EventRule(
+                event="DifferentEvent",
+                action="test_action",
+                params={},
+            ),
+        )
+        handler_calls: list[dict[str, str]] = []
+
+        def test_handler(params: dict[str, str]) -> None:
+            handler_calls.append(params)
+
+        action_handlers = {"test_action": test_handler}
+        evaluate_rules(event, rules, action_handlers)
+
+        assert len(handler_calls) == 0
+
+    def test_evaluate_rules_disabled_rule_skipped(self) -> None:
+        """enabled: false rules are ignored."""
+        event = _TestEvent()
+        rules = (
+            EventRule(
+                event="_TestEvent",
+                action="test_action",
+                params={},
+                enabled=False,
+            ),
+        )
+        handler_calls: list[dict[str, str]] = []
+
+        def test_handler(params: dict[str, str]) -> None:
+            handler_calls.append(params)
+
+        action_handlers = {"test_action": test_handler}
+        evaluate_rules(event, rules, action_handlers)
+
+        assert len(handler_calls) == 0
+
+    def test_evaluate_rules_action_error_does_not_block(self) -> None:
+        """Action exception is caught, doesn't block other rules."""
+        event = _TestEvent()
+        rules = (
+            EventRule(
+                event="_TestEvent",
+                action="bad_action",
+                params={},
+            ),
+            EventRule(
+                event="_TestEvent",
+                action="good_action",
+                params={},
+            ),
+        )
+        handler_calls: list[str] = []
+
+        def bad_handler(params: dict[str, str]) -> None:
+            raise RuntimeError("action failed")
+
+        def good_handler(params: dict[str, str]) -> None:
+            handler_calls.append("good")
+
+        action_handlers = {
+            "bad_action": bad_handler,
+            "good_action": good_handler,
+        }
+        evaluate_rules(event, rules, action_handlers)
+
+        assert "good" in handler_calls
+
+    def test_evaluate_rules_unknown_action_skipped(self) -> None:
+        """Unknown action logs warning, doesn't crash."""
+        event = _TestEvent()
+        rules = (
+            EventRule(
+                event="_TestEvent",
+                action="unknown_action",
+                params={},
+            ),
+        )
+        action_handlers: dict[str, Callable[[dict[str, str]], None]] = {}
+
+        # Should not raise
+        evaluate_rules(event, rules, action_handlers)
+
+
+class TestBuildActionHandlers:
+    """Test build_action_handlers function."""
+
+    def test_build_action_handlers_returns_dict(self) -> None:
+        """Returns dict with expected action handlers."""
+        handlers = build_action_handlers()
+
+        assert isinstance(handlers, dict)
+        assert "log" in handlers
+        assert "enqueue_command_job" in handlers
+
+    def test_log_handler_callable(self) -> None:
+        """log action handler is callable."""
+        handlers = build_action_handlers()
+        log_handler = handlers["log"]
+
+        # Should not raise
+        log_handler({"message": "test message"})
+
+    def test_enqueue_handler_callable(self) -> None:
+        """enqueue_command_job action handler is callable."""
+        handlers = build_action_handlers()
+        enqueue_handler = handlers["enqueue_command_job"]
+
+        # Should not raise (placeholder implementation)
+        enqueue_handler({"command": "test command", "actor": "test"})

--- a/tests/vibe3/models/test_event_bus_hook.py
+++ b/tests/vibe3/models/test_event_bus_hook.py
@@ -1,0 +1,117 @@
+"""Tests for EventPublisher.on_publish hook mechanism."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibe3.models.domain_events import DomainEvent
+from vibe3.models.event_bus import EventPublisher
+
+
+@dataclass(frozen=True)
+class _TestEvent(DomainEvent):
+    """Test event for hook tests."""
+
+    value: str = "test"
+
+
+class TestAddPublishHook:
+    """Test add_publish_hook and hook invocation."""
+
+    def setup_method(self) -> None:
+        EventPublisher.reset()
+
+    def teardown_method(self) -> None:
+        EventPublisher.reset()
+
+    def test_add_publish_hook_receives_events(self) -> None:
+        """Hook called on publish()."""
+        publisher = EventPublisher()
+        received: list[DomainEvent] = []
+
+        def hook(event: DomainEvent) -> None:
+            received.append(event)
+
+        publisher.add_publish_hook(hook)
+        event = _TestEvent()
+        publisher.publish(event)
+
+        assert len(received) == 1
+        assert received[0] is event
+
+    def test_hook_error_does_not_block_handlers(self) -> None:
+        """Hook exception caught, handlers still run."""
+        publisher = EventPublisher()
+        handler_called: list[bool] = []
+
+        def bad_hook(event: DomainEvent) -> None:
+            raise RuntimeError("hook failed")
+
+        def handler(event: DomainEvent) -> None:
+            handler_called.append(True)
+
+        publisher.add_publish_hook(bad_hook)
+        publisher.subscribe("_TestEvent", handler)
+        publisher.publish(_TestEvent())
+
+        assert handler_called, "Handler should still run despite hook error"
+
+    def test_remove_publish_hook(self) -> None:
+        """Removed hook no longer receives events."""
+        publisher = EventPublisher()
+        received: list[DomainEvent] = []
+
+        def hook(event: DomainEvent) -> None:
+            received.append(event)
+
+        publisher.add_publish_hook(hook)
+        publisher.remove_publish_hook(hook)
+        publisher.publish(_TestEvent())
+
+        assert len(received) == 0
+
+    def test_hook_deduplicated(self) -> None:
+        """Same hook added twice only fires once."""
+        publisher = EventPublisher()
+        call_count: list[int] = [0]
+
+        def hook(event: DomainEvent) -> None:
+            call_count[0] += 1
+
+        publisher.add_publish_hook(hook)
+        publisher.add_publish_hook(hook)  # Second add should be deduped
+        publisher.publish(_TestEvent())
+
+        assert call_count[0] == 1
+
+    def test_reset_clears_hooks(self) -> None:
+        """reset() clears hooks from the instance."""
+        publisher = EventPublisher()
+        received: list[DomainEvent] = []
+
+        def hook(event: DomainEvent) -> None:
+            received.append(event)
+
+        publisher.add_publish_hook(hook)
+        EventPublisher.reset()
+        new_publisher = EventPublisher()
+        new_publisher.publish(_TestEvent())
+
+        assert len(received) == 0
+
+    def test_hooks_fire_before_handlers(self) -> None:
+        """Hooks fire before type-specific handlers."""
+        publisher = EventPublisher()
+        order: list[str] = []
+
+        def hook(event: DomainEvent) -> None:
+            order.append("hook")
+
+        def handler(event: DomainEvent) -> None:
+            order.append("handler")
+
+        publisher.add_publish_hook(hook)
+        publisher.subscribe("_TestEvent", handler)
+        publisher.publish(_TestEvent())
+
+        assert order == ["hook", "handler"]


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2169` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2169
```


---

Closes #2169

## Summary

Add configurable event→command routing engine that loads declarative rules from `config/policies/event-rules.yaml` and evaluates them on every published domain event via `on_publish` hook mechanism in EventPublisher.

## Changes

- **Hook mechanism**: Add `on_publish` hook to EventPublisher for catch-all event interception (3 new methods, minimal change)
- **Rule engine**: Create `domain/event_rules.py` module with EventRule model, YAML loading, template expansion, and rule evaluation
- **Configuration**: Add `config/policies/event-rules.yaml` with initial conservative ruleset (4 rules: 3 log + 1 placeholder)
- **Server wiring**: Wire rule engine into EventPublisher in registry.py composition root
- **Tests**: Add 23 unit tests covering hook mechanism and rule engine (all real tests, no mocking)
- **LOC exception**: Update registry.py limit from 510 to 540 lines

## Test Results

- ✅ 185 tests pass (23 new + 162 existing)
- ✅ mypy clean
- ✅ ruff clean
- ✅ No regression in existing tests

## Implementation Notes

- Conservative initial ruleset establishes infrastructure without behavior change
- Hook errors caught, don't block handlers
- Template expansion graceful on missing fields
- Rules loaded with validation, invalid skipped
- Job queue integration placeholder awaits future work

## Related

- Implements #2169
- Depends on #2165 (completed), #2166 (completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
