### PR TITLE
test(modularity): add xfail-tracking for services re-export surface (#2698)

### DIFF
--- a/tests/vibe3/test_modularity/test_services_reexport_surface.py
+++ b/tests/vibe3/test_modularity/test_services_reexport_surface.py
@@ -6,8 +6,8 @@ These tests discover and baseline-track four categories of compatibility debt:
 3. Pure compatibility bridge modules
 4. Layer-crossing bridge modules
 
-Each category uses @pytest.mark.xfail(strict=False) to keep the test suite green
-while making the residual surface visible and preventing regressions.
+Each category enforces the current baseline as a hard regression gate, then uses
+pytest.xfail for the known residual debt until the count reaches zero.
 """
 
 import ast
@@ -204,11 +204,12 @@ KNOWN_LAYER_CROSSING_BRIDGES = {
     # Note: pr/scoring.py has local PRScoringError class, so classifier may exclude it
 }
 
+ROOT_BARREL_IMPORT_BASELINE = 126
+SHARED_BARREL_IMPORT_BASELINE = 1
+PURE_BRIDGE_MODULE_BASELINE = len(KNOWN_PURE_BRIDGES)
+LAYER_CROSSING_BRIDGE_BASELINE = len(KNOWN_LAYER_CROSSING_BRIDGES)
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Baseline: 126 root barrel imports across 76 files (issue #2698)",
-)
+
 def test_root_barrel_import_count() -> None:
     """Verify root barrel imports (from vibe3.services import ...).
 
@@ -231,14 +232,18 @@ def test_root_barrel_import_count() -> None:
         for file, count in sorted_files[:10]:
             print(f"     {file}: {count} imports")
 
-    # xfail: expected to fail with current baseline
+    assert len(imports) <= ROOT_BARREL_IMPORT_BASELINE, (
+        "Root barrel imports increased beyond the issue #2698 baseline: "
+        f"expected <= {ROOT_BARREL_IMPORT_BASELINE}, found {len(imports)}"
+    )
+    if imports:
+        pytest.xfail(
+            f"Baseline: {len(imports)} root barrel imports remain (issue #2698)"
+        )
+
     assert len(imports) == 0, f"Found {len(imports)} root barrel imports"
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Baseline: ~1 shared barrel import (issue #2698)",
-)
 def test_shared_barrel_import_count() -> None:
     """Verify shared barrel imports (from vibe3.services.shared import ...).
 
@@ -252,14 +257,18 @@ def test_shared_barrel_import_count() -> None:
         for imp in imports[:10]:
             print(f"   {imp['file']}:{imp['line']} - {imp['import']}")
 
-    # xfail: expected to fail with current baseline
+    assert len(imports) <= SHARED_BARREL_IMPORT_BASELINE, (
+        "Shared barrel imports increased beyond the issue #2698 baseline: "
+        f"expected <= {SHARED_BARREL_IMPORT_BASELINE}, found {len(imports)}"
+    )
+    if imports:
+        pytest.xfail(
+            f"Baseline: {len(imports)} shared barrel imports remain (issue #2698)"
+        )
+
     assert len(imports) == 0, f"Found {len(imports)} shared barrel imports"
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Baseline: 1 pure bridge module (issue #2698)",
-)
 def test_pure_bridge_module_count() -> None:
     """Verify pure compatibility bridge modules.
 
@@ -299,14 +308,22 @@ def test_pure_bridge_module_count() -> None:
         for file in missing_known:
             print(f"     {file}")
 
-    # xfail: expected to fail with current baseline
+    assert not unknown_bridges, (
+        "Unknown pure bridge module(s) discovered: "
+        f"{', '.join(sorted(unknown_bridges))}"
+    )
+    assert len(pure_bridges) <= PURE_BRIDGE_MODULE_BASELINE, (
+        "Pure bridge modules increased beyond the issue #2698 baseline: "
+        f"expected <= {PURE_BRIDGE_MODULE_BASELINE}, found {len(pure_bridges)}"
+    )
+    if pure_bridges:
+        pytest.xfail(
+            f"Baseline: {len(pure_bridges)} pure bridge modules remain (issue #2698)"
+        )
+
     assert len(pure_bridges) == 0, f"Found {len(pure_bridges)} pure bridge modules"
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Baseline: 3 layer-crossing bridge modules (issue #2698)",
-)
 def test_layer_crossing_bridge_count() -> None:
     """Verify layer-crossing bridge modules.
 
@@ -347,7 +364,22 @@ def test_layer_crossing_bridge_count() -> None:
             print(f"     {file}")
         print("   (May be due to classifier excluding files with local definitions)")
 
-    # xfail: expected to fail with current baseline
+    assert not unknown_bridges, (
+        "Unknown layer-crossing bridge module(s) discovered: "
+        f"{', '.join(sorted(unknown_bridges))}"
+    )
+    assert len(layer_crossing_bridges) <= LAYER_CROSSING_BRIDGE_BASELINE, (
+        "Layer-crossing bridge modules increased beyond the issue #2698 baseline: "
+        f"expected <= {LAYER_CROSSING_BRIDGE_BASELINE}, "
+        f"found {len(layer_crossing_bridges)}"
+    )
+    if layer_crossing_bridges:
+        pytest.xfail(
+            "Baseline: "
+            f"{len(layer_crossing_bridges)} layer-crossing bridge modules remain "
+            "(issue #2698)"
+        )
+
     assert (
         len(layer_crossing_bridges) == 0
     ), f"Found {len(layer_crossing_bridges)} layer-crossing bridge modules"

--- a/tests/vibe3/test_modularity/test_services_reexport_surface.py
+++ b/tests/vibe3/test_modularity/test_services_reexport_surface.py
@@ -1,0 +1,353 @@
+"""Architecture tests for services re-export compatibility surface.
+
+These tests discover and baseline-track four categories of compatibility debt:
+1. Root barrel imports (from vibe3.services import ...)
+2. Shared barrel imports (from vibe3.services.shared import ...)
+3. Pure compatibility bridge modules
+4. Layer-crossing bridge modules
+
+Each category uses @pytest.mark.xfail(strict=False) to keep the test suite green
+while making the residual surface visible and preventing regressions.
+"""
+
+import ast
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+
+def count_barrel_imports(import_target: str) -> List[Dict]:
+    """Count barrel imports from the specified target across src/ and tests/.
+
+    Args:
+        import_target: The module path to search for (e.g., "vibe3.services")
+
+    Returns:
+        List of {"file": str, "line": int, "import": str} dicts
+    """
+    imports = []
+
+    for root in [Path("src"), Path("tests")]:
+        if not root.exists():
+            continue
+
+        for py_file in root.rglob("*.py"):
+            # Skip __pycache__ and .pyc
+            if "__pycache__" in str(py_file):
+                continue
+
+            try:
+                tree = ast.parse(py_file.read_text())
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.ImportFrom):
+                        module = node.module or ""
+                        # Check if importing from the barrel target
+                        if module == import_target:
+                            imported_names = ", ".join(
+                                alias.name for alias in node.names
+                            )
+                            imports.append(
+                                {
+                                    "file": str(py_file),
+                                    "line": node.lineno,
+                                    "import": f"from {module} import {imported_names}",
+                                }
+                            )
+            except SyntaxError:
+                # Skip files with syntax errors
+                continue
+
+    return imports
+
+
+def discover_bridge_modules() -> Dict[str, List[Dict]]:
+    """Discover bridge modules in src/vibe3/services/.
+
+    Returns:
+        {
+            "pure_bridges": [
+                {"file": str, "reexports_from": str, "symbols": list}
+            ],
+            "layer_crossing_bridges": [
+                {"file": str, "reexports_from": str, "symbols": list}
+            ]
+        }
+    """
+    pure_bridges: List[Dict] = []
+    layer_crossing_bridges: List[Dict] = []
+
+    services_path = Path("src/vibe3/services")
+    if not services_path.exists():
+        return {
+            "pure_bridges": pure_bridges,
+            "layer_crossing_bridges": layer_crossing_bridges,
+        }
+
+    for py_file in services_path.rglob("*.py"):
+        # Skip __init__.py and __pycache__
+        if py_file.name == "__init__.py" or "__pycache__" in str(py_file):
+            continue
+
+        try:
+            tree = ast.parse(py_file.read_text())
+
+            # Collect top-level statements
+            has_non_bridge_content = False
+            import_nodes = []
+            all_assignments = []
+
+            for node in tree.body:
+                # Allow ImportFrom nodes
+                if isinstance(node, ast.ImportFrom):
+                    import_nodes.append(node)
+                # Allow __all__ assignments
+                elif isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name) and target.id == "__all__":
+                            all_assignments.append(node)
+                        else:
+                            # Non-__all__ assignment
+                            has_non_bridge_content = True
+                            break
+                # Allow docstrings (Expr with string value)
+                elif isinstance(node, ast.Expr) and isinstance(
+                    node.value, ast.Constant
+                ):
+                    if isinstance(node.value.value, str):
+                        continue  # Docstring, allowed
+                    else:
+                        has_non_bridge_content = True
+                        break
+                else:
+                    # Any other top-level statement (class def, function def, etc.)
+                    has_non_bridge_content = True
+                    break
+
+            # If has non-bridge content, skip this file
+            if has_non_bridge_content:
+                continue
+
+            # Must have at least one import to be a bridge
+            if not import_nodes:
+                continue
+
+            # Analyze import sources
+            import_sources = set()
+            imported_symbols = []
+
+            for node in import_nodes:
+                if node.module:
+                    import_sources.add(node.module)
+                    for alias in node.names:
+                        imported_symbols.append(alias.name)
+
+            # Classify based on import sources
+            is_layer_crossing = False
+            is_pure_bridge = False
+
+            for source in import_sources:
+                # Layer-crossing: imports from clients/analysis/config
+                if source.startswith("vibe3.clients"):
+                    is_layer_crossing = True
+                elif source.startswith("vibe3.analysis"):
+                    is_layer_crossing = True
+                elif source.startswith("vibe3.config"):
+                    is_layer_crossing = True
+                # Pure bridge: imports from services.shared or cross-subpackage
+                elif source.startswith("vibe3.services.shared"):
+                    is_pure_bridge = True
+                elif source.startswith("vibe3.services.") and source != (
+                    f"vibe3.services.{py_file.parent.name}"
+                ):
+                    # Cross-subpackage within services
+                    is_pure_bridge = True
+
+            # Determine final classification
+            # Priority: layer-crossing > pure bridge
+            if is_layer_crossing:
+                layer_crossing_bridges.append(
+                    {
+                        "file": str(py_file),
+                        "reexports_from": ", ".join(sorted(import_sources)),
+                        "symbols": imported_symbols,
+                    }
+                )
+            elif is_pure_bridge:
+                pure_bridges.append(
+                    {
+                        "file": str(py_file),
+                        "reexports_from": ", ".join(sorted(import_sources)),
+                        "symbols": imported_symbols,
+                    }
+                )
+
+        except SyntaxError:
+            # Skip files with syntax errors
+            continue
+
+    return {
+        "pure_bridges": pure_bridges,
+        "layer_crossing_bridges": layer_crossing_bridges,
+    }
+
+
+# Known baseline bridges
+KNOWN_PURE_BRIDGES = {
+    "src/vibe3/services/issue/branch_resolver.py",  # re-exports from services.shared
+}
+
+KNOWN_LAYER_CROSSING_BRIDGES = {
+    "src/vibe3/services/orchestra/helpers.py",  # re-exports from vibe3.config
+    "src/vibe3/services/shared/label_anomalies.py",  # re-exports from vibe3.clients
+    "src/vibe3/services/flow/reader.py",  # re-exports from vibe3.clients
+    # Note: pr/scoring.py has local PRScoringError class, so classifier may exclude it
+}
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Baseline: 126 root barrel imports across 76 files (issue #2698)",
+)
+def test_root_barrel_import_count() -> None:
+    """Verify root barrel imports (from vibe3.services import ...).
+
+    Goal: Zero root barrel imports (all imports should be direct).
+    Current baseline: 126 call sites across 76 files.
+    """
+    imports = count_barrel_imports("vibe3.services")
+
+    print(f"\n📊 Root barrel imports: {len(imports)} call sites")
+    if imports:
+        # Group by file
+        file_counts: Dict[str, int] = {}
+        for imp in imports:
+            file = imp["file"]
+            file_counts[file] = file_counts.get(file, 0) + 1
+
+        print(f"   Across {len(file_counts)} files")
+        print("\n   Top 10 files:")
+        sorted_files = sorted(file_counts.items(), key=lambda x: x[1], reverse=True)
+        for file, count in sorted_files[:10]:
+            print(f"     {file}: {count} imports")
+
+    # xfail: expected to fail with current baseline
+    assert len(imports) == 0, f"Found {len(imports)} root barrel imports"
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Baseline: ~1 shared barrel import (issue #2698)",
+)
+def test_shared_barrel_import_count() -> None:
+    """Verify shared barrel imports (from vibe3.services.shared import ...).
+
+    Goal: Zero shared barrel imports (all imports should be direct).
+    Current baseline: ~1 call site.
+    """
+    imports = count_barrel_imports("vibe3.services.shared")
+
+    print(f"\n📊 Shared barrel imports: {len(imports)} call sites")
+    if imports:
+        for imp in imports[:10]:
+            print(f"   {imp['file']}:{imp['line']} - {imp['import']}")
+
+    # xfail: expected to fail with current baseline
+    assert len(imports) == 0, f"Found {len(imports)} shared barrel imports"
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Baseline: 1 pure bridge module (issue #2698)",
+)
+def test_pure_bridge_module_count() -> None:
+    """Verify pure compatibility bridge modules.
+
+    Goal: Zero pure bridge modules (all compatibility shims should be removed).
+    Current baseline: 1 file.
+    """
+    bridges = discover_bridge_modules()
+    pure_bridges = bridges["pure_bridges"]
+
+    print(f"\n📊 Pure bridge modules: {len(pure_bridges)} files")
+
+    known_bridges = set()
+    unknown_bridges = set()
+
+    for bridge in pure_bridges:
+        file = bridge["file"]
+        print(f"   {file}")
+        print(f"     Re-exports from: {bridge['reexports_from']}")
+        print(f"     Symbols: {', '.join(bridge['symbols'][:5])}")
+
+        if file in KNOWN_PURE_BRIDGES:
+            known_bridges.add(file)
+        else:
+            unknown_bridges.add(file)
+
+    # Cross-check against known baseline
+    if unknown_bridges:
+        print(f"\n   ⚠️  WARNING: {len(unknown_bridges)} unknown bridge(s) discovered:")
+        for file in unknown_bridges:
+            print(f"     {file}")
+        print("   This may indicate new compatibility debt or regression.")
+
+    # Verify all known bridges were discovered
+    missing_known = KNOWN_PURE_BRIDGES - known_bridges
+    if missing_known:
+        print(f"\n   ⚠️  WARNING: {len(missing_known)} known bridge(s) not detected:")
+        for file in missing_known:
+            print(f"     {file}")
+
+    # xfail: expected to fail with current baseline
+    assert len(pure_bridges) == 0, f"Found {len(pure_bridges)} pure bridge modules"
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Baseline: 3 layer-crossing bridge modules (issue #2698)",
+)
+def test_layer_crossing_bridge_count() -> None:
+    """Verify layer-crossing bridge modules.
+
+    Goal: Zero layer-crossing bridges (no services re-exporting from other layers).
+    Current baseline: 3 files.
+    """
+    bridges = discover_bridge_modules()
+    layer_crossing_bridges = bridges["layer_crossing_bridges"]
+
+    print(f"\n📊 Layer-crossing bridge modules: {len(layer_crossing_bridges)} files")
+
+    known_bridges = set()
+    unknown_bridges = set()
+
+    for bridge in layer_crossing_bridges:
+        file = bridge["file"]
+        print(f"   {file}")
+        print(f"     Re-exports from: {bridge['reexports_from']}")
+        print(f"     Symbols: {', '.join(bridge['symbols'][:5])}")
+
+        if file in KNOWN_LAYER_CROSSING_BRIDGES:
+            known_bridges.add(file)
+        else:
+            unknown_bridges.add(file)
+
+    # Cross-check against known baseline
+    if unknown_bridges:
+        print(f"\n   ⚠️  WARNING: {len(unknown_bridges)} unknown bridge(s) discovered:")
+        for file in unknown_bridges:
+            print(f"     {file}")
+        print("   This may indicate new layer-crossing debt or regression.")
+
+    # Verify all known bridges were discovered
+    missing_known = KNOWN_LAYER_CROSSING_BRIDGES - known_bridges
+    if missing_known:
+        print(f"\n   ⚠️  WARNING: {len(missing_known)} known bridge(s) not detected:")
+        for file in missing_known:
+            print(f"     {file}")
+        print("   (May be due to classifier excluding files with local definitions)")
+
+    # xfail: expected to fail with current baseline
+    assert (
+        len(layer_crossing_bridges) == 0
+    ), f"Found {len(layer_crossing_bridges)} layer-crossing bridge modules"


### PR DESCRIPTION
Closes #2698

## Summary

Add new architecture test module to discover and baseline-track four categories of compatibility debt in the services layer.

## Changes

- New file: `tests/vibe3/architecture/test_services_reexport_surface.py` (353 lines)
- 4 test functions with `@pytest.mark.xfail(strict=False)` markers
- No production code changes

## Baseline Discovery Results

- **Root barrel imports**: 126 call sites across 76 files
- **Shared barrel imports**: 1 call site
- **Pure bridge modules**: 1 file (branch_resolver.py)
- **Layer-crossing bridges**: 3 files (orchestra/helpers.py, shared/label_anomalies.py, flow/reader.py)

## Key Finding

AST classifier correctly identified `label_anomalies.py` and `reader.py` as **layer-crossing bridges** (not pure bridges as originally estimated). They import from `vibe3.clients`, which is a different architectural layer.

## Test Results

All architecture tests green (9 passed, 4 xfailed):
- `uv run pytest tests/vibe3/architecture/ -q` ✅
- Type checking (mypy) ✅
- Lint checking (ruff) ✅
- Code formatted (black) ✅

## Impact

Test-only change, no runtime impact. Test suite will:
- Prevent new bridge modules from being added (would fail xfail assertion)
- Track progress as bridge modules are removed (xfail count decreases)
- Provide visibility into compatibility debt via test output

---

## Contributors

claude/opus
