### PR TITLE
fix(governance): orchestra-scanned 不应阻止 assignee-pool 扫描

### DIFF
--- a/src/vibe3/domain/protocols/dispatch_protocols.py
+++ b/src/vibe3/domain/protocols/dispatch_protocols.py
@@ -167,6 +167,14 @@ class CheckServiceProtocol(Protocol):
         """Run consistency checks for flows in the store."""
         ...
 
+    def clean_orchestra_scanned_with_assignee(self) -> int:
+        """Remove orchestra-scanned label from issues with assignee.
+
+        Returns:
+            Number of issues cleaned.
+        """
+        ...
+
     def invalidate_pr_cache(self) -> None:
         """Invalidate PR cache to force refresh on next check."""
         ...

--- a/src/vibe3/orchestra/domain_types.py
+++ b/src/vibe3/orchestra/domain_types.py
@@ -124,6 +124,14 @@ class CheckServiceProtocol(Protocol):
         """Run consistency checks for flows in the store."""
         ...
 
+    def clean_orchestra_scanned_with_assignee(self) -> int:
+        """Remove orchestra-scanned label from issues with assignee.
+
+        Returns:
+            Number of issues cleaned.
+        """
+        ...
+
     def invalidate_pr_cache(self) -> None:
         """Invalidate PR cache to force refresh on next check."""
         ...

--- a/src/vibe3/roles/governance_utils.py
+++ b/src/vibe3/roles/governance_utils.py
@@ -112,6 +112,16 @@ def build_broader_repo_entries(
         # Three-layer governance filter + legacy compat. Roadmap intake must not
         # trust stale orchestra-governed labels on unassigned issues; it owns the
         # broader unassigned pool and should re-evaluate those candidates.
+        #
+        # Note: orchestra-scanned is roadmap-intake's mechanism to mark
+        # "not for intake". Assignee-pool should NOT filter by
+        # orchestra-scanned because:
+        # 1. orchestra-scanned is only meaningful for roadmap-intake
+        # 2. Issues can have both assignee and orchestra-scanned (when
+        #    roadmap-intake skipped but later got assignee via vibe-roadmap
+        #    dependency resolution)
+        # 3. Assignee-pool's job is to process assigned issues, only checking
+        #    orchestra-governed to avoid re-scanning already decided issues.
         if material_name == "roadmap-intake.md":
             if (
                 "supervisor" in labels
@@ -122,7 +132,6 @@ def build_broader_repo_entries(
                 continue
         elif (
             "supervisor" in labels
-            or "orchestra-scanned" in labels
             or has_orchestra_governed(labels)
             or "orchestra" in labels
         ):

--- a/src/vibe3/runtime/periodic_check_executor.py
+++ b/src/vibe3/runtime/periodic_check_executor.py
@@ -73,6 +73,15 @@ async def execute_periodic_check(
                 f"Periodic check completed: all {total} flows are healthy"
             )
 
+        # Clean orchestra-scanned labels from issues with assignee
+        cleaned = await asyncio.to_thread(
+            check_service.clean_orchestra_scanned_with_assignee
+        )
+        if cleaned > 0:
+            logger.bind(domain="orchestra", action="periodic_check").info(
+                f"Cleaned orchestra-scanned from {cleaned} issues with assignee"
+            )
+
     except Exception as exc:
         append_orchestra_event(
             "server",

--- a/src/vibe3/services/check/service.py
+++ b/src/vibe3/services/check/service.py
@@ -672,3 +672,95 @@ class CheckService(CheckRemote):
             )
             return FixResult(success=False, error=error)
         return FixResult(success=True, applied=fixed)
+
+    def clean_orchestra_scanned_with_assignee(self) -> int:
+        """Remove orchestra-scanned label from issues with assignee.
+
+        orchestra-scanned is a roadmap-intake mechanism to mark "not for intake".
+        When an issue gets an assignee (e.g., via vibe-roadmap dependency resolution),
+        it should have orchestra-scanned removed to avoid confusing assignee-pool.
+
+        Returns:
+            Number of issues cleaned.
+        """
+        import subprocess
+        import time
+
+        from vibe3.config import load_orchestra_config
+
+        config = load_orchestra_config()
+        cleaned_count = 0
+
+        try:
+            # Fetch all open issues with orchestra-scanned label
+            raw_issues = self.github_client.list_issues(
+                limit=100,
+                state="open",
+                assignee=None,
+                repo=config.repo,
+            )
+
+            manager_usernames = set(config.manager_usernames)
+
+            for issue in raw_issues:
+                number = issue.get("number")
+                if not isinstance(number, int):
+                    continue
+
+                # Check if issue has orchestra-scanned label
+                labels = issue.get("labels", [])
+                if not isinstance(labels, list):
+                    continue
+
+                has_orchestra_scanned = any(
+                    isinstance(label, dict) and label.get("name") == "orchestra-scanned"
+                    for label in labels
+                )
+
+                if not has_orchestra_scanned:
+                    continue
+
+                # Check if issue has assignee from manager pool
+                assignees = issue.get("assignees", [])
+                if not isinstance(assignees, list):
+                    continue
+
+                has_manager_assignee = any(
+                    isinstance(a, dict) and a.get("login") in manager_usernames
+                    for a in assignees
+                )
+
+                if has_manager_assignee:
+                    # Remove orchestra-scanned label using gh CLI
+                    try:
+                        cmd = [
+                            "gh",
+                            "issue",
+                            "edit",
+                            str(number),
+                            "--remove-label",
+                            "orchestra-scanned",
+                        ]
+                        if config.repo:
+                            cmd.extend(["--repo", config.repo])
+
+                        subprocess.run(cmd, capture_output=True, text=True, check=True)
+                        logger.bind(domain="check").info(
+                            f"Removed orchestra-scanned from issue #{number} "
+                            f"(has manager assignee)"
+                        )
+                        cleaned_count += 1
+                        # Rate limiting
+                        time.sleep(0.5)
+                    except subprocess.CalledProcessError as exc:
+                        logger.bind(domain="check").warning(
+                            f"Failed to remove orchestra-scanned from issue #{number}: "
+                            f"{exc.stderr}"
+                        )
+
+        except Exception as exc:
+            logger.bind(domain="check").error(
+                f"Failed to clean orchestra-scanned issues: {exc}"
+            )
+
+        return cleaned_count


### PR DESCRIPTION
## 问题

**orchestra-scanned label 的语义混淆**导致 assignee-pool 跳过了有 assignee 的 issues：

```
Roadmap-intake 扫描 → 打 orchestra-scanned (不打算 intake)
         ↓
依赖解除，vibe-roadmap 分配 assignee
         ↓
Assignee-pool 扫描 → 看到 orchestra-scanned → 跳过 ❌
         ↓
结果：有 assignee 但没人处理
```

## 修复

1. **governance_utils.py**: 移除 assignee-pool 对 `orchestra-scanned` 的检查
   - `orchestra-scanned` 只对 roadmap-intake 有意义
   - Assignee-pool 应该只检查 `orchestra-governed`

2. **check/service.py**: 增加 `clean_orchestra_scanned_with_assignee()` 方法
   - 定期清理 `orchestra-scanned` + assignee 的冲突
   - 自动移除有 assignee 的 issues 的 `orchestra-scanned` label

3. **periodic_check_executor.py**: 调用清理方法
   - 在每次定期检查时执行清理

## 语义澄清

- **orchestra-scanned**: roadmap-intake 专属，标记"不打算 intake"
- **orchestra-governed**: assignee-pool 专属，标记"已扫描过"

## 测试计划

- [ ] 验证现有卡住的 issues (#2335, #2336, #2337, #2555, #2690, #2693) 能被 assignee-pool 扫描
- [ ] 验证定期检查能清理 `orchestra-scanned` + assignee 的冲突
- [ ] 验证 roadmap-intake 仍然检查 `orchestra-scanned`（保持不变）

## 相关

- Fixes #2718
- Related: #2335, #2336, #2337, #2555, #2690, #2693

🤖 Generated with [Claude Code](https://claude.com/claude-code)