### PR TITLE
fix(check): recover state labels from local flow refs

### DIFF
--- a/src/vibe3/clients/label_utils.py
+++ b/src/vibe3/clients/label_utils.py
@@ -69,16 +69,29 @@ def has_manager_assignee(
     return any(assignee in manager_usernames for assignee in assignees)
 
 
-# Label constants (duplicated from services/shared/labels.py
-# to avoid cross-category imports)
-EXECUTION_STATES = frozenset({"in-progress", "review", "handoff", "blocked"})
+# Label constants duplicated from services/shared/labels.py to avoid
+# cross-category imports. Keep these semantics in sync.
+ROADMAP_LIFECYCLE_LABELS = frozenset({"roadmap/rfc", "roadmap/epic"})
+EXECUTION_STATES = frozenset(
+    {"merge-ready", "review", "in-progress", "handoff", "claimed"}
+)
+STATE_PRIORITY_ORDER = (
+    "blocked",
+    "done",
+    "merge-ready",
+    "review",
+    "in-progress",
+    "handoff",
+    "claimed",
+    "ready",
+)
 
 ORCHESTRA_GOVERNED_LABEL = "orchestra-governed"
 
 
 def has_roadmap_label(labels: list[str]) -> bool:
-    """Check if issue has a roadmap label."""
-    return any(lb.startswith("roadmap/") for lb in labels)
+    """Check if issue has an RFC or epic roadmap lifecycle label."""
+    return bool(ROADMAP_LIFECYCLE_LABELS & set(labels))
 
 
 def has_execution_state(labels: list[str]) -> bool:
@@ -94,6 +107,16 @@ def get_state_labels(labels: list[str]) -> list[str]:
     return [lb for lb in labels if lb.startswith("state/")]
 
 
+def get_highest_priority_state(labels: list[str]) -> str | None:
+    """Return highest-priority state/* label from labels, or None."""
+    state_set = set(get_state_labels(labels))
+    for priority_state in STATE_PRIORITY_ORDER:
+        candidate = f"state/{priority_state}"
+        if candidate in state_set:
+            return candidate
+    return None
+
+
 def has_orchestra_governed(labels: list[str]) -> bool:
     """Check if issue has orchestra-governed label."""
     return ORCHESTRA_GOVERNED_LABEL in labels
@@ -102,10 +125,10 @@ def has_orchestra_governed(labels: list[str]) -> bool:
 def get_conflicting_states(labels: list[str]) -> list[str]:
     """Get conflicting state labels (multiple state labels on same issue)."""
     state_labels = get_state_labels(labels)
-    if len(state_labels) > 1:
-        # Return all but the first one (keep the first, remove the rest)
-        return state_labels[1:]
-    return []
+    if len(state_labels) <= 1:
+        return []
+    highest = get_highest_priority_state(labels)
+    return [lb for lb in state_labels if lb != highest]
 
 
 @dataclass(frozen=True)
@@ -113,7 +136,8 @@ class LabelAnomaly:
     """Audit finding for a single issue's label state."""
 
     issue_number: int
-    rule: str  # roadmap_conflict | multi_state | orphan_execution | orphan_orchestra
+    # roadmap_conflict | multi_state | orphan_execution | governed_missing_state
+    rule: str
     removed: list[str]
     added: list[str]
 
@@ -164,13 +188,13 @@ def collect_label_anomalies(
                 added.append("state/ready")
                 rules.append("orphan_execution")
 
-    # Rule 4: orphan orchestra-governed (manager issues only)
+    # Rule 4: governed issue missing its terminal state (manager issues only)
     if is_manager_issue and has_orchestra_governed(labels):
         has_state = bool(get_state_labels(labels))
         has_roadmap = has_roadmap_label(labels)
         if not has_state and not has_roadmap:
-            removed.append(ORCHESTRA_GOVERNED_LABEL)
-            rules.append("orphan_orchestra")
+            added.append("state/ready")
+            rules.append("governed_missing_state")
 
     if not rules:
         return []

--- a/src/vibe3/services/check/service.py
+++ b/src/vibe3/services/check/service.py
@@ -18,6 +18,7 @@ from vibe3.services.check.remote import (
     is_empty_auto_scene,
     issue_state_from_payload,
 )
+from vibe3.services.check.state_label_recovery import should_recover_missing_state_label
 from vibe3.services.flow.status import FlowStatusService
 from vibe3.services.pr.service import PRService
 
@@ -306,8 +307,11 @@ class CheckService(CheckRemote):
             task_issue_closed = False
             orchestration_state: IssueState | None = None
             issue_payload: dict | None = None
+            issue_labels: list[str] = []
+            issue_labels_loaded = False
             if task_issue:
                 from vibe3.clients import GITHUB_DEFAULT_VIEW_FIELDS
+                from vibe3.services.shared.labels import normalize_labels
 
                 # Need state, labels, and body for state validation
                 issue = self.github_client.view_issue(
@@ -321,6 +325,10 @@ class CheckService(CheckRemote):
                     issues.append(f"Task issue #{task_issue} not found on GitHub")
                 elif isinstance(issue, dict):
                     issue_payload = issue
+                    raw_labels = issue_payload.get("labels")
+                    if isinstance(raw_labels, list):
+                        issue_labels = normalize_labels(raw_labels)
+                        issue_labels_loaded = True
                     orchestration_state = issue_state_from_payload(issue)
                     if str(issue.get("state", "")).upper() == "CLOSED":
                         task_issue_closed = True
@@ -333,6 +341,7 @@ class CheckService(CheckRemote):
                     issues.extend(label_issues)
                     if fixed_state is not None:
                         orchestration_state = fixed_state
+                        issue_labels = [fixed_state.to_label()]
 
             # only one task issue per branch
             if len(task_issues) > 1:
@@ -543,6 +552,35 @@ class CheckService(CheckRemote):
                             f"Auto-recovery failed: {e}. "
                             f"Manual fix: vibe3 flow rebuild {task_issue} --yes"
                         )
+
+            if task_issue and should_recover_missing_state_label(
+                labels=issue_labels,
+                flow_status=str(flow_status),
+                issue_loaded=issue_payload is not None and issue_labels_loaded,
+                task_issue_closed=task_issue_closed,
+            ):
+                try:
+                    result = recovery_svc.recover(
+                        branch=branch,
+                        issue_number=task_issue,
+                        reason="Remote state label missing",
+                        auto=False,
+                        ensure_worktree=True,
+                    )
+                    logger.info(
+                        "Recovered missing remote state label",
+                        branch=branch,
+                        action=result.action.value,
+                        detail=result.detail,
+                    )
+                    return CheckResult(is_valid=True, branch=branch, issues=[])
+                except Exception as e:
+                    logger.error(
+                        "Failed to recover missing remote state label",
+                        branch=branch,
+                        error=str(e),
+                    )
+                    issues.append(f"Missing state label auto-recovery failed: {e}")
 
             # Read-only dependency check
             if task_issue and flow_status not in self.INACTIVE_FLOW_STATUSES:

--- a/src/vibe3/services/check/state_label_recovery.py
+++ b/src/vibe3/services/check/state_label_recovery.py
@@ -1,0 +1,22 @@
+"""State label recovery predicates for local check."""
+
+from __future__ import annotations
+
+from vibe3.services.shared.labels import get_state_labels, has_roadmap_label
+
+
+def should_recover_missing_state_label(
+    *,
+    labels: list[str],
+    flow_status: str,
+    issue_loaded: bool,
+    task_issue_closed: bool,
+) -> bool:
+    """Whether check may restore a missing state label from local flow refs."""
+    return (
+        issue_loaded
+        and not task_issue_closed
+        and flow_status != "blocked"
+        and not get_state_labels(labels)
+        and not has_roadmap_label(labels)
+    )

--- a/tests/vibe3/orchestra/test_remote_check_integration.py
+++ b/tests/vibe3/orchestra/test_remote_check_integration.py
@@ -281,14 +281,18 @@ class TestRemoteLabelCheck:
 
         label_port = MagicMock()
 
-        monkeypatch.setattr("vibe3.config.load_orchestra_config", lambda: config)
         monkeypatch.setattr(
-            "vibe3.config.get_manager_usernames",
+            "vibe3.orchestra.remote_check.load_orchestra_config", lambda: config
+        )
+        monkeypatch.setattr(
+            "vibe3.orchestra.remote_check.get_manager_usernames",
             lambda loaded_config: loaded_config.manager_usernames,
         )
-        monkeypatch.setattr("vibe3.clients.GitHubClient", lambda: github)
-        monkeypatch.setattr("vibe3.clients.SQLiteClient", lambda: store)
-        monkeypatch.setattr("vibe3.clients.GhIssueLabelPort", lambda repo: label_port)
+        monkeypatch.setattr("vibe3.orchestra.remote_check.GitHubClient", lambda: github)
+        monkeypatch.setattr("vibe3.orchestra.remote_check.SQLiteClient", lambda: store)
+        monkeypatch.setattr(
+            "vibe3.orchestra.remote_check.GhIssueLabelPort", lambda repo: label_port
+        )
 
         result = run_remote_label_check(dry_run=False)
 

--- a/tests/vibe3/services/test_check_missing_state_recovery.py
+++ b/tests/vibe3/services/test_check_missing_state_recovery.py
@@ -1,0 +1,231 @@
+"""Tests for check-time recovery of missing remote state labels."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from vibe3.clients import SQLiteClient
+from vibe3.models.orchestration import IssueState
+from vibe3.services.check.service import CheckService
+
+
+def test_verify_branch_recovers_missing_state_label_from_flow_refs(
+    tmp_path: Path,
+) -> None:
+    """Missing remote state label is restored through resume auto inference."""
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-501"
+    worktree_path = tmp_path / "worktree-501"
+    worktree_path.mkdir()
+    (worktree_path / "plan.md").write_text("plan", encoding="utf-8")
+
+    store.update_flow_state(
+        branch,
+        flow_status="active",
+        plan_ref="plan.md",
+        worktree_path=str(worktree_path),
+    )
+    store.add_issue_link(branch, 501, "task")
+
+    mock_git = MagicMock()
+    mock_git.get_git_common_dir.return_value = tmp_path
+    mock_git._run.return_value = branch
+    mock_git.find_worktree_path_for_branch.return_value = worktree_path
+
+    mock_github = MagicMock()
+    mock_github.view_issue.return_value = {
+        "number": 501,
+        "state": "open",
+        "labels": [{"name": "roadmap/p1"}],
+    }
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+    mock_github.get_issue_body.return_value = ""
+    mock_github.update_issue_body.return_value = True
+
+    with patch(
+        "vibe3.services.flow.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        mock_label_service = MagicMock()
+        mock_label_service.confirm_issue_state.return_value = "advanced"
+        mock_label_service_cls.return_value = mock_label_service
+
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is True
+        mock_label_service.confirm_issue_state.assert_called_once_with(
+            501,
+            IssueState.IN_PROGRESS,
+            actor="human:resume",
+            force=True,
+        )
+
+
+def test_verify_branch_does_not_recover_missing_state_for_blocked_flow(
+    tmp_path: Path,
+) -> None:
+    """Blocked flows require explicit resume; check must not auto-unblock them."""
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-502"
+    worktree_path = tmp_path / "worktree-502"
+    worktree_path.mkdir()
+
+    store.update_flow_state(
+        branch,
+        flow_status="blocked",
+        worktree_path=str(worktree_path),
+    )
+    store.add_issue_link(branch, 502, "task")
+
+    mock_git = MagicMock()
+    mock_git.get_git_common_dir.return_value = tmp_path
+    mock_git._run.return_value = branch
+    mock_git.find_worktree_path_for_branch.return_value = worktree_path
+
+    mock_github = MagicMock()
+    mock_github.view_issue.return_value = {
+        "number": 502,
+        "state": "open",
+        "labels": [],
+    }
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+
+    with patch(
+        "vibe3.services.flow.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is True
+        mock_label_service_cls.assert_not_called()
+
+
+def test_verify_branch_does_not_recover_missing_state_for_rfc_or_epic(
+    tmp_path: Path,
+) -> None:
+    """RFC and epic issues may intentionally have no execution state label."""
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-503"
+    worktree_path = tmp_path / "worktree-503"
+    worktree_path.mkdir()
+    (worktree_path / "plan.md").write_text("plan", encoding="utf-8")
+
+    store.update_flow_state(
+        branch,
+        flow_status="active",
+        plan_ref="plan.md",
+        worktree_path=str(worktree_path),
+    )
+    store.add_issue_link(branch, 503, "task")
+
+    mock_git = MagicMock()
+    mock_git.get_git_common_dir.return_value = tmp_path
+    mock_git._run.return_value = branch
+    mock_git.find_worktree_path_for_branch.return_value = worktree_path
+
+    mock_github = MagicMock()
+    mock_github.view_issue.return_value = {
+        "number": 503,
+        "state": "open",
+        "labels": [{"name": "roadmap/rfc"}, {"name": "roadmap/p1"}],
+    }
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+
+    with patch(
+        "vibe3.services.flow.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is True
+        mock_label_service_cls.assert_not_called()
+
+
+def test_verify_branch_does_not_recover_missing_state_when_issue_not_loaded(
+    tmp_path: Path,
+) -> None:
+    """Network failures must not be treated as missing state labels."""
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-504"
+    worktree_path = tmp_path / "worktree-504"
+    worktree_path.mkdir()
+
+    store.update_flow_state(
+        branch,
+        flow_status="active",
+        worktree_path=str(worktree_path),
+    )
+    store.add_issue_link(branch, 504, "task")
+
+    mock_git = MagicMock()
+    mock_git.get_git_common_dir.return_value = tmp_path
+    mock_git._run.return_value = branch
+    mock_git.find_worktree_path_for_branch.return_value = worktree_path
+
+    mock_github = MagicMock()
+    mock_github.view_issue.return_value = "network_error"
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+
+    with patch(
+        "vibe3.services.flow.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is False
+        assert any("network/auth error" in issue for issue in result.issues)
+        mock_label_service_cls.assert_not_called()
+
+
+def test_verify_branch_does_not_recover_missing_state_when_labels_not_loaded(
+    tmp_path: Path,
+) -> None:
+    """Missing or malformed label payloads must not be treated as missing state."""
+    store = SQLiteClient(db_path=tmp_path / "test.db")
+    branch = "task/issue-505"
+    worktree_path = tmp_path / "worktree-505"
+    worktree_path.mkdir()
+
+    store.update_flow_state(
+        branch,
+        flow_status="active",
+        worktree_path=str(worktree_path),
+    )
+    store.add_issue_link(branch, 505, "task")
+
+    mock_git = MagicMock()
+    mock_git.get_git_common_dir.return_value = tmp_path
+    mock_git._run.return_value = branch
+    mock_git.find_worktree_path_for_branch.return_value = worktree_path
+
+    mock_github = MagicMock()
+    mock_github.view_issue.return_value = {"number": 505, "state": "open"}
+    mock_github.list_all_prs.return_value = []
+    mock_github.list_prs_for_branch.return_value = []
+
+    with patch(
+        "vibe3.services.flow.blocked_state_io.LabelService"
+    ) as mock_label_service_cls:
+        service = CheckService(
+            store=store, git_client=mock_git, github_client=mock_github
+        )
+        service._initialize_pr_cache()
+        result = service.verify_branch(branch)
+
+        assert result.is_valid is True
+        mock_label_service_cls.assert_not_called()

--- a/tests/vibe3/utils/test_label_anomaly_regression.py
+++ b/tests/vibe3/utils/test_label_anomaly_regression.py
@@ -1,0 +1,41 @@
+"""Regression tests for shared label anomaly rules."""
+
+from vibe3.services.shared.label_anomalies import collect_label_anomalies
+from vibe3.services.shared.labels import has_roadmap_label
+
+
+def test_priority_roadmap_is_not_lifecycle_roadmap() -> None:
+    assert has_roadmap_label(["roadmap/p1", "state/ready"]) is False
+
+
+def test_priority_roadmap_does_not_remove_state() -> None:
+    result = collect_label_anomalies(
+        ["roadmap/p1", "state/ready"],
+        issue_number=1,
+        has_local_flow=True,
+        is_manager_issue=True,
+    )
+    assert result == []
+
+
+def test_orphan_merge_ready_is_reset_to_ready() -> None:
+    result = collect_label_anomalies(
+        ["state/merge-ready"],
+        issue_number=1,
+        has_local_flow=False,
+        is_manager_issue=True,
+    )
+    assert len(result) == 1
+    assert "orphan_execution" in result[0].rule
+    assert result[0].removed == ["state/merge-ready"]
+    assert result[0].added == ["state/ready"]
+
+
+def test_orphan_blocked_is_not_reset_to_ready() -> None:
+    result = collect_label_anomalies(
+        ["state/blocked"],
+        issue_number=1,
+        has_local_flow=False,
+        is_manager_issue=True,
+    )
+    assert result == []

--- a/tests/vibe3/utils/test_shared_labels.py
+++ b/tests/vibe3/utils/test_shared_labels.py
@@ -311,7 +311,7 @@ class TestCollectLabelAnomalies:
 
     def test_multi_state_no_roadmap(self) -> None:
         result = collect_label_anomalies(
-            ["state/blocked", "state/review"],
+            ["state/review", "state/blocked"],
             issue_number=1,
             has_local_flow=True,
             is_manager_issue=False,
@@ -341,7 +341,7 @@ class TestCollectLabelAnomalies:
         )
         assert result == []
 
-    def test_orphan_orchestra_governed(self) -> None:
+    def test_governed_without_terminal_label_backfills_ready(self) -> None:
         result = collect_label_anomalies(
             ["orchestra-governed"],
             issue_number=1,
@@ -349,9 +349,11 @@ class TestCollectLabelAnomalies:
             is_manager_issue=True,
         )
         assert len(result) == 1
-        assert "orphan_orchestra" in result[0].rule
+        assert "governed_missing_state" in result[0].rule
+        assert result[0].removed == []
+        assert result[0].added == ["state/ready"]
 
-    def test_orphan_orchestra_skipped_when_has_state(self) -> None:
+    def test_governed_missing_state_skipped_when_has_state(self) -> None:
         result = collect_label_anomalies(
             ["orchestra-governed", "state/ready"],
             issue_number=1,
@@ -359,6 +361,16 @@ class TestCollectLabelAnomalies:
             is_manager_issue=True,
         )
         assert result == []
+
+    def test_governed_missing_state_skipped_when_rfc_or_epic(self) -> None:
+        for roadmap_label in ("roadmap/rfc", "roadmap/epic"):
+            result = collect_label_anomalies(
+                ["orchestra-governed", roadmap_label],
+                issue_number=1,
+                has_local_flow=True,
+                is_manager_issue=True,
+            )
+            assert result == []
 
     def test_roadmap_skips_multi_state_rule(self) -> None:
         result = collect_label_anomalies(


### PR DESCRIPTION
## Summary
- Limit roadmap lifecycle label handling to `roadmap/rfc` and `roadmap/epic`; priority labels such as `roadmap/p1` no longer clear `state/*`.
- Keep remote label anomaly handling aligned with shared label priority rules, including `state/claimed` and `state/merge-ready`.
- Add local check recovery for missing remote state labels by reusing existing resume label inference (`FlowRecoveryService.recover(... auto=False ...)`) when a local flow ref exists, the flow is not blocked, and the issue is not RFC/Epic.
- Require a real loaded GitHub `labels` list before treating an issue as missing a state label.

## Remediation Run
- Ran targeted `vibe3 check --branch` recovery for local active flows and restored labels for #2580, #2604, #2616, #2617, and #2645.
- Verified `vibe3 check remote --dry-run` reports 0 anomalies after recovery.

## Tests
- `uv run pytest tests/vibe3/utils/test_shared_labels.py tests/vibe3/utils/test_label_anomaly_regression.py tests/vibe3/services/test_check_service_verify_branch.py tests/vibe3/services/test_check_missing_state_recovery.py tests/vibe3/orchestra/test_remote_check_integration.py`
- `uv run pytest tests/vibe3/services/test_check_verify.py::TestVerifyCurrentFlow::test_verify_flow_valid tests/vibe3/services/test_check_missing_state_recovery.py tests/vibe3/utils/test_shared_labels.py tests/vibe3/utils/test_label_anomaly_regression.py tests/vibe3/orchestra/test_remote_check_integration.py`
- `uv run mypy src`
- `git diff --check`
- `ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-per-file-loc.sh`
- `ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-test-file-loc.sh`
- pre-push incremental suite: 151 passed

## Contributors
- Chen Yi
- Codex (GPT-5)
