### PR TITLE
refactor(task): use public API for IssueFlowService imports

### DIFF
--- a/src/vibe3/services/task/resume.py
+++ b/src/vibe3/services/task/resume.py
@@ -14,7 +14,7 @@ from vibe3.clients import BackendProtocol, GitClient, GitHubClient
 from vibe3.exceptions import UserError
 from vibe3.models import IssueState
 from vibe3.services.flow.service import FlowService
-from vibe3.services.issue.flow import IssueFlowService
+from vibe3.services.issue import IssueFlowService
 from vibe3.services.shared.label_service import LabelService
 from vibe3.services.shared.status_query import StatusQueryService
 

--- a/src/vibe3/services/task/show.py
+++ b/src/vibe3/services/task/show.py
@@ -332,7 +332,7 @@ class TaskShowService:
         local_task = self.flow_service.get_flow_status(target_branch)
 
         # Resolve task issue numbers from DB links
-        from vibe3.services.issue.flow import IssueFlowService
+        from vibe3.services.issue import IssueFlowService
 
         issue_flow_service = IssueFlowService(store=self.store)
         task_issue_number = issue_flow_service.resolve_task_issue_number(target_branch)


### PR DESCRIPTION
Closes #2576

Replace deep imports from services.issue.flow with public API access via services.issue.__init__.py to complete Phase 6b decoupling.

## Changes
- src/vibe3/services/task/resume.py: import from vibe3.services.issue
- src/vibe3/services/task/show.py: import from vibe3.services.issue

IssueFlowService is already exported in issue/__init__.py public API, so this is a path-only fix with no behavior changes.

## Test Results
- Tests: 29/29 passed (modularity + task resume tests)
- Type check: ✅ No issues
- Lint: ✅ All checks passed

Refs: #2576

---

## Contributors

claude/opus
