### PR TITLE
fix(control-plane): pass branch field to WebhookPRMerged constructor

### DIFF
--- a/src/vibe3/server/control_plane.py
+++ b/src/vibe3/server/control_plane.py
@@ -269,6 +269,7 @@ def _construct_event(event_type: str, payload: dict[str, Any]) -> DomainEvent | 
 
             return WebhookPRMerged(
                 pr_number=pr_number,
+                branch=payload.get("branch", ""),
                 sender=payload.get("sender", ""),
                 timestamp=payload.get("timestamp"),
             )

--- a/tests/vibe3/server/test_control_plane_events.py
+++ b/tests/vibe3/server/test_control_plane_events.py
@@ -218,6 +218,7 @@ class TestPublishEvent:
             "event_type": "WebhookPRMerged",
             "payload": {
                 "pr_number": 456,
+                "branch": "feature/test",
                 "sender": "test-user",
             },
             "actor": "test-actor",
@@ -233,6 +234,7 @@ class TestPublishEvent:
             event = first_call[0][0]
             assert isinstance(event, WebhookPRMerged)
             assert event.pr_number == 456
+            assert event.branch == "feature/test"
 
     def test_webhookprreviewed_publishes_event(
         self, client: TestClient, clean_idempotency_store, monkeypatch


### PR DESCRIPTION
Add `branch=payload.get("branch", "")` to WebhookPRMerged constructor in `control_plane.py:_construct_event` to match the pattern in `webhook.py:_convert_to_event` and fully utilize the model's branch field.

Fixes #2778

---

## Contributors

claude/opus
