### PR TITLE
feat(event-rules): extend action types beyond log and enqueue placeholder

### DIFF
--- a/config/policies/event-rules.yaml
+++ b/config/policies/event-rules.yaml
@@ -3,7 +3,7 @@
 # Rules are evaluated for every published domain event.
 # Each rule specifies:
 #   - event: DomainEvent class name to match
-#   - action: Action identifier (e.g., "log", "enqueue_command_job")
+#   - action: Action identifier (e.g., "log", "enqueue_command_job", "refresh_queue_priority")
 #   - params: Template parameters with {{ event.field }} syntax
 #   - enabled: Whether the rule is active (default: true)
 #
@@ -14,30 +14,50 @@
 # This file is loaded at server startup via EventPublisher.on_publish hook.
 
 rules:
-  # Governance scan started → log for observability
+  # P0: Issue failed → auto-dispatch manager for recovery
+  - event: IssueFailed
+    action: enqueue_command_job
+    params:
+      command_type: "manager"
+      issue_number: "{{ event.issue_number }}"
+      actor: "{{ event.actor }}"
+
+  # P0: Issue failed → refresh queue priority
+  - event: IssueFailed
+    action: refresh_queue_priority
+    params:
+      issue: "{{ event.issue_number }}"
+      actor: "event:issue_failed"
+
+  # P1: Governance scan started → log for observability
   - event: GovernanceScanStarted
     action: log
     params:
       message: "governance scan started (tick={{ event.tick_count }})"
 
-  # Manager dispatch → queue manager command
-  - event: ManagerDispatchIntent
-    action: enqueue_command_job
-    params:
-      command: "vibe3 internal manager {{ event.issue_number }}"
-      actor: "{{ event.actor }}"
+  # P1: Governance scan completed → reload materials
+  - event: GovernanceScanCompleted
+    action: reload_material
+    scope: [governance, prompts]
 
-  # Supervisor issue identified → log for tracking
+  # P1: Supervisor issue identified → trigger governance scan
+  - event: SupervisorIssueIdentified
+    action: trigger_governance_scan
+    params:
+      issue_number: "{{ event.issue_number }}"
+
+  # P1: Supervisor issue identified → log for tracking
   - event: SupervisorIssueIdentified
     action: log
     params:
       message: "supervisor candidate: issue #{{ event.issue_number }}"
 
-  # Issue failed → record for error tracking
+  # P2: Issue failed → notify (stub)
   - event: IssueFailed
-    action: log
+    action: notify
     params:
       message: "issue #{{ event.issue_number }} failed: {{ event.reason }}"
+      target: "manager"
 
   # Webhook: label changed → log (upstream handler can refresh queue)
   - event: WebhookLabelChanged

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -28,9 +28,13 @@ code_limits:
         reason: "校验聚合服务，核心校验链路不适合再细碎拆分，包含 PR 状态处理、分支清理、flow 状态标记、PR closed 阻塞逻辑等紧密耦合逻辑；迁移至 check/ 子包（Issue #2584）"
 
       # Exceptions 聚合 —— 允许 480-600
+      # Domain 层
       - path: "src/vibe3/domain/qualify_gate.py"
         limit: 620
         reason: "Qualify gate 域服务，包含 truth-first 决策流程、blocked 对齐、auto-resume、worktree 健康检查、依赖检查、github_state CLOSED guard、dep-closure detection 等紧密耦合逻辑；PR #1983 重构后新增统一 closed issue 检测（_terminalize_closed_issue 方法），将 HealthCheck 的业务逻辑迁移到 QualifyGate，实现单一职责（business qualification）；PR #2349 新增 dep-closure detection（_notify_dep_resolved 方法）并统一架构（使用 FlowRecoveryService）；Issue #2369 新增 mark_flow_aborted 调用与 terminal-state guard 逻辑（+13 行）"
+      - path: "src/vibe3/domain/event_rules.py"
+        limit: 550
+        reason: "Event rules 引擎核心聚合，包含规则加载、模板展开、规则评估、action handler 构建（9 个 handler，含 enqueue_command_job、refresh_queue_priority、reload_material、governance_scan 等业务动作）等紧密耦合逻辑；handler 函数与 build_action_handlers 工厂内聚性强，拆分会破坏注册一致性"
       - path: "src/vibe3/services/handoff/service.py"
         limit: 650
         reason: "Handoff 记录管理核心服务，内聚度高，模板函数共生；包含 terminology 统一映射逻辑；--branch 参数统一支持后略微膨胀；新增 blocked_reason 自动清除逻辑（当 plan_ref/report_ref 写入时）；新增 event 驱动架构支持（FlowTimelineService 集成，issue_number 查询，event 记录逻辑）；迁移至 handoff/ 子包（Issue #2099）"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -300,6 +300,9 @@ code_limits:
       - path: "tests/vibe3/domain/handlers/test_dispatch.py"
         limit: 420
         reason: "Dispatch handler 测试集（已拆分 test_dispatch_not_launched.py），覆盖 planner/executor/reviewer 三个角色的 dispatch 逻辑，共享 mock setup，继续拆分收益低；rebase 后新增 launch_failed 测试略微超标"
+      - path: "tests/vibe3/domain/test_event_rules.py"
+        limit: 480
+        reason: "Event rules 引擎完整测试集，覆盖规则加载（5 个）、模板展开（4 个）、规则评估（5 个）、action handler 构建（3 个）、9 个 action handler 单元测试（9 个）、config↔code 一致性验证（1 个）等 30 个测试，按测试类组织内聚度高，拆分降低可读性"
       - path: "tests/vibe3/services/test_pr_service.py"
         limit: 450
         reason: "PRService 测试集，新增 cache 行为测试（56行）验证 60s TTL 缓存和过期恢复逻辑，与 PRService fixture 紧密耦合，拆分收益低"

--- a/src/vibe3/domain/event_rules.py
+++ b/src/vibe3/domain/event_rules.py
@@ -15,7 +15,15 @@ import yaml
 from loguru import logger
 
 if TYPE_CHECKING:
-    from vibe3.models import DomainEvent
+    from vibe3.models import (
+        CommandType as CommandTypeType,
+    )
+    from vibe3.models import (
+        DomainEvent,
+        ExecutionRequest,
+        IssueInfo,
+        OrchestraConfig,
+    )
 
 
 @dataclass(frozen=True)
@@ -176,12 +184,127 @@ def evaluate_rules(
             )
 
 
+def _dispatch_command_job(
+    command_type: str,
+    issue_number: int,
+    actor: str,
+    refs: dict[str, str] | None = None,
+) -> None:
+    """Internal helper to dispatch a command job via ExecutionCoordinator.
+
+    Args:
+        command_type: CommandType value (plan, run, review, manager)
+        issue_number: Issue number to dispatch for
+        actor: Actor identifier for the dispatch
+        refs: Optional refs dict for the execution request
+    """
+    from vibe3.clients import get_store
+    from vibe3.config import load_orchestra_config
+    from vibe3.execution import ExecutionCoordinator
+    from vibe3.models import CommandType
+    from vibe3.services import load_issue_info
+
+    config = load_orchestra_config()
+    effective_refs = {"issue_number": str(issue_number)}
+    if refs:
+        effective_refs.update(refs)
+
+    try:
+        cmd_type = CommandType(command_type)
+    except ValueError:
+        logger.bind(domain="event_rules").warning(
+            f"Unknown command_type '{command_type}', skipping dispatch"
+        )
+        return
+
+    with get_store() as store:
+        issue = load_issue_info(issue_number, config=config)
+        if issue is None:
+            logger.bind(domain="event_rules").warning(
+                f"Failed to load issue #{issue_number}, skipping dispatch"
+            )
+            return
+
+        # Build ExecutionRequest based on command type
+        request = _build_execution_request(
+            cmd_type, config, issue, actor, effective_refs
+        )
+        if request is None:
+            logger.bind(domain="event_rules").warning(
+                f"Failed to build execution request for {cmd_type.value} "
+                f"on #{issue_number}"
+            )
+            return
+
+        coordinator = ExecutionCoordinator(config, store)
+        result = coordinator.dispatch_execution(request)
+
+        if result.launched:
+            logger.bind(
+                domain="event_rules",
+                command_type=command_type,
+                issue_number=issue_number,
+            ).info(f"Command job dispatched: {command_type}")
+        elif result.skipped:
+            logger.bind(
+                domain="event_rules",
+                command_type=command_type,
+                issue_number=issue_number,
+            ).info(f"Command job skipped: {result.reason}")
+        else:
+            logger.bind(
+                domain="event_rules",
+                command_type=command_type,
+                issue_number=issue_number,
+            ).warning(f"Command job dispatch failed: {result.reason}")
+
+
+def _build_execution_request(
+    command_type: "CommandTypeType",
+    config: "OrchestraConfig",
+    issue: "IssueInfo",
+    actor: str,
+    refs: dict[str, str],
+) -> "ExecutionRequest | None":
+    """Build ExecutionRequest for a given command type."""
+    from vibe3.config import get_convention
+    from vibe3.models import ExecutionRequest, WorktreeRequirement
+
+    convention = get_convention()
+    target_branch = convention.branch.canonical_branch(issue.number)
+
+    # Map command type to role and worktree requirement
+    role_map = {
+        "plan": ("planner", WorktreeRequirement.PERMANENT),
+        "run": ("executor", WorktreeRequirement.PERMANENT),
+        "review": ("reviewer", WorktreeRequirement.PERMANENT),
+        "manager": ("manager", WorktreeRequirement.PERMANENT),
+    }
+
+    role, wt_req = role_map.get(
+        command_type.value, ("unknown", WorktreeRequirement.NONE)
+    )
+
+    return ExecutionRequest(
+        role=role,
+        target_branch=target_branch,
+        target_id=issue.number,
+        execution_name=f"vibe3-{role}-issue-{issue.number}",
+        actor=actor,
+        refs=refs,
+        worktree_requirement=wt_req,
+        mode="async",
+    )
+
+
 def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
     """Build action handlers dict for rule evaluation.
 
     Returns:
         Dict mapping action names to handler functions.
-        Currently supports: log, enqueue_command_job
+        Supports: log, enqueue_command_job, enqueue_plan, enqueue_run,
+        enqueue_review, refresh_queue_priority, reload_material,
+        trigger_governance_scan, notify
     """
 
     def log_action(params: dict[str, str]) -> None:
@@ -192,17 +315,243 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
     def enqueue_command_job_action(params: dict[str, str]) -> None:
         """Enqueue command job action handler.
 
-        NOTE: This is a placeholder for now. Full implementation
-        requires integration with the job queue system.
+        Dispatches a command job via ExecutionCoordinator.
+        Params:
+            - command_type: CommandType value (plan, run, review, manager)
+            - issue_number: Issue number to dispatch for
+            - actor: Actor identifier (optional, defaults to
+              "event:enqueue_command_job")
         """
-        command = params.get("command", "")
-        actor = params.get("actor", "system")
-        logger.bind(domain="event_rules").info(
-            f"Would enqueue command: {command} (actor={actor})"
+        command_type = params.get("command_type")
+        if not command_type:
+            logger.bind(domain="event_rules").warning(
+                "enqueue_command_job missing 'command_type' param, skipping"
+            )
+            return
+
+        issue_number_str = params.get("issue_number")
+        if not issue_number_str:
+            logger.bind(domain="event_rules").warning(
+                "enqueue_command_job missing 'issue_number' param, skipping"
+            )
+            return
+
+        try:
+            issue_number = int(issue_number_str)
+        except ValueError:
+            logger.bind(domain="event_rules").warning(
+                f"enqueue_command_job invalid issue_number "
+                f"'{issue_number_str}', skipping"
+            )
+            return
+
+        actor = params.get("actor", "event:enqueue_command_job")
+        refs = {
+            k: v
+            for k, v in params.items()
+            if k not in ("command_type", "issue_number", "actor")
+        }
+
+        _dispatch_command_job(command_type, issue_number, actor, refs)
+
+    def enqueue_plan_action(params: dict[str, str]) -> None:
+        """Enqueue plan action handler (syntactic sugar for enqueue_command_job)."""
+        issue_number_str = params.get("issue_number")
+        if not issue_number_str:
+            logger.bind(domain="event_rules").warning(
+                "enqueue_plan missing 'issue_number' param, skipping"
+            )
+            return
+
+        try:
+            issue_number = int(issue_number_str)
+        except ValueError:
+            logger.bind(domain="event_rules").warning(
+                f"enqueue_plan invalid issue_number '{issue_number_str}', skipping"
+            )
+            return
+
+        actor = params.get("actor", "event:enqueue_plan")
+        refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
+
+        _dispatch_command_job("plan", issue_number, actor, refs)
+
+    def enqueue_run_action(params: dict[str, str]) -> None:
+        """Enqueue run action handler (syntactic sugar for enqueue_command_job)."""
+        issue_number_str = params.get("issue_number")
+        if not issue_number_str:
+            logger.bind(domain="event_rules").warning(
+                "enqueue_run missing 'issue_number' param, skipping"
+            )
+            return
+
+        try:
+            issue_number = int(issue_number_str)
+        except ValueError:
+            logger.bind(domain="event_rules").warning(
+                f"enqueue_run invalid issue_number '{issue_number_str}', skipping"
+            )
+            return
+
+        actor = params.get("actor", "event:enqueue_run")
+        refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
+
+        _dispatch_command_job("run", issue_number, actor, refs)
+
+    def enqueue_review_action(params: dict[str, str]) -> None:
+        """Enqueue review action handler (syntactic sugar for enqueue_command_job)."""
+        issue_number_str = params.get("issue_number")
+        if not issue_number_str:
+            logger.bind(domain="event_rules").warning(
+                "enqueue_review missing 'issue_number' param, skipping"
+            )
+            return
+
+        try:
+            issue_number = int(issue_number_str)
+        except ValueError:
+            logger.bind(domain="event_rules").warning(
+                f"enqueue_review invalid issue_number '{issue_number_str}', skipping"
+            )
+            return
+
+        actor = params.get("actor", "event:enqueue_review")
+        refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
+
+        _dispatch_command_job("review", issue_number, actor, refs)
+
+    def refresh_queue_priority_action(params: dict[str, str]) -> None:
+        """Refresh queue priority action handler.
+
+        Publishes ManagerDispatchIntent to trigger queue rebuild.
+        Uses actor-based loop guard to prevent re-entrant publishing.
+        """
+        from vibe3.domain import publish
+        from vibe3.models import ManagerDispatchIntent
+
+        # Loop guard: skip if we're already in a refresh cycle
+        actor_param = params.get("actor", "")
+        if actor_param == "event:refresh_queue_priority":
+            logger.bind(domain="event_rules").debug(
+                "refresh_queue_priority loop detected, skipping re-entrant publish"
+            )
+            return
+
+        issue_number_str = params.get("issue")
+        if not issue_number_str:
+            issue_number_str = params.get("issue_number")
+
+        if not issue_number_str:
+            logger.bind(domain="event_rules").warning(
+                "refresh_queue_priority missing 'issue' param, skipping"
+            )
+            return
+
+        try:
+            issue_number = int(issue_number_str)
+        except ValueError:
+            logger.bind(domain="event_rules").warning(
+                f"refresh_queue_priority invalid issue '{issue_number_str}', skipping"
+            )
+            return
+
+        # Get branch from params or use convention
+        branch = params.get("branch")
+        if not branch:
+            from vibe3.config import get_convention
+
+            convention = get_convention()
+            branch = convention.branch.canonical_branch(issue_number)
+
+        actor = params.get("actor", "event:refresh_queue_priority")
+
+        event = ManagerDispatchIntent(
+            issue_number=issue_number,
+            branch=branch,
+            trigger_state="ready",
+            actor=actor,
         )
-        # TODO: Integrate with actual job queue when available
+        publish(event)
+
+        logger.bind(
+            domain="event_rules",
+            issue_number=issue_number,
+        ).info("Published ManagerDispatchIntent for queue refresh")
+
+    def reload_material_action(params: dict[str, str]) -> None:
+        """Reload material action handler.
+
+        Publishes GovernanceScanStarted to trigger governance material re-read.
+        """
+        from vibe3.domain import publish
+        from vibe3.domain.events.governance import GovernanceScanStarted
+
+        tick_count = 0
+        tick_str = params.get("tick_count")
+        if tick_str:
+            try:
+                tick_count = int(tick_str)
+            except ValueError:
+                pass
+
+        event = GovernanceScanStarted(
+            tick_count=tick_count,
+            actor="event:reload_material",
+        )
+        publish(event)
+
+        logger.bind(domain="event_rules").info(
+            f"Published GovernanceScanStarted for material reload (tick={tick_count})"
+        )
+
+    def trigger_governance_scan_action(params: dict[str, str]) -> None:
+        """Trigger governance scan action handler.
+
+        Publishes GovernanceScanStarted directly (bypasses heartbeat interval gating).
+        """
+        from vibe3.domain import publish
+        from vibe3.domain.events.governance import GovernanceScanStarted
+
+        tick_count = 0
+        tick_str = params.get("tick_count")
+        if tick_str:
+            try:
+                tick_count = int(tick_str)
+            except ValueError:
+                pass
+
+        actor = params.get("actor", "event:trigger_governance_scan")
+
+        event = GovernanceScanStarted(
+            tick_count=tick_count,
+            actor=actor,
+        )
+        publish(event)
+
+        logger.bind(domain="event_rules").info(
+            f"Published GovernanceScanStarted (tick={tick_count})"
+        )
+
+    def notify_action(params: dict[str, str]) -> None:
+        """Notify action handler (stub).
+
+        Logs notification intent for future channel integration.
+        """
+        message = params.get("message", "")
+        target = params.get("target", "unknown")
+
+        logger.bind(domain="event_rules").info(
+            f"[NOTIFY] target={target} message={message}"
+        )
 
     return {
         "log": log_action,
+        "refresh_queue_priority": refresh_queue_priority_action,
         "enqueue_command_job": enqueue_command_job_action,
+        "enqueue_plan": enqueue_plan_action,
+        "enqueue_run": enqueue_run_action,
+        "enqueue_review": enqueue_review_action,
+        "reload_material": reload_material_action,
+        "trigger_governance_scan": trigger_governance_scan_action,
+        "notify": notify_action,
     }

--- a/src/vibe3/domain/event_rules.py
+++ b/src/vibe3/domain/event_rules.py
@@ -6,6 +6,7 @@ on every published domain event via EventPublisher.on_publish hook.
 
 from __future__ import annotations
 
+import functools
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -354,12 +355,12 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
 
         _dispatch_command_job(command_type, issue_number, actor, refs)
 
-    def enqueue_plan_action(params: dict[str, str]) -> None:
-        """Enqueue plan action handler (syntactic sugar for enqueue_command_job)."""
+    def _enqueue_by_role(role: str, params: dict[str, str]) -> None:
+        """Validate params and dispatch via _dispatch_command_job."""
         issue_number_str = params.get("issue_number")
         if not issue_number_str:
             logger.bind(domain="event_rules").warning(
-                "enqueue_plan missing 'issue_number' param, skipping"
+                f"enqueue_{role} missing 'issue_number' param, skipping"
             )
             return
 
@@ -367,58 +368,14 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
             issue_number = int(issue_number_str)
         except ValueError:
             logger.bind(domain="event_rules").warning(
-                f"enqueue_plan invalid issue_number '{issue_number_str}', skipping"
+                f"enqueue_{role} invalid issue_number '{issue_number_str}', skipping"
             )
             return
 
-        actor = params.get("actor", "event:enqueue_plan")
+        actor = params.get("actor", f"event:enqueue_{role}")
         refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
 
-        _dispatch_command_job("plan", issue_number, actor, refs)
-
-    def enqueue_run_action(params: dict[str, str]) -> None:
-        """Enqueue run action handler (syntactic sugar for enqueue_command_job)."""
-        issue_number_str = params.get("issue_number")
-        if not issue_number_str:
-            logger.bind(domain="event_rules").warning(
-                "enqueue_run missing 'issue_number' param, skipping"
-            )
-            return
-
-        try:
-            issue_number = int(issue_number_str)
-        except ValueError:
-            logger.bind(domain="event_rules").warning(
-                f"enqueue_run invalid issue_number '{issue_number_str}', skipping"
-            )
-            return
-
-        actor = params.get("actor", "event:enqueue_run")
-        refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
-
-        _dispatch_command_job("run", issue_number, actor, refs)
-
-    def enqueue_review_action(params: dict[str, str]) -> None:
-        """Enqueue review action handler (syntactic sugar for enqueue_command_job)."""
-        issue_number_str = params.get("issue_number")
-        if not issue_number_str:
-            logger.bind(domain="event_rules").warning(
-                "enqueue_review missing 'issue_number' param, skipping"
-            )
-            return
-
-        try:
-            issue_number = int(issue_number_str)
-        except ValueError:
-            logger.bind(domain="event_rules").warning(
-                f"enqueue_review invalid issue_number '{issue_number_str}', skipping"
-            )
-            return
-
-        actor = params.get("actor", "event:enqueue_review")
-        refs = {k: v for k, v in params.items() if k not in ("issue_number", "actor")}
-
-        _dispatch_command_job("review", issue_number, actor, refs)
+        _dispatch_command_job(role, issue_number, actor, refs)
 
     def refresh_queue_priority_action(params: dict[str, str]) -> None:
         """Refresh queue priority action handler.
@@ -478,14 +435,18 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
             issue_number=issue_number,
         ).info("Published ManagerDispatchIntent for queue refresh")
 
+    def _publish_governance_scan(actor: str, tick_count: int) -> None:
+        """Publish GovernanceScanStarted with the given actor and tick."""
+        from vibe3.domain import publish
+        from vibe3.domain.events.governance import GovernanceScanStarted
+
+        publish(GovernanceScanStarted(tick_count=tick_count, actor=actor))
+
     def reload_material_action(params: dict[str, str]) -> None:
         """Reload material action handler.
 
         Publishes GovernanceScanStarted to trigger governance material re-read.
         """
-        from vibe3.domain import publish
-        from vibe3.domain.events.governance import GovernanceScanStarted
-
         tick_count = 0
         tick_str = params.get("tick_count")
         if tick_str:
@@ -494,12 +455,7 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
             except ValueError:
                 pass
 
-        event = GovernanceScanStarted(
-            tick_count=tick_count,
-            actor="event:reload_material",
-        )
-        publish(event)
-
+        _publish_governance_scan("event:reload_material", tick_count)
         logger.bind(domain="event_rules").info(
             f"Published GovernanceScanStarted for material reload (tick={tick_count})"
         )
@@ -509,9 +465,6 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
 
         Publishes GovernanceScanStarted directly (bypasses heartbeat interval gating).
         """
-        from vibe3.domain import publish
-        from vibe3.domain.events.governance import GovernanceScanStarted
-
         tick_count = 0
         tick_str = params.get("tick_count")
         if tick_str:
@@ -521,13 +474,7 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
                 pass
 
         actor = params.get("actor", "event:trigger_governance_scan")
-
-        event = GovernanceScanStarted(
-            tick_count=tick_count,
-            actor=actor,
-        )
-        publish(event)
-
+        _publish_governance_scan(actor, tick_count)
         logger.bind(domain="event_rules").info(
             f"Published GovernanceScanStarted (tick={tick_count})"
         )
@@ -548,9 +495,9 @@ def build_action_handlers() -> dict[str, Callable[[dict[str, str]], None]]:
         "log": log_action,
         "refresh_queue_priority": refresh_queue_priority_action,
         "enqueue_command_job": enqueue_command_job_action,
-        "enqueue_plan": enqueue_plan_action,
-        "enqueue_run": enqueue_run_action,
-        "enqueue_review": enqueue_review_action,
+        "enqueue_plan": functools.partial(_enqueue_by_role, "plan"),
+        "enqueue_run": functools.partial(_enqueue_by_role, "run"),
+        "enqueue_review": functools.partial(_enqueue_by_role, "review"),
         "reload_material": reload_material_action,
         "trigger_governance_scan": trigger_governance_scan_action,
         "notify": notify_action,

--- a/tests/vibe3/domain/test_event_rules.py
+++ b/tests/vibe3/domain/test_event_rules.py
@@ -275,3 +275,177 @@ class TestBuildActionHandlers:
 
         # Should not raise (placeholder implementation)
         enqueue_handler({"command": "test command", "actor": "test"})
+
+
+class TestActionHandlers:
+    """Test new action handlers."""
+
+    def test_build_action_handlers_all_keys(self) -> None:
+        """Dict contains all 9 expected keys."""
+        handlers = build_action_handlers()
+
+        expected_keys = {
+            "log",
+            "refresh_queue_priority",
+            "enqueue_command_job",
+            "enqueue_plan",
+            "enqueue_run",
+            "enqueue_review",
+            "reload_material",
+            "trigger_governance_scan",
+            "notify",
+        }
+        assert set(handlers.keys()) == expected_keys
+
+    def test_refresh_queue_priority_publishes_intent(self) -> None:
+        """ManagerDispatchIntent is published with correct issue_number."""
+        from unittest.mock import MagicMock, patch
+
+        handlers = build_action_handlers()
+        handler = handlers["refresh_queue_priority"]
+
+        mock_publish = MagicMock()
+        with patch("vibe3.domain.publish", mock_publish):
+            handler({"issue": "123", "actor": "test_actor"})
+
+        assert mock_publish.called
+        event = mock_publish.call_args[0][0]
+        assert event.issue_number == 123
+        assert event.trigger_state == "ready"
+        assert event.actor == "test_actor"
+
+    def test_refresh_queue_priority_loop_guard(self) -> None:
+        """Re-entrant call with actor='event:refresh_queue_priority' is skipped."""
+        from unittest.mock import MagicMock, patch
+
+        handlers = build_action_handlers()
+        handler = handlers["refresh_queue_priority"]
+
+        mock_publish = MagicMock()
+        with patch("vibe3.domain.publish", mock_publish):
+            # This should be skipped due to loop guard
+            handler({"issue": "123", "actor": "event:refresh_queue_priority"})
+
+        assert not mock_publish.called
+
+    def test_enqueue_command_job_missing_command_type(self) -> None:
+        """Graceful handling of missing command_type."""
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_command_job"]
+
+        # Should not raise, just log warning
+        handler({"issue_number": "123", "actor": "test"})
+
+    def test_enqueue_command_job_missing_issue_number(self) -> None:
+        """Graceful handling of missing issue_number."""
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_command_job"]
+
+        # Should not raise, just log warning
+        handler({"command_type": "plan", "actor": "test"})
+
+    def test_enqueue_command_job_invalid_issue_number(self) -> None:
+        """Graceful handling of invalid issue_number."""
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_command_job"]
+
+        # Should not raise, just log warning
+        handler({"command_type": "plan", "issue_number": "not_a_number"})
+
+    def test_enqueue_plan_callable(self) -> None:
+        """enqueue_plan action handler is callable."""
+        from unittest.mock import patch
+
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_plan"]
+
+        # Mock the internal dispatch helper
+        with patch("vibe3.domain.event_rules._dispatch_command_job") as mock_dispatch:
+            handler({"issue_number": "123", "actor": "test"})
+            mock_dispatch.assert_called_once_with("plan", 123, "test", {})
+
+    def test_enqueue_run_callable(self) -> None:
+        """enqueue_run action handler is callable."""
+        from unittest.mock import patch
+
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_run"]
+
+        with patch("vibe3.domain.event_rules._dispatch_command_job") as mock_dispatch:
+            handler({"issue_number": "456", "actor": "test"})
+            mock_dispatch.assert_called_once_with("run", 456, "test", {})
+
+    def test_enqueue_review_callable(self) -> None:
+        """enqueue_review action handler is callable."""
+        from unittest.mock import patch
+
+        handlers = build_action_handlers()
+        handler = handlers["enqueue_review"]
+
+        with patch("vibe3.domain.event_rules._dispatch_command_job") as mock_dispatch:
+            handler({"issue_number": "789", "actor": "test"})
+            mock_dispatch.assert_called_once_with("review", 789, "test", {})
+
+    def test_reload_material_publishes_event(self) -> None:
+        """GovernanceScanStarted is published."""
+        from unittest.mock import MagicMock, patch
+
+        handlers = build_action_handlers()
+        handler = handlers["reload_material"]
+
+        mock_publish = MagicMock()
+        with patch("vibe3.domain.publish", mock_publish):
+            handler({"tick_count": "5"})
+
+        assert mock_publish.called
+        event = mock_publish.call_args[0][0]
+        assert event.tick_count == 5
+        assert event.actor == "event:reload_material"
+
+    def test_trigger_governance_scan_publishes_event(self) -> None:
+        """GovernanceScanStarted is published."""
+        from unittest.mock import MagicMock, patch
+
+        handlers = build_action_handlers()
+        handler = handlers["trigger_governance_scan"]
+
+        mock_publish = MagicMock()
+        with patch("vibe3.domain.publish", mock_publish):
+            handler({"tick_count": "10", "actor": "custom_actor"})
+
+        assert mock_publish.called
+        event = mock_publish.call_args[0][0]
+        assert event.tick_count == 10
+        assert event.actor == "custom_actor"
+
+    def test_notify_logs_message(self) -> None:
+        """Handler is callable and logs with [NOTIFY] prefix."""
+        from unittest.mock import patch
+
+        handlers = build_action_handlers()
+        handler = handlers["notify"]
+
+        # Should not raise
+        with patch("vibe3.domain.event_rules.logger") as mock_logger:
+            handler({"message": "test notification", "target": "manager"})
+            # Verify the bind was called
+            assert mock_logger.bind.called
+
+
+class TestRulesHaveMatchingHandlers:
+    """Test that rules in config have matching handlers."""
+
+    def test_rules_have_matching_handlers(self, tmp_path: Path) -> None:
+        """All rules in config have matching action handlers."""
+        from vibe3.utils import find_repo_root
+
+        rules_dir = find_repo_root() / "config" / "policies"
+        rules = load_rules(rules_dir)
+        handlers = build_action_handlers()
+
+        missing_actions: list[str] = []
+        for rule in rules:
+            if rule.action not in handlers:
+                missing_actions.append(rule.action)
+
+        assert not missing_actions, f"Missing handlers for actions: {missing_actions}"


### PR DESCRIPTION
## Summary

Extend `build_action_handlers()` from 2 action types (log, enqueue_command_job placeholder) to 9 real action handlers, and update `config/policies/event-rules.yaml` with 7 production rules.

## Changes

- **src/vibe3/domain/event_rules.py**: Added 7 new action handlers:
  - `refresh_queue_priority`: Publishes ManagerDispatchIntent with loop guard
  - `enqueue_command_job`: Real implementation using ExecutionCoordinator
  - `enqueue_plan/run/review`: Syntactic sugar for specific command types
  - `reload_material`: Publishes GovernanceScanStarted
  - `trigger_governance_scan`: Publishes GovernanceScanStarted directly
  - `notify`: Stub for future notification integration

- **config/policies/event-rules.yaml**: Added 7 production rules:
  - P0: IssueFailed → enqueue manager + refresh queue priority
  - P1: GovernanceScanStarted → log
  - P1: GovernanceScanCompleted → reload material
  - P1: SupervisorIssueIdentified → trigger governance scan + log
  - P2: IssueFailed → notify (stub)

- **tests/vibe3/domain/test_event_rules.py**: Added 13 new unit tests

## Test Plan

- All 30 tests pass (17 existing + 13 new)
- All 146 domain module tests pass
- mypy: Success
- ruff: All checks passed
- Integration test validates config↔code consistency

Closes #2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
