### PR TITLE
refactor(config): move _vibe3_config_root to loader as find_install_root

### DIFF
--- a/src/vibe3/config/loader.py
+++ b/src/vibe3/config/loader.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import yaml
 from loguru import logger
 
-from vibe3.config.settings import VibeConfig, _vibe3_config_root
+from vibe3.config.settings import VibeConfig
 
 
 def _expand_variables(
@@ -30,6 +30,35 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
             merged[key] = value
 
     return merged
+
+
+def find_install_root() -> Path:
+    """Find the vibe3 installation root by walking up from this module's file.
+
+    Returns the directory containing config/v3/settings.yaml, which is the
+    vibe3 installation root (repo root for source installs, ~/.vibe for pip
+    installs). Used as fallback when CWD-relative config paths fail
+    (cross-project invocation).
+    """
+    current = Path(__file__).resolve()
+    for _ in range(10):
+        parent = current.parent
+        if parent == current:
+            break
+        if (parent / "config" / "v3" / "settings.yaml").exists():
+            return parent
+        current = parent
+
+    current = Path(__file__).resolve()
+    for _ in range(10):
+        parent = current.parent
+        if parent == current:
+            break
+        if (parent / "src" / "vibe3").exists():
+            return parent
+        current = parent
+
+    return Path.cwd()
 
 
 def load_yaml_config(path: Path, strict: bool = False) -> dict[str, Any]:
@@ -116,13 +145,17 @@ def find_config_file() -> Path | None:
         return old_config
 
     # Check vibe3 installation root as fallback (for cross-project invocation)
-    import_root = _vibe3_config_root()
-    root_config = import_root / "config" / "v3" / "settings.yaml"
-    if root_config.exists() and root_config.resolve() != new_config.resolve():
-        logger.bind(domain="config", action="find", path=str(root_config)).debug(
-            "Found vibe3 installation config"
-        )
-        return root_config
+    try:
+        import_root = find_install_root()
+    except OSError:
+        import_root = None
+    if import_root is not None:
+        root_config = import_root / "config" / "v3" / "settings.yaml"
+        if root_config.exists() and root_config.resolve() != new_config.resolve():
+            logger.bind(domain="config", action="find", path=str(root_config)).debug(
+                "Found vibe3 installation config"
+            )
+            return root_config
 
     # Check global config
     global_config = Path.home() / ".vibe" / "config.yaml"
@@ -185,7 +218,12 @@ def load_config(
             else Path("config/v3/settings.yaml")
         )
         if not repo_config_path.exists():
-            repo_config_path = _vibe3_config_root() / "config" / "v3" / "settings.yaml"
+            try:
+                repo_config_path = (
+                    find_install_root() / "config" / "v3" / "settings.yaml"
+                )
+            except OSError:
+                pass  # Keep as non-existent path; load_config falls through to defaults
 
         # Check if config_path is auto-detected or explicit
         auto_detected = find_config_file()

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -28,47 +28,6 @@ from vibe3.config.settings_pr import (
 )
 
 
-def _vibe3_config_root() -> Path:
-    """Find the vibe3 config root directory by walking up from this module.
-
-    Returns the directory containing config/v3/settings.yaml, which is the vibe3
-    installation root (repo root for source installs, ~/.vibe for pip installs).
-
-    Used as fallback when CWD-relative config paths fail (cross-project invocation).
-    """
-    # Start from this module's location
-    current = Path(__file__).resolve()
-
-    # Walk up to find the directory containing config/v3/settings.yaml
-    # Max 10 levels to prevent infinite loops
-    for _ in range(10):
-        parent = current.parent
-        if parent == current:
-            # Reached filesystem root, stop
-            break
-
-        # Check if this parent contains config/v3/settings.yaml
-        if (parent / "config" / "v3" / "settings.yaml").exists():
-            return parent
-
-        current = parent
-
-    # Fallback: return parent of src/ directory (repo root for source installs)
-    # This handles the case where config/v3/settings.yaml doesn't exist yet
-    # Walk up from __file__ to find the directory containing src/vibe3/
-    current = Path(__file__).resolve()
-    for _ in range(10):
-        parent = current.parent
-        if parent == current:
-            break
-        if (parent / "src" / "vibe3").exists():
-            return parent
-        current = parent
-
-    # Last resort: return current working directory
-    return Path.cwd()
-
-
 class AIConfig(BaseModel):
     """AI 辅助配置.
 
@@ -374,9 +333,14 @@ class VibeConfig(BaseModel):
         # Try new path first, then fallback to old path
         new_loc_limits_path = Path("config/v3/loc_limits.yaml")
         if not new_loc_limits_path.exists():
-            new_loc_limits_path = (
-                _vibe3_config_root() / "config" / "v3" / "loc_limits.yaml"
-            )
+            from vibe3.config.loader import find_install_root
+
+            try:
+                new_loc_limits_path = (
+                    find_install_root() / "config" / "v3" / "loc_limits.yaml"
+                )
+            except OSError:
+                new_loc_limits_path = Path("config/v3/loc_limits.yaml")  # fallback
         old_loc_limits_path = Path("config/loc_limits.yaml")
         loc_limits_path = None
 
@@ -464,7 +428,12 @@ class VibeConfig(BaseModel):
         if new_default_path.exists():
             return cls.from_yaml(new_default_path)
         # Fallback: vibe3 installation default config
-        root = _vibe3_config_root()
+        from vibe3.config.loader import find_install_root
+
+        try:
+            root = find_install_root()
+        except OSError:
+            return cls()  # Last resort: pure defaults
         root_new_path = root / "config" / "v3" / "settings.yaml"
         if root_new_path.exists():
             return cls.from_yaml(root_new_path)

--- a/src/vibe3/config/timeline_comment_policy.py
+++ b/src/vibe3/config/timeline_comment_policy.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from loguru import logger
 from pydantic import BaseModel
 
-from vibe3.config.settings import _vibe3_config_root
+from vibe3.config.loader import find_install_root
 
 
 class TimelineCommentPolicy(BaseModel):
@@ -113,7 +113,11 @@ class TimelineCommentPolicy(BaseModel):
         from vibe3.config.loader import load_yaml_config
 
         # Use install root for cross-project invocation support
-        yaml_path = path or _vibe3_config_root() / "config" / "v3" / "timeline.yaml"
+        try:
+            default_path = find_install_root() / "config" / "v3" / "timeline.yaml"
+        except OSError:
+            default_path = Path("config/v3/timeline.yaml")
+        yaml_path = path or default_path
         data = load_yaml_config(yaml_path)
 
         if not data:


### PR DESCRIPTION
## Summary

Move _vibe3_config_root() from settings.py to loader.py as find_install_root() to improve separation of concerns. Settings module should only define Pydantic models, while path discovery logic belongs in the loader layer.

## Changes

- loader.py: Added find_install_root() function with __file__-based upward search; updated 2 call sites with try/except guards
- settings.py: Removed _vibe3_config_root() function; updated 2 internal call sites with lazy imports and try/except guards  
- timeline_comment_policy.py: Updated import and call site with try/except guard

## Test Plan

- All 157 config module tests pass (including test_load_config_from_external_cwd which validates the fallback path)
- Type checks pass (mypy on all 3 files)
- Lint checks pass (ruff on all 3 files)
- Pre-commit hooks pass
- No remaining references to _vibe3_config_root in codebase

## Technical Details

- Cross-project invocation semantics preserved by using __file__-based upward search (distinct from find_repo_root()'s CWD/git-based approach)
- Circular import avoided via lazy imports in settings.py
- All call sites updated with try/except guards for OSError handling

Closes #2479

---

## Contributors

claude/opus
