### PR TITLE
refactor(analysis): remove redundant __pycache__ filter in scan_dead_code

### DIFF
--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -277,8 +277,6 @@ class SerenaService:
                 raise SerenaError("scan_dead_code", f"Root directory not found: {root}")
 
             python_files = sorted(root_path.glob("**/*.py"))
-            # Filter out __pycache__
-            python_files = [f for f in python_files if "__pycache__" not in str(f)]
 
             log.bind(file_count=len(python_files)).debug("Found Python files")
 


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2653` is behind `main` by **1 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2653
```


---

Closes #2653

## Summary

Remove redundant `__pycache__` filtering in `SerenaService.scan_dead_code`.

**Changes**:
- Deleted 2 lines (comment + list comprehension) from `src/vibe3/analysis/serena_service.py`
- The filter was a no-op since `glob("**/*.py")` only matches `.py` files while `__pycache__` directories only contain `.pyc` files

**Rationale**:
- Eliminates a Filter-Instead-of-Delete anti-pattern
- No functional change (the filter had zero practical effect)
- Reduces unnecessary code complexity

## Test Plan

- [x] All tests pass (146/146 in analysis module)
- [x] Type check clean (mypy)
- [x] Lint clean (ruff)
- [x] Pre-commit hooks passed
- [x] Commit message follows standards

**Issue**: #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
