### PR TITLE
refactor(agents): eliminate subprocess roundabout in run_inspect_json

### DIFF
--- a/src/vibe3/agents/review_pipeline_helpers.py
+++ b/src/vibe3/agents/review_pipeline_helpers.py
@@ -1,35 +1,36 @@
 """Service-layer helpers for review pipeline dependencies."""
 
-import json
-import subprocess
-from typing import Any
-
-import typer
 from loguru import logger
 
 from vibe3.analysis import (
     SnapshotError,
+    build_change_analysis,
     build_snapshot,
     compute_diff,
     find_snapshot_by_branch,
 )
+from vibe3.exceptions import SystemError
 from vibe3.models import StructureDiff
 
 
 def run_inspect_json(args: list[str]) -> dict[str, object]:
     """Call inspect subcommand and return parsed JSON result."""
-    result = subprocess.run(
-        ["uv", "run", "python", "-m", "vibe3", "inspect", *args, "--json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        logger.error(f"inspect failed: {result.stderr}")
-        raise typer.Exit(1)
-    payload: Any = json.loads(result.stdout)
-    if not isinstance(payload, dict):
-        raise typer.Exit(1)
-    return {str(key): value for key, value in payload.items()}
+    if not args:
+        raise SystemError("Missing inspect subcommand")
+
+    subcommand = args[0]
+    if subcommand not in ("pr", "base"):
+        raise SystemError(f"Unknown inspect subcommand: {subcommand}")
+
+    if len(args) < 2:
+        raise SystemError(f"Missing identifier for inspect {subcommand}")
+
+    identifier = args[1]
+
+    if subcommand == "pr":
+        return build_change_analysis("pr", identifier)
+    else:  # subcommand == "base"
+        return build_change_analysis("branch", identifier)
 
 
 def build_snapshot_diff(

--- a/tests/vibe3/agents/test_review_pipeline_helpers.py
+++ b/tests/vibe3/agents/test_review_pipeline_helpers.py
@@ -1,0 +1,72 @@
+"""Tests for review_pipeline_helpers module."""
+
+import unittest
+from unittest.mock import patch
+
+from vibe3.agents.review_pipeline_helpers import run_inspect_json
+from vibe3.exceptions import SystemError
+
+
+class TestRunInspectJson(unittest.TestCase):
+    """Test cases for run_inspect_json function."""
+
+    @patch("vibe3.agents.review_pipeline_helpers.build_change_analysis")
+    def test_pr_dispatch(self, mock_build_change_analysis: unittest.mock.Mock) -> None:
+        """Test PR dispatch calls build_change_analysis with correct arguments."""
+        mock_build_change_analysis.return_value = {
+            "impact": {},
+            "changed_symbols": {},
+            "dag": {},
+            "score": {},
+        }
+
+        result = run_inspect_json(["pr", "123"])
+
+        mock_build_change_analysis.assert_called_once_with("pr", "123")
+        assert isinstance(result, dict)
+        assert "score" in result
+        assert "changed_symbols" in result
+
+    @patch("vibe3.agents.review_pipeline_helpers.build_change_analysis")
+    def test_base_dispatch(
+        self, mock_build_change_analysis: unittest.mock.Mock
+    ) -> None:
+        """Test base dispatch calls build_change_analysis with 'branch' source_type."""
+        mock_build_change_analysis.return_value = {
+            "impact": {},
+            "changed_symbols": {},
+            "dag": {},
+            "score": {},
+        }
+
+        result = run_inspect_json(["base", "main"])
+
+        mock_build_change_analysis.assert_called_once_with("branch", "main")
+        assert isinstance(result, dict)
+        assert "score" in result
+        assert "changed_symbols" in result
+
+    def test_unknown_subcommand(self) -> None:
+        """Test unknown subcommand raises SystemError."""
+        with self.assertRaises(SystemError) as context:
+            run_inspect_json(["unknown"])
+
+        self.assertIn("Unknown inspect subcommand: unknown", str(context.exception))
+
+    def test_missing_identifier(self) -> None:
+        """Test missing identifier raises SystemError."""
+        with self.assertRaises(SystemError) as context:
+            run_inspect_json(["pr"])
+
+        self.assertIn("Missing identifier for inspect pr", str(context.exception))
+
+    def test_empty_args(self) -> None:
+        """Test empty args raises SystemError."""
+        with self.assertRaises(SystemError) as context:
+            run_inspect_json([])
+
+        self.assertIn("Missing inspect subcommand", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR refactors `run_inspect_json` in `review_pipeline_helpers.py` to eliminate subprocess-based roundabout logic and layer violation. The function now directly calls the `build_change_analysis` service function, removing unnecessary subprocess overhead and fixing the broken `["pr", ...]` call path.

## Changes

- **src/vibe3/agents/review_pipeline_helpers.py**: Refactored `run_inspect_json` function
  - Removed subprocess-based implementation that called `vibe3 inspect` as external command
  - Implemented direct dispatcher that calls `build_change_analysis(source_type, identifier)`
  - Added proper error handling for invalid subcommands and missing identifiers
  - Removed imports: `json`, `subprocess`, `typer`
  - Added imports: `build_change_analysis`, `SystemError`

- **tests/vibe3/agents/test_review_pipeline_helpers.py**: Created comprehensive test suite
  - 5 test cases covering dispatch logic and error handling
  - All tests pass ✅

## Motivation

### Issues Fixed
- **Roundabout logic**: The old implementation used subprocess to call `vibe3 inspect` as an external command, which created unnecessary overhead
- **Layer violation**: Used `typer.Exit(1)` in service layer, which violates architectural boundaries
- **Broken `["pr", ...]` call path**: The subprocess path was broken for PR analysis

### Solution
The `build_change_analysis` service function already handles both PR (`"pr"`) and branch (`"branch"`) analysis, returning a dict with `"score"`, `"changed_symbols"`, `"impact"`, `"dag"` keys. By calling this function directly, we:
- Eliminate subprocess overhead
- Replace `typer.Exit` with proper domain exceptions (`SystemError`)
- Fix the broken PR analysis path

## Testing

### New Tests
- `tests/vibe3/agents/test_review_pipeline_helpers.py`: 5/5 tests pass ✅
  - Test PR dispatch: verifies `["pr", "123"]` calls `build_change_analysis("pr", "123")`
  - Test base dispatch: verifies `["base", "main"]` calls `build_change_analysis("branch", "main")`
  - Test unknown subcommand: verifies `SystemError` raised for invalid subcommands
  - Test missing identifier: verifies `SystemError` raised when identifier missing
  - Test empty args: verifies `SystemError` raised when no arguments provided

### Affected Tests
- `tests/vibe3/commands/test_review.py`: 16/16 tests pass ✅
- `tests/vibe3/commands/test_pr_show_local_review.py`: 4/4 tests pass ✅
- `tests/vibe3/commands/test_show_prompt_validation.py`: 10/12 tests pass (2 pre-existing failures unrelated to changes)
- `tests/vibe3/commands/test_command_params_unified.py`: 19/19 tests pass ✅

### Type Checking and Linting
- `mypy src/vibe3`: Zero errors (434 source files) ✅
- `ruff check src/vibe3`: Zero errors ✅

## Verification

- ✅ All new tests pass (5/5)
- ✅ Affected command tests pass (49/51, 2 pre-existing failures)
- ✅ Type checking: zero errors
- ✅ Lint checking: zero errors
- ✅ LOC checks: all files under CI block threshold (400 lines)
- ✅ Pre-push checks: all passed

## Related Issue

Closes #2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
