### PR TITLE
fix(roles): add missing --show-prompt to async CLI commands

### DIFF
--- a/src/vibe3/roles/manager.py
+++ b/src/vibe3/roles/manager.py
@@ -246,11 +246,19 @@ def build_manager_request(
         return request
 
     # Async mode: non-blocking tmux execution (default)
+    # Async CLI 命令必须显式传递 --show-prompt（默认 False）
+    # 因为子进程会重新调用 run_issue_role_sync，需要必选参数
     request = build_issue_async_cli_request(
         role="manager",
         issue=issue,
         target_branch=flow_branch,
-        command_args=["internal", "manager", str(issue.number), "--no-async"],
+        command_args=[
+            "internal",
+            "manager",
+            str(issue.number),
+            "--no-async",
+            "--show-prompt",
+        ],
         actor=actor,
         execution_name=get_manager_session_name(issue.number),
         refs=refs,

--- a/src/vibe3/roles/plan.py
+++ b/src/vibe3/roles/plan.py
@@ -195,11 +195,19 @@ def build_plan_request(
     """Build the planner async execution request for dispatch."""
     convention = get_convention()
     target_branch = branch or convention.branch.canonical_branch(issue.number)
+    # Async CLI 命令必须显式传递 --show-prompt（默认 False）
+    # 因为子进程会重新调用 run_issue_role_sync，需要必选参数
     return build_role_async_request(
         role="planner",
         config=config,
         issue=issue,
-        command_args=["plan", "--branch", target_branch, "--no-async"],
+        command_args=[
+            "plan",
+            "--branch",
+            target_branch,
+            "--no-async",
+            "--show-prompt",
+        ],
         worktree_requirement=PLANNER_ROLE.worktree,
         branch=branch,
         repo_path=repo_path,

--- a/src/vibe3/roles/review.py
+++ b/src/vibe3/roles/review.py
@@ -229,7 +229,15 @@ def build_issue_review_request(
     async_refs: dict[str, str] = {"issue_number": str(issue.number)}
     if report_ref:
         async_refs["report_ref"] = report_ref
-    command_args = ["review", "--branch", target_branch, "--no-async"]
+    # Async CLI 命令必须显式传递 --show-prompt（默认 False）
+    # 因为子进程会重新调用 run_issue_role_sync，需要必选参数
+    command_args = [
+        "review",
+        "--branch",
+        target_branch,
+        "--no-async",
+        "--show-prompt",
+    ]
 
     return build_issue_async_cli_request(
         role="reviewer",

--- a/src/vibe3/roles/run_request.py
+++ b/src/vibe3/roles/run_request.py
@@ -58,6 +58,8 @@ def build_run_request(
         ]
         refs["commit_mode"] = "true"
     elif plan_ref:
+        # Async CLI 命令必须显式传递 --show-prompt（默认 False）
+        # 因为子进程会重新调用 run_issue_role_sync，需要必选参数
         command_args = [
             "run",
             "--branch",
@@ -65,9 +67,18 @@ def build_run_request(
             "--plan",
             plan_ref,
             "--no-async",
+            "--show-prompt",
         ]
     else:
-        command_args = ["run", "--branch", target_branch, "--no-async"]
+        # Async CLI 命令必须显式传递 --show-prompt（默认 False）
+        # 因为子进程会重新调用 run_issue_role_sync，需要必选参数
+        command_args = [
+            "run",
+            "--branch",
+            target_branch,
+            "--no-async",
+            "--show-prompt",
+        ]
 
     return build_role_async_request(
         role="executor",


### PR DESCRIPTION
## Summary
修复所有角色 async dispatch 缺少 `--show-prompt` 参数导致 reviewer 崩溃的问题

## Root Cause
所有角色的 async CLI 命令（reviewer/planner/executor/manager）都缺少 `--show-prompt` 参数。子进程重新进入 `run_issue_role_sync()` 时因为缺少必选参数而崩溃。

## Fix
在以下位置的 async CLI 命令构建中显式添加 `--show-prompt` 参数（默认 False）：
- `src/vibe3/roles/review.py` (reviewer)
- `src/vibe3/roles/plan.py` (planner)
- `src/vibe3/roles/run_request.py` (executor, 2个分支)
- `src/vibe3/roles/manager.py` (manager)

## Impact
- ✅ 解除所有 REVIEW 状态的 task 阻塞
- ⚠️ 需要 restart serve 以重新 dispatch 被阻塞的 task

## Test Plan
- [ ] 创建测试 issue 触发 manager → planner → executor → reviewer 链路
- [ ] 确认 reviewer 执行成功并生成 audit report
- [ ] 确认 flow 正常进入 merge-ready 状态

Fixes #2656

🤖 Generated with [Claude Code](https://claude.com/claude-code)