### PR TITLE
perf(clients): add issue_index to merged PR cache for O(1) lookup

### DIFF
--- a/src/vibe3/clients/merged_pr_cache.py
+++ b/src/vibe3/clients/merged_pr_cache.py
@@ -82,6 +82,23 @@ class MergedPRCache:
         # Return empty structure
         return {"last_sync": None, "prs": {}}
 
+    def _build_issue_index(self, prs: dict[str, Any]) -> dict[str, str]:
+        """Build reverse index from issue_number to pr_number.
+
+        Args:
+            prs: Dict of PR data keyed by PR number (as string)
+
+        Returns:
+            Dict mapping issue_number (as string) to pr_number (as string)
+        """
+        index: dict[str, str] = {}
+        for pr_number_str, pr_data in prs.items():
+            if not isinstance(pr_data, dict):
+                continue
+            for issue_number in pr_data.get("issues", []):
+                index[str(issue_number)] = pr_number_str
+        return index
+
     def _save_cache(self, data: dict[str, Any]) -> None:
         """Save cache to file.
 
@@ -89,6 +106,7 @@ class MergedPRCache:
             data: Cache data structure
         """
         self._ensure_dir()
+        data["issue_index"] = self._build_issue_index(data.get("prs", {}))
         with open(self.cache_file, "w") as f:
             json.dump(data, f, indent=2)
 
@@ -104,7 +122,22 @@ class MergedPRCache:
         """
         cache = self._load_cache()
         prs = cache.get("prs", {})
+        issue_index = cache.get("issue_index")
 
+        # Fast path: O(1) lookup via index
+        if issue_index is not None:
+            pr_number_str = issue_index.get(str(issue_number))
+            if pr_number_str is not None:
+                pr_data = prs.get(pr_number_str)
+                if isinstance(pr_data, dict):
+                    logger.bind(
+                        domain="merged_pr_cache",
+                        issue_number=issue_number,
+                        pr_number=pr_data.get("number"),
+                    ).debug("Cache hit for issue")
+                    return pr_data
+
+        # Fallback path: linear scan (backward compat with old cache)
         for pr_data in prs.values():
             if not isinstance(pr_data, dict):
                 continue

--- a/tests/vibe3/clients/test_merged_pr_cache.py
+++ b/tests/vibe3/clients/test_merged_pr_cache.py
@@ -98,6 +98,11 @@ def test_get_merged_pr_for_issue_hit_and_miss(cache: MergedPRCache) -> None:
     }
     cache._save_cache(test_data)
 
+    # Verify issue_index is created
+    loaded = cache._load_cache()
+    assert "issue_index" in loaded
+    assert loaded["issue_index"] == {"456": "100", "789": "101"}
+
     result = cache.get_merged_pr_for_issue(456)
     assert result is not None
     assert result["number"] == 100
@@ -298,6 +303,10 @@ def test_single_pr_closes_multiple_issues(cache: MergedPRCache) -> None:
     }
     cache._save_cache(test_data)
 
+    # Verify index has entries for both issues
+    loaded = cache._load_cache()
+    assert loaded["issue_index"] == {"456": "100", "789": "100"}
+
     for issue in [456, 789]:
         result = cache.get_merged_pr_for_issue(issue)
         assert result is not None
@@ -345,3 +354,46 @@ def test_sync_and_rebuild_index_all_linked_issues(cache: MergedPRCache) -> None:
     assert loaded["prs"]["200"]["issues"] == [111, 222]
     for issue in [111, 222]:
         assert cache.get_merged_pr_for_issue(issue) is not None
+
+
+def test_get_merged_pr_for_issue_fallback_on_missing_index(
+    cache: MergedPRCache,
+) -> None:
+    """get_merged_pr_for_issue falls back to linear scan when index is missing."""
+    import json
+
+    # Manually write a cache file without issue_index (legacy format)
+    test_data = {
+        "last_sync": "2024-01-15T10:00:00Z",
+        "prs": {
+            "100": {
+                "number": 100,
+                "headRefName": "feature/foo",
+                "body": "Closes #456",
+                "mergedAt": "2024-01-10T12:00:00Z",
+                "issues": [456],
+            },
+            "101": {
+                "number": 101,
+                "headRefName": "feature/bar",
+                "body": "Fixes #789",
+                "mergedAt": "2024-01-11T12:00:00Z",
+                "issues": [789],
+            },
+        },
+    }
+    # Write directly to file to avoid index building in _save_cache
+    cache._ensure_dir()
+    with open(cache.cache_file, "w") as f:
+        json.dump(test_data, f, indent=2)
+
+    # Verify lookup still works via fallback path
+    result = cache.get_merged_pr_for_issue(456)
+    assert result is not None
+    assert result["number"] == 100
+    assert 456 in result["issues"]
+
+    result = cache.get_merged_pr_for_issue(789)
+    assert result is not None and result["number"] == 101 and 789 in result["issues"]
+
+    assert cache.get_merged_pr_for_issue(999) is None


### PR DESCRIPTION
## Summary

Add persistent reverse index (issue_number → pr_number) to the merged PR cache JSON structure, eliminating O(n) linear scans in get_merged_pr_for_issue. The index is built automatically during _save_cache with backward-compatible fallback for legacy cache files.

## Changes

- src/vibe3/clients/merged_pr_cache.py:
  - Added _build_issue_index helper to construct reverse map
  - Modified _save_cache to persist issue_index alongside prs
  - Refactored get_merged_pr_for_issue for O(1) lookup with fallback

- tests/vibe3/clients/test_merged_pr_cache.py:
  - Enhanced existing tests to verify index structure
  - Added backward-compatibility test for legacy cache files

## Test Plan

- [x] Direct tests: 12 passed (merged_pr_cache module)
- [x] Integration tests: 18 passed + 3 xpassed (including check_pr_status service)
- [x] Type check: mypy clean
- [x] Lint: ruff clean
- [x] Pre-push checks: All passed

## Backward Compatibility

Full backward compatibility maintained:
- Legacy cache files without index work via linear-scan fallback
- Index auto-created on next sync/rebuild
- No cache migration needed

Closes #2796

---

## Contributors

claude/sonnet
