### PR TITLE
docs(standards): add DomainEvent → FlowEvent projection rules

### DIFF
--- a/docs/standards/v3/command-standard.md
+++ b/docs/standards/v3/command-standard.md
@@ -192,6 +192,24 @@ related_docs:
 - 需要时按需 hydrate GitHub issue / PR 信息
 - 不把远端展示字段持久化成长期本地真源
 
+### 4.5 命令观察层级
+
+不同命令观察不同的事件层和数据源：
+
+| 命令 | 观察层级 | 主要数据源 | 用途 |
+|------|---------|-----------|------|
+| `vibe3 serve status` | Runtime DomainEvent 层 | Event bus、handler health、FailedGate、recent orchestration activity | 运行时健康状态、错误诊断 |
+| `vibe3 flow show` | FlowEvent 层 | Flow timeline (audit projection events) | Flow 生命周期审计、人类可读时间线 |
+| `vibe3 task status` | Task Pool 聚合 | Flow/issue/orchestra/worktree summary (not event log) | 项目级总览、容量管理 |
+
+**使用原则**：
+
+- `serve status` 用于观察运行时 DomainEvent（因果信号），**不应用于**检查 flow 时间线
+- `flow show` 用于观察 FlowEvent（审计投影），**不应用于**检查运行时编排过程
+- `task status` 用于项目级聚合视图，不提供事件级细节
+
+详细的事件层定义和投影规则见 [event-driven-standard.md](event-driven-standard.md) §十二。
+
 ## 5. `status` 与 `gh` 的分工
 
 `vibe3 task status` 保留的原因是它提供了 `gh` 没有的项目内聚合视图。

--- a/docs/standards/v3/database-schema-standard.md
+++ b/docs/standards/v3/database-schema-standard.md
@@ -12,6 +12,7 @@ last_updated: 2026-05-25
 related_docs:
   - docs/standards/v3/data-model-standard.md
   - docs/standards/glossary.md
+  - docs/standards/v3/event-driven-standard.md
 ---
 
 # 数据库 Schema 标准 (v3)
@@ -77,6 +78,8 @@ WHERE issue_role = 'task';
 ### 1.3 `flow_events`
 
 记录 Flow 生命周期内的关键事件。
+
+**重要**：此表存储 **FlowEvent** 记录（flow-local 审计投影），不是 **DomainEvent** 记录（运行时因果事件）。DomainEvent 到 FlowEvent 的投影规则见 [event-driven-standard.md](event-driven-standard.md) §十二。
 
 ```sql
 CREATE TABLE flow_events (

--- a/docs/standards/v3/event-driven-standard.md
+++ b/docs/standards/v3/event-driven-standard.md
@@ -515,6 +515,7 @@ LabelService().transition(
 
 ### 11.1 引用标准
 
+- **[ADR-0004](../../decisions/0004-domain-flow-event-boundary.md)**: 定义 DomainEvent 与 FlowEvent 的边界和投影关系，本文件 §十二 实现该决策。
 - **[worktree-ownership-standard.md](worktree-ownership-standard.md)**: 定义执行层级与 worktree 语义，本文件补充事件语义。
 - **[vibe3-orchestra-runtime-standard.md](../vibe3-orchestra-runtime-standard.md)**: 定义 driver/tick/async child 架构，事件发布时机参考该文件。
 - **[command-standard.md](command-standard.md)**: 定义 flow 状态机，事件触发条件参考该文件。
@@ -529,7 +530,116 @@ LabelService().transition(
 
 ---
 
-## 十二、三层概念说明：governance / apply / runtime
+## 十二、DomainEvent → FlowEvent 投影规则
+
+### 12.1 投影原则
+
+根据 [ADR-0004](../../decisions/0004-domain-flow-event-boundary.md)，DomainEvent 到 FlowEvent 的投影**不是默认行为**。只有对 flow 场景具有审计价值的 DomainEvent 才应投影到 FlowEvent。
+
+### 12.2 事件分类与投影规则
+
+#### Flow Lifecycle Events（投影）
+
+这些事件直接改变 flow 场景，具有人类审计价值，**投影到 FlowEvent**。
+
+- `FlowBlocked`
+- `FlowCompleted`
+- `IssueFailed`
+- `PRMerged`
+
+#### Dispatch Intent Events（仅运行时）
+
+这些事件驱动编排流程，但**不是时间线事件**，不投影。
+
+- `ManagerDispatchIntent`
+- `PlannerDispatchIntent`
+- `ExecutorDispatchIntent`
+- `ReviewerDispatchIntent`
+
+#### Governance Scan Events（仅 Serve/运行时观察）
+
+这些事件用于治理扫描观察，**不投影**。
+
+- `GovernanceScanStarted`
+- `GovernanceScanCompleted`
+- `GovernanceDecisionRequired`
+- `PolicyChanged`
+
+#### Supervisor Apply Events（仅 Serve/运行时观察）
+
+这些事件记录 Supervisor 执行过程，**不投影**。
+
+- `SupervisorIssueIdentified`
+- `SupervisorPromptRendered`
+- `SupervisorApplyDispatched`
+- `SupervisorApplyStarted`
+- `SupervisorApplyCompleted`
+- `SupervisorApplyDelegated`
+
+#### External Trigger Events（仅运行时）
+
+这些事件是外部触发信号，**不投影**。
+
+- `WebhookLabelChanged`
+- `WebhookIssueUpdated`
+- `WebhookPRMerged`
+- `WebhookPRReviewed`
+- `WebhookIssueClosed`
+
+#### CLI Invocation Events（仅运行时）
+
+这些事件是 CLI 用户操作，**不投影**。
+
+- `ManualPlanIntent`
+- `ManualRunIntent`
+- `ManualReviewIntent`
+
+#### Infrastructure Events（仅 Serve/运行时观察）
+
+- `ControlPlaneEventPublished`：用于 `serve status` 审计记录，**不投影**。
+
+### 12.3 投影规则表
+
+| DomainEvent | → FlowEvent? | flow_event_type | Layer | Rationale |
+|---|---|---|---|---|
+| `FlowBlocked` | Yes | `flow_blocked` | Flow Timeline | Human-visible blocked state; note: blocked state remains owned by blocked-state/flow store write paths |
+| `FlowCompleted` | Yes | `flow_completed` | Flow Timeline | Flow lifecycle milestone |
+| `IssueFailed` | Yes | `flow_failed` | Flow Timeline | Flow-level error audit |
+| `PRMerged` | Yes | `pr_merged` | Flow Timeline | Flow lifecycle milestone |
+| `*DispatchIntent` (4 events) | No | — | Runtime | Orchestration signals, not timeline |
+| `GovernanceScan*` (3 events) | No | — | Serve/Runtime | Governance observation only |
+| `Supervisor*` (6 events) | No | — | Serve/Runtime | Supervisor execution recording |
+| `Webhook*` (5 events) | No | — | Serve/Runtime | External trigger signals |
+| `Manual*Intent` (3 events) | No | — | Runtime | CLI user actions |
+| `PolicyChanged` | No | — | Serve/Runtime | Configuration change observation |
+| `ControlPlaneEventPublished` | No | — | Serve/Runtime | Audit record for serve status |
+
+### 12.4 FlowBlocked 显式规则
+
+`FlowBlocked` DomainEvent 可能投影到 `flow_blocked` FlowEvent，但需明确：
+
+- **Blocked 状态归属**：flow 是否 blocked、blocked 原因、依赖追踪，这些状态由 blocked-state service 和 flow store 写入路径管理
+- **FlowEvent 性质**：`flow_blocked` FlowEvent 是只读审计投影，不决定也不修改 blocked 状态
+- **单状态机原则**：这确保时间线不会成为第二个状态机
+
+### 12.5 Blocked / Failed / Warning 区分
+
+- `flow_blocked` (FlowEvent)：flow 被阻塞，需要人工关注，显示在 flow 时间线
+- `flow_failed` (FlowEvent)：运行时错误发生，显示在 flow 时间线用于审计
+- `IssueFailed` (DomainEvent)：运行时因果事件，由错误处理器消费；作为**可能**投影到 `flow_failed` 的源信号
+- Warning-level events（如 `codeagent_*_warning`）：是 FlowEvent 层的显示变体，不是 DomainEvent 投影
+
+### 12.6 维护要求
+
+新增 DomainEvent 类型时，**必须**在此表格中分类并明确投影规则。
+
+### 12.7 规范回链
+
+本投影规则表实现了 [ADR-0004](../../decisions/0004-domain-flow-event-boundary.md) 定义的单向投影关系。
+
+---
+
+## 十三、三层概念说明：governance / apply / runtime
 
 以下三个概念容易混淆，特此明确：
 
@@ -568,7 +678,7 @@ LabelService().transition(
 
 ---
 
-## 十三、变更历史
+## 十四、变更历史
 
 | 版本 | 日期 | 变更说明 |
 |------|------|----------|

--- a/docs/standards/v3/serve-debugging-guide.md
+++ b/docs/standards/v3/serve-debugging-guide.md
@@ -14,6 +14,7 @@ related_docs:
   - docs/standards/vibe3-orchestra-runtime-standard.md
   - docs/standards/v3/noop-gate-boundary-standard.md
   - docs/standards/v3/command-standard.md
+  - docs/standards/v3/event-driven-standard.md
 ---
 
 # Vibe3 Serve 调试指南
@@ -105,16 +106,19 @@ uv run python src/vibe3/cli.py serve start -vv   # DEBUG
 
 **不要只看日志，必须交叉验证真源**：
 
-| 真源 | 命令 | 用途 |
-|-----|------|------|
-| Flow 状态 | `vibe3 flow show` | 当前 flow 的状态机、事件时间线 |
-| Task 状态 | `vibe3 task status` | issue 归属、执行阶段、最新 actor |
-| GitHub Issue | `gh issue view <number>` | 外部可见状态、labels、comments |
+| 真源 | 命令 | 观察层级 | 用途 |
+|-----|------|---------|------|
+| Runtime 状态 | `vibe3 serve status` | DomainEvent 层（运行时因果信号） | Event bus、handler health、FailedGate、编排活动 |
+| Flow 时间线 | `vibe3 flow show` | FlowEvent 层（审计投影） | Flow 生命周期事件、人类可读时间线 |
+| Task 状态 | `vibe3 task status` | Task Pool 聚合 | Issue 归属、执行阶段、最新 actor |
+| GitHub Issue | `gh issue view <number>` | 外部事实 | 外部可见状态、labels、comments |
 
 **调试原则**：
 - 日志告诉你"发生了什么"
 - 真源告诉你"结果是什么"
 - 两者必须一致，否则有状态同步 bug
+
+**重要**：`serve status` 观察运行时 DomainEvents（因果信号）。对于 flow 特定的时间线记录，使用 `flow show` 观察 FlowEvents（审计投影）。详见 [event-driven-standard.md](./v3/event-driven-standard.md) §十二 了解 DomainEvent → FlowEvent 投影规则。
 
 ---
 

--- a/docs/standards/v3/serve-debugging-guide.md
+++ b/docs/standards/v3/serve-debugging-guide.md
@@ -118,7 +118,7 @@ uv run python src/vibe3/cli.py serve start -vv   # DEBUG
 - 真源告诉你"结果是什么"
 - 两者必须一致，否则有状态同步 bug
 
-**重要**：`serve status` 观察运行时 DomainEvents（因果信号）。对于 flow 特定的时间线记录，使用 `flow show` 观察 FlowEvents（审计投影）。详见 [event-driven-standard.md](./v3/event-driven-standard.md) §十二 了解 DomainEvent → FlowEvent 投影规则。
+**重要**：`serve status` 观察运行时 DomainEvents（因果信号）。对于 flow 特定的时间线记录，使用 `flow show` 观察 FlowEvents（审计投影）。详见 [event-driven-standard.md](event-driven-standard.md) §十二 了解 DomainEvent → FlowEvent 投影规则。
 
 ---
 


### PR DESCRIPTION
Closes #2746

## Summary

Add comprehensive projection rule documentation to clarify which DomainEvents project to FlowEvents and which remain runtime-only. This implements ADR-0004 by documenting the one-way projection relationship.

## Changes

### event-driven-standard.md
- Added §十二 "DomainEvent → FlowEvent 投影规则"
- Projection principle statement (ADR-0004)
- Event category definitions (7 categories)
- Projection rule table covering all 27 DomainEvent types
- FlowBlocked explicit rule clarifying state ownership
- Blocked/Failed/Warning distinction
- Three ADR-0004 backlinks

### command-standard.md
- Added §4.5 "命令观察层级"
- Table mapping commands to event layers
- Usage principles for `serve status`, `flow show`, `task status`

### serve-debugging-guide.md
- Updated §3.2 Ground Truth table
- Distinguished runtime observation vs flow timeline
- Added event-driven-standard.md reference

### database-schema-standard.md
- Updated §1.3 flow_events description
- Clarified FlowEvent vs DomainEvent distinction
- Added event-driven-standard.md reference

## DomainEvent Coverage

All 27 DomainEvent types categorized:

**Project to FlowEvent (4 events)**:
- FlowBlocked → `flow_blocked`
- FlowCompleted → `flow_completed`
- IssueFailed → `flow_failed`
- PRMerged → `pr_merged`

**Runtime-only (23 events)**:
- Dispatch Intent events (4): ManagerDispatchIntent, PlannerDispatchIntent, ExecutorDispatchIntent, ReviewerDispatchIntent
- Governance events (4): GovernanceScanStarted, GovernanceScanCompleted, GovernanceDecisionRequired, PolicyChanged
- Supervisor events (6): SupervisorIssueIdentified, SupervisorPromptRendered, SupervisorApplyDispatched, SupervisorApplyStarted, SupervisorApplyCompleted, SupervisorApplyDelegated
- Webhook events (5): WebhookLabelChanged, WebhookIssueUpdated, WebhookPRMerged, WebhookPRReviewed, WebhookIssueClosed
- CLI events (3): ManualPlanIntent, ManualRunIntent, ManualReviewIntent
- Infrastructure events (1): ControlPlaneEventPublished

## Test Plan

Documentation-only change. No automated tests needed.

Manual verification:
- [x] All 27 DomainEvent types covered in projection table
- [x] ADR-0004 backlinks present (3 occurrences)
- [x] Cross-references between all 4 standards files
- [x] No broken links (verified all relative paths)

## Related

- ADR-0004: docs/decisions/0004-domain-flow-event-boundary.md
- Issue: #2746

---

## Contributors

claude/opus
