### PR TITLE
refactor(monitor): use enum types in ActiveJob dataclass

### DIFF
--- a/src/vibe3/execution/job_monitor_service.py
+++ b/src/vibe3/execution/job_monitor_service.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vibe3.execution.actor import ActorStatus, JobType
+
 if TYPE_CHECKING:
     from vibe3.execution.actor import JobActor
 
@@ -19,8 +21,8 @@ class ActiveJob:
     """Immutable view of a single actor job for monitoring display."""
 
     actor_id: str
-    job_type: str  # "dispatch" / "governance" / "flow"
-    status: str  # "running" / "done" / "failed" / "dead"
+    job_type: JobType  # DISPATCH / GOVERNANCE / FLOW
+    status: ActorStatus  # RUNNING / DONE / FAILED / DEAD / QUEUED
     issue_number: int
     branch: str
     started_at: str | None
@@ -90,8 +92,8 @@ def _to_active_job(actor: JobActor) -> ActiveJob:
     """
     return ActiveJob(
         actor_id=actor.actor_id,
-        job_type=actor.job_type.value,
-        status=actor.status.value,
+        job_type=actor.job_type,
+        status=actor.status,
         issue_number=actor.issue_number,
         branch=actor.branch,
         started_at=actor.started_at,

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -211,8 +211,8 @@ def _build_server_with_launch_cwd(
         def _job_to_dict(job: ActiveJob) -> dict:
             return {
                 "actor_id": job.actor_id,
-                "job_type": job.job_type,
-                "status": job.status,
+                "job_type": job.job_type.value,
+                "status": job.status.value,
                 "issue_number": job.issue_number,
                 "branch": job.branch,
                 "started_at": job.started_at,

--- a/tests/vibe3/execution/test_job_monitor_service.py
+++ b/tests/vibe3/execution/test_job_monitor_service.py
@@ -9,6 +9,7 @@ import pytest
 from vibe3.clients import SQLiteClient
 from vibe3.execution.actor import (
     ActorRegistry,
+    ActorStatus,
     JobActor,
     JobType,
     _reset_registry,
@@ -70,7 +71,7 @@ class TestJobMonitorService:
         assert len(snap.active_jobs) == 1
         job = snap.active_jobs[0]
         assert job.actor_id == actor.actor_id
-        assert job.status == "running"
+        assert job.status == ActorStatus.RUNNING
         assert job.issue_number == 200
 
     def test_queued_actor_appears_in_active_jobs(self) -> None:
@@ -88,7 +89,7 @@ class TestJobMonitorService:
         snap = svc.snapshot()
 
         assert len(snap.active_jobs) == 1
-        assert snap.active_jobs[0].status == "queued"
+        assert snap.active_jobs[0].status == ActorStatus.QUEUED
 
     def test_completed_actor_appears_in_recent_jobs(self) -> None:
         """DONE actors appear in recent_jobs."""
@@ -102,7 +103,7 @@ class TestJobMonitorService:
         assert snap.completed_count == 1
         assert snap.running_count == 0
         assert len(snap.recent_jobs) == 1
-        assert snap.recent_jobs[0].status == "done"
+        assert snap.recent_jobs[0].status == ActorStatus.DONE
 
     def test_failed_actor_appears_in_recent_jobs(self) -> None:
         """FAILED actors appear in recent_jobs with failed_count."""
@@ -116,7 +117,7 @@ class TestJobMonitorService:
         assert snap.failed_count == 1
         assert snap.completed_count == 0
         assert len(snap.recent_jobs) == 1
-        assert snap.recent_jobs[0].status == "failed"
+        assert snap.recent_jobs[0].status == ActorStatus.FAILED
 
     def test_dead_actor_counted_as_failed(self) -> None:
         """DEAD actors count toward failed_count."""
@@ -128,7 +129,7 @@ class TestJobMonitorService:
         snap = svc.snapshot()
 
         assert snap.failed_count == 1
-        assert snap.recent_jobs[0].status == "dead"
+        assert snap.recent_jobs[0].status == ActorStatus.DEAD
 
     def test_mixed_states_correct_counts(self) -> None:
         """Multiple actors with different states produce correct counts."""
@@ -171,8 +172,8 @@ class TestJobMonitorService:
         job = snap.active_jobs[0]
         assert isinstance(job, ActiveJob)
         assert job.actor_id == actor.actor_id
-        assert job.job_type == "governance"
-        assert job.status == "running"
+        assert job.job_type == JobType.GOVERNANCE
+        assert job.status == ActorStatus.RUNNING
         assert job.issue_number == 700
         assert job.branch == "task/issue-700"
         assert job.started_at is not None


### PR DESCRIPTION
## Summary

Changes `ActiveJob.job_type` and `ActiveJob.status` from `str` to `JobType` and `ActorStatus` enums respectively, restoring type safety at the monitoring layer.

## Changes

- `src/vibe3/execution/job_monitor_service.py`: Changed field types from `str` to `JobType`/`ActorStatus` enums
- `src/vibe3/server/registry.py`: Added `.value` calls for JSON serialization  
- `tests/vibe3/execution/test_job_monitor_service.py`: Updated assertions to use enum constants

Both enums inherit from `str, Enum`, so `.upper()` calls in `app.py` continue to work unchanged.

## Test Plan

- [x] Direct tests: `tests/vibe3/execution/test_job_monitor_service.py` (10/10 pass)
- [x] Module tests: `tests/vibe3/execution/` (273/273 pass) and `tests/vibe3/server/` (10/10 pass)
- [x] Type check: `mypy src/vibe3/execution/job_monitor_service.py src/vibe3/server/registry.py` (clean)
- [x] Lint check: `ruff check` (clean)
- [x] LOC check: All files under CI block threshold (400 lines)

Closes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)