### PR TITLE
fix(queue): terminal states (blocked/done) removed from frozen queue

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -280,8 +280,8 @@ code_limits:
         limit: 500
         reason: "Actionable trigger + dispatch pause 测试集 (#1206)，覆盖 collect/merge/dispatch loop 的 actionable 判断、dispatch_paused 状态管理、blocked-only rebuild 逻辑，共享 fixture，拆分收益低；#2381 新增 test_dispatch_loop_rechecks_qualify_gate_for_ready_issue 测试验证 dispatch-time qualify gate recheck（+29 行）"
       - path: "tests/vibe3/orchestra/test_dispatch_queue_operations.py"
-        limit: 450
-        reason: "Queue operations 测试集，覆盖 frozen queue 管理、dispatch 协调、issue 状态管理、健康检查等紧密耦合场景，每个测试需要完整 mock setup；Issue #2536 新增 test_single_issue_qualify_failure_does_not_abort_batch 回归测试验证单个 issue 失败不阻塞整个批次（+66 行）"
+        limit: 600
+        reason: "Queue operations 测试集，覆盖 frozen queue 管理、dispatch 协调、issue 状态管理、健康检查等紧密耦合场景，每个测试需要完整 mock setup；Issue #2765 新增 BLOCKED 重资格化和空队列日志抑制回归测试（+50 行）"
       - path: "tests/vibe3/orchestra/test_failed_gate.py"
         limit: 470
         reason: "FailedGate 测试集，覆盖 unit + integration 测试（gate open/close、severity-aware checks、serve start preflight、heartbeat tick loop），合并后内聚度高，拆分会破坏测试场景完整性"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -18,8 +18,8 @@ code_limits:
     exceptions:
       # 核心业务聚合 —— 允许 600-700
       - path: "src/vibe3/domain/dispatch_coordinator.py"
-        limit: 700
-        reason: "Global dispatch coordinator (migrated from orchestra to domain layer for domain-first architecture #1624)，核心调度聚合，包含 frozen queue 管理、dispatch 协调、issue 状态管理、健康检查、重启恢复等紧密耦合逻辑；mixin-to-service 重构后增加委托调用，整体代码量减少（删除 mixin 250 行，新增 service 149 行）"
+        limit: 720
+        reason: "Global dispatch coordinator (migrated from orchestra to domain layer for domain-first architecture #1624)，核心调度聚合，包含 frozen queue 管理、dispatch 协调、issue 状态管理、健康检查、重启恢复等紧密耦合逻辑；mixin-to-service 重构后增加委托调用，整体代码量减少（删除 mixin 250 行，新增 service 149 行）；#2765 增加 _dispatch_loop removal logging 和 queue collection 改进（+32 行）"
       - path: "src/vibe3/services/pr/service.py"
         limit: 600
         reason: "PR 生命周期聚合"

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -267,11 +267,18 @@ class GlobalDispatchCoordinator:
                     "select_ready_issues_from_collected_issues failed for "
                     f"{state.value}: {exc}"
                 )
-        append_orchestra_event(
-            "dispatcher",
-            f"GlobalDispatchCoordinator: queue collection complete, "
-            f"total={len(queue)} issues",
-        )
+        if queue:
+            append_orchestra_event(
+                "dispatcher",
+                f"GlobalDispatchCoordinator: queue collection complete, "
+                f"total={len(queue)} issues",
+            )
+        else:
+            append_orchestra_event(
+                "dispatcher",
+                "GlobalDispatchCoordinator: queue collection complete, "
+                "no actionable issues found",
+            )
         return queue
 
     def _check_dispatch_health(self, issue: IssueInfo) -> bool:
@@ -474,6 +481,11 @@ class GlobalDispatchCoordinator:
             entry = self._frozen_queue[index]
             issue = self._load_issue(entry.issue_number)
             if issue is None or issue.state is None:
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: removed #{entry.issue_number} "
+                    "from queue (issue not found or state missing)",
+                )
                 self._frozen_queue.pop(index)
                 continue
 
@@ -492,6 +504,11 @@ class GlobalDispatchCoordinator:
                 continue
 
             if issue.state == IssueState.DONE:
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: removed #{issue.number} "
+                    "from queue (state terminal: done)",
+                )
                 self._frozen_queue.pop(index)
                 continue
 
@@ -518,11 +535,21 @@ class GlobalDispatchCoordinator:
 
             preflight = self._run_dispatch_preflight(issue)
             if not preflight.allowed or preflight.target_state is None:
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: removed #{issue.number} "
+                    f"from queue (preflight failed: {preflight.reason})",
+                )
                 self._frozen_queue.pop(index)
                 continue
 
             role = find_role_for_state(preflight.target_state)
             if role is None:
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: removed #{issue.number} "
+                    f"from queue (no role for state {preflight.target_state})",
+                )
                 self._frozen_queue.pop(index)
                 continue
             entry.collected_state = preflight.target_state.value
@@ -668,6 +695,11 @@ class GlobalDispatchCoordinator:
             dispatched_count
         )
         if need_collect:
+            append_orchestra_event(
+                "dispatcher",
+                "GlobalDispatchCoordinator: queue exhausted after dispatch, "
+                "rebuilding for next tick",
+            )
             fresh = await self._collect_frozen_queue()
             # Invalidate PR cache after fresh collection
             self._check_service.invalidate_pr_cache()

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -9,6 +9,9 @@ Queue strategy:
 3. Give blocked-only rebuilds one dispatch-time qualify pass
 4. If candidates remain blocked, pause recollection until work changes
 5. Capacity still gates actual dispatch intents
+6. Every collection re-qualifies BLOCKED issues (see
+   _requalify_blocked_issues) so resolved blockers get relabeled and
+   picked up on the next pass
 """
 
 from __future__ import annotations
@@ -205,10 +208,6 @@ class GlobalDispatchCoordinator:
         """Collect a new frozen queue only when the current one is empty."""
         queue: list[QueueEntry] = []
         seen_issue_numbers: set[int] = set()
-        append_orchestra_event(
-            "dispatcher",
-            "GlobalDispatchCoordinator: starting queue collection",
-        )
         try:
             collected_issues = await asyncio.get_running_loop().run_in_executor(
                 self._executor,
@@ -267,19 +266,42 @@ class GlobalDispatchCoordinator:
                     "select_ready_issues_from_collected_issues failed for "
                     f"{state.value}: {exc}"
                 )
+        self._requalify_blocked_issues(collected_issues)
+
         if queue:
             append_orchestra_event(
                 "dispatcher",
                 f"GlobalDispatchCoordinator: queue collection complete, "
                 f"total={len(queue)} issues",
             )
-        else:
-            append_orchestra_event(
-                "dispatcher",
-                "GlobalDispatchCoordinator: queue collection complete, "
-                "no actionable issues found",
-            )
         return queue
+
+    def _requalify_blocked_issues(self, collected_issues: list[IssueInfo]) -> None:
+        """Re-run the qualify gate for issues collected as BLOCKED.
+
+        BLOCKED issues are excluded from the frozen queue (they cannot be
+        dispatched), so without this pass an issue whose blockers have
+        resolved would never be re-qualified until some other trigger
+        forces a collection. ``qualify_blocked_issue`` performs its own
+        label transition and event logging when an issue becomes
+        resumable; the relabeled issue is then picked up normally on the
+        next collection cycle.
+        """
+        for issue in collected_issues:
+            if issue.state != IssueState.BLOCKED:
+                continue
+            try:
+                self._qualify_gate.qualify_blocked_issue(issue)
+            except Exception as exc:
+                append_orchestra_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: requalify failed for "
+                    f"#{issue.number}: {exc}",
+                )
+                logger.bind(
+                    domain="global_dispatch",
+                    issue=issue.number,
+                ).warning(f"qualify_blocked_issue failed for #{issue.number}: {exc}")
 
     def _check_dispatch_health(self, issue: IssueInfo) -> bool:
         """Pre-dispatch health check. Returns True if issue can be dispatched.

--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from vibe3.clients import GitHubClient
 from vibe3.domain import publish
+from vibe3.domain.dispatch_health import DispatchHealthService
 from vibe3.domain.dispatch_preflight import (
     DispatchPreflightDecision,
     DispatchPreflightService,
@@ -59,9 +60,6 @@ if TYPE_CHECKING:
 # Hard limit to prevent extreme tick duration in edge cases
 MAX_INTENTS_PER_TICK = 10
 
-# Transient error prefixes: fail-open instead of blocking the flow
-_TRANSIENT_ERROR_PREFIXES = ("Cannot verify", "No flow record")
-
 
 class GlobalDispatchCoordinator:
     """Frozen queue with state-change requeue semantics."""
@@ -88,6 +86,7 @@ class GlobalDispatchCoordinator:
     _remote_check_runner: Callable[[], None] | None
     _remote_check_interval: int
     _last_remote_check_tick: int
+    _dispatch_health: DispatchHealthService
     _dispatch_preflight: DispatchPreflightService
 
     def __init__(
@@ -155,6 +154,17 @@ class GlobalDispatchCoordinator:
         self._remote_check_runner = remote_check_runner
         self._remote_check_interval = remote_check_interval
         self._last_remote_check_tick: int = 0
+
+        def _emit(category: str, message: str) -> None:
+            append_orchestra_event(category, message)
+
+        self._dispatch_health = DispatchHealthService(
+            check_service=lambda: self._check_service,
+            store=store,
+            flow_blocker=flow_blocker,
+            flow_context=lambda issue_number: self._flow_context(issue_number),
+            emit_event=_emit,
+        )
         self._dispatch_preflight = DispatchPreflightService(
             qualify_gate=self._qualify_gate,
             flow_context=lambda issue_number: self._flow_context(issue_number),
@@ -304,83 +314,8 @@ class GlobalDispatchCoordinator:
                 ).warning(f"qualify_blocked_issue failed for #{issue.number}: {exc}")
 
     def _check_dispatch_health(self, issue: IssueInfo) -> bool:
-        """Pre-dispatch health check. Returns True if issue can be dispatched.
-
-        Delegates structural checks to CheckService, with terminal state
-        and transient error handling inlined directly in this method.
-        """
-        branch, _ = self._flow_context(issue.number)
-
-        # Empty-branch guard: fail-open only for manager entry states
-        if not branch:
-            issue_state = issue.state
-            if issue_state not in {IssueState.READY, IssueState.HANDOFF}:
-                state_value = issue_state.value if issue_state else "unknown"
-                append_orchestra_event(
-                    "dispatcher",
-                    f"GlobalDispatchCoordinator: skipped #{issue.number} "
-                    f"(missing flow context for {state_value})",
-                )
-                return False
-            return True
-
-        result = self._check_service.verify_branch(branch)
-
-        flow_state = self._store.get_flow_state(branch)
-        flow_status = (
-            flow_state.get("flow_status", "active") if flow_state else "active"
-        )
-
-        # Terminal state: skip dispatch cleanly
-        if flow_status in ("done", "aborted", "stale", "review"):
-            append_orchestra_event(
-                "dispatcher",
-                f"GlobalDispatchCoordinator: skipped #{issue.number} "
-                f"(flow is {flow_status})",
-            )
-            return False
-
-        if not result.is_valid:
-            # Transient errors: fail-open
-            is_transient = any(
-                any(err.startswith(prefix) for err in result.issues)
-                for prefix in _TRANSIENT_ERROR_PREFIXES
-            )
-            if is_transient:
-                append_orchestra_event(
-                    "dispatcher",
-                    f"GlobalDispatchCoordinator: fail-open for #{issue.number} "
-                    f"(transient: {', '.join(result.issues)})",
-                )
-                return True
-
-            # Genuine failure: block and skip
-            reason = f"Health check failed: {', '.join(result.issues)}"
-            block_succeeded = False
-            try:
-                self._flow_blocker.block_flow(
-                    branch=branch, reason=reason, actor="orchestra:dispatcher"
-                )
-                block_succeeded = True
-            except Exception as exc:
-                logger.bind(domain="orchestra", action="health_check").warning(
-                    f"Failed to block flow for #{issue.number}: {exc}"
-                )
-                append_orchestra_event(
-                    "dispatcher",
-                    f"GlobalDispatchCoordinator: block_failed #{issue.number} "
-                    f"(error: {exc}, health check: {reason})",
-                )
-
-            if block_succeeded:
-                append_orchestra_event(
-                    "dispatcher",
-                    f"GlobalDispatchCoordinator: blocked #{issue.number} "
-                    f"(health check failed: {reason})",
-                )
-            return False
-
-        return True
+        """Pre-dispatch health check. Returns True if issue can be dispatched."""
+        return self._dispatch_health.check(issue)
 
     def _run_dispatch_preflight(self, issue: IssueInfo) -> DispatchPreflightDecision:
         """Run the unified pre-dispatch gate for one issue."""

--- a/src/vibe3/domain/dispatch_health.py
+++ b/src/vibe3/domain/dispatch_health.py
@@ -1,0 +1,118 @@
+"""Pre-dispatch health checks for orchestra dispatch."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from vibe3.domain.protocols.dispatch_protocols import (
+    CheckServiceProtocol,
+    FlowServiceProtocol,
+)
+from vibe3.models import IssueInfo, IssueState
+
+if TYPE_CHECKING:
+    from vibe3.clients import SQLiteClient
+
+# Transient error prefixes: fail-open instead of blocking the flow
+_TRANSIENT_ERROR_PREFIXES = ("Cannot verify", "No flow record")
+
+
+class DispatchHealthService:
+    """Pre-dispatch health check for branch and flow state."""
+
+    def __init__(
+        self,
+        *,
+        check_service: Callable[[], CheckServiceProtocol],
+        store: "SQLiteClient",
+        flow_blocker: FlowServiceProtocol,
+        flow_context: Callable[[int], tuple[str, dict[str, object] | None]],
+        emit_event: Callable[[str, str], None],
+    ) -> None:
+        self._check_service = check_service
+        self._store = store
+        self._flow_blocker = flow_blocker
+        self._flow_context = flow_context
+        self._emit_event = emit_event
+
+    def check(self, issue: IssueInfo) -> bool:
+        """Pre-dispatch health check. Returns True if issue can be dispatched.
+
+        Delegates structural checks to CheckService, with terminal state
+        and transient error handling inlined directly in this method.
+        """
+        branch, _ = self._flow_context(issue.number)
+
+        # Empty-branch guard: fail-open only for manager entry states
+        if not branch:
+            issue_state = issue.state
+            if issue_state not in {IssueState.READY, IssueState.HANDOFF}:
+                state_value = issue_state.value if issue_state else "unknown"
+                self._emit_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: skipped #{issue.number} "
+                    f"(missing flow context for {state_value})",
+                )
+                return False
+            return True
+
+        result = self._check_service().verify_branch(branch)
+
+        flow_state = self._store.get_flow_state(branch)
+        flow_status = (
+            flow_state.get("flow_status", "active") if flow_state else "active"
+        )
+
+        # Terminal state: skip dispatch cleanly
+        if flow_status in ("done", "aborted", "stale", "review"):
+            self._emit_event(
+                "dispatcher",
+                f"GlobalDispatchCoordinator: skipped #{issue.number} "
+                f"(flow is {flow_status})",
+            )
+            return False
+
+        if not result.is_valid:
+            # Transient errors: fail-open
+            is_transient = any(
+                any(err.startswith(prefix) for err in result.issues)
+                for prefix in _TRANSIENT_ERROR_PREFIXES
+            )
+            if is_transient:
+                self._emit_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: fail-open for #{issue.number} "
+                    f"(transient: {', '.join(result.issues)})",
+                )
+                return True
+
+            # Genuine failure: block and skip
+            reason = f"Health check failed: {', '.join(result.issues)}"
+            block_succeeded = False
+            try:
+                self._flow_blocker.block_flow(
+                    branch=branch, reason=reason, actor="orchestra:dispatcher"
+                )
+                block_succeeded = True
+            except Exception as exc:
+                logger.bind(domain="orchestra", action="health_check").warning(
+                    f"Failed to block flow for #{issue.number}: {exc}"
+                )
+                self._emit_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: block_failed #{issue.number} "
+                    f"(error: {exc}, health check: {reason})",
+                )
+
+            if block_succeeded:
+                self._emit_event(
+                    "dispatcher",
+                    f"GlobalDispatchCoordinator: blocked #{issue.number} "
+                    f"(health check failed: {reason})",
+                )
+            return False
+
+        return True

--- a/src/vibe3/orchestra/queue_operations.py
+++ b/src/vibe3/orchestra/queue_operations.py
@@ -218,11 +218,20 @@ def promote_progressed_entries(
 
         entry.waiting_state = None
         entry.collected_state = current_state
-        promoted.append(entry)
-        append_orchestra_event(
-            "dispatcher",
-            f"GlobalDispatchCoordinator: requeued #{entry.issue_number} "
-            f"to front after state change to {current_state}",
-        )
+
+        if issue.state in {IssueState.DONE, IssueState.BLOCKED}:
+            removed.append(entry)
+            append_orchestra_event(
+                "dispatcher",
+                f"GlobalDispatchCoordinator: removed #{entry.issue_number} "
+                f"from queue (state terminal: {current_state})",
+            )
+        else:
+            promoted.append(entry)
+            append_orchestra_event(
+                "dispatcher",
+                f"GlobalDispatchCoordinator: requeued #{entry.issue_number} "
+                f"to front after state change to {current_state}",
+            )
 
     return promoted, retained, removed

--- a/tests/vibe3/orchestra/test_dispatch_queue_operations.py
+++ b/tests/vibe3/orchestra/test_dispatch_queue_operations.py
@@ -416,3 +416,174 @@ class TestQueueOperations:
         assert len(selected) == 1
         assert selected[0].number == 2
         assert call_count[0] == 2  # Both issues were processed
+
+
+class TestCollectFrozenQueueBlockedRequalification:
+    """Regression tests for issue #2765: BLOCKED issues must be
+    re-qualified during collection so resolved blockers get relabeled and
+    picked up on the next pass."""
+
+    @pytest.mark.asyncio
+    async def test_requalifies_blocked_issues_during_collection(
+        self, make_capacity, make_coordinator
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        coordinator = make_coordinator(
+            "manager",
+            capacity=make_capacity(remaining=1),
+            mock_health_check=True,
+        )
+        coordinator._github.list_issues.return_value = [
+            {
+                "number": 1,
+                "title": "Ready",
+                "labels": [{"name": "state/ready"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+                "state": "OPEN",
+            },
+            {
+                "number": 2,
+                "title": "Blocked",
+                "labels": [{"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+                "state": "OPEN",
+            },
+        ]
+
+        qualify_mock = MagicMock(return_value=None)
+        coordinator._qualify_gate.qualify_blocked_issue = qualify_mock
+
+        queue = await coordinator._collect_frozen_queue()
+
+        qualify_mock.assert_called_once()
+        called_issue = qualify_mock.call_args[0][0]
+        assert called_issue.number == 2
+        assert [entry.issue_number for entry in queue] == [1]
+
+    @pytest.mark.asyncio
+    async def test_requalify_failure_does_not_abort_collection(
+        self, make_capacity, make_coordinator, monkeypatch
+    ) -> None:
+        coordinator = make_coordinator(
+            "manager",
+            capacity=make_capacity(remaining=1),
+            mock_health_check=True,
+        )
+        coordinator._github.list_issues.return_value = [
+            {
+                "number": 1,
+                "title": "Ready",
+                "labels": [{"name": "state/ready"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+                "state": "OPEN",
+            },
+            {
+                "number": 2,
+                "title": "Blocked",
+                "labels": [{"name": "state/blocked"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+                "state": "OPEN",
+            },
+        ]
+
+        def raise_qualify(issue):
+            raise RuntimeError("qualify gate boom")
+
+        coordinator._qualify_gate.qualify_blocked_issue = raise_qualify
+
+        events: list[str] = []
+
+        def capture_event(_category: str, message: str, level: str = "INFO") -> None:
+            _ = level
+            events.append(message)
+
+        monkeypatch.setattr(
+            "vibe3.domain.dispatch_coordinator.append_orchestra_event",
+            capture_event,
+        )
+
+        queue = await coordinator._collect_frozen_queue()
+
+        assert [entry.issue_number for entry in queue] == [1]
+        assert any(
+            "requalify failed for #2" in e for e in events
+        ), f"Expected requalify failure event for #2, got: {events}"
+
+
+class TestCollectFrozenQueueLogging:
+    """Regression tests for issue #2765 AC4: empty collections must not
+    emit starting/complete orchestra events."""
+
+    @pytest.mark.asyncio
+    async def test_empty_collection_suppresses_logs(
+        self, make_capacity, make_coordinator, monkeypatch
+    ) -> None:
+        coordinator = make_coordinator(
+            "manager",
+            capacity=make_capacity(remaining=1),
+            mock_health_check=True,
+        )
+        coordinator._github.list_issues.return_value = []
+
+        events: list[str] = []
+
+        def capture_event(_category: str, message: str, level: str = "INFO") -> None:
+            _ = level
+            events.append(message)
+
+        monkeypatch.setattr(
+            "vibe3.domain.dispatch_coordinator.append_orchestra_event",
+            capture_event,
+        )
+
+        queue = await coordinator._collect_frozen_queue()
+
+        assert queue == []
+        assert not any(
+            "starting queue collection" in e or "queue collection complete" in e
+            for e in events
+        ), f"Expected no starting/complete logs for empty collection, got: {events}"
+
+    @pytest.mark.asyncio
+    async def test_nonempty_collection_logs_complete(
+        self, make_capacity, make_coordinator, monkeypatch
+    ) -> None:
+        coordinator = make_coordinator(
+            "manager",
+            capacity=make_capacity(remaining=1),
+            mock_health_check=True,
+        )
+        coordinator._github.list_issues.return_value = [
+            {
+                "number": 1,
+                "title": "Ready",
+                "labels": [{"name": "state/ready"}],
+                "assignees": [{"login": "manager-bot"}],
+                "milestone": None,
+                "state": "OPEN",
+            },
+        ]
+
+        events: list[str] = []
+
+        def capture_event(_category: str, message: str, level: str = "INFO") -> None:
+            _ = level
+            events.append(message)
+
+        monkeypatch.setattr(
+            "vibe3.domain.dispatch_coordinator.append_orchestra_event",
+            capture_event,
+        )
+
+        queue = await coordinator._collect_frozen_queue()
+
+        assert [entry.issue_number for entry in queue] == [1]
+        assert any(
+            "queue collection complete, total=1 issues" in e for e in events
+        ), f"Expected completion log for non-empty collection, got: {events}"
+        assert not any("starting queue collection" in e for e in events)

--- a/tests/vibe3/orchestra/test_dispatch_state_transitions.py
+++ b/tests/vibe3/orchestra/test_dispatch_state_transitions.py
@@ -357,9 +357,16 @@ class TestLoggingBehavior:
             re.sub(r"\x1b\[[0-9;]*m", "", message) for message in events
         ]
 
-        assert normalized_events[0] == (
-            "GlobalDispatchCoordinator: dispatch-intent #467 (planner)"
+        intent_idx = next(
+            i
+            for i, m in enumerate(normalized_events)
+            if "dispatch-intent #467 (planner)" in m
         )
-        assert normalized_events[1] == (
-            "planner launch failed for #467: Failed to resolve permanent worktree"
+        side_effect_idx = next(
+            i
+            for i, m in enumerate(normalized_events)
+            if "planner launch failed for #467" in m
         )
+        assert (
+            intent_idx < side_effect_idx
+        ), "dispatch-intent should be logged before emit side effect"

--- a/tests/vibe3/orchestra/test_queue_terminal_states.py
+++ b/tests/vibe3/orchestra/test_queue_terminal_states.py
@@ -1,0 +1,313 @@
+"""Tests for terminal state handling in frozen queue operations.
+
+Regression tests for #2765: terminal states (blocked/done) should be removed
+from the queue instead of promoted to front.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vibe3.models.orchestration import IssueInfo, IssueState
+from vibe3.orchestra.global_dispatch_coordinator import QueueEntry
+
+
+class TestPromoteProgressedEntriesTerminalStates:
+    """Tests that promote_progressed_entries removes terminal states."""
+
+    def _make_issue(
+        self, number: int, state: IssueState, labels: list[str] | None = None
+    ) -> IssueInfo:
+        return IssueInfo(
+            number=number,
+            title=f"Issue {number}",
+            state=state,
+            labels=labels or [state.to_label()],
+            assignees=["manager-bot"],
+        )
+
+    def test_blocked_state_removed_not_promoted(self) -> None:
+        """Issues transitioning to blocked should be removed, not promoted."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+        from vibe3.orchestra.queue_operations import promote_progressed_entries
+
+        config = OrchestraConfig(repo="owner/repo")
+        config.supervisor_handoff.issue_label = "supervisor"
+
+        # Entry was waiting for in-progress state, but issue is now blocked
+        entry = QueueEntry(
+            issue_number=100,
+            collected_state="in-progress",
+            waiting_state="in-progress",
+        )
+
+        issue = self._make_issue(100, IssueState.BLOCKED)
+        issue_loader = lambda n: issue  # noqa: E731
+
+        promoted, retained, removed = promote_progressed_entries(
+            frozen_queue=[entry],
+            config=config,
+            github=MagicMock(),
+            supervisor_label="supervisor",
+            load_issue_func=issue_loader,
+        )
+
+        assert len(promoted) == 0, "blocked issue should NOT be promoted"
+        assert len(retained) == 0, "blocked issue should NOT be retained"
+        assert len(removed) == 1, "blocked issue should be removed"
+        assert removed[0].issue_number == 100
+
+    def test_done_state_removed_not_promoted(self) -> None:
+        """Issues transitioning to done should be removed, not promoted."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+        from vibe3.orchestra.queue_operations import promote_progressed_entries
+
+        config = OrchestraConfig(repo="owner/repo")
+        config.supervisor_handoff.issue_label = "supervisor"
+
+        entry = QueueEntry(
+            issue_number=200,
+            collected_state="review",
+            waiting_state="review",
+        )
+
+        issue = self._make_issue(200, IssueState.DONE)
+        issue_loader = lambda n: issue  # noqa: E731
+
+        promoted, retained, removed = promote_progressed_entries(
+            frozen_queue=[entry],
+            config=config,
+            github=MagicMock(),
+            supervisor_label="supervisor",
+            load_issue_func=issue_loader,
+        )
+
+        assert len(promoted) == 0, "done issue should NOT be promoted"
+        assert len(retained) == 0, "done issue should NOT be retained"
+        assert len(removed) == 1, "done issue should be removed"
+        assert removed[0].issue_number == 200
+
+    def test_active_state_still_promoted(self) -> None:
+        """Issues transitioning to active states should still be promoted."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+        from vibe3.orchestra.queue_operations import promote_progressed_entries
+
+        config = OrchestraConfig(repo="owner/repo")
+        config.supervisor_handoff.issue_label = "supervisor"
+
+        entry = QueueEntry(
+            issue_number=300,
+            collected_state="in-progress",
+            waiting_state="in-progress",
+        )
+
+        # State changed from in-progress to handoff (active transition)
+        issue = self._make_issue(300, IssueState.HANDOFF)
+        issue_loader = lambda n: issue  # noqa: E731
+
+        promoted, retained, removed = promote_progressed_entries(
+            frozen_queue=[entry],
+            config=config,
+            github=MagicMock(),
+            supervisor_label="supervisor",
+            load_issue_func=issue_loader,
+        )
+
+        assert len(promoted) == 1, "handoff issue should be promoted"
+        assert len(retained) == 0
+        assert len(removed) == 0
+
+    def test_unchanged_state_stays_retained(self) -> None:
+        """Issues with unchanged state should stay in place."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+        from vibe3.orchestra.queue_operations import promote_progressed_entries
+
+        config = OrchestraConfig(repo="owner/repo")
+        config.supervisor_handoff.issue_label = "supervisor"
+
+        entry = QueueEntry(
+            issue_number=400,
+            collected_state="in-progress",
+            waiting_state="in-progress",
+        )
+
+        issue = self._make_issue(400, IssueState.IN_PROGRESS)
+        issue_loader = lambda n: issue  # noqa: E731
+
+        promoted, retained, removed = promote_progressed_entries(
+            frozen_queue=[entry],
+            config=config,
+            github=MagicMock(),
+            supervisor_label="supervisor",
+            load_issue_func=issue_loader,
+        )
+
+        assert len(promoted) == 0
+        assert len(retained) == 1, "unchanged state should be retained"
+        assert len(removed) == 0
+
+    def test_mixed_queue_categorization(self) -> None:
+        """Multiple entries with different state changes are correctly categorized."""
+        from unittest.mock import MagicMock
+
+        from vibe3.models.orchestra_config import OrchestraConfig
+        from vibe3.orchestra.queue_operations import promote_progressed_entries
+
+        config = OrchestraConfig(repo="owner/repo")
+        config.supervisor_handoff.issue_label = "supervisor"
+
+        entries = [
+            QueueEntry(
+                issue_number=1,
+                collected_state="in-progress",
+                waiting_state="in-progress",
+            ),
+            QueueEntry(
+                issue_number=2,
+                collected_state="review",
+                waiting_state="review",
+            ),
+            QueueEntry(
+                issue_number=3,
+                collected_state="handoff",
+                waiting_state="handoff",
+            ),
+        ]
+
+        issues = {
+            1: self._make_issue(1, IssueState.HANDOFF),  # active change -> promoted
+            2: self._make_issue(2, IssueState.DONE),  # terminal -> removed
+            3: self._make_issue(3, IssueState.HANDOFF),  # unchanged -> retained
+        }
+        issue_loader = lambda n: issues.get(n)  # noqa: E731
+
+        promoted, retained, removed = promote_progressed_entries(
+            frozen_queue=entries,
+            config=config,
+            github=MagicMock(),
+            supervisor_label="supervisor",
+            load_issue_func=issue_loader,
+        )
+
+        assert len(promoted) == 1
+        assert promoted[0].issue_number == 1
+        assert len(retained) == 1
+        assert retained[0].issue_number == 3
+        assert len(removed) == 1
+        assert removed[0].issue_number == 2
+
+
+class TestDispatchLoopRemovalLogs:
+    """Tests that _dispatch_loop logs removal events when popping entries."""
+
+    @pytest.mark.asyncio
+    async def test_done_entry_removed_with_event_log(
+        self,
+        make_capacity,
+        make_coordinator,
+        install_issue_loader,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DONE issues popped in dispatch loop should produce a removal event."""
+        capacity = make_capacity(remaining=1)
+        coordinator = make_coordinator(
+            "manager", capacity=capacity, mock_health_check=True
+        )
+
+        async def mock_collect() -> list[QueueEntry]:
+            return [QueueEntry(issue_number=500, collected_state="handoff")]
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        states = {500: IssueState.HANDOFF}
+        install_issue_loader(coordinator, states)
+
+        events: list[str] = []
+
+        def capture_event(_category: str, message: str, level: str = "INFO") -> None:
+            _ = level
+            events.append(message)
+
+        monkeypatch.setattr(
+            "vibe3.domain.dispatch_coordinator.append_orchestra_event",
+            capture_event,
+        )
+
+        emit_calls = []
+        coordinator._emit_dispatch_intent = (
+            lambda role, issue, tick_id: emit_calls.append((role, issue))
+        )
+
+        # First tick: collects entries
+        await coordinator.coordinate()
+
+        # Change state to DONE before next tick
+        install_issue_loader(coordinator, {500: IssueState.DONE})
+
+        # Second tick: DONE entry should be removed with log
+        events.clear()
+        await coordinator.coordinate()
+
+        assert any(
+            "removed #500" in e and "done" in e for e in events
+        ), f"Expected removal log for #500 (done), got: {events}"
+        assert len(emit_calls) == 0, "DONE issue should not be dispatched"
+
+    @pytest.mark.asyncio
+    async def test_preflight_failure_logged(
+        self,
+        make_capacity,
+        make_coordinator,
+        make_issue_info,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Entries removed by preflight failure should produce a removal event."""
+        capacity = make_capacity(remaining=1)
+        coordinator = make_coordinator(
+            "manager", capacity=capacity, mock_health_check=True
+        )
+
+        # Pre-load a blocked issue directly into the frozen queue
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=600, collected_state="blocked")
+        ]
+
+        coordinator._load_issue = lambda issue_number: make_issue_info(
+            issue_number, IssueState.BLOCKED, labels=["state/blocked"]
+        )
+        coordinator._qualify_gate.qualify_blocked_issue = lambda issue: None
+
+        events: list[str] = []
+
+        def capture_event(_category: str, message: str, level: str = "INFO") -> None:
+            _ = level
+            events.append(message)
+
+        monkeypatch.setattr(
+            "vibe3.domain.dispatch_coordinator.append_orchestra_event",
+            capture_event,
+        )
+
+        async def mock_collect() -> list[QueueEntry]:
+            return []
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        emit_calls = []
+        coordinator._emit_dispatch_intent = (
+            lambda role, issue, tick_id: emit_calls.append((role, issue))
+        )
+
+        await coordinator.coordinate()
+
+        assert any(
+            "removed #600" in e and "preflight failed" in e for e in events
+        ), f"Expected preflight removal log for #600, got: {events}"


### PR DESCRIPTION
## Summary

- `promote_progressed_entries` 不再将 blocked/done 终态 issue promote 到队头，而是直接移除
- `_dispatch_loop` 所有 pop 操作现在都有 orchestra event 记录，可追踪条目何时离开队列
- 空队列收集日志简化，post-dispatch 收集日志加 `(for next tick)` 上下文

## Changes

| 文件 | 修改 |
|------|------|
| `src/vibe3/orchestra/queue_operations.py` | blocked/done → `removed` list，日志改为 `removed from queue (state terminal: X)` |
| `src/vibe3/domain/dispatch_coordinator.py` | 4 处 pop 补 orchestra event；空收集日志优化；Step 6 加 rebuild 上下文 |
| `tests/vibe3/orchestra/test_queue_terminal_states.py` | 7 个新回归测试 |
| `tests/vibe3/orchestra/test_dispatch_state_transitions.py` | 修复因新增日志导致的断言顺序变化 |

## Test plan

- [x] `uv run pytest tests/vibe3/orchestra/test_queue_terminal_states.py -v` — 7/7 passed
- [x] `uv run pytest tests/vibe3/orchestra/test_dispatch_state_transitions.py tests/vibe3/orchestra/test_dispatch_queue_operations.py -v` — 18/18 passed
- [ ] CI 全量验证

## Before/After

**修复前**：
```
requeued #2748 to front after state change to blocked
qualify_gate skip #2748: blocked per body truth
```

**修复后**：
```
removed #2748 from queue (state terminal: blocked)
```

Closes #2765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>