### PR TITLE
docs: align documentation with V3 reality (#2644)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,14 +104,14 @@ This project has **two parallel implementations**:
 - `vibe3 handoff show <artifact-path>`：读取共享 handoff artifact
 - `vibe3 handoff append "内容"`：追加 handoff 记录，提供后续上下文
 - `vibe3 handoff verdict`：提交任务执行裁决（PASS/MAJOR/BLOCK/UNKNOWN）
-- `vibe3 handoff plan/report/audit/next`：记录特定阶段的责任链上下文
+- `vibe3 handoff plan/report/indicate/audit/next`：记录特定阶段的责任链上下文
 - `handoff show` 不再用于状态总览；遇到 `vibe3/handoff/...` 这类共享路径时，应通过 `handoff show <path>` 读取
 
 ## 架构层级 (Three-Tier Architecture)
 
-- **Tier 3 (Cognitive/Governance)**: Policies, rules, supervisor. (Rules and Principles)
-- **Tier 2 (Skill Layer)**: Orchestration and context management. (Workflow and Logic)
-- **Tier 1 (Shell Layer)**: Atomic capabilities and state access. (Tools and Execution)
+- **Tier 3 (Cognitive/Governance)**: 认知与治理层。负责全局策略、规则、Supervisor 治理。核心命令：`serve`, `scan`, `check`, `mcp`。
+- **Tier 2 (Skill Layer)**: 技能/编排层。负责 Flow 状态机、任务编排、Agent 执行。核心命令：`flow`, `task`, `run`, `plan`, `review`。
+- **Tier 1 (Shell Layer)**: 壳层/原子能力。提供原子级能力访问、状态读取与项目信息检索。核心命令：`handoff`, `inspect`, `pr`, `snapshot`, `ask`。
 
 ## 🤖 Protocol
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -143,6 +143,7 @@ AI Agent → AGENTS.md → SOUL.md (宪法和原则)
 - `execution/` - 执行控制平面（统一协调层：coordinator, capacity, lifecycle, gates）
 - `exceptions/` - 统一异常层级
 - `domain/` - 领域事件与 handlers（events, handlers, orchestration_facade）
+  - `domain/protocols/` - 领域协议与抽象接口
 - `models/` - 领域数据模型（Flow, Handoff, Task, PR, Verdict 等 Pydantic 模型）
 - `observability/` - 日志、链路追踪、审计
 - `orchestra/` - 编排中枢（issue 分诊、事件调度）
@@ -152,6 +153,7 @@ AI Agent → AGENTS.md → SOUL.md (宪法和原则)
 - `runtime/` - 事件驱动运行时（EventBus, Heartbeat）
 - `server/` - HTTP 服务层（webhook, MCP, health check）
 - `services/` - 核心业务逻辑（issue, pr, task, handoff, check）
+  - `services/flow/` - Flow 状态转换、注册、重建与清理
   - `services/issue/` - Issue 生命流程、标题缓存与失败处理
   - `services/pr/` - PR 创建、评审、质量评分与分析
   - `services/task/` - Task 绑定、状态分类与恢复逻辑

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -125,12 +125,12 @@ def register_dispatch_handlers() -> None:
 
 ### 4. Audit 事件
 
-**事件**：`audit_recorded`
+**事件**：`handoff_audit`
 
 **语义**：
-- 系统解析 review output，提取 verdict，写入 audit_ref
-- 不是 agent 的 handoff 行为，是系统的解析行为
-- 区别于 `handoff_plan` / `handoff_report` / `handoff_indicate`（agent 主动提交）
+- Reviewer 主动发起的权威审计行为，记录审计结果（verdict）与审计引用（audit_ref）。
+- 区别于 `audit_recorded`（系统被动解析 review output 的 legacy 事件）。
+- 与 `handoff_plan` / `handoff_report` / `handoff_indicate` 属于同一级别的 Agent 主动提交行为。
 
 **详细文档**: [event-driven-standard.md](standards/v3/event-driven-standard.md) §1.2
 

--- a/docs/standards/v3/command-standard.md
+++ b/docs/standards/v3/command-standard.md
@@ -295,23 +295,21 @@ vibe3 flow rebuild [<issue>] [--branch <branch>] [--keep-remote] [--no-worktree]
 - 操作顺序：hard cleanup -> bootstrap flow/worktree -> append rebuild handoff -> label-auto resume。
 - 不能作为普通 blocked 恢复入口使用；blocked 恢复优先使用 `task resume`。
 
-### 7.5 `flow show` / `flow status`
-
+### 7.6 `flow show` / `flow status`
 
 ```bash
+# Show single flow
 vibe3 flow show [--branch <branch>] [--snapshot] [--format json]
-```
 
-### 7.5 `flow status`
-
-```bash
+# List all flows
 vibe3 flow status [--all] [--format json]
 ```
 
-### 7.6 `status`
+### 7.7 `status` [Legacy Alias]
 
 ```bash
-vibe3 task status [--all] [--format json]
+# Alias for 'vibe3 task status'
+vibe3 status [--all] [--format json]
 ```
 
 ## 8. 禁止语义

--- a/docs/v3/architecture/public-api-guide.md
+++ b/docs/v3/architecture/public-api-guide.md
@@ -70,12 +70,13 @@ MY_ROLE = TriggerableRoleDefinition(
 `FlowService` 和 `TaskService` 是管理流程状态、Issue 链接和 PR 关联的核心服务。
 
 ```python
-from vibe3.services.flow_service import FlowService
-from vibe3.services.task_service import TaskService
+from vibe3.services.flow import FlowService
+from vibe3.services.task import TaskService
 
 # 初始化
 flow_service = FlowService()
 task_service = TaskService()
+```
 
 # 示例：绑定 Spec 到当前 Flow
 # spec_ref 可以是 issue 编号或文件路径


### PR DESCRIPTION
This PR aligns several core documents with the current V3 implementation reality.

Target Documents:
1. docs/ARCHITECTURE_GUIDE.md: Fix outdated handoff event names and Audit semantics.
2. STRUCTURE.md: Sync src/vibe3/ directory structure with actual code.
3. AGENTS.md: Update handoff command list and architecture tier descriptions.
4. docs/v3/architecture/public-api-guide.md: Fix outdated import paths.
5. docs/standards/v3/command-standard.md: Align command usage descriptions and fix section numbering.

Closes #2644