### PR TITLE
fix(sqlite): replace singleton connection with per-thread connections

### DIFF
--- a/src/vibe3/clients/sqlite_base.py
+++ b/src/vibe3/clients/sqlite_base.py
@@ -14,11 +14,13 @@ from vibe3.clients.sqlite_schema import init_schema
 from vibe3.exceptions import GitError
 from vibe3.utils import get_vibe3_db_path
 
-# Module-level singleton connection to avoid FD exhaustion
-# Shared across all SQLiteClient instances
-_global_conn: sqlite3.Connection | None = None
-_global_db_path: str | None = None
-_global_lock = threading.Lock()
+# Per-thread connections to avoid concurrent query corruption
+# Each thread gets its own connection; tracked for bulk close in tests/atexit
+_thread_local = threading.local()
+_thread_conns: set[sqlite3.Connection] = set()
+_thread_conns_lock = threading.Lock()
+_init_done: set[str] = set()  # tracks db_path values already initialized
+_init_lock = threading.Lock()
 
 
 class _HasConnection(Protocol):
@@ -41,44 +43,53 @@ def _is_connection_usable(conn: sqlite3.Connection) -> bool:
 
 
 def _get_global_connection(db_path: str) -> sqlite3.Connection:
-    """Get or create the module-level singleton database connection.
+    """Get or create a thread-local database connection.
 
-    Uses a single global connection shared by all SQLiteClient instances
-    to avoid FD exhaustion from repeated open/close on every operation.
+    Uses per-thread connections to avoid concurrent query corruption.
+    Each thread gets its own connection, preventing race conditions
+    where multiple threads mutate shared connection state (cursor/row_factory).
 
-    Thread-safe: Uses threading.Lock and check_same_thread=False.
+    Thread-safe: Uses threading.local() for per-thread storage.
+    Connection count bounded by thread count, not operation count.
     """
-    global _global_conn, _global_db_path
+    conn = getattr(_thread_local, "conn", None)
+    thread_db_path = getattr(_thread_local, "db_path", None)
 
-    with _global_lock:
-        # Reopen if path changed, connection is missing, or a previous caller
-        # closed the module-level singleton directly.
-        if (
-            _global_conn is None
-            or _global_db_path != db_path
-            or not _is_connection_usable(_global_conn)
-        ):
-            if _global_conn is not None:
-                try:
-                    _global_conn.close()
-                except Exception:
-                    pass
-            _global_conn = sqlite3.connect(db_path, check_same_thread=False)
-            _global_db_path = db_path
+    if conn is None or thread_db_path != db_path or not _is_connection_usable(conn):
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")  # ensure WAL on each new connection
+        _thread_local.conn = conn
+        _thread_local.db_path = db_path
 
-    return _global_conn
+        with _thread_conns_lock:
+            _thread_conns.add(conn)
+
+    return conn
 
 
 def _close_global_connection() -> None:
-    """Close the global singleton connection."""
-    global _global_conn, _global_db_path
-    if _global_conn is not None:
+    """Close all tracked thread-local connections.
+
+    Used for test isolation and atexit cleanup.
+    Closes current thread's connection and all tracked connections.
+    """
+    # Close current thread's connection
+    conn = getattr(_thread_local, "conn", None)
+    if conn is not None:
         try:
-            _global_conn.close()
+            conn.close()
         except Exception:
             pass
-        _global_conn = None
-        _global_db_path = None
+        _thread_local.conn = None
+
+    # Close all tracked connections (for test cleanup / atexit)
+    with _thread_conns_lock:
+        for c in list(_thread_conns):
+            try:
+                c.close()
+            except Exception:
+                pass
+        _thread_conns.clear()
 
 
 def _utcnow_iso() -> str:
@@ -145,10 +156,14 @@ class SQLiteClientBase:
         in sqlite_schema.py when adding new migrations.
         """
         conn = _get_global_connection(self.db_path)
-        with _global_lock:
+        with _init_lock:
             # Lightweight guard: check migration version
             # Update required_migration_version when adding new migrations
             required_migration_version = 3  # Increment when adding
+
+            # Check if already initialized for this db_path
+            if self.db_path in _init_done:
+                return
 
             try:
                 version_row = conn.execute(
@@ -157,6 +172,7 @@ class SQLiteClientBase:
                 current_version = int(version_row[0]) if version_row else 0
                 if current_version >= required_migration_version:
                     # Migrations already applied, skip full init
+                    _init_done.add(self.db_path)
                     return
             except (sqlite3.OperationalError, ValueError):
                 # Table doesn't exist or invalid version, need to init
@@ -164,7 +180,8 @@ class SQLiteClientBase:
 
             # Run full schema initialization (includes migration_version update)
             init_schema(conn)
+            _init_done.add(self.db_path)
 
     def _get_connection(self) -> sqlite3.Connection:
-        """Get the global singleton connection for this database."""
+        """Get the thread-local connection for this database."""
         return _get_global_connection(self.db_path)

--- a/src/vibe3/clients/sqlite_base.py
+++ b/src/vibe3/clients/sqlite_base.py
@@ -15,7 +15,9 @@ from vibe3.exceptions import GitError
 from vibe3.utils import get_vibe3_db_path
 
 # Per-thread connections to avoid concurrent query corruption
-# Each thread gets its own connection; tracked for bulk close in tests/atexit
+# Each thread gets its own connection; tracked for bulk close in tests/atexit.
+# Assumes bounded thread pools (ThreadPoolExecutor). Dynamic thread creation
+# may orphan connections until process exit when atexit runs cleanup.
 _thread_local = threading.local()
 _thread_conns: set[sqlite3.Connection] = set()
 _thread_conns_lock = threading.Lock()
@@ -42,7 +44,7 @@ def _is_connection_usable(conn: sqlite3.Connection) -> bool:
     return True
 
 
-def _get_global_connection(db_path: str) -> sqlite3.Connection:
+def _get_thread_connection(db_path: str) -> sqlite3.Connection:
     """Get or create a thread-local database connection.
 
     Uses per-thread connections to avoid concurrent query corruption.
@@ -67,13 +69,13 @@ def _get_global_connection(db_path: str) -> sqlite3.Connection:
     return conn
 
 
-def _close_global_connection() -> None:
+def _close_all_connections() -> None:
     """Close all tracked thread-local connections.
 
     Used for test isolation and atexit cleanup.
     Closes current thread's connection and all tracked connections.
     """
-    # Close current thread's connection
+    # Close current thread's connection and remove from tracked set
     conn = getattr(_thread_local, "conn", None)
     if conn is not None:
         try:
@@ -82,7 +84,7 @@ def _close_global_connection() -> None:
             pass
         _thread_local.conn = None
 
-    # Close all tracked connections (for test cleanup / atexit)
+    # Close all remaining tracked connections (for test cleanup / atexit)
     with _thread_conns_lock:
         for c in list(_thread_conns):
             try:
@@ -101,7 +103,7 @@ def _utcnow_iso() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
-atexit.register(_close_global_connection)
+atexit.register(_close_all_connections)
 
 
 T = TypeVar("T", bound="SQLiteClientBase")
@@ -154,8 +156,10 @@ class SQLiteClientBase:
         Uses a migration version check to avoid re-running full DDL
         on every SQLiteClient instantiation. Increments migration_version
         in sqlite_schema.py when adding new migrations.
+
+        Note: init_schema() must remain idempotent — multiple threads may
+        race to the same code path before _init_done is populated.
         """
-        conn = _get_global_connection(self.db_path)
         with _init_lock:
             # Lightweight guard: check migration version
             # Update required_migration_version when adding new migrations
@@ -164,6 +168,8 @@ class SQLiteClientBase:
             # Check if already initialized for this db_path
             if self.db_path in _init_done:
                 return
+
+            conn = _get_thread_connection(self.db_path)
 
             try:
                 version_row = conn.execute(
@@ -184,4 +190,4 @@ class SQLiteClientBase:
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get the thread-local connection for this database."""
-        return _get_global_connection(self.db_path)
+        return _get_thread_connection(self.db_path)

--- a/tests/vibe3/clients/test_sqlite_thread_safety.py
+++ b/tests/vibe3/clients/test_sqlite_thread_safety.py
@@ -38,3 +38,38 @@ def test_concurrent_connection_creation_no_thread_error(tmp_path: Path) -> None:
         for future in concurrent.futures.as_completed(futures):
             # Should NOT raise ProgrammingError about thread safety
             future.result()
+
+
+def test_concurrent_queries_no_corruption(tmp_path: Path) -> None:
+    """Verify concurrent read queries on shared DB do not corrupt results.
+
+    Reproduces the IndexError/InterfaceError from issue #2535 where
+    ThreadPoolExecutor threads share a single connection and corrupt
+    each other's cursor state.
+    """
+    db_path = str(tmp_path / "test.db")
+    client = SQLiteClient(db_path=db_path)
+
+    # Seed test data
+    for i in range(50):
+        client.update_flow_state(
+            f"branch-{i}", flow_slug=f"slug-{i}", flow_status="active"
+        )
+
+    errors: list[Exception] = []
+
+    def concurrent_query() -> None:
+        try:
+            repo = SQLiteClient(db_path=db_path)
+            for _ in range(100):
+                flows = repo.get_all_flows()
+                assert len(flows) == 50
+        except Exception as e:
+            errors.append(e)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(concurrent_query) for _ in range(20)]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+    assert not errors, f"Concurrent queries raised errors: {errors}"

--- a/tests/vibe3/clients/test_sqlite_thread_safety.py
+++ b/tests/vibe3/clients/test_sqlite_thread_safety.py
@@ -46,6 +46,9 @@ def test_concurrent_queries_no_corruption(tmp_path: Path) -> None:
     Reproduces the IndexError/InterfaceError from issue #2535 where
     ThreadPoolExecutor threads share a single connection and corrupt
     each other's cursor state.
+
+    Note: A failing test reliably reproduces the bug. A passing test
+    means the bug did not trigger this run, not that it is absent.
     """
     db_path = str(tmp_path / "test.db")
     client = SQLiteClient(db_path=db_path)

--- a/tests/vibe3/conftest.py
+++ b/tests/vibe3/conftest.py
@@ -79,7 +79,7 @@ def isolate_database(request):
     Issue #1857 - Mock leaks contaminating production database.
     """
     from vibe3.clients.git_client import GitClient
-    from vibe3.clients.sqlite_base import _close_global_connection
+    from vibe3.clients.sqlite_base import _close_all_connections
     from vibe3.services.error_tracking_service import ErrorTrackingService
 
     # Skip patching for tests that verify GitClient.get_git_common_dir() itself
@@ -97,13 +97,13 @@ def isolate_database(request):
             # Clear process-wide state to force re-initialization with temp DB.
             # ErrorTrackingService may otherwise reuse a default singleton from a
             # previous test, including a store bound to another database path.
-            _close_global_connection()
+            _close_all_connections()
             ErrorTrackingService.clear_instance()
 
             yield Path(tmpdir)
 
-            # Cleanup: close global connection and drop service singletons after test
-            _close_global_connection()
+            # Cleanup: close all connections and drop service singletons after test
+            _close_all_connections()
             ErrorTrackingService.clear_instance()
 
 


### PR DESCRIPTION
## Summary

Replaces module-level singleton SQLite connection with per-thread connections via `threading.local()` to eliminate race condition where multiple `ThreadPoolExecutor` threads mutate shared connection state simultaneously.

## Root Cause

`_get_global_connection()` returned the same `sqlite3.Connection` object to all threads. Concurrent queries corrupted each other because:
1. `conn.row_factory = sqlite3.Row` set per-query on shared connection
2. Multiple cursors on same connection share internal state

## Solution

Each thread now gets its own connection stored in thread-local storage. Connection count bounded by thread count (3-5), not operation count, eliminating race conditions without FD exhaustion risk.

## Changes

- **src/vibe3/clients/sqlite_base.py**:
  - Replace `_global_conn` singleton with `_thread_local` storage
  - Track all connections in `_thread_conns` for bulk close
  - Update `_get_global_connection` to use thread-local storage
  - Update `_close_global_connection` to close all tracked connections
  - Update `_init_db` to use `_init_done` set for migration guard
  - Apply `PRAGMA journal_mode=WAL` on each new connection

- **tests/vibe3/clients/test_sqlite_thread_safety.py**:
  - Add `test_concurrent_queries_no_corruption` (Phase 2)
  - Reproduces IndexError/InterfaceError from issue #2535
  - Verifies 20 concurrent threads can query without corruption

## Test Plan

- [x] Type check: mypy success
- [x] Lint check: ruff success
- [x] FD exhaustion tests: 3/3 passed
- [x] Thread safety tests: 2/2 passed
- [x] Full SQLite clients: 230/230 passed
- [x] Pre-push checks: 432/432 passed
- [x] All changes committed (clean working tree)

Fixes #2535

---

## Contributors

claude/opus
