### PR TITLE
refactor(roles): remove dead code and simplify token resolution in manager.py

### DIFF
--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -116,38 +116,15 @@ MANAGER_BRANCH_RESOLVER = build_task_flow_branch_resolver(
 
 
 def resolve_manager_token(config: OrchestraConfig) -> str | None:
-    """Resolve manager token with fallback: env var (.zshrc) → keys.env → None."""
+    """Resolve manager token from environment variable.
+
+    Relies on load_keys_env_fallback() (called during config loading)
+    to populate os.environ from keys.env if the shell wrapper didn't.
+    """
     token_env = config.assignee_dispatch.token_env
     if not token_env:
         return None
-
-    # 1. Environment variable (set via .zshrc / direnv)
-    token = os.getenv(token_env)
-    if token:
-        return token
-
-    # 2. Fallback to config/keys.env
-    try:
-        from vibe3.execution import resolve_orchestra_repo_root
-
-        keys_path = resolve_orchestra_repo_root() / "config" / "keys.env"
-        if keys_path.exists():
-            prefix = f"{token_env}="
-            for line in keys_path.read_text(encoding="utf-8").splitlines():
-                stripped = line.strip()
-                if stripped.startswith(prefix) and not stripped.startswith("#"):
-                    value = stripped[len(prefix) :].strip().strip("\"'")
-                    if value:
-                        logger.bind(domain="manager").debug(
-                            f"Manager token loaded from {keys_path}"
-                        )
-                        return value
-    except (OSError, UnicodeDecodeError) as e:
-        logger.bind(domain="manager").debug(
-            f"Failed to read keys.env for manager token: {e}"
-        )
-
-    return None
+    return os.getenv(token_env) or None
 
 
 def _make_section_provider(
@@ -286,9 +263,6 @@ def build_manager_request(
     else:
         request.env.update(env)
     return request
-
-
-_resolve_manager_token = resolve_manager_token
 
 
 def build_manager_sync_request(


### PR DESCRIPTION
Closes #2560

## Summary

Remove redundant imports, dead alias, and manual keys.env parsing in `src/vibe3/roles/manager.py`.

## Changes

- **Remove redundant inner import** (line 131): `from vibe3.execution import resolve_orchestra_repo_root`
  - Already imported at module level (line 36)
  - No functional change

- **Remove dead alias** (line 291): `_resolve_manager_token = resolve_manager_token`
  - Never referenced outside manager.py
  - Dead code removal

- **Simplify `resolve_manager_token`** (lines 118-150)
  - Removed manual keys.env fallback parsing
  - Now relies solely on `os.getenv(token_env)`
  - The manual parsing was redundant with `load_keys_env_fallback()` in config/loader.py
  - Config loader already populates os.environ from keys.env before role execution

## Why This Works

The manual keys.env parsing duplicated logic in `config/loader.py:load_keys_env_fallback()`:

1. `load_keys_env_fallback()` runs during `get_config_with_env_override()` (before any role execution)
2. It loads ALL keys from keys.env into `os.environ`
3. Default `token_env` is `"VIBE_MANAGER_GITHUB_TOKEN"` (loaded by the fallback)
4. By the time `resolve_manager_token` is called, `os.getenv(token_env)` already has the value

## Testing

- **Direct tests**: 8/8 passed (tests/vibe3/roles/test_manager.py)
- **Module tests**: 143/143 passed (tests/vibe3/roles/)
- **Type check**: mypy - Success
- **Lint**: ruff - All checks passed
- **Pre-commit**: All hooks passed

## Impact

- **Risk**: LOW - Function signature unchanged, behavioral equivalence verified by tests
- **LOC reduction**: -26 lines (net)
- **Logging**: Removed one debug log line (token loading already logged by config loader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
