### PR TITLE
refactor(flow): optimize get_flow_for_issue with targeted SQL lookup

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -50,7 +50,7 @@ code_limits:
         limit: 520
         reason: "GitHub PR 只读查询聚合，新增 CI 失败分类与检查步骤解析逻辑，包含失败分类、日志解析、状态映射等紧密耦合逻辑"
       - path: "src/vibe3/clients/sqlite_flow_state_repo.py"
-        limit: 540
+        limit: 600
         reason: |
           Repo 层职责内聚，包含：
           - 基础 CRUD 操作（10 个 get 方法）
@@ -58,9 +58,10 @@ code_limits:
           - Cascade delete 逻辑
           - Query 过滤逻辑（WHERE deleted_at IS NULL）
           - get_task_issue_number 方法（从 flow_issue_links 查询 task issue）
+          - get_branch_for_task_issue 方法（反向查询，issue_number → branch）
           - UTC-aware datetime 写入（update_flow_state, add_issue_link）
           - Status 参数验证（get_flows_by_status 增加 VALID_FLOW_STATUSES 校验）
-          - Bulk retrieval optimization（get_flow_state_bulk、get_flows_by_issues_bulk，Issue #2542 N+1 查询优化）
+          - Bulk retrieval optimization（get_flow_state_bulk、get_flows_by_issues_bulk）
 
           拆分会破坏：
           - 数据访问层完整性
@@ -70,6 +71,7 @@ code_limits:
 
           PR #2409 新增 status 验证逻辑，提升类型安全和 fail-fast 行为（+18 行）
           PR #2542 新增 bulk retrieval 方法，修复 N+1 查询模式，减少 100x 数据库查询（+62 行）
+          PR #2741 新增 get_branch_for_task_issue 方法，优化 get_flow_for_issue 性能（+28 行）
 
       # Commands 层 —— 允许 480-550
       - path: "src/vibe3/commands/status.py"

--- a/src/vibe3/clients/sqlite_flow_state_repo.py
+++ b/src/vibe3/clients/sqlite_flow_state_repo.py
@@ -233,6 +233,39 @@ class SQLiteFlowStateRepo(_HasConnection):
         ).debug("Retrieved task issue number")
         return result
 
+    def get_branch_for_task_issue(self, issue_number: int) -> str | None:
+        """Get branch name for a task issue number from flow_issue_links.
+
+        This is the inverse of get_task_issue_number(branch).
+
+        Note: When multiple branches link to the same issue as task,
+        this returns an arbitrary one (LIMIT 1). For priority-based
+        selection (active canonical → active non-canonical), use
+        IssueFlowService.find_active_flow instead.
+
+        Args:
+            issue_number: Issue number to query
+
+        Returns:
+            Branch name if found, None otherwise
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT branch FROM flow_issue_links "
+            "WHERE issue_number = ? AND issue_role = 'task' LIMIT 1",
+            (issue_number,),
+        )
+        row = cursor.fetchone()
+        result = row[0] if row and row[0] is not None else None
+        logger.bind(
+            external="sqlite",
+            operation="get_branch_for_task_issue",
+            branch=result,
+            issue_number=issue_number,
+        ).debug("Retrieved branch for task issue")
+        return result
+
     def get_all_flows(self) -> list[dict[str, Any]]:
         """Get all flows (excludes soft-deleted flows)."""
         conn = self._get_connection()

--- a/src/vibe3/services/flow/read_mixin.py
+++ b/src/vibe3/services/flow/read_mixin.py
@@ -161,13 +161,10 @@ class FlowReadMixin:
         Returns:
             Flow data dict or None if not found
         """
-        # Query all flows and find one with matching task_issue_number
-        flows = self.list_flows(status=None)
-        for flow in flows:
-            if flow.task_issue_number == issue_number:
-                flow_data = self.store.get_flow_state(flow.branch)
-                if flow_data:
-                    return flow_data
+        # Direct branch lookup via indexed SQL
+        branch = self.store.get_branch_for_task_issue(issue_number)
+        if branch:
+            return self.store.get_flow_state(branch)
         return None
 
     def list_flows(

--- a/tests/vibe3/clients/test_flow_state_repo.py
+++ b/tests/vibe3/clients/test_flow_state_repo.py
@@ -146,3 +146,68 @@ def test_get_flows_by_issues_bulk_missing_issue() -> None:
         assert len(result) == 2
         assert len(result[100]) == 1
         assert result[999] == []
+
+
+def test_get_branch_for_task_issue_returns_branch() -> None:
+    """Get branch for task issue should return correct branch."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Create flow and issue link
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-100", 100, "task"),
+        )
+        conn.commit()
+
+        # Query for branch
+        result = store.get_branch_for_task_issue(100)
+
+        assert result == "task/issue-100"
+
+
+def test_get_branch_for_task_issue_returns_none_for_missing() -> None:
+    """Get branch for non-existent issue should return None."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Query for non-existent issue
+        result = store.get_branch_for_task_issue(999)
+
+        assert result is None
+
+
+def test_get_branch_for_task_issue_returns_none_for_non_task_role() -> None:
+    """Get branch should not return dependency role links."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        store = SQLiteClient(db_path=str(db_path))
+
+        # Create flow and issue link with dependency role
+        store.update_flow_state(
+            "task/issue-100", flow_slug="issue-100", flow_status="active"
+        )
+        conn = store._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO flow_issue_links "
+            "(branch, issue_number, issue_role, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("task/issue-100", 100, "dependency"),
+        )
+        conn.commit()
+
+        # Query for branch with task role
+        result = store.get_branch_for_task_issue(100)
+
+        # Should return None because link is 'dependency' not 'task'
+        assert result is None


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2741` is behind `main` by **4 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2741
```


---

## Summary

Replace all-flow load + Python filter with direct indexed lookup in `FlowReadMixin.get_flow_for_issue`, reducing complexity from O(n) to O(1).

## Changes

### Core Implementation
- **Add `get_branch_for_task_issue()` to SQLiteFlowStateRepo**
  - Inverse of existing `get_task_issue_number(branch)` method
  - Direct indexed SQL lookup: `SELECT branch FROM flow_issue_links WHERE issue_number = ? AND issue_role = 'task' LIMIT 1`
  - Avoids loading all flows into memory

- **Refactor `FlowReadMixin.get_flow_for_issue`**
  - Replace `self.list_flows(status=None)` + Python iteration with targeted lookup
  - New implementation: `branch = self.store.get_branch_for_task_issue(issue_number)` + `self.store.get_flow_state(branch)`
  - Maintains same contract: `issue_number -> flow_data dict | None`
  - Simpler code (13 lines → 9 lines)

### Test Coverage
- **Add 3 new unit tests** for `get_branch_for_task_issue`
  - `test_get_branch_for_task_issue_returns_branch`: Valid issue returns correct branch
  - `test_get_branch_for_task_issue_returns_none_for_missing`: Non-existent issue returns None
  - `test_get_branch_for_task_issue_returns_none_for_non_task_role`: Dependency role links are excluded

### Configuration
- **Update LOC exception limit** for `sqlite_flow_state_repo.py` (540 → 600)
  - Rationale: File already has exception for repo layer cohesion
  - New method follows established pattern
  - Consistent with other repo files (dispatch_coordinator: 700, qualify_gate: 750)

## Performance Impact

**Before**:
- `get_flow_for_issue` called `list_flows(status=None)` which loaded all flows into memory
- Complexity: O(n) flows loaded, each with O(m) issue links checked
- Memory: All flow states + issue links materialized in Python

**After**:
- Direct indexed SQL lookup on `flow_issue_links` table
- Complexity: O(1) indexed lookup + O(1) flow state fetch
- Memory: Only one flow state materialized

**Estimated improvement**: Significant for databases with 10+ flows, dramatic for 100+ flows.

## Test Results

✅ **Direct tests**: 9 passed (test_flow_state_repo.py)
✅ **Integration tests**: 8 passed (test_flow_query.py)
✅ **Regression tests**: 11 passed (test_flow_status.py)
✅ **Type checking**: mypy passed (no errors)
✅ **Linting**: ruff passed (all checks)

## Design Rationale

1. **Method placement**: Added to `SQLiteFlowStateRepo` as it's the inverse of existing `get_task_issue_number`, maintaining repo layer cohesion
2. **No JOIN with flow_state**: Caller reads full flow state separately, keeping method single-purpose
3. **LIMIT 1**: Matches original behavior (first match); for priority-based selection, use `IssueFlowService.find_active_flow`
4. **Docstring note**: Documents non-determinism when multiple branches link to same issue

## Related

- Closes #2741
- Follows inverse pattern of `get_task_issue_number` (sqlite_flow_state_repo.py:210)
- Schema verified: `flow_issue_links` table with `idx_flow_single_task_issue` unique index

---

## Contributors

claude/opus
