### PR TITLE
refactor(analysis): eliminate redundant classify_confidence calls in scan_dead_code

### DIFF
--- a/src/vibe3/analysis/dead_code_rules.py
+++ b/src/vibe3/analysis/dead_code_rules.py
@@ -178,7 +178,7 @@ def is_dead_code(
     ref_count: int,
     is_cli_command: bool = False,
     router_funcs: set[str] | None = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, Literal["high", "medium", "low", "excluded"]]:
     """Determine if a symbol is dead code.
 
     Args:
@@ -188,7 +188,7 @@ def is_dead_code(
         router_funcs: Set of router-decorated function names (for exclusion check)
 
     Returns:
-        Tuple of (is_dead: bool, reason: str)
+        Tuple of (is_dead: bool, reason: str, confidence: str)
     """
     confidence = classify_confidence(
         symbol_name, ref_count, is_cli_command, router_funcs
@@ -196,17 +196,23 @@ def is_dead_code(
 
     if confidence == "excluded":
         if is_cli_command:
-            return False, "CLI command (invoked via CLI, not code)"
+            return False, "CLI command (invoked via CLI, not code)", confidence
         if router_funcs is not None and symbol_name in router_funcs:
-            return False, "FastAPI endpoint (invoked via HTTP router)"
+            return False, "FastAPI endpoint (invoked via HTTP router)", confidence
         if should_exclude(symbol_name):
-            return False, "Excluded pattern (test/special method)"
-        return False, f"Has {ref_count} references"
+            return False, "Excluded pattern (test/special method)", confidence
+        return False, f"Has {ref_count} references", confidence
 
     if confidence == "high":
-        return True, "Unused function with 0 references (high confidence)"
+        return True, "Unused function with 0 references (high confidence)", confidence
 
     if confidence == "medium":
-        return True, "Unused private function with 0 references (medium confidence)"
+        return (
+            True,
+            "Unused private function with 0 references (medium confidence)",
+            confidence,
+        )
 
-    return False, "Not dead code"
+    return False, "Not dead code", confidence
+
+    return False, "Not dead code", confidence

--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from loguru import logger
 
@@ -268,7 +268,6 @@ class SerenaService:
             SerenaError: If scan fails
         """
         from vibe3.analysis.dead_code_rules import (
-            classify_confidence,
             get_router_functions,
             is_dead_code,
         )
@@ -316,7 +315,7 @@ class SerenaService:
                         is_cli_command = sym_type == "cli_command"
 
                         # Apply dead code rules
-                        is_dead, reason = is_dead_code(
+                        is_dead, reason, confidence = is_dead_code(
                             sym_name, ref_count, is_cli_command, router_funcs
                         )
 
@@ -331,31 +330,23 @@ class SerenaService:
                                 else 0
                             )
 
-                            confidence = classify_confidence(
-                                sym_name, ref_count, is_cli_command, router_funcs
+                            # Type narrowing: is_dead=True → confidence != "excluded"
+                            confidence_narrowed = cast(
+                                Literal["high", "medium", "low"], confidence
                             )
-                            # Type narrowing
-                            if confidence == "excluded":
-                                continue
-
                             findings.append(
                                 DeadCodeFinding(
                                     symbol=sym_name,
                                     file=relative_file,
                                     line=line,
                                     loc=loc,
-                                    confidence=confidence,
+                                    confidence=confidence_narrowed,
                                     category="unused_function",
                                     reason=reason,
                                 )
                             )
                             total_dead += 1
-                        elif (
-                            classify_confidence(
-                                sym_name, ref_count, is_cli_command, router_funcs
-                            )
-                            == "excluded"
-                        ):
+                        elif confidence == "excluded":
                             excluded.append(f"{relative_file}:{sym_name}")
                             total_excluded += 1
 

--- a/tests/vibe3/analysis/test_dead_code_rules.py
+++ b/tests/vibe3/analysis/test_dead_code_rules.py
@@ -128,7 +128,7 @@ class TestIsDeadCode:
         reason_contains: str,
     ):
         """Test functions that should not be flagged as dead."""
-        is_dead, reason = is_dead_code(func_name, ref_count, is_cli_command)
+        is_dead, reason, _ = is_dead_code(func_name, ref_count, is_cli_command)
         assert is_dead is expected_is_dead
         assert reason_contains in reason
 
@@ -143,7 +143,7 @@ class TestIsDeadCode:
     )
     def test_is_dead(self, func_name: str, ref_count: int, expected_confidence: str):
         """Test functions that should be flagged as dead."""
-        is_dead, reason = is_dead_code(func_name, ref_count)
+        is_dead, reason, _ = is_dead_code(func_name, ref_count)
         assert is_dead is True
         assert expected_confidence in reason
 


### PR DESCRIPTION
## Summary

Refactor `is_dead_code` to return confidence level as third element, eliminating 2 duplicate `classify_confidence` calls and 1 unreachable code block in `scan_dead_code`.

This refactoring complements #2803 (issue #2771) which optimized decorator checking. While #2803 eliminated N× AST parses per file, this PR eliminates duplicate `classify_confidence` calls per symbol.

## Changes

- **`src/vibe3/analysis/dead_code_rules.py`**: Modified `is_dead_code` return type from `tuple[bool, str]` to `tuple[bool, str, Literal["high", "medium", "low", "excluded"]]`, packing the already-computed `confidence` as the third element.
- **`src/vibe3/analysis/serena_service.py`**: Updated `scan_dead_code` to destructure all three values from `is_dead_code`, removing duplicate `classify_confidence` calls.
- **`tests/vibe3/analysis/test_dead_code_rules.py`**: Updated 2 test methods to destructure three values from `is_dead_code`.

## Performance Impact

**Before**: `is_dead_code` computed confidence, then `scan_dead_code` recomputed it 1-3 times per symbol
**After**: `is_dead_code` computes confidence once and returns it, `scan_dead_code` reuses the value

This eliminates redundant calls to `classify_confidence` which involves pattern matching and exclusion checks.

## Verification

- ✅ All 167 tests in `tests/vibe3/analysis/` pass
- ✅ Type checking passes for all 19 source files
- ✅ No lint errors
- ✅ Pre-push checks pass (compile, type, tests, LOC)

## Related Work

- #2803 (issue #2771): Eliminated N× AST parses by extracting all router-decorated functions in a single pass
- This PR: Eliminates 1-3× duplicate confidence classifications per symbol

Both refactorings work together to optimize dead code detection performance.

Closes #2772

---

## Contributors

claude/opus
