### PR TITLE
refactor(orchestra): remove duplicate FailedGate check from OrchestrationFacade

### DIFF
--- a/src/vibe3/commands/run.py
+++ b/src/vibe3/commands/run.py
@@ -81,7 +81,8 @@ def run_command(
     # Validate --show-prompt requires --dry-run
     validate_show_prompt_dependency(dry_run, show_prompt)
 
-    # Register EDA event handlers for run command (may publish events)
+    # Register EDA event handlers (defensive: ensures handlers are bound even
+    # if the CLI path ever publishes domain events in the future)
     from vibe3.domain import register_event_handlers
 
     register_event_handlers()

--- a/src/vibe3/domain/orchestration_facade.py
+++ b/src/vibe3/domain/orchestration_facade.py
@@ -22,7 +22,6 @@ from vibe3.models import IssueInfo, OrchestraConfig
 
 if TYPE_CHECKING:
     from vibe3.domain.dispatch_coordinator import GlobalDispatchCoordinator
-    from vibe3.domain.failed_gate import FailedGate
     from vibe3.domain.protocols.flow_protocols import FlowManagerProtocol
     from vibe3.environment import SessionRegistryService
     from vibe3.execution import CapacityService
@@ -47,7 +46,6 @@ class OrchestrationFacade(ServiceBase):
         tick_count: int = 0,
         config: OrchestraConfig | None = None,
         capacity: "CapacityService | None" = None,
-        failed_gate: "FailedGate | None" = None,
         store: "SQLiteClient | None" = None,
         github: "GitHubClient | None" = None,
         flow_manager: "FlowManagerProtocol | None" = None,
@@ -68,9 +66,6 @@ class OrchestrationFacade(ServiceBase):
                 When provided, GlobalDispatchCoordinator is used for unified
                 dispatch with capacity checks before emitting intents.
                 When None, legacy concurrent gather path is used (backward compat).
-            failed_gate: Optional FailedGate retained for compatibility with
-                existing server assembly. Runtime dispatch is no longer frozen
-                here; gating belongs on the authoritative sync execution path.
             store: Optional SQLiteClient for dependency injection. When omitted
                 with capacity provided, creates a new SQLiteClient instance.
             github: Optional GitHubClient for dependency injection. When omitted,
@@ -95,7 +90,6 @@ class OrchestrationFacade(ServiceBase):
         self._last_governance_started_at: float | None = None
         self._capacity = capacity
         self._coordinator: GlobalDispatchCoordinator | None = None
-        self._failed_gate = failed_gate
         self._github = github or GitHubClient()
         from vibe3.domain import FlowManager
 
@@ -154,25 +148,6 @@ class OrchestrationFacade(ServiceBase):
         from vibe3.observability import append_orchestra_event
 
         self.on_heartbeat_tick()
-
-        # Check failed gate before any dispatch (supervisor included)
-        if self._failed_gate is not None:
-            gate_result = self._failed_gate.check()
-            if gate_result.blocked:
-                reason_part = (
-                    f" reason={gate_result.reason}" if gate_result.reason else ""
-                )
-                append_orchestra_event(
-                    "dispatcher",
-                    f"dispatch blocked by failed gate:{reason_part}",
-                )
-                logger.bind(
-                    domain="orchestration_facade",
-                    reason=gate_result.reason,
-                    blocked_ticks=gate_result.blocked_ticks,
-                ).warning("Dispatch blocked by failed gate")
-                self._failed_gate.increment_blocked_ticks()
-                return
 
         # Scan for supervisor candidates and publish events
         try:

--- a/src/vibe3/runtime/heartbeat.py
+++ b/src/vibe3/runtime/heartbeat.py
@@ -46,9 +46,9 @@ class FailedGateProtocol(Protocol):
 class HeartbeatServer:
     """Manages the orchestra event loop.
 
-    Two event sources:
-    - Webhook events (real-time, primary): pushed via emit()
-    - Polling tick (fallback): calls service.on_tick() every polling_interval s
+    Primary event source: periodic polling tick, calling service.on_tick()
+    every polling_interval seconds. Real-time webhook events (planned, not
+    yet implemented) will be pushed via emit() when available.
     """
 
     def __init__(

--- a/src/vibe3/server/registry.py
+++ b/src/vibe3/server/registry.py
@@ -169,7 +169,6 @@ def _build_server_with_launch_cwd(
     facade = OrchestrationFacade(
         config=config,
         capacity=shared_capacity,
-        failed_gate=failed_gate,
         store=shared_store,
         coordinator_factory=create_global_dispatch_coordinator,  # type: ignore[arg-type]
         coordinator_class=GlobalDispatchCoordinator,

--- a/tests/vibe3/domain/test_orchestration_facade.py
+++ b/tests/vibe3/domain/test_orchestration_facade.py
@@ -1,6 +1,6 @@
 """Tests for OrchestrationFacade."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,7 +9,6 @@ from vibe3.domain.events.supervisor_apply import SupervisorIssueIdentified
 from vibe3.domain.orchestration_facade import OrchestrationFacade
 from vibe3.models.orchestra_config import GovernanceConfig, OrchestraConfig
 from vibe3.models.orchestration import IssueInfo, IssueState
-from vibe3.orchestra.failed_gate import GateResult
 
 
 @pytest.fixture
@@ -128,37 +127,6 @@ class TestOrchestrationFacade:
         call_args = mock_add_comment.call_args
         assert call_args.args[0] == 42
         assert "Manual review required" in call_args.args[1]
-
-    @pytest.mark.asyncio
-    @patch("vibe3.observability.orchestra_log.append_orchestra_event")
-    async def test_on_tick_blocks_dispatch_when_failed_gate_is_closed(
-        self,
-        mock_append_event: MagicMock,
-    ) -> None:
-        """Failed gate should freeze dispatch-intent emission, not heartbeat itself."""
-        capacity = MagicMock()
-        gate = MagicMock()
-        gate.check.return_value = GateResult(
-            blocked=True,
-            reason="manager failed",
-            blocked_ticks=0,
-        )
-
-        facade = OrchestrationFacade(
-            capacity=capacity,
-            failed_gate=gate,
-            coordinator_factory=lambda **kwargs: MagicMock(),
-        )
-        facade.on_supervisor_scan = AsyncMock()
-        facade._coordinator = MagicMock()
-        facade._coordinator.coordinate = AsyncMock()
-
-        await facade.on_tick()
-
-        gate.check.assert_called_once()
-        facade._coordinator.coordinate.assert_not_awaited()
-        assert mock_append_event.called
-        assert "dispatch blocked by failed gate" in mock_append_event.call_args.args[1]
 
     @pytest.mark.asyncio
     @patch(


### PR DESCRIPTION
Closes #2603

## Summary

Remove redundant FailedGate check from `OrchestrationFacade.on_tick()` since `HeartbeatServer` already checks the gate before dispatching to the facade. Also update stale docstrings.

## Changes

- **orchestration_facade.py**: Remove `failed_gate` parameter, attribute, and duplicate gate check block (lines 153-170)
- **registry.py**: Remove `failed_gate=failed_gate` argument from facade construction
- **heartbeat.py**: Update `HeartbeatServer` class docstring to reflect actual implementation (polling is primary, webhook events are planned but not yet implemented)
- **run.py**: Add clarifying comment on defensive `register_event_handlers()` call
- **test_orchestration_facade.py**: Remove test for unreachable gate check logic

## Verification

- ✅ All 42 tests pass in recommended scope (domain, runtime, orchestra modules)
- ✅ Type checking clean (mypy: "Success: no issues found in 4 source files")
- ✅ Lint checking clean (ruff: "All checks passed!")
- ✅ No scope violations - only files explicitly planned were modified
- ✅ No deviations from implementation plan

## Behavior Notes

The gate check at `HeartbeatServer` (heartbeat.py:183-202) is the authoritative interception point. It `continue`s before calling `service.on_tick()`, making the facade's own check unreachable. This refactoring has no behavioral change since:
- When HeartbeatServer blocks on the gate, it skips calling `service.on_tick()`
- The facade's own gate check only ran when gate was OPEN
- Therefore, removing the facade check has no runtime effect

## Test Coverage

Gate functionality is still properly tested at:
- **HeartbeatServer level**: `test_heartbeat.py` validates gate blocking at the correct layer
- **FailedGate level**: `test_failed_gate.py` validates gate implementation
- Removed test covered unreachable code in OrchestrationFacade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
