### PR TITLE
feat(task): add blocked_by dependency check to resume

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -103,8 +103,8 @@ code_limits:
         limit: 450
         reason: "Shared utilities 聚合，由 path_helpers.py + git_path_client.py 合理合并而成（解决 tight coupling），包含路径规范化、Git path 解析、handoff target resolution、ref normalization 等紧密耦合的路径处理逻辑；职责单一（path utilities）且架构质量已通过 code-reviewer 评估；PR #2406 Phase 1-2a modularity refactoring 创建；Issue #2514 新增三个 centralized path helpers（get_vibe3_cache_path/get_vibe3_db_path/get_vibe3_log_dir）以消除 8 个文件中的重复路径构造，提升代码一致性"
       - path: "src/vibe3/services/task/resume.py"
-        limit: 570
-        reason: "Task resume operations 聚合，包含 TaskResumeOperations（非破坏性 blocked issue resume）、ResumeCandidateFinder（候选查找与验证）、ResumeCoordinator（多 issue 协调恢复）等三个紧密耦合类；职责内聚（label 清除、状态恢复、一致性校验、live session 检测）且已按职责拆分为独立类，进一步拆分文件会破坏 resume domain 完整性；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问"
+        limit: 650
+        reason: "Task resume operations 聚合，包含 TaskResumeOperations（非破坏性 blocked issue resume）、ResumeCandidateFinder（候选查找与验证）、ResumeCoordinator（多 issue 协调恢复）等三个紧密耦合类；职责内聚（label 清除、状态恢复、一致性校验、live session 检测）且已按职责拆分为独立类，进一步拆分文件会破坏 resume domain 完整性；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问；PR #2774 新增 blocked_by 依赖检查逻辑（verify_issue_state_for_resume 返回值改为 tuple、blocked_by_issue 状态查询、错误消息处理）增加 79 行"
       - path: "src/vibe3/services/task/service.py"
         limit: 500
         reason: "Task 服务聚合，包含 issue link/reclassify、superseded flow 降级、分支解析、issue comment 查询等紧密耦合的核心 task 状态管理逻辑；职责单一（task state lifecycle）但方法较多，拆分收益低；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问"

--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -104,7 +104,7 @@ code_limits:
         reason: "Shared utilities 聚合，由 path_helpers.py + git_path_client.py 合理合并而成（解决 tight coupling），包含路径规范化、Git path 解析、handoff target resolution、ref normalization 等紧密耦合的路径处理逻辑；职责单一（path utilities）且架构质量已通过 code-reviewer 评估；PR #2406 Phase 1-2a modularity refactoring 创建；Issue #2514 新增三个 centralized path helpers（get_vibe3_cache_path/get_vibe3_db_path/get_vibe3_log_dir）以消除 8 个文件中的重复路径构造，提升代码一致性"
       - path: "src/vibe3/services/task/resume.py"
         limit: 650
-        reason: "Task resume operations 聚合，包含 TaskResumeOperations（非破坏性 blocked issue resume）、ResumeCandidateFinder（候选查找与验证）、ResumeCoordinator（多 issue 协调恢复）等三个紧密耦合类；职责内聚（label 清除、状态恢复、一致性校验、live session 检测）且已按职责拆分为独立类，进一步拆分文件会破坏 resume domain 完整性；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问；PR #2774 新增 blocked_by 依赖检查逻辑（verify_issue_state_for_resume 返回值改为 tuple、blocked_by_issue 状态查询、错误消息处理）增加 79 行"
+        reason: "Task resume operations 聚合，包含 TaskResumeOperations（非破坏性 blocked issue resume）、ResumeCandidateFinder（候选查找与验证）、ResumeCoordinator（多 issue 协调恢复）等三个紧密耦合类；职责内聚（label 清除、状态恢复、一致性校验、live session 检测）且已按职责拆分为独立类，进一步拆分文件会破坏 resume domain 完整性；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问；Issue #2774 新增 blocked_by 依赖检查逻辑（verify_issue_state_for_resume 返回值改为 tuple、blocked_by_issue 状态查询、错误消息处理）增加 79 行"
       - path: "src/vibe3/services/task/service.py"
         limit: 500
         reason: "Task 服务聚合，包含 issue link/reclassify、superseded flow 降级、分支解析、issue comment 查询等紧密耦合的核心 task 状态管理逻辑；职责单一（task state lifecycle）但方法较多，拆分收益低；Issue #2575 Protocol/DI 重构后新增公共 flow_service 属性（+5 行）供测试访问"

--- a/src/vibe3/services/task/resume.py
+++ b/src/vibe3/services/task/resume.py
@@ -465,7 +465,7 @@ class TaskResumeUsecase:
             return self._flow_service_input
         from vibe3.services import FlowService
 
-        return FlowService()  # type: ignore[return-value]
+        return FlowService()
 
     @property
     def flow_service(self) -> "FlowQueryProtocol":

--- a/src/vibe3/services/task/resume.py
+++ b/src/vibe3/services/task/resume.py
@@ -6,6 +6,8 @@ scene rebuild belongs to FlowRebuildUsecase.
 
 from __future__ import annotations
 
+import json
+import subprocess
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 from loguru import logger
@@ -320,7 +322,7 @@ class TaskResumeCandidates:
 
     def verify_issue_state_for_resume(
         self, issue_number: int, resume_kind: str, repo: str | None
-    ) -> bool:
+    ) -> tuple[bool, str | None]:
         """Verify issue is still in expected state for resume.
 
         Args:
@@ -329,7 +331,8 @@ class TaskResumeCandidates:
             repo: Repository (owner/repo format, optional)
 
         Returns:
-            True if issue can be resumed, False otherwise
+            Tuple of (can_resume, reason). can_resume is True if issue can be resumed.
+            reason is a human-readable message if can_resume is False, None otherwise.
         """
         # ✅ Use authoritative truth: check if issue has merged PR
         from vibe3.services import has_merged_pr_for_issue
@@ -341,22 +344,87 @@ class TaskResumeCandidates:
                 issue_number=issue_number,
                 resume_kind=resume_kind,
             ).info("Issue has merged PR, cannot be resumed")
-            return False
+            return False, f"Issue #{issue_number} has a merged PR, cannot be resumed"
 
         current_state = self.label_service.get_state(issue_number)
 
         if current_state is None:
-            return False
+            return False, None
 
         if resume_kind == "blocked":
-            return current_state.value == "blocked"
+            if current_state.value != "blocked":
+                return (
+                    False,
+                    f"Issue #{issue_number} is not in expected state for {resume_kind}",
+                )
+
+            # Check blocked_by_issue dependency
+            flow_dict = self._flow_service.get_flow_for_issue(issue_number)
+            if flow_dict:
+                blocked_by_issue = flow_dict.get("blocked_by_issue")
+                if isinstance(blocked_by_issue, int) and blocked_by_issue > 0:
+                    # Query the dependency issue state via gh CLI
+                    try:
+                        result = subprocess.run(
+                            [
+                                "gh",
+                                "issue",
+                                "view",
+                                str(blocked_by_issue),
+                                "--json",
+                                "state",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            timeout=10,
+                        )
+                        if result.returncode == 0:
+                            data = json.loads(result.stdout)
+                            if data.get("state") != "CLOSED":
+                                return (
+                                    False,
+                                    f"task 不满足 resume 条件，所依赖的 "
+                                    f"task #{blocked_by_issue} 尚未关闭",
+                                )
+                        else:
+                            # gh command failed, log warning but continue (fail open)
+                            logger.bind(
+                                domain="resume",
+                                issue_number=issue_number,
+                                blocked_by_issue=blocked_by_issue,
+                            ).warning(
+                                f"Failed to check dependency issue #{blocked_by_issue} "
+                                f"state, allowing resume"
+                            )
+                    except (
+                        subprocess.TimeoutExpired,
+                        json.JSONDecodeError,
+                        FileNotFoundError,
+                    ) as e:
+                        # Fail open: if gh is not available or times out, allow resume
+                        logger.bind(
+                            domain="resume",
+                            issue_number=issue_number,
+                            blocked_by_issue=blocked_by_issue,
+                            error=str(e),
+                        ).warning(
+                            f"Error checking dependency issue #{blocked_by_issue}, "
+                            f"allowing resume"
+                        )
+
+            return True, None
         elif resume_kind == "aborted":
             # Aborted flows can be resumed from READY or HANDOFF states
             # The flow_status=aborted check is done in fetch_resume_candidates
             # Here we verify the issue is in a valid state for resumption
-            return current_state.value in ("ready", "handoff")
+            if current_state.value not in ("ready", "handoff"):
+                return (
+                    False,
+                    f"Issue #{issue_number} is not in expected state for {resume_kind}",
+                )
+            return True, None
 
-        return False
+        return False, None
 
 
 def _format_resume_failure_reason(exc: Exception) -> str:
@@ -520,13 +588,14 @@ class TaskResumeUsecase:
                 branch=branch,
             ).info("Processing resume candidate")
 
-            if not self.candidates.verify_issue_state_for_resume(
+            can_resume, verify_reason = self.candidates.verify_issue_state_for_resume(
                 issue_number, resume_kind, repo
-            ):
+            )
+            if not can_resume:
                 result["skipped"].append(
                     {
                         "number": issue_number,
-                        "reason": "状态验证失败，跳过恢复",
+                        "reason": verify_reason or "状态验证失败，跳过恢复",
                     }
                 )
                 continue

--- a/tests/vibe3/services/test_aborted_flow_resume.py
+++ b/tests/vibe3/services/test_aborted_flow_resume.py
@@ -63,7 +63,7 @@ class TestAbortedFlowRecovery:
 
         mock_status_service.fetch_resume_candidates.return_value = candidates
         resume_usecase.candidates.verify_issue_state_for_resume = MagicMock(
-            return_value=True
+            return_value=(True, None)
         )
 
         with patch.object(

--- a/tests/vibe3/services/test_task_resume_usecase.py
+++ b/tests/vibe3/services/test_task_resume_usecase.py
@@ -1,7 +1,7 @@
 """Tests for task resume usecase error reporting."""
 
 import inspect
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from vibe3.models.orchestration import IssueState
 from vibe3.services.task import TaskResumeUsecase
@@ -28,7 +28,9 @@ def test_resume_issues_surfaces_operation_error_in_skipped_reason() -> None:
         "flow": None,
     }
     usecase.status_service.fetch_resume_candidates.return_value = [candidate]
-    usecase.candidates.verify_issue_state_for_resume = MagicMock(return_value=True)
+    usecase.candidates.verify_issue_state_for_resume = MagicMock(
+        return_value=(True, None)
+    )
     usecase.operations.reset_issue_to_ready = MagicMock(
         side_effect=RuntimeError("scene cleanup failed")
     )
@@ -51,7 +53,9 @@ def test_resume_issues_uses_exception_class_when_message_missing() -> None:
         "flow": None,
     }
     usecase.status_service.fetch_resume_candidates.return_value = [candidate]
-    usecase.candidates.verify_issue_state_for_resume = MagicMock(return_value=True)
+    usecase.candidates.verify_issue_state_for_resume = MagicMock(
+        return_value=(True, None)
+    )
     usecase.operations.reset_issue_to_ready = MagicMock(side_effect=RuntimeError())
 
     result = usecase.resume_issues(dry_run=False)
@@ -72,7 +76,9 @@ def test_resume_issues_defaults_to_label_auto_and_skips_reset_comment() -> None:
         "flow": MagicMock(branch="task/issue-303"),
     }
     usecase.status_service.fetch_resume_candidates.return_value = [candidate]
-    usecase.candidates.verify_issue_state_for_resume = MagicMock(return_value=True)
+    usecase.candidates.verify_issue_state_for_resume = MagicMock(
+        return_value=(True, None)
+    )
     usecase.operations.reset_issue_to_ready = MagicMock()
     result = usecase.resume_issues(dry_run=False)
 
@@ -86,3 +92,93 @@ def test_resume_issues_has_no_all_task_candidate_mode() -> None:
     params = inspect.signature(TaskResumeUsecase.resume_issues).parameters
 
     assert "candidate_mode" not in params
+
+
+def test_verify_rejects_when_blocked_by_dependency_still_open() -> None:
+    """Test that resume is rejected when blocked_by_issue is still OPEN."""
+    usecase = _make_usecase()
+    usecase.label_service.get_state.return_value = MagicMock(value="blocked")
+    usecase.candidates._flow_service.get_flow_for_issue.return_value = {
+        "blocked_by_issue": 999
+    }
+
+    # Mock gh CLI to return OPEN state
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"state": "OPEN"}', stderr=""
+        )
+        can_resume, reason = usecase.candidates.verify_issue_state_for_resume(
+            123, "blocked", None
+        )
+
+    assert can_resume is False
+    assert reason == "task 不满足 resume 条件，所依赖的 task #999 尚未关闭"
+
+
+def test_verify_allows_when_blocked_by_dependency_closed() -> None:
+    """Test that resume is allowed when blocked_by_issue is CLOSED."""
+    usecase = _make_usecase()
+    usecase.label_service.get_state.return_value = MagicMock(value="blocked")
+    usecase.candidates._flow_service.get_flow_for_issue.return_value = {
+        "blocked_by_issue": 999
+    }
+
+    # Mock gh CLI to return CLOSED state
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"state": "CLOSED"}', stderr=""
+        )
+        can_resume, reason = usecase.candidates.verify_issue_state_for_resume(
+            123, "blocked", None
+        )
+
+    assert can_resume is True
+    assert reason is None
+
+
+def test_verify_skips_check_when_blocked_by_issue_empty() -> None:
+    """Test that dependency check is skipped when blocked_by_issue is None or 0."""
+    usecase = _make_usecase()
+    usecase.label_service.get_state.return_value = MagicMock(value="blocked")
+
+    # Test with None
+    usecase.candidates._flow_service.get_flow_for_issue.return_value = {
+        "blocked_by_issue": None
+    }
+    can_resume, reason = usecase.candidates.verify_issue_state_for_resume(
+        123, "blocked", None
+    )
+    assert can_resume is True
+    assert reason is None
+
+    # Test with 0
+    usecase.candidates._flow_service.get_flow_for_issue.return_value = {
+        "blocked_by_issue": 0
+    }
+    can_resume, reason = usecase.candidates.verify_issue_state_for_resume(
+        123, "blocked", None
+    )
+    assert can_resume is True
+    assert reason is None
+
+
+def test_verify_allows_when_gh_command_fails() -> None:
+    """Test that resume is allowed (fail open) when gh command fails."""
+    usecase = _make_usecase()
+    usecase.label_service.get_state.return_value = MagicMock(value="blocked")
+    usecase.candidates._flow_service.get_flow_for_issue.return_value = {
+        "blocked_by_issue": 999
+    }
+
+    # Mock gh CLI to fail (non-zero return code)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error: issue not found"
+        )
+        can_resume, reason = usecase.candidates.verify_issue_state_for_resume(
+            123, "blocked", None
+        )
+
+    # Should fail open: allow resume despite gh failure
+    assert can_resume is True
+    assert reason is None


### PR DESCRIPTION
## ⚠️ Branch Behind Base

The PR branch `task/issue-2774` is behind `main` by **6 commit(s)**.

### Recommended Actions

```bash
git fetch origin main
git rebase origin/main
git push --force-with-lease origin task/issue-2774
```


---

## Summary

Add dependency guard in TaskResumeCandidateSelector.verify_issue_state_for_resume() to reject resume if blocked_by_issue is still open.

## Changes

- Modified verify_issue_state_for_resume() return type: bool → tuple[bool, str | None]
- Added blocked_by dependency check via gh issue view --json state
- Updated resume_issues() call site to unpack tuple and use reason string

## Behavior

- Query blocked_by_issue from flow record
- Check dependency issue state via gh CLI
- Reject resume if dependency is OPEN
- Allow resume if CLOSED or blocked_by_issue empty
- Fail open if gh CLI unavailable (logs warning)

## Test Evidence

Added 4 new test cases covering rejection, allowance, skip, and fail-open scenarios.

Test Results: 25/25 passed
Type Check: Success
Lint Check: Passed

Closes #2774

---

## Contributors

claude/opus
