### PR TITLE
refactor(server): remove duplicate service instantiation and dead code

### DIFF
--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -33,7 +33,6 @@ from .registry import (
     _build_server_with_launch_cwd,
     _kill_orchestra_tmux_session,
     _orchestra_tmux_session_exists,
-    _resolve_async_cli_override_root,
     _resolve_dispatcher_models_root,
     _resolve_orchestra_log_dir,
     _setup_tailscale_webhook,
@@ -323,11 +322,7 @@ def start(
         os.environ["VIBE3_REPO_MODELS_ROOT"] = str(
             _resolve_dispatcher_models_root(config, Path.cwd())
         )
-        async_cli_root = _resolve_async_cli_override_root(config, Path.cwd())
-        if async_cli_root is None:
-            os.environ.pop("VIBE3_ASYNC_CLI_PROJECT_ROOT", None)
-        else:
-            os.environ["VIBE3_ASYNC_CLI_PROJECT_ROOT"] = str(async_cli_root)
+        os.environ.pop("VIBE3_ASYNC_CLI_PROJECT_ROOT", None)
         os.environ["VIBE3_ASYNC_LOG_DIR"] = str(_resolve_orchestra_log_dir(Path.cwd()))
         # --no-async flag: propagate to all dispatched role agents
         # Only set when user explicitly requested --no-async (not in async wrapper)

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -36,30 +36,6 @@ def _resolve_dispatcher_models_root(
     return resolve_orchestra_repo_root().resolve()
 
 
-def _resolve_async_cli_override_root(
-    config: "OrchestraConfig",
-    launch_cwd: Path | None = None,
-) -> Path | None:
-    """Resolve optional async child code-root override.
-
-    DEPRECATED: Always returns None.
-
-    Cross-project dispatch must always use the installed/source vibe3 project
-    root, never the caller repository. This ensures correct cli.py resolution
-    when running `vibe3 scan` from external projects.
-
-    Debug mode only affects logging verbosity and debug output, not code paths.
-    See VIBE3_REPO_MODELS_ROOT for project-specific models root override
-    (which IS debug-mode sensitive).
-
-    Historical context (PR #1662):
-    - Pre-fix: debug mode returned launch_cwd, breaking cross-project dispatch
-    - Post-fix: always returns None, forcing module-based resolution
-    - Rationale: cli.py must always point to vibe3 installation, not caller repo
-    """
-    return None
-
-
 def _resolve_orchestra_log_dir(launch_cwd: Path | None = None) -> Path:
     """Resolve the shared orchestra log root anchored to the launch cwd."""
     return (launch_cwd or Path.cwd()).resolve() / "temp" / "logs"
@@ -139,22 +115,10 @@ def _build_server_with_launch_cwd(
         failed_gate=failed_gate,
     )
 
-    # Create shared service instances for the assembly layer.
-    shared_check_service = CheckService(
-        store=shared_store,
-        git_client=shared_flow_manager.git,
-        github_client=shared_github,
-    )
-    shared_flow_service = FlowService(
-        store=shared_store,
-        git_client=shared_flow_manager.git,
-    )
-
     # Register OrchestrationFacade as the single domain-first
     # heartbeat entry point. It incorporates governance scan,
     # supervisor scan, and issue-label dispatch polling.
     # GlobalDispatchCoordinator is created internally by the facade.
-    from vibe3.services import CheckService, FlowService
 
     shared_check_service = CheckService(
         store=shared_store,
@@ -419,7 +383,6 @@ def _build_async_serve_command(
 
     models_root = _resolve_dispatcher_models_root(config, launch_cwd)
     log_dir = _resolve_orchestra_log_dir(launch_cwd)
-    async_cli_root = _resolve_async_cli_override_root(config, launch_cwd)
 
     # Resolve the absolute path to vibe3 project root via module location.
     # This works correctly in both:
@@ -432,11 +395,7 @@ def _build_async_serve_command(
 
     # Always explicitly set VIBE3_ASYNC_CLI_PROJECT_ROOT to prevent
     # parent environment hijacking the async child's code-root resolution
-    async_cli_root_env = (
-        f"VIBE3_ASYNC_CLI_PROJECT_ROOT={async_cli_root}"
-        if async_cli_root is not None
-        else "VIBE3_ASYNC_CLI_PROJECT_ROOT="
-    )
+    async_cli_root_env = "VIBE3_ASYNC_CLI_PROJECT_ROOT="
     cmd = [
         "env",
         "VIBE3_ORCHESTRA_EVENT_LOG=1",


### PR DESCRIPTION
## Summary

Remove two pieces of dead code from registry.py and app.py:

1. **Duplicate CheckService/FlowService instantiation** in registry.py
   - First creation at lines 142-151 immediately overwritten at lines 159-167
   - Duplicate import at line 157 (already imported at line 104)

2. **Deprecated `_resolve_async_cli_override_root()` function**
   - Always returned `None`, no longer needed
   - Removed function definition (registry.py:39-60)
   - Simplified `_build_async_serve_command` to hardcode empty env var
   - Removed import and call site in app.py

No behavioral changes - pure dead code removal.

## Changes

- `src/vibe3/server/registry.py`: Removed 46 lines of dead code
- `src/vibe3/server/app.py`: Simplified env var handling

## Test Plan

- ✅ Verified test `test_build_async_serve_command_never_sets_code_root_override` passes
- ✅ Type check passes (mypy)
- ✅ Lint check passes (ruff)
- ✅ All pre-push checks passed
- ✅ 49 related tests passed

Closes #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
