### PR TITLE
fix(control-plane): address MINOR review findings from #2678

### DIFF
--- a/src/vibe3/server/control_plane.py
+++ b/src/vibe3/server/control_plane.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from vibe3.models import DomainEvent
@@ -37,7 +37,7 @@ class EventPublishRequest(BaseModel):
     payload: dict[str, Any]  # Fields for the target DomainEvent
     actor: str  # e.g. "dashboard:jacobcy"
     source: str = "api-client"  # e.g. "web-dashboard"
-    idempotency_key: str  # Client-generated unique key
+    idempotency_key: str = Field(min_length=1)  # Client-generated unique key
 
 
 class DispatchRequest(BaseModel):
@@ -47,7 +47,7 @@ class DispatchRequest(BaseModel):
     branch: str
     actor: str
     source: str = "api-client"
-    idempotency_key: str
+    idempotency_key: str = Field(min_length=1)
 
 
 class ApiResponse(BaseModel):
@@ -626,11 +626,7 @@ async def list_events(
     store = SQLiteClient()
 
     # Query events
-    events_data = store.get_events(limit=limit, branch=None)
-
-    # Filter by event_type if provided
-    if event_type:
-        events_data = [e for e in events_data if e.get("event_type") == event_type]
+    events_data = store.get_events(limit=limit, branch=None, event_type=event_type)
 
     # Convert to EventEntry models
     events = [

--- a/tests/vibe3/server/test_control_plane_auth.py
+++ b/tests/vibe3/server/test_control_plane_auth.py
@@ -221,3 +221,23 @@ class TestIdempotency:
             response2 = client.post("/api/dispatch/manager", json=dispatch_request)
             assert response2.status_code == 200
             assert response2.json()["status"] == "duplicate"
+
+    def test_empty_idempotency_key_rejected(
+        self, client: TestClient, clean_idempotency_store, monkeypatch
+    ):
+        """Empty string idempotency_key is rejected by Pydantic validation."""
+        monkeypatch.delenv("VIBE_CONTROL_PLANE_TOKEN", raising=False)
+        request_data = {
+            "event_type": "WebhookLabelChanged",
+            "payload": {
+                "issue_number": 123,
+                "label": "x",
+                "action": "labeled",
+                "sender": "u",
+            },
+            "actor": "test-actor",
+            "source": "test-source",
+            "idempotency_key": "",
+        }
+        response = client.post("/api/events", json=request_data)
+        assert response.status_code == 422  # Pydantic validation error

--- a/tests/vibe3/server/test_control_plane_events.py
+++ b/tests/vibe3/server/test_control_plane_events.py
@@ -13,6 +13,8 @@ from vibe3.models import (
     WebhookIssueClosed,
     WebhookIssueUpdated,
     WebhookLabelChanged,
+    WebhookPRMerged,
+    WebhookPRReviewed,
 )
 from vibe3.server.control_plane import _idempotency_store, router
 
@@ -206,6 +208,62 @@ class TestPublishEvent:
             assert isinstance(event, SupervisorIssueIdentified)
             assert event.issue_number == 123
 
+    def test_webhookprmerged_publishes_event(
+        self, client: TestClient, clean_idempotency_store, monkeypatch
+    ):
+        """WebhookPRMerged event publishes correctly."""
+        monkeypatch.delenv("VIBE_CONTROL_PLANE_TOKEN", raising=False)
+
+        request_data = {
+            "event_type": "WebhookPRMerged",
+            "payload": {
+                "pr_number": 456,
+                "sender": "test-user",
+            },
+            "actor": "test-actor",
+            "source": "test-source",
+            "idempotency_key": "test-key",
+        }
+
+        with patch("vibe3.models.publish") as _mock_publish:
+            response = client.post("/api/events", json=request_data)
+            assert response.status_code == 200
+
+            first_call = _mock_publish.call_args_list[0]
+            event = first_call[0][0]
+            assert isinstance(event, WebhookPRMerged)
+            assert event.pr_number == 456
+
+    def test_webhookprreviewed_publishes_event(
+        self, client: TestClient, clean_idempotency_store, monkeypatch
+    ):
+        """WebhookPRReviewed event publishes correctly."""
+        monkeypatch.delenv("VIBE_CONTROL_PLANE_TOKEN", raising=False)
+
+        request_data = {
+            "event_type": "WebhookPRReviewed",
+            "payload": {
+                "pr_number": 789,
+                "reviewer": "reviewer-user",
+                "state": "approved",
+                "sender": "test-user",
+            },
+            "actor": "test-actor",
+            "source": "test-source",
+            "idempotency_key": "test-key",
+        }
+
+        with patch("vibe3.models.publish") as _mock_publish:
+            response = client.post("/api/events", json=request_data)
+            assert response.status_code == 200
+
+            first_call = _mock_publish.call_args_list[0]
+            event = first_call[0][0]
+            assert isinstance(event, WebhookPRReviewed)
+            assert event.pr_number == 789
+            assert event.reviewer == "reviewer-user"
+            assert event.state == "approved"
+
 
 class TestListEvents:
     """Test events listing endpoint."""
@@ -239,7 +297,7 @@ class TestListEvents:
     def test_filter_by_event_type(
         self, client: TestClient, clean_idempotency_store, monkeypatch
     ):
-        """Verify filtering by event type works."""
+        """Verify filtering by event type works at DB level."""
         monkeypatch.delenv("VIBE_CONTROL_PLANE_TOKEN", raising=False)
 
         mock_events = [
@@ -252,21 +310,18 @@ class TestListEvents:
                 "refs": {"issue": 123},
                 "created_at": "2024-01-01T00:00:00Z",
             },
-            {
-                "id": 2,
-                "branch": "test-branch",
-                "event_type": "WebhookIssueUpdated",
-                "actor": "test-actor",
-                "detail": "Test detail",
-                "refs": {"issue": 456},
-                "created_at": "2024-01-01T01:00:00Z",
-            },
         ]
 
-        with patch("vibe3.clients.SQLiteClient.get_events", return_value=mock_events):
+        with patch(
+            "vibe3.clients.SQLiteClient.get_events", return_value=mock_events
+        ) as mock_get:
             response = client.get("/api/events?event_type=WebhookLabelChanged")
             assert response.status_code == 200
             data = response.json()
             # Should only return the WebhookLabelChanged event
             assert data["count"] == 1
             assert data["events"][0]["event_type"] == "WebhookLabelChanged"
+            # Verify event_type was passed to DB-level query
+            mock_get.assert_called_once_with(
+                limit=50, branch=None, event_type="WebhookLabelChanged"
+            )


### PR DESCRIPTION
## Summary

Three targeted fixes to address MINOR review findings from #2678:

1. **Pushed `event_type` filter to SQL level** - Changed `list_events` endpoint to pass `event_type` directly to `get_events()` for database-level filtering instead of Python-level filtering
2. **Added `min_length=1` validation** - Added Pydantic `Field(min_length=1)` constraint to `idempotency_key` fields in both `EventPublishRequest` and `DispatchRequest`
3. **Added test coverage** - Added tests for `WebhookPRMerged` and `WebhookPRReviewed` events, plus updated `test_filter_by_event_type` to verify DB-level filtering

## Changes

- `control_plane.py`: Pass `event_type` to `get_events()` for DB-level filtering
- `control_plane.py`: Add `Field(min_length=1)` to `idempotency_key` in `EventPublishRequest` and `DispatchRequest`
- `test_control_plane_events.py`: Add tests for `WebhookPRMerged`/`WebhookPRReviewed`
- `test_control_plane_events.py`: Update `test_filter_by_event_type` to verify DB-level filtering
- `test_control_plane_auth.py`: Add test for empty idempotency key rejection

## Test Plan

- ✅ All tests pass (55 tests in `tests/vibe3/server/`)
- ✅ No type errors (mypy success)
- ✅ No lint errors (ruff success)
- ✅ Pre-push checks passed

## Related Issues

Closes #2693
Follow-up to #2678

---

## Contributors

claude/opus
