### PR TITLE
docs: align STRUCTURE.md with ADR system and fix residual V2 paths

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -3,6 +3,7 @@ document_type: core-entry
 authority:
   - project-structure
   - file-organization
+  - docs/decisions/ (Architecture Decision Records - authority for "WHY" decisions)
 audience: both
 review_frequency: on-change
 author: Claude Sonnet 4.5
@@ -28,6 +29,21 @@ Vibe Center 包含**两个并行实现**：
 - **V2 (Shell)** - Shell 实现，Zsh，入口 `bin/vibe`
 
 本文档以 **V3 为主视角**进行说明。
+
+### 核心架构 (3-Tier Model)
+
+V3 采用 3-Tier 顶层架构，定义系统的战略职责边界：
+
+- **Tier 3 (Cognitive / Governance Layer)**: 负责全局策略、规则、Supervisor 治理、Issue 分检与 Roadmap 规划。
+- **Tier 2 (Skill Layer)**: 负责 Flow 状态机、任务编排、Agent 执行 (Plan/Run/Review)。
+- **Tier 1 (Shell Layer)**: 提供原子级能力访问、状态读取、环境原语与项目信息检索。
+
+### 执行等级 (Execution Levels)
+
+- **Level 1 (L1 - Inspection)**: 无 Worktree 观察层，负责只读观察与 Metadata 扫描。
+- **Level 2 (L2 - Governance)**: 临时隔离治理层，使用临时 Worktree 进行文档治理、测试修补。
+- **Level 3 (L3 - Main Development)**: 持久隔离开发层，承载完整的 Plan/Run/Review 生命周期。
+- **Level 4 (L4 - Atomic)**: 原子工具层，负责底层原子操作执行。
 
 ## 📁 根目录结构
 
@@ -68,9 +84,12 @@ vibe-center/
 ├── tests/                       # 测试 (vibe2, vibe3, 覆盖率报告)
 ├── skills/                      # 技能定义 (Canonical Source)
 ├── docs/                        # 人类文档区 (Standards, PRDs, Specs, Reports)
+│   ├── decisions/               # [Authority] ADR 系统 (Architecture Decision Records)
 │   ├── directives/              # [V3 Active] 指令集文档 (Executor/Manager/Supervisor)
 │   ├── handoff/                 # [V3 Active] 执行交接现场 (Artifacts, Results)
-│   └── standards/               # 项目标准与规范
+│   ├── publish-directives/      # [V3 Active] 发布指令集 (Post-Review Actions)
+│   ├── standards/               # 项目标准与规范
+│   └── validation/              # [V3 Active] 验证报告与一致性检查
 │
 ├── debug/                       # 调试信息与临时分析报告
 ├── openspec/                    # 开放规范集成区

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -291,8 +291,8 @@ vibe_init() {
 
     # Create supervisor structure if profile requires
     if [[ "$ENABLE_SUPERVISOR" == true ]]; then
-        mkdir -p "$REPO_ROOT/.agent/supervisor"
-        _log_success "Created: .agent/supervisor/ directory"
+        mkdir -p "$REPO_ROOT/supervisor"
+        _log_success "Created: supervisor/ directory"
     fi
 
     _seed_claude_assets "$PROFILE_NAME" "$REPO_ROOT"
@@ -477,8 +477,8 @@ vibe_init() {
         fi
         echo "  4. Optional: start orchestra with ${CYAN}vibe3 serve${NC}"
         echo "  5. Review created directories: ${CYAN}.agent/${NC}, ${CYAN}skills/${NC}, ${CYAN}.claude/${NC}"
-        echo "  6. Policies and prompts from: ${CYAN}.agent/policies${NC} and ${CYAN}config/prompts${NC}"
-        echo "  7. Supervisor orchestration: ${CYAN}.agent/supervisor/${NC}"
+        echo "  6. Policies and prompts from: ${CYAN}supervisor/policies/${NC} and ${CYAN}config/prompts${NC}"
+        echo "  7. Supervisor orchestration: ${CYAN}supervisor/${NC}"
     fi
     echo ""
 }

--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -90,9 +90,9 @@ PROFILE_VIBE_CENTER=(
     "conventions.labels.state_prefix:state/"
     "conventions.labels.vibe_task:vibe-task"
     "conventions.supervisor.enabled:true"
-    "conventions.supervisor.apply_file:.agent/supervisor/apply.md"
+    "conventions.supervisor.apply_file:supervisor/apply.md"
     "conventions.agents.manager_name:vibe-manager-agent"
-    "paths.policies_root:.agent/policies"
+    "paths.policies_root:supervisor/policies"
     "paths.prompts_root:config/prompts"
     "paths.skills_manifest:config/v3/skills.json"
 )


### PR DESCRIPTION
Closes #2789. This PR aligns STRUCTURE.md with the ADR system and 3-Tier architecture, and fixes stale .agent/ paths in shell scripts.