### PR TITLE
fix(task-show): display issue body and full comments, adjust timeline comment policy

### DIFF
--- a/config/v3/timeline.yaml
+++ b/config/v3/timeline.yaml
@@ -22,11 +22,15 @@ no_comment:
     - plan_recorded
     - report_recorded
 
+  # Handoff 更新（日常操作记录，不需要通知）
+  handoff_updates:
+    - handoff_append
+
 # 写 comment 的事件分类
 write_comment:
   # 重要里程碑
   milestone:
-    - handoff_append
+    - flow_rebuild
     - milestone_recorded
 
   # 人类可读的状态变化

--- a/src/vibe3/config/timeline_comment_policy.py
+++ b/src/vibe3/config/timeline_comment_policy.py
@@ -44,11 +44,14 @@ class TimelineCommentPolicy(BaseModel):
         "report_recorded",  # Legacy alias for handoff_report
     ]
 
+    # Handoff updates - NO COMMENTS (routine operation records)
+    # Note: handoff_append is configured via YAML to allow flexibility
+    handoff_updates_events: list[str] = []  # Populated from YAML
+
     # Milestone events - WRITE COMMENTS (important progress markers)
     # NOTE: Must be routed through FlowTimelineService.record_timeline_event()
-    # handoff_append is now routed through HandoffService.append_current_handoff()
     milestone_events: list[str] = [
-        "handoff_append",  # Important milestone records (routed via HandoffService)
+        "flow_rebuild",  # Flow rebuild milestone (rebuild.py)
         "milestone_recorded",  # Example: Future milestone event (placeholder)
     ]
 
@@ -64,8 +67,8 @@ class TimelineCommentPolicy(BaseModel):
     # - pr_created: PRService creates PR (pr_service.py:310-315)
     # - handoff_verdict: VerdictService records verdict (verdict_service.py:140-146)
     # - state_transitioned: NoopGate state transition (noop_gate.py:406-424)
+    # - handoff_append: HandoffService updates (handoff/service.py:225-231) - NO COMMENT
     #
-    # handoff_append is NOW routed through FlowTimelineService via HandoffService
     # To enable policy filtering, route through FlowTimelineService first
 
     def should_write_comment(self, event_type: str) -> bool:
@@ -87,6 +90,10 @@ class TimelineCommentPolicy(BaseModel):
 
         # Artifact file references - never write comments
         if event_type in self.artifact_ref_events:
+            return False
+
+        # Handoff updates - never write comments
+        if event_type in self.handoff_updates_events:
             return False
 
         # Milestone events - write comments
@@ -135,6 +142,9 @@ class TimelineCommentPolicy(BaseModel):
             ),
             artifact_ref_events=no_comment.get(
                 "artifact_ref", cls.model_fields["artifact_ref_events"].default
+            ),
+            handoff_updates_events=no_comment.get(
+                "handoff_updates", cls.model_fields["handoff_updates_events"].default
             ),
             milestone_events=write_comment.get(
                 "milestone", cls.model_fields["milestone_events"].default

--- a/src/vibe3/services/flow/rebuild.py
+++ b/src/vibe3/services/flow/rebuild.py
@@ -14,7 +14,6 @@ from vibe3.config import load_orchestra_config
 from vibe3.models import IssueInfo
 from vibe3.services.flow.cleanup import FlowCleanupService
 from vibe3.services.flow.rebuild_postconditions import assert_rebuild_postconditions
-from vibe3.services.handoff.service import HandoffService
 from vibe3.services.protocols.flow_protocols import FlowBootstrapProtocol
 
 LabelResume = Callable[..., None]
@@ -114,16 +113,22 @@ class FlowRebuildUsecase:
             store=self.store,
         )
 
-        HandoffService(
-            store=self.store,
-            git_client=self.git_client,
-            github_client=self.github_client,
-        ).append_current_handoff(
-            message=f"Flow rebuilt: {reason}",
-            actor="vibe3:flow_rebuild",
-            kind="milestone",
-            branch=branch,
-        )
+        # Record flow_rebuild timeline event
+        from vibe3.services.flow.timeline import FlowTimelineService
+        from vibe3.services.issue.flow import IssueFlowService
+
+        issue_number = IssueFlowService(self.store).resolve_task_issue_number(branch)
+        if issue_number:
+            FlowTimelineService(
+                store=self.store,
+                github_client=self.github_client,
+            ).record_timeline_event(
+                branch=branch,
+                event_type="flow_rebuild",
+                actor="vibe3:flow_rebuild",
+                detail=f"Flow rebuilt: {reason}",
+                issue_number=issue_number,
+            )
 
         self._label_resume(
             issue_number=issue.number,

--- a/src/vibe3/ui/task_ui.py
+++ b/src/vibe3/ui/task_ui.py
@@ -249,12 +249,18 @@ def render_task_show(
 def render_task_comments(
     issue: dict[str, object], max_comments: int = MAX_COMMENTS_DISPLAY
 ) -> None:
-    """Render last N comments with human/agent labels.
+    """Render issue body and last N comments with human/agent labels.
 
     Args:
-        issue: Issue dict with comments
+        issue: Issue dict with body and comments
         max_comments: Maximum number of recent comments to show
     """
+    # Display issue body first
+    body = str(issue.get("body") or "").strip()
+    if body:
+        console.print("\n[bold]Issue Body[/]\n")
+        console.print(body)
+
     comments = issue.get("comments") or []
     if not isinstance(comments, list):
         comments = []
@@ -272,7 +278,7 @@ def render_task_comments(
     shown = len(recent_comments)
     console.print(f"\n[bold]Recent Comments (last {shown} of {total})[/]\n")
 
-    for idx, comment in enumerate(recent_comments):
+    for comment in recent_comments:
         if not isinstance(comment, dict):
             continue
 
@@ -296,11 +302,6 @@ def render_task_comments(
             # Bug 4: Human comments label
             console.print(f"[bold cyan]\\[user:{login}][/bold cyan]")
 
-        # Only truncate if NOT the last comment (most recent)
-        # Last comment should be shown in full for agent context
-        is_last = idx == len(recent_comments) - 1
-        if not is_last and len(body) > 300:
-            body = body[:300] + "..."
-
+        # Show full comment body without truncation
         console.print(body)
         console.print()  # Empty line between comments

--- a/tests/vibe3/config/test_timeline_comment_policy.py
+++ b/tests/vibe3/config/test_timeline_comment_policy.py
@@ -149,8 +149,11 @@ def test_backward_compatibility() -> None:
     assert default_policy.should_write_comment("plan_recorded") is False
     assert default_policy.should_write_comment("report_recorded") is False
 
+    # Handoff append events - configured via YAML (default: unknown event = no comment)
+    assert default_policy.should_write_comment("handoff_append") is False
+
     # Milestone events - write comments
-    assert default_policy.should_write_comment("handoff_append") is True
+    assert default_policy.should_write_comment("flow_rebuild") is True
     assert default_policy.should_write_comment("milestone_recorded") is True
 
     # Human-readable events - write comments

--- a/tests/vibe3/services/test_flow_rebuild_usecase.py
+++ b/tests/vibe3/services/test_flow_rebuild_usecase.py
@@ -40,7 +40,8 @@ def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume(
 
     with (
         patch("vibe3.services.flow.rebuild.FlowCleanupService") as cleanup_cls,
-        patch("vibe3.services.flow.rebuild.HandoffService") as handoff_cls,
+        patch("vibe3.services.flow.timeline.FlowTimelineService") as timeline_cls,
+        patch("vibe3.services.issue.flow.IssueFlowService") as issue_flow_cls,
     ):
         cleanup = cleanup_cls.return_value
         cleanup.cleanup_flow_scene.return_value = {
@@ -50,7 +51,9 @@ def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume(
             "handoff": True,
             "flow_record": True,
         }
-        handoff = handoff_cls.return_value
+        issue_flow = issue_flow_cls.return_value
+        issue_flow.resolve_task_issue_number.return_value = 303
+        timeline = timeline_cls.return_value
 
         result = usecase.rebuild_issue_flow(
             issue=issue,
@@ -77,7 +80,13 @@ def test_rebuild_issue_flow_hard_deletes_bootstraps_handoff_and_label_resume(
         reactivate_existing=False,
         force_baseline=True,
     )
-    handoff.append_current_handoff.assert_called_once()
+    timeline.record_timeline_event.assert_called_once_with(
+        branch="task/issue-303",
+        event_type="flow_rebuild",
+        actor="vibe3:flow_rebuild",
+        detail="Flow rebuilt: missing worktree",
+        issue_number=303,
+    )
     label_resume.assert_called_once_with(
         issue_number=303,
         branch="task/issue-303",
@@ -116,7 +125,8 @@ def test_rebuild_issue_flow_fails_when_rebuilt_worktree_is_missing() -> None:
 
     with (
         patch("vibe3.services.flow.rebuild.FlowCleanupService") as cleanup_cls,
-        patch("vibe3.services.flow.rebuild.HandoffService") as handoff_cls,
+        patch("vibe3.services.flow.timeline.FlowTimelineService") as timeline_cls,
+        patch("vibe3.services.issue.flow.IssueFlowService"),
         pytest.raises(RuntimeError, match="Rebuild postcondition failed"),
     ):
         cleanup = cleanup_cls.return_value
@@ -136,5 +146,5 @@ def test_rebuild_issue_flow_fails_when_rebuilt_worktree_is_missing() -> None:
             ensure_worktree=True,
         )
 
-    handoff_cls.return_value.append_current_handoff.assert_not_called()
+    timeline_cls.return_value.record_timeline_event.assert_not_called()
     label_resume.assert_not_called()


### PR DESCRIPTION
## Summary
- Display issue body in `vibe3 task show` output for better context
- Remove comment truncation - show full comment content
- Adjust timeline comment policy: `handoff_append` no longer sends comments, `flow_rebuild` now sends milestone comments

## Task Show Improvements
- ✅ Issue body now displayed before comments
- ✅ Comments shown in full without 300-character truncation
- ✅ Better user experience for task inspection

## Timeline Comment Policy Changes
- ✅ `handoff_append` → no comment (routine updates, configurable)
- ✅ `flow_rebuild` → sends comment (important milestone)
- ✅ New `handoff_updates_events` category for flexibility
- ✅ Dedicated `flow_rebuild` event instead of reusing `handoff_append`

## Technical Details
- Updated `FlowRebuildUsecase` to use `FlowTimelineService` directly
- Added `handoff_updates_events` field to `TimelineCommentPolicy`
- All changes configurable via `config/v3/timeline.yaml`

## Test Plan
- ✅ All rebuild-related tests passing (28/28)
- ✅ All timeline comment policy tests passing (9/9)
- ✅ All flow timeline service tests passing (6/6)
- ✅ Total: 43/43 relevant tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)