### PR TITLE
refactor(review): reorder build_snapshot_diff for efficient execution

### DIFF
--- a/src/vibe3/agents/review_pipeline_helpers.py
+++ b/src/vibe3/agents/review_pipeline_helpers.py
@@ -44,15 +44,15 @@ def build_snapshot_diff(
     structure_diff: StructureDiff | None = None
 
     try:
-        log.info("Building current snapshot")
-        current = build_snapshot()
-
         log.info(f"Loading baseline snapshot for branch: {base_branch}")
         baseline = find_snapshot_by_branch(base_branch, current_branch)
 
         if baseline is None:
             log.warning(f"No baseline snapshot found for branch: {base_branch}")
             return None
+
+        log.info("Building current snapshot")
+        current = build_snapshot()
 
         log.info("Computing structure diff")
         structure_diff = compute_diff(baseline, current)


### PR DESCRIPTION
## Summary

Swap the execution order inside `build_snapshot_diff()` so that the lightweight `find_snapshot_by_branch()` call runs **before** the expensive `build_snapshot()` call. If no baseline snapshot exists, return `None` immediately, avoiding wasted codebase scan.

## Changes

- `src/vibe3/agents/review_pipeline_helpers.py`: Reordered the try-block body
  - **Before**: `build_snapshot()` (expensive) → `find_snapshot_by_branch()` (cheap) → check baseline
  - **After**: `find_snapshot_by_branch()` (cheap) → check baseline → `build_snapshot()` (expensive)

## Performance Impact

- **Baseline missing**: Significantly faster (skips expensive codebase scan entirely)
- **Baseline exists**: Same cost as before (just different execution order)

## Verification

- ✅ Type checking: mypy passed with no issues
- ✅ Linting: ruff passed all checks
- ✅ Integration tests: 45 tests passed in 1.55s
- ✅ No behavioral regression (same inputs produce same outputs)
- ✅ Function signature, return type, and exception contract preserved

## Test Scope

- `tests/vibe3/commands/test_review.py`: Integration tests for review command
- `tests/vibe3/commands/test_command_params_unified.py`: Integration tests for command parameters
- `tests/vibe3/analysis/test_snapshot_diff_section.py`: Integration tests for snapshot diff

All tests pass with no behavioral changes.

Closes #2758

---

## Contributors

claude/opus
