### PR TITLE
perf(check): optimize dependency check with fields parameter

### DIFF
--- a/src/vibe3/services/check/service.py
+++ b/src/vibe3/services/check/service.py
@@ -394,9 +394,13 @@ class CheckService(CheckRemote):
                 resolver = CoordinationResolver(store=self.store)
                 truth = resolver.resolve_coordination(branch, task_issue)
                 if truth.dependencies:
+                    from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
+
                     unresolved = []
                     for dep in truth.dependencies:
-                        dep_issue = self.github_client.view_issue(dep)
+                        dep_issue = self.github_client.view_issue(
+                            dep, fields=list(GITHUB_FIELDS_STATE_ONLY)
+                        )  # type: ignore[call-overload]
                         if (
                             not isinstance(dep_issue, dict)
                             or dep_issue.get("state") != "closed"


### PR DESCRIPTION
## Summary
Optimize dependency check to eliminate over-fetching of GitHub issue data. Changed `view_issue` call at `src/vibe3/services/check/service.py:399` to use `fields=list(GITHUB_FIELDS_STATE_ONLY)`, reducing API payload from ~2-5KB to ~50 bytes per dependency.

## Changes
- Added local import of `GITHUB_FIELDS_STATE_ONLY` after line 396
- Modified `view_issue` call to include `fields=list(GITHUB_FIELDS_STATE_ONLY)` parameter
- Added `# type: ignore[call-overload]` comment to handle protocol/implementation signature mismatch

## Performance Impact
For an issue with 3 dependencies, this reduces GitHub API payload from ~6-15KB to ~150 bytes, significantly improving performance.

Example: If an issue has 3 dependencies, the old code would fetch ~6-15KB of unnecessary data. The new code fetches only ~150 bytes (just the state field for each dependency).

## Test Results
✅ All tests pass (10/10 in test_check_service_verify_branch.py)
✅ Type checking passes (mypy)
✅ Lint checking passes (ruff)

## Pattern Consistency
This change follows the established optimization patterns already present in:
- `cleanup.py:376`
- `pr_service.py:541`
- `qualify_gate_checks.py:104`
- Same file at line 323-324 (`GITHUB_DEFAULT_VIEW_FIELDS`)

Fixes #2781

---

## Contributors

claude/opus
