### PR TITLE
refactor(sessions): replace N+1 loop with bulk UPDATE in clear_all_sessions

### DIFF
--- a/src/vibe3/clients/sqlite_session_repo.py
+++ b/src/vibe3/clients/sqlite_session_repo.py
@@ -115,6 +115,28 @@ class SQLiteSessionRepo(_HasConnection):
             fields=list(kwargs.keys()),
         ).debug("Updated runtime session")
 
+    def stop_all_live_sessions(self) -> int:
+        """Mark all live (starting/running) sessions as stopped in a single query.
+
+        Returns:
+            Number of sessions updated.
+        """
+        conn = self._get_connection()
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE runtime_session SET status = 'stopped', updated_at = ? "
+                "WHERE status IN ('starting', 'running')",
+                (_utcnow_iso(),),
+            )
+            count = cursor.rowcount
+        logger.bind(
+            external="sqlite",
+            operation="stop_all_live_sessions",
+            count=count,
+        ).debug("Stopped all live sessions")
+        return count
+
     def list_live_runtime_sessions(
         self, *, role: str | None = None
     ) -> list[dict[str, Any]]:

--- a/src/vibe3/clients/sqlite_session_repo.py
+++ b/src/vibe3/clients/sqlite_session_repo.py
@@ -124,10 +124,12 @@ class SQLiteSessionRepo(_HasConnection):
         conn = self._get_connection()
         with conn:
             cursor = conn.cursor()
+            now = _utcnow_iso()
             cursor.execute(
-                "UPDATE runtime_session SET status = 'stopped', updated_at = ? "
+                "UPDATE runtime_session SET status = 'stopped', "
+                "updated_at = ?, ended_at = ? "
                 "WHERE status IN ('starting', 'running')",
-                (_utcnow_iso(),),
+                (now, now),
             )
             count = cursor.rowcount
         logger.bind(

--- a/src/vibe3/environment/session_registry.py
+++ b/src/vibe3/environment/session_registry.py
@@ -468,19 +468,7 @@ class SessionRegistryService:
         Returns:
             Number of sessions cleared.
         """
-        sessions = self._store.list_live_runtime_sessions()
-        cleared = 0
-        for session in sessions:
-            session_id = session.get("id")
-            if session_id is not None:
-                self._store.update_runtime_session(int(session_id), status="stopped")
-                cleared += 1
-                logger.bind(
-                    domain="session_registry",
-                    session_id=session_id,
-                    tmux=session.get("tmux_session"),
-                    role=session.get("role"),
-                ).debug(f"clear_all_sessions: marked session {session_id} as stopped")
+        cleared = self._store.stop_all_live_sessions()
         if cleared:
             logger.bind(domain="session_registry", cleared=cleared).info(
                 f"Server lifecycle cleanup: {cleared} sessions marked stopped "

--- a/tests/vibe3/clients/test_runtime_session_store.py
+++ b/tests/vibe3/clients/test_runtime_session_store.py
@@ -309,3 +309,47 @@ def test_get_latest_session_with_backend_id_filters_by_role(
 
     result = store.get_latest_session_with_backend_id(branch=branch, role="executor")
     assert result is None
+
+
+def test_stop_all_live_sessions(tmp_path: pytest.TempPathFactory) -> None:
+    store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+
+    # Create sessions in different states
+    id1 = store.create_runtime_session(
+        role="manager",
+        target_type="issue",
+        target_id="1",
+        branch="b1",
+        session_name="s1",
+        status="starting",
+    )
+    id2 = store.create_runtime_session(
+        role="executor",
+        target_type="issue",
+        target_id="2",
+        branch="b1",
+        session_name="s2",
+        status="running",
+    )
+    id3 = store.create_runtime_session(
+        role="planner",
+        target_type="issue",
+        target_id="3",
+        branch="b1",
+        session_name="s3",
+        status="stopped",
+    )
+
+    count = store.stop_all_live_sessions()
+    assert count == 2
+
+    # Verify live sessions are now stopped
+    assert store.get_runtime_session(id1)["status"] == "stopped"
+    assert store.get_runtime_session(id2)["status"] == "stopped"
+    # Already-stopped session unchanged
+    assert store.get_runtime_session(id3)["status"] == "stopped"
+
+
+def test_stop_all_live_sessions_no_sessions(tmp_path: pytest.TempPathFactory) -> None:
+    store = SQLiteClient(db_path=str(tmp_path / "handoff.db"))
+    assert store.stop_all_live_sessions() == 0

--- a/tests/vibe3/environment/test_session.py
+++ b/tests/vibe3/environment/test_session.py
@@ -119,4 +119,4 @@ class TestClearAllSessions:
         cleared = registry.clear_all_sessions()
         assert cleared == 1
         # _has_tmux_session should NOT be called
-        registry._backend.is_session_running.assert_not_called()
+        registry._backend.has_tmux_session.assert_not_called()

--- a/tests/vibe3/environment/test_session.py
+++ b/tests/vibe3/environment/test_session.py
@@ -87,41 +87,33 @@ class TestSessionManagerSafety:
 class TestClearAllSessions:
     """Tests for SessionRegistryService.clear_all_sessions()."""
 
-    def _make_registry(self, sessions: list[dict]) -> object:
+    def _make_registry(self, session_count: int) -> object:
         from unittest.mock import MagicMock
 
         from vibe3.environment.session_registry import SessionRegistryService
 
         store = MagicMock()
-        store.list_live_runtime_sessions.return_value = sessions
+        store.stop_all_live_sessions.return_value = session_count
         backend = MagicMock()
         registry = SessionRegistryService(store=store, backend=backend)
         return registry, store
 
     def test_clear_all_marks_all_sessions_stopped(self) -> None:
-        sessions = [
-            {"id": 1, "tmux_session": "vibe3-manager-1", "role": "manager"},
-            {"id": 2, "tmux_session": None, "role": "planner"},
-            {"id": 3, "tmux_session": "vibe3-executor-3", "role": "executor"},
-        ]
-        registry, store = self._make_registry(sessions)
+        registry, store = self._make_registry(3)
 
         cleared = registry.clear_all_sessions()
 
         assert cleared == 3
-        assert store.update_runtime_session.call_count == 3
-        for call in store.update_runtime_session.call_args_list:
-            assert call.kwargs.get("status") == "stopped" or call.args[1] == "stopped"
+        assert store.stop_all_live_sessions.call_count == 1
 
     def test_clear_all_no_sessions_returns_zero(self) -> None:
-        registry, store = self._make_registry([])
+        registry, store = self._make_registry(0)
         assert registry.clear_all_sessions() == 0
-        store.update_runtime_session.assert_not_called()
+        store.stop_all_live_sessions.assert_called_once()
 
     def test_clear_all_does_not_check_tmux(self) -> None:
         """clear_all_sessions skips tmux check — that's the whole point."""
-        sessions = [{"id": 1, "tmux_session": "alive-session", "role": "manager"}]
-        registry, store = self._make_registry(sessions)
+        registry, store = self._make_registry(1)
 
         # Even if tmux is alive, we still clear
         cleared = registry.clear_all_sessions()


### PR DESCRIPTION
Closes #2337

## Summary

Replace inefficient N+1 pattern in `SessionRegistryService.clear_all_sessions()` with a single bulk UPDATE statement.

- Added `SQLiteSessionRepo.stop_all_live_sessions()` for bulk session update
- Refactored `SessionRegistryService.clear_all_sessions()` to use bulk method
- Updated tests to match new call pattern

**Performance improvement**: Eliminates N round-trips to database (N = number of live sessions). Single indexed UPDATE WHERE status IN ('starting', 'running') using existing `idx_runtime_session_status_role` index.

## Test plan

- ✅ Store method tests: `uv run pytest tests/vibe3/clients/test_runtime_session_store.py -q` (15 passed)
- ✅ Service tests: `uv run pytest tests/vibe3/environment/test_session.py -q` (6 passed)
- ✅ Affected module tests: `uv run pytest tests/vibe3/services/test_session_registry.py -q` (20 passed)
- ✅ Type check: `uv run mypy src/vibe3/clients/sqlite_session_repo.py src/vibe3/environment/session_registry.py` (Success)
- ✅ Lint: `uv run ruff check src/vibe3/clients/sqlite_session_repo.py src/vibe3/environment/session_registry.py` (All checks passed)

All verification requirements satisfied. No deviation from plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
