### PR TITLE
test(vibe3): enhance weak assertion in test_recent_pr_cache.py

### DIFF
--- a/tests/vibe3/clients/test_recent_pr_cache.py
+++ b/tests/vibe3/clients/test_recent_pr_cache.py
@@ -102,4 +102,7 @@ def test_recent_pr_cache_sync_replaces_snapshot(cache: RecentPRCache) -> None:
     assert cached["feature/open"]["state"] == "OPEN"
     assert cached["feature/merged"]["number"] == 202
     assert cached["feature/merged"]["state"] == "CLOSED"
-    assert cached["feature/merged"]["merged_at"] is not None
+    # Verify merged_at is a valid ISO 8601 string
+    merged_at = cached["feature/merged"]["merged_at"]
+    assert merged_at is not None
+    datetime.fromisoformat(merged_at)


### PR DESCRIPTION
Fixes #2819. Enhanced the weak assertion in `tests/vibe3/clients/test_recent_pr_cache.py` to verify that `merged_at` is a valid ISO 8601 string.