### PR TITLE
refactor(scan): route manual scans through EventPublisher

### DIFF
--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -27,8 +27,7 @@ def _publish_governance_event(
             preserved for future tick-based material rotation support)
         tick_count: Tick count for the scan (default 0 for manual scans)
     """
-    from vibe3.domain import publish
-    from vibe3.domain.events.governance import GovernanceScanStarted
+    from vibe3.domain import GovernanceScanStarted, publish
 
     event = GovernanceScanStarted(
         tick_count=tick_count,
@@ -74,8 +73,7 @@ def _publish_supervisor_events(
         supervisor_file is left empty and resolved by the domain handler,
         which allows manual scans to use the same resolution logic as heartbeat scans.
     """
-    from vibe3.domain import publish
-    from vibe3.models.domain_events import SupervisorIssueIdentified
+    from vibe3.domain import SupervisorIssueIdentified, publish
 
     for candidate in candidates:
         event = SupervisorIssueIdentified(

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -24,7 +24,7 @@ def _publish_governance_event(
 
     Args:
         material_override: Optional governance role (not used in event,
-            preserved for future)
+            preserved for future tick-based material rotation support)
         tick_count: Tick count for the scan (default 0 for manual scans)
     """
     from vibe3.domain import publish
@@ -48,14 +48,15 @@ def _run_governance_scan(
 
     Args:
         material_override: Optional governance role (not used in event,
-            preserved for future)
+            preserved for future tick-based material rotation support)
         no_async: Deprecated flag (logs warning, always uses async dispatch
             via event bus)
     """
     if no_async:
         logger.warning(
-            "--no-async is deprecated; event bus triggers handler "
-            "with async tmux dispatch"
+            "--no-async is deprecated and ignored. Event bus now triggers handler "
+            "with async tmux dispatch. For synchronous execution, use "
+            "'vibe3 internal governance' directly."
         )
     _publish_governance_event(material_override=material_override)
     logger.bind(domain="orchestra").info("Governance scan event published")
@@ -68,6 +69,10 @@ def _publish_supervisor_events(
 
     Args:
         candidates: List of issue candidate dicts with 'number' and 'title' fields
+
+    Note:
+        supervisor_file is left empty and resolved by the domain handler,
+        which allows manual scans to use the same resolution logic as heartbeat scans.
     """
     from vibe3.domain import publish
     from vibe3.models.domain_events import SupervisorIssueIdentified

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -17,6 +17,27 @@ app = typer.Typer(
 )
 
 
+def _publish_governance_event(
+    material_override: str | None = None, tick_count: int = 0
+) -> None:
+    """Publish GovernanceScanStarted event to the event bus.
+
+    Args:
+        material_override: Optional governance role (not used in event,
+            preserved for future)
+        tick_count: Tick count for the scan (default 0 for manual scans)
+    """
+    from vibe3.domain import publish
+    from vibe3.domain.events.governance import GovernanceScanStarted
+
+    event = GovernanceScanStarted(
+        tick_count=tick_count,
+        execution_count=0,
+        actor="cli:scan-governance",
+    )
+    publish(event)
+
+
 def _execute_governance_internal(material_override: str | None = None) -> None:
     """Execute governance scan via service layer (no facade).
 
@@ -35,27 +56,45 @@ def _execute_governance_internal(material_override: str | None = None) -> None:
 def _run_governance_scan(
     material_override: str | None = None, no_async: bool = False
 ) -> None:
-    """Execute governance scan once.
+    """Execute governance scan once via event bus.
 
-    Async default (no_async=False): dispatches via tmux background session.
-    Sync (no_async=True): calls internal dispatch directly.
+    Publishes GovernanceScanStarted event, which triggers the domain handler
+    to dispatch via ExecutionCoordinator (async tmux).
 
     Args:
-        material_override: Optional governance role to override material rotation
-        no_async: Run synchronously (blocking) instead of async tmux session
+        material_override: Optional governance role (not used in event,
+            preserved for future)
+        no_async: Deprecated flag (logs warning, always uses async dispatch
+            via event bus)
     """
     if no_async:
-        _execute_governance_internal(material_override=material_override)
-        logger.bind(domain="orchestra").info("Governance scan completed")
-    else:
-        from vibe3.execution import run_governance_async
-        from vibe3.roles import build_governance_execution_name
-
-        run_governance_async(
-            tick_count=0,
-            material_override=material_override,
-            build_execution_name=build_governance_execution_name,
+        logger.warning(
+            "--no-async is deprecated for event-driven scans; "
+            "dispatching via event bus (async)"
         )
+    _publish_governance_event(material_override=material_override)
+    logger.bind(domain="orchestra").info("Governance scan event published")
+
+
+def _publish_supervisor_events(
+    candidates: list[dict],
+) -> None:
+    """Publish SupervisorIssueIdentified events for each candidate.
+
+    Args:
+        candidates: List of issue candidate dicts with 'number' and 'title' fields
+    """
+    from vibe3.domain import publish
+    from vibe3.models.domain_events import SupervisorIssueIdentified
+
+    for candidate in candidates:
+        event = SupervisorIssueIdentified(
+            issue_number=candidate["number"],
+            issue_title=candidate.get("title", ""),
+            supervisor_file="",  # Resolved by handler
+            actor="cli:scan-supervisor",
+        )
+        publish(event)
 
 
 def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
@@ -85,18 +124,15 @@ def _run_governance_scan_dry_run(material_override: str | None = None) -> None:
 
 
 def _run_supervisor_scan() -> tuple[int, int]:
-    """Execute supervisor scan once via execution layer (no facade).
+    """Execute supervisor scan once via event bus.
 
-    Fetches supervisor candidates and calls execution layer directly
-    without going through OrchestrationFacade or internal command layer.
+    Fetches supervisor candidates and publishes SupervisorIssueIdentified events
+    for each candidate, which triggers the domain handler to dispatch.
 
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
-    from vibe3.roles import (
-        dispatch_supervisor_execution,
-        fetch_supervisor_candidates,
-    )
+    from vibe3.roles import fetch_supervisor_candidates
 
     config = load_orchestra_config()
     github = GitHubClient()
@@ -105,10 +141,9 @@ def _run_supervisor_scan() -> tuple[int, int]:
     total_scanned, candidates = fetch_supervisor_candidates(github, config.repo)
     matched_count = len(candidates)
 
-    # Dispatch each candidate via execution layer
-    for candidate in candidates:
-        issue_number = candidate["number"]
-        dispatch_supervisor_execution(issue_number=issue_number, no_async=False)
+    # Publish events for each candidate
+    if candidates:
+        _publish_supervisor_events(candidates)
 
     return total_scanned, matched_count
 
@@ -270,16 +305,15 @@ def supervisor(
 
 
 async def _run_combined_scan_async() -> None:
-    """Execute both governance and supervisor scans in sequence.
+    """Execute both governance and supervisor scans in sequence via event bus.
 
-    Governance scan uses internal dispatch directly (no facade).
-    Supervisor scan uses internal apply dispatch directly (no facade).
+    Publishes events which trigger domain handlers to dispatch via ExecutionCoordinator.
     """
-    # Governance: call internal dispatch directly (no facade, no FailedGate)
-    _execute_governance_internal(material_override=None)
-    logger.bind(domain="orchestra").info("Governance scan completed")
+    # Governance: publish event
+    _publish_governance_event(material_override=None)
+    logger.bind(domain="orchestra").info("Governance scan event published")
 
-    # Supervisor: call internal dispatch directly (no facade)
+    # Supervisor: publish events
     total_scanned, matched_count = _run_supervisor_scan()
 
     # Display scan results

--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -38,21 +38,6 @@ def _publish_governance_event(
     publish(event)
 
 
-def _execute_governance_internal(material_override: str | None = None) -> None:
-    """Execute governance scan via service layer (no facade).
-
-    Direct path for manual governance scan, calling execution layer
-    without going through OrchestrationFacade heartbeat chain
-    or internal command layer.
-
-    Args:
-        material_override: Optional governance role to override material rotation
-    """
-    from vibe3.roles import dispatch_governance_execution
-
-    dispatch_governance_execution(material_override=material_override)
-
-
 def _run_governance_scan(
     material_override: str | None = None, no_async: bool = False
 ) -> None:
@@ -69,8 +54,8 @@ def _run_governance_scan(
     """
     if no_async:
         logger.warning(
-            "--no-async is deprecated for event-driven scans; "
-            "dispatching via event bus (async)"
+            "--no-async is deprecated; event bus triggers handler "
+            "with async tmux dispatch"
         )
     _publish_governance_event(material_override=material_override)
     logger.bind(domain="orchestra").info("Governance scan event published")

--- a/tests/vibe3/commands/test_scan.py
+++ b/tests/vibe3/commands/test_scan.py
@@ -63,16 +63,18 @@ class TestGovernanceScan:
         assert "Governance scan completed" in result.output
         mock_run.assert_called_once_with(material_override=None, no_async=True)
 
-    def test_governance_scan_does_not_call_on_heartbeat_tick(self):
-        """Sync path (--no-async) calls service layer directly, not through facade."""
-        with patch("vibe3.roles.dispatch_governance_execution") as mock_service_run:
-            with patch(
-                "vibe3.domain.orchestration_facade.OrchestrationFacade"
-            ) as mock_facade:
-                runner.invoke(app, ["scan", "governance", "--no-async"])
-                mock_facade.assert_not_called()
-                assert mock_service_run.called
-                mock_service_run.assert_called_once_with(material_override=None)
+    def test_governance_scan_publishes_event(self):
+        """Governance scan publishes GovernanceScanStarted event."""
+        with patch("vibe3.domain.publish") as mock_publish:
+            from vibe3.commands.scan import _run_governance_scan
+            from vibe3.domain.events.governance import GovernanceScanStarted
+
+            _run_governance_scan(no_async=True)
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args.args[0]
+            assert isinstance(event, GovernanceScanStarted)
+            assert event.actor == "cli:scan-governance"
+            assert event.tick_count == 0
 
 
 class TestSupervisorScan:
@@ -111,18 +113,21 @@ class TestCombinedScan:
 
 class TestScanIntegration:
     def test_governance_scan_registers_handlers(self):
-        """Sync governance scan calls service layer directly, not facade."""
-        with patch("vibe3.roles.dispatch_governance_execution") as mock_service:
+        """Governance scan publishes event, not direct dispatch."""
+        with patch("vibe3.domain.publish") as mock_publish:
             from vibe3.commands.scan import _run_governance_scan
+            from vibe3.domain.events.governance import GovernanceScanStarted
 
             _run_governance_scan(no_async=True)
-            mock_service.assert_called_once_with(material_override=None)
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args.args[0]
+            assert isinstance(event, GovernanceScanStarted)
 
-    def test_supervisor_scan_registers_handlers(self):
-        """Supervisor scan calls service layer directly, not facade."""
+    def test_supervisor_scan_publishes_events(self):
+        """Supervisor scan publishes SupervisorIssueIdentified events."""
         with (
             patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
-            patch("vibe3.roles.dispatch_supervisor_execution") as mock_apply,
+            patch("vibe3.domain.publish") as mock_publish,
         ):
             mock_fetch.return_value = (
                 1,
@@ -136,53 +141,69 @@ class TestScanIntegration:
             )
 
             from vibe3.commands.scan import _run_supervisor_scan
+            from vibe3.models.domain_events import SupervisorIssueIdentified
 
             _run_supervisor_scan()
             mock_fetch.assert_called_once()
-            mock_apply.assert_called_once()
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args.args[0]
+            assert isinstance(event, SupervisorIssueIdentified)
+            assert event.issue_number == 123
+            assert event.actor == "cli:scan-supervisor"
 
 
 class TestFailedGateBlocking:
-    def test_governance_scan_blocked_by_failed_gate(self):
-        """Sync governance scan ignores FailedGate (only for heartbeat)."""
-        with patch("vibe3.roles.dispatch_governance_execution") as mock_service:
+    def test_governance_scan_ignores_failed_gate(self):
+        """Manual governance scan ignores FailedGate (publishes event directly)."""
+        with patch("vibe3.domain.publish") as mock_publish:
             from vibe3.commands.scan import _run_governance_scan
+            from vibe3.domain.events.governance import GovernanceScanStarted
 
             _run_governance_scan(no_async=True)
-            mock_service.assert_called_once_with(material_override=None)
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args.args[0]
+            assert isinstance(event, GovernanceScanStarted)
 
-    def test_supervisor_scan_blocked_by_failed_gate(self):
-        """Manual supervisor scan ignores FailedGate (only for heartbeat)."""
-        with patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch:
+    def test_supervisor_scan_ignores_failed_gate(self):
+        """Manual supervisor scan ignores FailedGate (publishes events directly)."""
+        with (
+            patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
+            patch("vibe3.domain.publish") as mock_publish,
+        ):
             mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_supervisor_scan
 
             _run_supervisor_scan()
             mock_fetch.assert_called_once()
+            # No events published for empty candidates
+            mock_publish.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_combined_scan_blocked_by_failed_gate(self):
-        """Combined scan bypasses FailedGate for both governance and supervisor."""
+    async def test_combined_scan_ignores_failed_gate(self):
+        """Combined scan bypasses FailedGate (publishes events directly)."""
         with (
-            patch("vibe3.roles.dispatch_governance_execution") as mock_governance,
+            patch("vibe3.domain.publish") as mock_publish,
             patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
-            patch("vibe3.roles.dispatch_supervisor_execution"),
         ):
             mock_fetch.return_value = (0, [])
 
             from vibe3.commands.scan import _run_combined_scan_async
+            from vibe3.domain.events.governance import GovernanceScanStarted
 
             await _run_combined_scan_async()
-            mock_governance.assert_called_once()
+            # Governance event published
+            assert mock_publish.call_count >= 1
+            governance_event = mock_publish.call_args_list[0].args[0]
+            assert isinstance(governance_event, GovernanceScanStarted)
             mock_fetch.assert_called_once()
 
 
-def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
-    """Manual supervisor scan fetches candidates and dispatches each."""
+def test_supervisor_scan_fetches_candidates_and_publishes_events() -> None:
+    """Manual supervisor scan fetches candidates and publishes events."""
     with (
         patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
-        patch("vibe3.roles.dispatch_supervisor_execution") as mock_apply,
+        patch("vibe3.domain.publish") as mock_publish,
     ):
         mock_fetch.return_value = (
             2,
@@ -203,7 +224,7 @@ def test_supervisor_scan_fetches_candidates_and_calls_service_apply() -> None:
         result = runner.invoke(app, ["scan", "supervisor"])
         assert result.exit_code == 0
         mock_fetch.assert_called_once()
-        assert mock_apply.call_count == 2
+        assert mock_publish.call_count == 2
 
 
 def test_governance_list_shows_materials():
@@ -274,3 +295,39 @@ class TestCombinedScanDryRun:
         assert result.exit_code == 0
         mock_governance.assert_called_once()
         mock_supervisor.assert_called_once()
+
+
+def test_scan_governance_does_not_call_roles_dispatch():
+    """Verify governance scan does not call dispatch_governance_execution."""
+    with (
+        patch("vibe3.domain.publish") as mock_publish,
+        patch("vibe3.roles.dispatch_governance_execution") as mock_dispatch,
+    ):
+        from vibe3.commands.scan import _run_governance_scan
+
+        _run_governance_scan()
+        # Event published
+        mock_publish.assert_called_once()
+        # Direct dispatch NOT called
+        mock_dispatch.assert_not_called()
+
+
+def test_scan_supervisor_does_not_call_roles_dispatch():
+    """Verify supervisor scan does not call dispatch_supervisor_execution."""
+    with (
+        patch("vibe3.roles.fetch_supervisor_candidates") as mock_fetch,
+        patch("vibe3.domain.publish") as mock_publish,
+        patch("vibe3.roles.dispatch_supervisor_execution") as mock_dispatch,
+    ):
+        mock_fetch.return_value = (
+            1,
+            [{"number": 123, "title": "Issue A", "labels": ["supervisor"]}],
+        )
+
+        from vibe3.commands.scan import _run_supervisor_scan
+
+        _run_supervisor_scan()
+        # Event published
+        mock_publish.assert_called_once()
+        # Direct dispatch NOT called
+        mock_dispatch.assert_not_called()


### PR DESCRIPTION
Closes #2676

## Summary

Routes manual governance and supervisor scans through the EventPublisher event bus, unifying manual and heartbeat scan paths for consistent behavior.

**Changes**:
- Replace direct `dispatch_governance_execution()` with event publishing (`GovernanceScanStarted`)
- Replace direct `dispatch_supervisor_execution()` with event publishing (`SupervisorIssueIdentified`)
- Add `_publish_governance_event()` and `_publish_supervisor_events()` helpers
- Remove dead code `_execute_governance_internal()` function
- Clarify deprecation log message for `--no-async` flag

**Benefits**:
- Consistent on_publish hooks across all scan paths
- Unified event-rules and audit semantics
- Cleaner code architecture (removed 19 lines of dead code)

**Breaking change**: `--no-async` flag now logs deprecation warning and always uses async dispatch via event bus handler.

## Test plan

- [x] All 27 tests pass in `tests/vibe3/commands/test_scan.py`
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Pre-commit checks pass
- [x] LOC limits within CI thresholds

Refs: #2676

---

## Contributors

claude/opus
