### PR TITLE
fix(flow): restore now resets flow_status to active for aborted flows

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -319,6 +319,9 @@ code_limits:
       - path: "tests/vibe3/services/test_issue_flow_service.py"
         limit: 500
         reason: "IssueFlowService 测试集，覆盖 convention injection、branch naming、flow lookup、resolve_best_flow 优先级逻辑与 protected branch guard 等紧密耦合场景；PR #2581 新增 8 个 resolve_best_flow 测试（优先级逻辑 5 个 + protected branch guard 3 个）从 297 行增至 465 行"
+      - path: "tests/vibe3/clients/test_sqlite_flow_state_repo.py"
+        limit: 450
+        reason: "SQLite flow state repo 测试集，覆盖 flow CRUD、soft-delete、cascade delete、status validation、bulk retrieval optimization、restore flow deadlock fix 等紧密耦合场景，与 sqlite_flow_state_repo.py 源文件（limit 540）对应；Issue #2537 新增 test_restore_flow_resets_aborted_status 测试验证 aborted flow deadlock fix（+41 行）"
       - path: "src/vibe3/commands/status_render.py"
         limit: 450
         reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -393,24 +393,28 @@ class SQLiteFlowStateRepo(_HasConnection):
             self.soft_delete_flow(branch)
 
     def restore_flow(self, branch: str) -> None:
-        """Restore soft-deleted flow by clearing deleted_at.
+        """Restore soft-deleted or aborted flow by clearing deleted_at and status.
 
-        NOTE: This restores the flow record but preserves tombstone state.
-        Restored flows will have flow_status='aborted' and cleared refs/actors/worktree.
-        Use 'vibe flow update' to reset flow_status and re-establish metadata if needed.
+        This method handles two scenarios:
+        1. Soft-deleted flows (deleted_at IS NOT NULL, flow_status='aborted')
+        2. Aborted flows without tombstone (deleted_at IS NULL, flow_status='aborted')
+
+        In both cases, the flow is restored to active status.
         """
         conn = self._get_connection()
         with conn:
             cursor = conn.cursor()
             cursor.execute(
-                "UPDATE flow_state SET deleted_at = NULL WHERE branch = ?",
+                """UPDATE flow_state
+                   SET deleted_at = NULL, flow_status = 'active'
+                   WHERE branch = ?""",
                 (branch,),
             )
         logger.bind(
             external="sqlite",
             operation="restore_flow",
             branch=branch,
-        ).info("Restored soft-deleted flow")
+        ).info("Restored flow to active status")
 
     def get_deleted_flows(self) -> list[dict[str, Any]]:
         """Get all soft-deleted flows."""

--- a/src/vibe3/commands/flow_manage.py
+++ b/src/vibe3/commands/flow_manage.py
@@ -452,14 +452,18 @@ def restore_flow(
 
     store = SQLiteClient()
 
-    # Check if flow exists and is deleted
+    # Check if flow exists
     flow = store.get_flow_state_include_deleted(target_branch)
     if flow is None:
         console.print(f"[red]Error: Flow '{target_branch}' not found[/]")
         raise typer.Exit(1)
 
-    if flow.get("deleted_at") is None:
-        console.print(f"[yellow]Flow '{target_branch}' is not deleted[/]")
+    # Check if flow can be restored
+    is_deleted = flow.get("deleted_at") is not None
+    is_aborted = flow.get("flow_status") == "aborted"
+
+    if not is_deleted and not is_aborted:
+        console.print(f"[yellow]Flow '{target_branch}' is already active[/]")
         raise typer.Exit(0)
 
     # Restore the flow

--- a/tests/vibe3/clients/test_sqlite_flow_state_repo.py
+++ b/tests/vibe3/clients/test_sqlite_flow_state_repo.py
@@ -391,3 +391,44 @@ def test_get_flows_by_status_uses_sql_where_clause() -> None:
         assert len(result) == 50
         # All returned flows should be active
         assert all(f["flow_status"] == "active" for f in result)
+
+
+def test_restore_flow_resets_aborted_status() -> None:
+    """Test that restore_flow resets flow_status from aborted to active.
+
+    This tests the deadlock scenario where:
+    - flow_status='aborted' (set by abort_flow)
+    - deleted_at is NULL (no tombstone created)
+
+    The restore_flow method should reset flow_status to 'active'.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Create a flow with active status
+        store.update_flow_state(
+            "task/issue-789",
+            flow_slug="issue_789",
+            flow_status="active",
+            spec_ref="#789",
+            plan_ref="docs/plans/test.md",
+        )
+
+        # Simulate abort_flow by setting flow_status to 'aborted' without deleted_at
+        store.update_flow_state("task/issue-789", flow_status="aborted")
+
+        # Verify the deadlock state: aborted but no tombstone
+        aborted_flow = store.get_flow_state_include_deleted("task/issue-789")
+        assert aborted_flow is not None
+        assert aborted_flow["flow_status"] == "aborted"
+        assert aborted_flow["deleted_at"] is None
+
+        # Restore the flow
+        store.restore_flow("task/issue-789")
+
+        # Verify flow_status is reset to active and deleted_at remains NULL
+        restored_flow = store.get_flow_state_include_deleted("task/issue-789")
+        assert restored_flow is not None
+        assert restored_flow["flow_status"] == "active"
+        assert restored_flow["deleted_at"] is None

--- a/tests/vibe3/commands/test_flow_restore.py
+++ b/tests/vibe3/commands/test_flow_restore.py
@@ -1,0 +1,128 @@
+"""Tests for flow restore command."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from vibe3.commands.flow import app as flow_app
+
+runner = CliRunner()
+
+
+@patch("vibe3.services.resolve_branch_arg")
+@patch("vibe3.clients.SQLiteClient")
+def test_restore_aborted_flow_without_tombstone(
+    mock_client_class, mock_resolve_branch
+) -> None:
+    """Test that restore command succeeds for aborted flow with deleted_at=NULL.
+
+    This tests the deadlock scenario where:
+    - flow_status='aborted' (set by abort_flow)
+    - deleted_at is NULL (no tombstone created)
+
+    The restore command should succeed and call restore_flow method.
+    """
+    # Setup mocks
+    mock_resolve_branch.return_value = "task/issue-789"
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+
+    # Mock flow in deadlock state: aborted but no tombstone
+    mock_flow = {
+        "branch": "task/issue-789",
+        "flow_slug": "issue_789",
+        "flow_status": "aborted",
+        "deleted_at": None,  # No tombstone
+    }
+    mock_client.get_flow_state_include_deleted.return_value = mock_flow
+
+    # Execute restore command
+    result = runner.invoke(flow_app, ["restore", "task/issue-789"])
+
+    # Should succeed
+    assert result.exit_code == 0
+    assert "restored successfully" in result.output
+
+    # Verify restore_flow was called
+    mock_client.restore_flow.assert_called_once_with("task/issue-789")
+
+
+@patch("vibe3.services.resolve_branch_arg")
+@patch("vibe3.clients.SQLiteClient")
+def test_restore_soft_deleted_flow(mock_client_class, mock_resolve_branch) -> None:
+    """Test that restore command succeeds for soft-deleted flow."""
+    # Setup mocks
+    mock_resolve_branch.return_value = "task/issue-123"
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+
+    # Mock soft-deleted flow
+    mock_flow = {
+        "branch": "task/issue-123",
+        "flow_slug": "issue_123",
+        "flow_status": "aborted",
+        "deleted_at": "2024-01-01 00:00:00",  # Tombstone exists
+    }
+    mock_client.get_flow_state_include_deleted.return_value = mock_flow
+
+    # Execute restore command
+    result = runner.invoke(flow_app, ["restore", "task/issue-123"])
+
+    # Should succeed
+    assert result.exit_code == 0
+    assert "restored successfully" in result.output
+
+    # Verify restore_flow was called
+    mock_client.restore_flow.assert_called_once_with("task/issue-123")
+
+
+@patch("vibe3.services.resolve_branch_arg")
+@patch("vibe3.clients.SQLiteClient")
+def test_restore_already_active_flow(mock_client_class, mock_resolve_branch) -> None:
+    """Test that restore command rejects already active flow."""
+    # Setup mocks
+    mock_resolve_branch.return_value = "task/issue-456"
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+
+    # Mock active flow
+    mock_flow = {
+        "branch": "task/issue-456",
+        "flow_slug": "issue_456",
+        "flow_status": "active",
+        "deleted_at": None,
+    }
+    mock_client.get_flow_state_include_deleted.return_value = mock_flow
+
+    # Execute restore command
+    result = runner.invoke(flow_app, ["restore", "task/issue-456"])
+
+    # Should exit gracefully (exit code 0, no error)
+    assert result.exit_code == 0
+    assert "already active" in result.output
+
+    # Verify restore_flow was NOT called
+    mock_client.restore_flow.assert_not_called()
+
+
+@patch("vibe3.services.resolve_branch_arg")
+@patch("vibe3.clients.SQLiteClient")
+def test_restore_nonexistent_flow(mock_client_class, mock_resolve_branch) -> None:
+    """Test that restore command fails for nonexistent flow."""
+    # Setup mocks
+    mock_resolve_branch.return_value = "task/issue-999"
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+
+    # Mock flow not found
+    mock_client.get_flow_state_include_deleted.return_value = None
+
+    # Execute restore command
+    result = runner.invoke(flow_app, ["restore", "task/issue-999"])
+
+    # Should fail
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+    # Verify restore_flow was NOT called
+    mock_client.restore_flow.assert_not_called()


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2537` is behind `main` by **4 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2537
```


---

## Summary

Fixes #2537

When a flow is aborted without setting `deleted_at` (e.g., via `abort_flow` instead of `soft_delete_flow`), it enters a deadlock state where neither `flow restore` nor `flow rebuild` can recover it.

## Changes

- **Repo layer**: `restore_flow()` now resets `flow_status='active'` in addition to clearing `deleted_at`
- **Command layer**: `flow restore` command accepts flows with `flow_status='aborted'` (not just soft-deleted)
- **Config**: Added LOC exception for test file (434 lines, testing corresponding 540-line source file)

## Root Cause

Two independent code paths can set `flow_status='aborted'`:
1. `soft_delete_flow` → sets BOTH `deleted_at` and `flow_status='aborted'` (tombstone)
2. `abort_flow` → sets ONLY `flow_status='aborted'` (no tombstone)

When path #2 occurs and the worktree is cleaned up, the flow becomes unrecoverable.

## Testing

- Added repo-layer test for deadlock scenario
- Added comprehensive command-layer tests (4 scenarios)
- All 25 tests pass
- Type checking + linting clean

## Impact

- Backward compatible with existing soft-delete behavior
- Minimal scope (2 implementation files + 2 test files + 1 config file)
- Low risk (only 2 callers of `restore_flow`, both verified safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
