### PR TITLE
fix(clients): pass fields=["comments"] to view_issue in list_issue_comments

### DIFF
--- a/src/vibe3/clients/github_issues_ops.py
+++ b/src/vibe3/clients/github_issues_ops.py
@@ -366,7 +366,7 @@ class IssuesMixin(IssueAdminMixin):
         Returns:
             List of comment dicts with keys: id, body, author, etc.
         """
-        result = self.view_issue(issue_number, repo=repo)
+        result = self.view_issue(issue_number, repo=repo, fields=["comments"])
         if isinstance(result, dict):
             return cast(list[dict[str, Any]], result.get("comments", []))
         return []

--- a/tests/vibe3/clients/test_github_client_issues.py
+++ b/tests/vibe3/clients/test_github_client_issues.py
@@ -332,6 +332,8 @@ def test_list_issue_comments_success(github_client: GitHubClient) -> None:
 
         result = github_client.list_issue_comments(issue_number=123)
 
+        mock_view.assert_called_once_with(123, repo=None, fields=["comments"])
+
         assert len(result) == 2
         assert result[0]["body"] == "First comment"
         assert result[1]["body"] == "Second comment"


### PR DESCRIPTION
## Summary

Fixes #2783

The `list_issue_comments` method was calling `view_issue` without requesting the `comments` field, resulting in empty comment lists being returned to callers.

## Changes

**Source Code**:
- `src/vibe3/clients/github_issues_ops.py:369`: Added `fields=["comments"]` parameter to the `view_issue` call

**Tests**:
- `tests/vibe3/clients/test_github_client_issues.py:335`: Added mock assertion to prevent regression

## Root Cause

GitHub API only returns requested fields when the `fields` parameter is specified. Without `fields=["comments"]`, the `view_issue` call would return an empty `comments` array, causing `list_issue_comments` to always return an empty list.

## Verification

All tests pass:
- ✅ 27 tests in `test_github_client_issues.py`
- ✅ 13 tests in `test_check_service.py`
- ✅ Type check clean (mypy)
- ✅ Pre-commit hooks passed
- ✅ LOC limits within bounds

## Test Plan

```bash
# Run affected tests
uv run pytest tests/vibe3/clients/test_github_client_issues.py -q
uv run pytest tests/vibe3/services/test_check_service.py -q

# Type check
uv run mypy src/vibe3/clients/github_issues_ops.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/opus
