### PR TITLE
refactor(clients): split GitHub field constants for view vs list operations

### DIFF
--- a/src/vibe3/clients/github_field_constants.py
+++ b/src/vibe3/clients/github_field_constants.py
@@ -10,18 +10,25 @@ from typing import Final
 # GitHub Issue Field Constants
 # =============================================================================
 
-# Default fields for view_issue - excludes expensive 'comments' field
-# Suitable for callers that need issue metadata but not comments
-GITHUB_DEFAULT_VIEW_FIELDS: Final[tuple[str, ...]] = (
+# Shared metadata fields used by both view and list operations
+GITHUB_FIELDS_ISSUE_META: Final[tuple[str, ...]] = (
     "number",
     "title",
-    "body",
     "state",
     "updatedAt",
     "labels",
-    "milestone",
     "assignees",
+    "milestone",
 )
+
+# Default fields for view_issue — includes body and url
+GITHUB_DEFAULT_VIEW_FIELDS: Final[tuple[str, ...]] = GITHUB_FIELDS_ISSUE_META + (
+    "body",
+    "url",
+)
+
+# Default fields for list_issues — excludes body (expensive) and url
+GITHUB_DEFAULT_LIST_FIELDS: Final[tuple[str, ...]] = GITHUB_FIELDS_ISSUE_META
 
 # Minimal field sets for specific operations
 GITHUB_FIELDS_STATE_ONLY: Final[tuple[str, ...]] = ("state",)

--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from loguru import logger
 
 from vibe3.clients.github_field_constants import (
+    GITHUB_DEFAULT_LIST_FIELDS,
     GITHUB_DEFAULT_VIEW_FIELDS,
     GITHUB_KNOWN_ISSUE_FIELDS,
 )
@@ -25,8 +26,6 @@ _BLOCKED_BY_RE = re.compile(
     r"(?:blocked\s+by|depends\s+on|依赖)[:\s]+([#\d,\s#]+)",
     re.IGNORECASE,
 )
-
-_DEFAULT_LIST_FIELDS = "number,title,state,updatedAt,labels,assignees,milestone"
 
 # Pre-computed set for O(1) field validation lookups
 _KNOWN_FIELDS_SET: frozenset[str] = frozenset(GITHUB_KNOWN_ISSUE_FIELDS)
@@ -181,7 +180,11 @@ class IssuesMixin(IssueAdminMixin):
             search=search,
             fields=fields,
         ).debug("Calling GitHub API: list_issues")
-        json_fields = ",".join(fields) if fields is not None else _DEFAULT_LIST_FIELDS
+        json_fields = (
+            ",".join(fields)
+            if fields is not None
+            else ",".join(GITHUB_DEFAULT_LIST_FIELDS)
+        )
         cmd = [
             "gh",
             "issue",

--- a/tests/vibe3/clients/test_github_client_issues.py
+++ b/tests/vibe3/clients/test_github_client_issues.py
@@ -232,7 +232,7 @@ def test_view_issue_with_default_fields(github_client: GitHubClient) -> None:
         json_index = call_args.index("--json")
         assert (
             call_args[json_index + 1]
-            == "number,title,body,state,updatedAt,labels,milestone,assignees"
+            == "number,title,state,updatedAt,labels,assignees,milestone,body,url"
         )
 
 

--- a/tests/vibe3/clients/test_github_field_constants.py
+++ b/tests/vibe3/clients/test_github_field_constants.py
@@ -1,0 +1,64 @@
+"""Tests for GitHub field constants."""
+
+from vibe3.clients.github_field_constants import (
+    GITHUB_DEFAULT_LIST_FIELDS,
+    GITHUB_DEFAULT_VIEW_FIELDS,
+    GITHUB_FIELDS_ISSUE_META,
+    GITHUB_KNOWN_ISSUE_FIELDS,
+)
+
+
+def test_meta_fields_definition() -> None:
+    """GITHUB_FIELDS_ISSUE_META should contain shared metadata fields."""
+    assert "number" in GITHUB_FIELDS_ISSUE_META
+    assert "title" in GITHUB_FIELDS_ISSUE_META
+    assert "state" in GITHUB_FIELDS_ISSUE_META
+    assert "updatedAt" in GITHUB_FIELDS_ISSUE_META
+    assert "labels" in GITHUB_FIELDS_ISSUE_META
+    assert "assignees" in GITHUB_FIELDS_ISSUE_META
+    assert "milestone" in GITHUB_FIELDS_ISSUE_META
+    # Should NOT contain body or url
+    assert "body" not in GITHUB_FIELDS_ISSUE_META
+    assert "url" not in GITHUB_FIELDS_ISSUE_META
+
+
+def test_view_fields_definition() -> None:
+    """GITHUB_DEFAULT_VIEW_FIELDS should include body and url."""
+    # Should include all meta fields
+    for field in GITHUB_FIELDS_ISSUE_META:
+        assert field in GITHUB_DEFAULT_VIEW_FIELDS
+
+    # Should include body and url
+    assert "body" in GITHUB_DEFAULT_VIEW_FIELDS
+    assert "url" in GITHUB_DEFAULT_VIEW_FIELDS
+
+
+def test_list_fields_definition() -> None:
+    """GITHUB_DEFAULT_LIST_FIELDS should exclude body and url."""
+    # Should be exactly equal to meta fields
+    assert GITHUB_DEFAULT_LIST_FIELDS == GITHUB_FIELDS_ISSUE_META
+
+    # Should NOT contain body or url
+    assert "body" not in GITHUB_DEFAULT_LIST_FIELDS
+    assert "url" not in GITHUB_DEFAULT_LIST_FIELDS
+
+
+def test_all_fields_are_known() -> None:
+    """All defined fields should be in GITHUB_KNOWN_ISSUE_FIELDS."""
+    known_set = set(GITHUB_KNOWN_ISSUE_FIELDS)
+
+    for field in GITHUB_FIELDS_ISSUE_META:
+        assert field in known_set, f"Field {field} not in known fields"
+
+    for field in GITHUB_DEFAULT_VIEW_FIELDS:
+        assert field in known_set, f"Field {field} not in known fields"
+
+    for field in GITHUB_DEFAULT_LIST_FIELDS:
+        assert field in known_set, f"Field {field} not in known fields"
+
+
+def test_no_duplicate_fields() -> None:
+    """Field constants should not contain duplicates."""
+    assert len(GITHUB_FIELDS_ISSUE_META) == len(set(GITHUB_FIELDS_ISSUE_META))
+    assert len(GITHUB_DEFAULT_VIEW_FIELDS) == len(set(GITHUB_DEFAULT_VIEW_FIELDS))
+    assert len(GITHUB_DEFAULT_LIST_FIELDS) == len(set(GITHUB_DEFAULT_LIST_FIELDS))


### PR DESCRIPTION
## Summary

重构 GitHub API 字段常量，分离 view 和 list 操作的字段需求，消除硬编码字段串，提高可维护性。

## Problem

之前的 `GITHUB_DEFAULT_VIEW_FIELDS` 混合了 view 和 list 操作的字段，导致：
- `list_issues` 使用硬编码字段串，不便维护
- view 和 list 操作的字段需求不清晰

## Solution

- 新增 `GITHUB_FIELDS_ISSUE_META` 作为共享元数据字段
- 新增 `GITHUB_DEFAULT_LIST_FIELDS`（明确 list 操作的字段需求）
- 更新 `GITHUB_DEFAULT_VIEW_FIELDS` 包含 body 和 url（明确 view 操作的字段需求）
- 移除 `github_issues_ops.py` 中的硬编码字段

## Benefits

- 消除硬编码字段串，提高可维护性
- 明确分离 view 和 list 操作的字段需求
- 为未来优化字段选择提供基础

## Testing

- ✅ 181/181 tests pass
- ✅ mypy: success
- ✅ ruff: all checks passed
- ✅ **新增测试**：验证字段常量定义的正确性

## Changes

- `src/vibe3/clients/github_field_constants.py` - 字段重构
- `src/vibe3/clients/github_issues_ops.py` - 使用新常量
- `tests/vibe3/clients/test_github_client_issues.py` - 更新字段顺序测试
- `tests/vibe3/clients/test_github_field_constants.py` - **新增**字段常量定义测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)