### PR TITLE
[supervisor] Documentation Alignment: Legacy paths and Tier terminology

### DIFF
--- a/docs/standards/glossary.md
+++ b/docs/standards/glossary.md
@@ -93,24 +93,28 @@ V3 采用 3-Tier 顶层架构模型，定义系统的战略职责边界。
 ### 4.1 Level 1 (L1 - Inspection Level)
 
 - 定义：**无 Worktree 观察层**。在主仓库或内存中运行，仅负责只读观察、Metadata 扫描或轻量 Label 路由。
+- 对应架构层：**Tier 3**
 - 典型场景：`governance/roadmap` 扫描、`assignee-pool` 巡检、心跳状态监测。
 - 隔离：无隔离，直接访问共享真源。
 
 ### 4.2 Level 2 (L2 - Governance Execution Level)
 
 - 定义：**临时隔离治理层**。使用临时创建且自动销毁的 Git Worktree 进行文档治理、测试修补或环境清理。
+- 对应架构层：**Tier 3**
 - 典型场景：`supervisor/apply` 任务执行。
 - 隔离：文件系统级临时隔离。
 
 ### 4.3 Level 3 (L3 - Main Development Level)
 
 - 定义：**持久隔离开发层**。为每个 GitHub Issue 分配持久化的独立 Worktree，承载完整的 Plan/Run/Review 生命周期。
+- 对应架构层：**Tier 2**
 - 典型场景：核心业务开发、架构调整、大型特性实现。
 - 隔离：文件系统级持久隔离 + 独立的 Flow 状态机。
 
 ### 4.4 Level 4 (L4 - Atomic Collaboration Level)
 
 - 定义：**原子协作层**。由人类或外部系统通过单一指令/工具进行的细粒度干预或原子级交付。
+- 对应架构层：**Tier 1**
 - 典型场景：手动 PR 合并、密钥注入、配置热更新。
 - 隔离：通常在 L3 环境内执行或通过 API 远程执行。
 
@@ -660,7 +664,7 @@ V3 采用 3-Tier 顶层架构模型，定义系统的战略职责边界。
   - **不再复写通用执行框架，其执行动作应交由 Execution 层**。
 - 落点：
   - Python 模块：`src/vibe3/roles/manager.py`（Manager 角色定义）
-  - Skill: `skills/vibe-manager/SKILL.md`
+  - Skill: `skills/vibe-task/SKILL.md` (或其它活跃技能目录；`vibe-manager` 技能已废弃)
 
 ### 7.15 `Shell 能力层`
 

--- a/docs/v3/infrastructure/02-architecture.md
+++ b/docs/v3/infrastructure/02-architecture.md
@@ -10,7 +10,7 @@ related_docs:
   - docs/standards/v3/github-remote-call-standard.md
   - docs/v3/handoff/v3-rewrite-plan.md
   - docs/v3/infrastructure/03-coding-standards.md
-  - .agent/rules/python-standards.md
+  - .claude/rules/python-standards.md
 ---
 
 # Vibe 3.0 - 架构设计
@@ -64,29 +64,29 @@ src/vibe3/
 
 ## 分层架构与职责 (强制)
 
-Vibe 3.0 采用 domain-first 架构，收敛为以下六层：
+Vibe 3.0 采用 domain-first 架构，收敛为以下六层实现，它们分别对应系统的三个架构分层 (Tier 1-3)：
 
-### Layer 1: Server (server/)
+### Layer 1: Server (server/) - [Tier 3]
 - **职责**：HTTP/Webhook 暴露、进程级驱动装配、Runtime 启停。
 - **要求**：禁止包含业务判断或角色特定逻辑。
 
-### Layer 2: Runtime (runtime/)
+### Layer 2: Runtime (runtime/) - [Tier 3]
 - **职责**：Heartbeat、事件路由、将外部 Observation 翻译并交给 Domain。
 - **要求**：不持有角色编排逻辑。
 
-### Layer 3: Domain (domain/)
+### Layer 3: Domain (domain/) - [Tier 2]
 - **职责**：定义领域事件、处理业务逻辑编排、驱动状态机。
 - **要求**：业务语义判断的唯一真源。
 
-### Layer 4: Execution (execution/)
+### Layer 4: Execution (execution/) - [Tier 2]
 - **职责**：统一执行控制面（Capacity, Lifecycle, Session, Agent Launch）。
 - **要求**：所有角色执行（Plan/Run/Review）的唯一启动入口。
 
-### Layer 5: Environment (environment/)
+### Layer 5: Environment (environment/) - [Tier 1]
 - **职责**：资源原语（Worktree 管理、Tmux Session 隔离）。
 - **要求**：不涉及业务状态逻辑。
 
-### Layer 6: Role Adapters (manager/, orchestra/, etc.)
+### Layer 6: Role Adapters (roles/, orchestra/, etc.) - [Tier 2/3]
 - **职责**：角色特定输入/输出处理、Prompt 渲染。
 - **要求**：薄层适配器，不复写执行框架。
 
@@ -114,7 +114,7 @@ Server → Runtime → Domain → Execution → Environment
 | Domain | domain/ | 业务编排 | Execution, Models | Server, UI |
 | Execution | execution/ | 执行控制 | Environment, Role Adapters, Models | Server, UI |
 | Environment | environment/ | 资源原语 | Models | Domain, Execution |
-| Role Adapters | manager/ orchestra/ | 角色逻辑 | Models | Runtime, Server |
+| Role Adapters | roles/ orchestra/ | 角色逻辑 | Models | Runtime, Server |
 
 ---
 
@@ -123,7 +123,7 @@ Server → Runtime → Domain → Execution → Environment
 - **[03-coding-standards.md](03-coding-standards.md)** - 编码标准
 - **[05-logging.md](05-logging.md)** - 日志规范
 - **[06-error-handling.md](06-error-handling.md)** - 异常处理
-- **[.agent/rules/python-standards.md](../../../.agent/rules/python-standards.md)** - Python 标准
+- **[.claude/rules/python-standards.md](../../../.claude/rules/python-standards.md)** - Python 标准
 
 ---
 

--- a/docs/v3/infrastructure/03-coding-standards.md
+++ b/docs/v3/infrastructure/03-coding-standards.md
@@ -9,14 +9,14 @@ related_docs:
   - docs/standards/v3/handoff-store-standard.md
   - docs/standards/v3/github-remote-call-standard.md
   - docs/v3/infrastructure/02-architecture.md
-  - .agent/rules/python-standards.md
+  - .claude/rules/python-standards.md
 ---
 
 # Vibe 3.0 - 编码标准
 
 本文档定义 Vibe 3.0 的**架构相关编码标准**。
 
-**通用 Python 标准**：见 **[.agent/rules/python-standards.md](../../../.agent/rules/python-standards.md)**
+**通用 Python 标准**：见 **[.claude/rules/python-standards.md](../../../.claude/rules/python-standards.md)**
 
 ---
 
@@ -42,7 +42,7 @@ related_docs:
 
 ## 类型注解与命名规范
 
-见 **[.agent/rules/python-standards.md](../../../.agent/rules/python-standards.md)** §类型注解、§命名规范
+见 **[.claude/rules/python-standards.md](../../../.claude/rules/python-standards.md)** §类型注解、§命名规范
 
 ---
 
@@ -247,7 +247,7 @@ markers = [
 
 ## 参考文档
 
-- **[.agent/rules/python-standards.md](../../../.agent/rules/python-standards.md)** - 完整 Python 标准
+- **[.claude/rules/python-standards.md](../../../.claude/rules/python-standards.md)** - 完整 Python 标准
 - **[02-architecture.md](02-architecture.md)** - 架构设计
 - **[06-error-handling.md](06-error-handling.md)** - 异常处理
 
@@ -255,3 +255,4 @@ markers = [
 
 **维护者**：Vibe Team
 **最后更新**：2026-03-15
+

--- a/docs/v3/infrastructure/README.md
+++ b/docs/v3/infrastructure/README.md
@@ -9,7 +9,7 @@ related_docs:
   - docs/standards/v3/handoff-store-standard.md
   - docs/standards/v3/github-remote-call-standard.md
   - docs/v3/handoff/v3-rewrite-plan.md
-  - .agent/rules/python-standards.md
+  - .claude/rules/python-standards.md
 purpose: Phase 1 基础设施层的核心文档，包含架构设计、编码标准、测试标准等技术规范
 ---
 


### PR DESCRIPTION
This PR aligns 5 documentation objects with V3 truth as requested in #2688.

- Updated rule paths from `.agent/rules/` to `.claude/rules/`.
- Updated Role Adapters directory from `manager/` to `roles/`.
- Aligned Layer/Tier terminology in architecture docs.
- Harmonized Tier/Level mapping in glossary.
- Updated Manager skill path in glossary.