### PR TITLE
refactor(test): relocate orphaned tests and remove weak mock test

### DIFF
--- a/tests/vibe3/domain/test_state_machine.py
+++ b/tests/vibe3/domain/test_state_machine.py
@@ -29,7 +29,7 @@ def test_validate_transition_honors_force() -> None:
 
 
 def test_validate_transition_blocked_to_handoff_forbidden() -> None:
-    """blocked → handoff should be forbidden without force (Issue #303)."""
+    """blocked → handoff should be forbidden without force (#2561)."""
     with pytest.raises(InvalidTransitionError):
         validate_transition(IssueState.BLOCKED, IssueState.HANDOFF, force=False)
 

--- a/tests/vibe3/domain/test_state_machine.py
+++ b/tests/vibe3/domain/test_state_machine.py
@@ -26,3 +26,14 @@ def test_validate_transition_allows_missing_from_state() -> None:
 
 def test_validate_transition_honors_force() -> None:
     validate_transition(IssueState.READY, IssueState.DONE, force=True)
+
+
+def test_validate_transition_blocked_to_handoff_forbidden() -> None:
+    """blocked → handoff should be forbidden without force (Issue #303)."""
+    with pytest.raises(InvalidTransitionError):
+        validate_transition(IssueState.BLOCKED, IssueState.HANDOFF, force=False)
+
+
+def test_validate_transition_blocked_to_handoff_allowed_with_force() -> None:
+    """Manual resume commands can bypass blocked state with force=True."""
+    validate_transition(IssueState.BLOCKED, IssueState.HANDOFF, force=True)

--- a/tests/vibe3/roles/test_manager.py
+++ b/tests/vibe3/roles/test_manager.py
@@ -1,9 +1,4 @@
-"""Tests for manager role dispatching and state transition behavior.
-
-钉死 manager 的关键行为：
-1. blocked issue 不应该被派发
-2. blocked → handoff 转换应该被阻止
-3. blocked_reason 字段正确写入
+"""Tests for manager prompt assembly behavior.
 
 Note: Dispatch queue filtering tests moved to
 test_dispatch_queue_operations.py after StateLabelDispatchService
@@ -11,12 +6,9 @@ deletion in issue-462 refactoring.
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from vibe3.models.orchestra_config import AssigneeDispatchConfig, OrchestraConfig
-from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.models.orchestration import IssueInfo
 from vibe3.roles.manager import build_manager_sync_request
 
 
@@ -313,79 +305,3 @@ manager:
         assert request.dry_run_summary["session_reused"] is True
         assert request.dry_run_summary["session_id"] == "session-1"
         assert request.dry_run_summary["sections"] == ["manager.retry_task"]
-
-
-class TestManagerBlockedToHandoffTransitionBlocked:
-    """blocked → handoff 转换应该被阻止"""
-
-    def test_blocked_to_handoff_forbidden_without_force(
-        self,
-    ) -> None:
-        """ALLOWED_TRANSITIONS 应该拒绝 blocked → handoff"""
-        from vibe3.exceptions import InvalidTransitionError
-        from vibe3.models.state_machine import validate_transition
-
-        # Try blocked → handoff
-        with pytest.raises(InvalidTransitionError):
-            validate_transition(
-                from_state=IssueState.BLOCKED,
-                to_state=IssueState.HANDOFF,
-                force=False,  # ← 不强制
-            )
-
-    def test_blocked_to_handoff_allowed_with_force(
-        self,
-    ) -> None:
-        """手动 resume 命令可以用 force=True 绕过"""
-        from vibe3.models.state_machine import validate_transition
-
-        # Try blocked → handoff with force=True
-        validate_transition(
-            from_state=IssueState.BLOCKED,
-            to_state=IssueState.HANDOFF,
-            force=True,  # ← 强制绕过（用于手动命令）
-        )
-
-
-class TestManagerBlockedReasonWriting:
-    """blocked_reason 字段写入"""
-
-    def test_manager_blocked_calls_ensure_flow_state(
-        self,
-    ) -> None:
-        """Manager blocked 应该通过 block_flow 设置 blocked_reason"""
-        mock_issue_number = 305
-
-        with patch(
-            "vibe3.services.issue.failure._get_issue_flow_service"
-        ) as mock_get_service:
-            mock_service = MagicMock()
-            mock_store = MagicMock()
-            mock_service.store = mock_store
-            mock_get_service.return_value = mock_service
-
-            # Mock flow data
-            mock_store.get_flows_by_issue.return_value = [
-                {"branch": "task/issue-305", "task_issue_number": 305}
-            ]
-
-            with patch("vibe3.services.flow_service.FlowService") as mock_flow_service:
-                mock_flow_instance = mock_flow_service.return_value
-
-                from vibe3.services.issue.failure import (
-                    block_manager_noop_issue,
-                )
-
-                block_manager_noop_issue(
-                    issue_number=mock_issue_number,
-                    repo="jacobcy/vibe-coding-control-center",
-                    reason="manager 本轮未产生状态迁移",
-                    actor="test-backend/test-model",
-                )
-
-                # Verify: block_flow called with correct parameters
-                mock_flow_instance.block_flow.assert_called_once_with(
-                    "task/issue-305",
-                    reason="manager 本轮未产生状态迁移",
-                    actor="test-backend/test-model",
-                )


### PR DESCRIPTION
## Summary
Relocated two orphaned state machine tests to their correct module and removed one weak mock-only test that was already covered by superior integration tests.

## Changes

### tests/vibe3/domain/test_state_machine.py
- Added `test_validate_transition_blocked_to_handoff_forbidden()`: Verifies blocked→handoff transitions are forbidden without force (Issue #303)
- Added `test_validate_transition_blocked_to_handoff_allowed_with_force()`: Verifies manual resume commands can bypass blocked state with force=True

### tests/vibe3/roles/test_manager.py
- Removed `TestManagerBlockedToHandoffTransitionBlocked`: Misplaced state machine tests (moved to test_state_machine.py)
- Removed `TestManagerBlockedReasonWriting`: Weak mock-only test duplicated by integration tests
- Cleaned up unused imports: `MagicMock`, `patch`, `pytest`, `IssueState`
- Updated docstring to reflect current scope (manager prompt assembly tests only)

## Test Results
- All tests pass: 3339 passed, 1 xpassed
- Affected modules: 18 passed (state_machine, manager, issue_failure_service)
- No new type errors or lint issues
- Pre-commit hooks: Ruff ✓, Black ✓, MyPy ✓

## Related
Fixes #2561