### PR TITLE
feat(status): align observation layer labels with ADR 0004 boundaries

### DIFF
--- a/docs/standards/v3/serve-debugging-guide.md
+++ b/docs/standards/v3/serve-debugging-guide.md
@@ -113,6 +113,11 @@ uv run python src/vibe3/cli.py serve start -vv   # DEBUG
 | Task 状态 | `vibe3 task status` | Task Pool 聚合 | Issue 归属、执行阶段、最新 actor |
 | GitHub Issue | `gh issue view <number>` | 外部事实 | 外部可见状态、labels、comments |
 
+**观察层边界**（参见 ADR 0004）：
+- `vibe3 serve status` — 运行时编排观测（runtime observation）
+- `vibe3 flow show` — 单 flow 时间线/审计（flow-local audit）
+- `vibe3 task status` — 任务池聚合（task pool aggregation）
+
 **调试原则**：
 - 日志告诉你"发生了什么"
 - 真源告诉你"结果是什么"

--- a/src/vibe3/commands/status.py
+++ b/src/vibe3/commands/status.py
@@ -408,6 +408,9 @@ def _full_status_dashboard(
         ]
         render_completed_flows(completed_flows)
 
+    # Cross-reference hint for runtime observation layer
+    console.print("[dim]For runtime health: vibe3 serve status[/]")
+
 
 def status(
     check: Annotated[

--- a/src/vibe3/server/app.py
+++ b/src/vibe3/server/app.py
@@ -455,6 +455,10 @@ def status() -> None:
     # Display active jobs from actor registry
     _display_active_jobs(console)
 
+    # Cross-reference hints for other observation layers
+    console.print("[dim]For flow timeline events, use: vibe3 flow show[/]")
+    console.print("[dim]For task aggregation, use:    vibe3 task status[/]")
+
 
 @app.command()
 def stop() -> None:

--- a/src/vibe3/services/orchestra/serve_status.py
+++ b/src/vibe3/services/orchestra/serve_status.py
@@ -49,6 +49,7 @@ class ServeStatusService:
         self._display_recent_activity()
         self._display_failed_gate()
         self._display_error_tracking()
+        self.console.print("\n[dim]For flow timeline events: vibe3 flow show[/]")
 
     @staticmethod
     def _clean_error_message(error_message: str, max_length: int = 100) -> str:
@@ -142,7 +143,9 @@ class ServeStatusService:
             last_tick = tick_matches[-1]
             tick_time, tick_num, tick_status = last_tick
             status_str = "in progress" if tick_status == "start" else "completed"
-            self.console.print("[cyan]Last Tick Activity:[/cyan]")
+            self.console.print(
+                "[bold]Orchestration Activity[/] [dim](runtime, not flow timeline)[/]"
+            )
             self.console.print(f"  - Tick #{tick_num} ({status_str} at {tick_time})")
 
             # Extract dispatcher activity for this tick

--- a/src/vibe3/services/orchestra/serve_status.py
+++ b/src/vibe3/services/orchestra/serve_status.py
@@ -49,7 +49,6 @@ class ServeStatusService:
         self._display_recent_activity()
         self._display_failed_gate()
         self._display_error_tracking()
-        self.console.print("\n[dim]For flow timeline events: vibe3 flow show[/]")
 
     @staticmethod
     def _clean_error_message(error_message: str, max_length: int = 100) -> str:

--- a/src/vibe3/ui/flow_ui_timeline.py
+++ b/src/vibe3/ui/flow_ui_timeline.py
@@ -279,7 +279,7 @@ def _render_timeline(
             if e.actor and fnmatch.fnmatch(e.actor.lower(), actor_filter.lower())
         ]
 
-    console.print("[bold]--- Timeline ---[/]")
+    console.print("[bold]--- Flow Timeline ---[/]")
     console.print()
 
     for event in reversed(events):


### PR DESCRIPTION
Closes #2748

## Summary

Align observation layer labels across three commands to unambiguously distinguish their boundaries per ADR 0004:
- `serve status`: runtime orchestration observation
- `flow show`: flow-local audit timeline  
- `task status`: task pool aggregation

## Changes

### 1. Serve Status Labels
- Renamed "Last Tick Activity" to "Orchestration Activity (runtime, not flow timeline)"
- Added cross-reference hints for `flow show` and `task status`

### 2. Flow Timeline Label
- Changed "--- Timeline ---" to "--- Flow Timeline ---"

### 3. Task Status Footer
- Added footer hint for `serve status`

### 4. Documentation
- Added ADR 0004 observation layer boundary note to serve-debugging-guide.md

## Test Plan

- [x] 32 tests pass (serve_status_service, serve_status, flow_status, task_status_dashboard)
- [x] MyPy type check passes
- [x] Ruff lint check passes
- [x] Pre-commit hooks pass
- [x] LOC limits check passes

## Related

- Issue: #2748
- ADR: docs/decisions/0004-domain-flow-event-boundary.md

---

## Contributors

claude/opus
