### PR TITLE
perf(analysis): optimize snapshot lookup by branch with glob pre-filtering

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -348,6 +348,9 @@ code_limits:
       - path: "tests/vibe3/clients/test_sqlite_flow_state_repo.py"
         limit: 450
         reason: "SQLite flow state repo 测试集，覆盖 flow CRUD、soft-delete、cascade delete、status validation、bulk retrieval optimization、restore flow deadlock fix 等紧密耦合场景，与 sqlite_flow_state_repo.py 源文件（limit 540）对应；Issue #2537 新增 test_restore_flow_resets_aborted_status 测试验证 aborted flow deadlock fix（+41 行）"
+      - path: "tests/vibe3/analysis/test_snapshot_service.py"
+        limit: 480
+        reason: "Snapshot service 测试集，覆盖 find_snapshot_by_branch（7 个测试含 branch 查找、origin/ 前缀归一化、glob 预过滤验证）、build_snapshot（1 个测试）、baseline 操作（5 个测试含 save/load/not found/no baseline dir/list excludes/save for diff）等 13 个紧密耦合场景，共享 snapshot_dir fixture 和 mock setup，拆分收益低；Issue #2616 新增 test_find_snapshot_by_branch_glob_filters_candidates 验证 glob 预过滤行为（+65 行）"
       - path: "src/vibe3/commands/status_render.py"
         limit: 450
         reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -349,8 +349,8 @@ code_limits:
         limit: 450
         reason: "SQLite flow state repo 测试集，覆盖 flow CRUD、soft-delete、cascade delete、status validation、bulk retrieval optimization、restore flow deadlock fix 等紧密耦合场景，与 sqlite_flow_state_repo.py 源文件（limit 540）对应；Issue #2537 新增 test_restore_flow_resets_aborted_status 测试验证 aborted flow deadlock fix（+41 行）"
       - path: "tests/vibe3/analysis/test_snapshot_service.py"
-        limit: 480
-        reason: "Snapshot service 测试集，覆盖 find_snapshot_by_branch（7 个测试含 branch 查找、origin/ 前缀归一化、glob 预过滤验证）、build_snapshot（1 个测试）、baseline 操作（5 个测试含 save/load/not found/no baseline dir/list excludes/save for diff）等 13 个紧密耦合场景，共享 snapshot_dir fixture 和 mock setup，拆分收益低；Issue #2616 新增 test_find_snapshot_by_branch_glob_filters_candidates 验证 glob 预过滤行为（+65 行）"
+        limit: 500
+        reason: "Snapshot service 测试集，覆盖 find_snapshot_by_branch（8 个测试含 branch 查找、origin/ 前缀归一化、glob 预过滤验证、非常规文件名回退扫描）、build_snapshot（1 个测试）、baseline 操作（5 个测试含 save/load/not found/no baseline dir/list excludes/save for diff）等 14 个紧密耦合场景，共享 snapshot_dir fixture 和 mock setup，拆分收益低；Issue #2616 新增 test_find_snapshot_by_branch_glob_filters_candidates 和 test_find_snapshot_by_branch_fallback_for_nonconforming_filename 验证 glob 预过滤与回退扫描行为（+94 行）"
       - path: "src/vibe3/commands/status_render.py"
         limit: 450
         reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"

--- a/src/vibe3/analysis/snapshot_service.py
+++ b/src/vibe3/analysis/snapshot_service.py
@@ -299,31 +299,18 @@ def find_snapshot_by_branch(
     pattern = str(snapshot_dir / f"*_{sanitized_branch}_*.json")
     candidate_paths = set(glob_mod.glob(pattern))
 
-    # Also check the unsanitized form if different
-    # (e.g., "origin/main" -> "*_origin-main_*.json")
-    unsanitized = branch.replace("/", "-")
-    if sanitized_branch != unsanitized:
-        alt_pattern = str(snapshot_dir / f"*_{unsanitized}_*.json")
-        candidate_paths.update(glob_mod.glob(alt_pattern))
-
     # Stage 2: Load and verify branch field for narrowed candidates
-    snapshots = []
-    for fp_str in candidate_paths:
-        fp = Path(fp_str)
-        try:
-            data = json.loads(fp.read_text(encoding="utf-8"))
-            snapshot_branch = data.get("branch", "")
-            if snapshot_branch == normalized_branch or snapshot_branch == branch:
-                snapshots.append(
-                    {
-                        "id": data.get("snapshot_id", fp.stem),
-                        "created_at": data.get("created_at", ""),
-                        "branch": snapshot_branch,
-                        "commit": data.get("commit", ""),
-                    }
-                )
-        except (json.JSONDecodeError, KeyError):
-            continue
+    snapshots = _load_snapshots_for_branch(candidate_paths, normalized_branch, branch)
+
+    # Fallback: the glob pre-filter assumes snapshot filenames embed the
+    # branch name (see StructureSnapshot.generate_id). If no candidate
+    # matched, scan remaining files to catch snapshots saved under other
+    # naming conventions rather than silently returning None.
+    if not snapshots:
+        all_paths = {str(p) for p in snapshot_dir.glob("*.json")}
+        snapshots = _load_snapshots_for_branch(
+            all_paths - candidate_paths, normalized_branch, branch
+        )
 
     if not snapshots:
         return None
@@ -350,6 +337,30 @@ def find_snapshot_by_branch(
     # Sort by created_at descending and return the most recent
     snapshots.sort(key=lambda x: x["created_at"], reverse=True)
     return load_snapshot(snapshots[0]["id"])
+
+
+def _load_snapshots_for_branch(
+    paths: set[str], normalized_branch: str, branch: str
+) -> list[dict[str, str]]:
+    """Load snapshot metadata for files whose `branch` field matches."""
+    snapshots: list[dict[str, str]] = []
+    for fp_str in paths:
+        fp = Path(fp_str)
+        try:
+            data = json.loads(fp.read_text(encoding="utf-8"))
+            snapshot_branch = data.get("branch", "")
+            if snapshot_branch == normalized_branch or snapshot_branch == branch:
+                snapshots.append(
+                    {
+                        "id": data.get("snapshot_id", fp.stem),
+                        "created_at": data.get("created_at", ""),
+                        "branch": snapshot_branch,
+                        "commit": data.get("commit", ""),
+                    }
+                )
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return snapshots
 
 
 def save_branch_baseline(branch: str) -> Path | None:

--- a/src/vibe3/analysis/snapshot_service.py
+++ b/src/vibe3/analysis/snapshot_service.py
@@ -1,5 +1,6 @@
 """Snapshot service - Build, load, and manage structure snapshots."""
 
+import glob as glob_mod
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -292,9 +293,23 @@ def find_snapshot_by_branch(
 
     # Normalize branch name for comparison
     normalized_branch = branch.replace("origin/", "")
+    sanitized_branch = normalized_branch.replace("/", "-")
 
+    # Stage 1: Glob pre-filter using branch name in filename
+    pattern = str(snapshot_dir / f"*_{sanitized_branch}_*.json")
+    candidate_paths = set(glob_mod.glob(pattern))
+
+    # Also check the unsanitized form if different
+    # (e.g., "origin/main" -> "*_origin-main_*.json")
+    unsanitized = branch.replace("/", "-")
+    if sanitized_branch != unsanitized:
+        alt_pattern = str(snapshot_dir / f"*_{unsanitized}_*.json")
+        candidate_paths.update(glob_mod.glob(alt_pattern))
+
+    # Stage 2: Load and verify branch field for narrowed candidates
     snapshots = []
-    for fp in snapshot_dir.glob("*.json"):
+    for fp_str in candidate_paths:
+        fp = Path(fp_str)
         try:
             data = json.loads(fp.read_text(encoding="utf-8"))
             snapshot_branch = data.get("branch", "")

--- a/tests/vibe3/analysis/test_snapshot_service.py
+++ b/tests/vibe3/analysis/test_snapshot_service.py
@@ -215,6 +215,35 @@ def test_find_snapshot_by_branch_glob_filters_candidates(
     assert result.snapshot_id == "2026-03-22T12-00-00_main_def5678"  # Most recent
 
 
+def test_find_snapshot_by_branch_fallback_for_nonconforming_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fallback scan finds snapshots whose filenames don't embed `_{branch}_`."""
+    from vibe3.analysis import snapshot_service
+
+    snapshot_dir = tmp_path / "vibe3" / "structure" / "snapshots"
+    snapshot_dir.mkdir(parents=True)
+    snapshot = {
+        "snapshot_id": "flow-1-main-abc1234-2026-03-19T09-00-00",
+        "branch": "main",
+        "commit": "abc1234",
+        "commit_short": "abc1234",
+        "created_at": "2026-03-19T09:00:00",
+        "root": "src/vibe3",
+        "files": [],
+        "modules": [],
+        "dependencies": [],
+        "metrics": {},
+    }
+    (snapshot_dir / f"{snapshot['snapshot_id']}.json").write_text(json.dumps(snapshot))
+    monkeypatch.setattr(snapshot_service, "_get_snapshot_dir", lambda: snapshot_dir)
+
+    result = find_snapshot_by_branch("main")
+
+    assert result is not None
+    assert result.snapshot_id == "flow-1-main-abc1234-2026-03-19T09-00-00"
+
+
 def test_build_snapshot_uses_shared_python_collection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/vibe3/analysis/test_snapshot_service.py
+++ b/tests/vibe3/analysis/test_snapshot_service.py
@@ -151,6 +151,70 @@ def test_find_snapshot_by_branch_nonexistent_dir(
     assert result is None
 
 
+def test_find_snapshot_by_branch_glob_filters_candidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that glob pre-filter correctly narrows candidates by branch."""
+    from vibe3.analysis import snapshot_service
+
+    # Create snapshots with branch names that share substrings
+    snapshot_dir = tmp_path / "vibe3" / "structure" / "snapshots"
+    snapshot_dir.mkdir(parents=True)
+
+    snapshots = [
+        {
+            "snapshot_id": "2026-03-20T10-00-00_main_abc1234",
+            "branch": "main",
+            "commit": "abc1234",
+            "commit_short": "abc1234",
+            "created_at": "2026-03-20T10:00:00",
+            "root": "src/vibe3",
+            "files": [],
+            "modules": [],
+            "dependencies": [],
+            "metrics": {},
+        },
+        {
+            "snapshot_id": "2026-03-21T11-00-00_feature-main_xyz9876",
+            "branch": "feature-main",
+            "commit": "xyz9876",
+            "commit_short": "xyz9876",
+            "created_at": "2026-03-21T11:00:00",
+            "root": "src/vibe3",
+            "files": [],
+            "modules": [],
+            "dependencies": [],
+            "metrics": {},
+        },
+        {
+            "snapshot_id": "2026-03-22T12-00-00_main_def5678",
+            "branch": "main",
+            "commit": "def5678",
+            "commit_short": "def5678",
+            "created_at": "2026-03-22T12:00:00",
+            "root": "src/vibe3",
+            "files": [],
+            "modules": [],
+            "dependencies": [],
+            "metrics": {},
+        },
+    ]
+
+    for snapshot in snapshots:
+        filepath = snapshot_dir / f"{snapshot['snapshot_id']}.json"
+        filepath.write_text(json.dumps(snapshot, indent=2))
+
+    monkeypatch.setattr(snapshot_service, "_get_snapshot_dir", lambda: snapshot_dir)
+
+    # Search for "main" should only return snapshots with branch "main"
+    # not "feature-main" even though glob pattern "*_main_*.json" matches both
+    result = find_snapshot_by_branch("main")
+
+    assert result is not None
+    assert result.branch == "main"
+    assert result.snapshot_id == "2026-03-22T12-00-00_main_def5678"  # Most recent
+
+
 def test_build_snapshot_uses_shared_python_collection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Optimize `find_snapshot_by_branch` by replacing full-scan-then-filter pattern with a two-stage approach plus a safety-net fallback:
1. Glob pre-filter using branch name in filename
2. Verify branch field in narrowed candidates
3. Fallback to a full-directory scan if the pre-filter yields no matches (catches snapshots saved under non-conforming filenames)

This eliminates loading all snapshot JSON files when searching for a specific branch in the common case, significantly reducing I/O and parsing overhead as the number of snapshots grows, while guaranteeing no silent misses for older-format filenames.

## Changes

**Core optimization** (`src/vibe3/analysis/snapshot_service.py`):
- Add glob-based pre-filtering before JSON loading
- Extract sanitized branch name and construct glob pattern `*_{branch}_*.json`
- Extract shared candidate-loading logic into `_load_snapshots_for_branch()` helper, reused by both the pre-filter stage and the fallback stage
- Branch field verification ensures false positives are filtered out
- Add a full-directory fallback scan when the glob pre-filter matches nothing, so snapshots using the older `flow-{id}-{branch}-{commit}-{timestamp}.json` naming convention are still found
- Remove the dead "unsanitized branch" glob variant (it never matched any `branch` field produced by `build_snapshot`, and the new fallback scan subsumes any case it might have caught)

**Test coverage** (`tests/vibe3/analysis/test_snapshot_service.py`):
- Add `test_find_snapshot_by_branch_glob_filters_candidates`
  - Verifies that searching for "main" returns only "main" snapshots, not "feature-main"
  - Confirms branch field verification prevents false matches from glob false positives
- Add `test_find_snapshot_by_branch_fallback_for_nonconforming_filename`
  - Verifies that a snapshot saved under the older `flow-*` naming convention (no `_{branch}_` substring) is still found via the fallback full scan

**LOC exception** (`config/v3/loc_limits.yaml`):
- `src/vibe3/analysis/snapshot_service.py`: unchanged, existing exception (limit 480) still covers the file at 436 lines
- `tests/vibe3/analysis/test_snapshot_service.py`: raise exception limit 480 -> 500; file grew from 398 lines on `main` to 491 lines (+93) due to the two new tests

## Test Results

✅ All tests pass: 14/14 tests in test_snapshot_service.py
✅ Type check: mypy no issues found
✅ Lint check: ruff all checks passed
✅ Pre-push checks: All passed (compile, type, test, LOC)

## Performance Impact

**Before**: Loaded ALL snapshot JSON files, then filtered by branch field
**After**: Uses glob pattern to narrow candidates first, loads only those; falls back to a full scan only when the pre-filter finds nothing

Example: Searching for "main" branch in a directory with 100 snapshots (90 for other branches, all using the current naming convention):
- **Before**: Loads 100 JSON files
- **After**: Loads ~10 JSON files (only those matching `*_main_*.json`)

## Edge Cases Handled

- Empty directory: returns None
- Nonexistent directory: returns None
- Branch not found: returns None
- `origin/` prefix normalization: "origin/main" finds "main" snapshots
- Glob false positives: "main" pattern matches "feature-main" file, but branch field verification filters it out
- JSON decode errors: gracefully skipped
- Non-conforming filenames (e.g. older `flow-*` naming convention): fallback full scan still finds them

Fixes #2616

---

## Contributors

claude/opus