### PR TITLE
fix(tests): use monkeypatch.setenv to prevent test log leakage

### DIFF
--- a/tests/vibe3/runtime/test_heartbeat.py
+++ b/tests/vibe3/runtime/test_heartbeat.py
@@ -50,14 +50,11 @@ def test_run_separator_appends_instead_of_truncating(
     tmp_path: Path, monkeypatch
 ) -> None:
     """Run separator should append to existing events.log, not overwrite it."""
-    import os
-
     from vibe3.orchestra.logging import append_orchestra_run_separator
 
     # Clear any environment variables that might affect log directory
     monkeypatch.delenv("VIBE3_ASYNC_LOG_DIR", raising=False)
-
-    os.environ["VIBE3_ORCHESTRA_EVENT_LOG"] = "1"
+    monkeypatch.setenv("VIBE3_ORCHESTRA_EVENT_LOG", "1")
     log_path = tmp_path / "temp" / "logs" / "orchestra" / "events.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("old event from previous run\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

PR #2588 的修复不完全有效。虽然添加了 session-scoped `_silence_orchestra_log` fixture，但遗漏了一个不安全的环境变量设置，导致测试泄漏持续发生。

**问题证据**：
- PR #2588 合并时间：2026-06-10 07:10:02
- 最新泄漏时间：2026-06-10 08:12:31（PR 合并后仍有新泄漏）
- 泄漏条目：222 个 `_MockService` 注册事件

**根本原因**：
`tests/vibe3/runtime/test_heartbeat.py:60` 使用了 `os.environ["VIBE3_ORCHESTRA_EVENT_LOG"] = "1"` 而非 `monkeypatch.setenv()`，导致：
1. 测试失败时环境变量不会被清理
2. Session-scoped fixture 无法阻止测试运行期间的重新设置
3. 后续测试运行时环境变量仍为 "1"，触发泄漏

**修复内容**：
- 替换 `os.environ[...] = "1"` 为 `monkeypatch.setenv(..., "1")`
- 删除不必要的 `import os`

## Verification

- [x] 30 tests pass (14 heartbeat + 16 failed_gate)
- [x] 0 `_MockService` leaks in production log after test run
- [x] Minimal change: +1 -4 lines (1 line core modification)

## Test Plan

```bash
# 运行测试
uv run pytest tests/vibe3/runtime/test_heartbeat.py tests/vibe3/orchestra/test_failed_gate.py -v

# 验证无泄漏
grep -c "_MockService" temp/logs/orchestra/events.log
# 应输出: 0
```

## Related

- PR #2588 — 首次修复尝试（不完全）
- Issue #1857 — Mock 泄漏导致 E_DISPATCH_FAILURE

🤖 Generated with [Claude Code](https://claude.com/claude-code)