### PR TITLE
Fix standalone scan commands missing event handler registration

### DIFF
--- a/src/vibe3/commands/scan.py
+++ b/src/vibe3/commands/scan.py
@@ -51,6 +51,11 @@ def _run_governance_scan(
         no_async: Deprecated flag (logs warning, always uses async dispatch
             via event bus)
     """
+    # Register event handlers before publishing (required for standalone scan)
+    from vibe3.domain import register_event_handlers
+
+    register_event_handlers()
+
     if no_async:
         logger.warning(
             "--no-async is deprecated and ignored. Event bus now triggers handler "
@@ -120,6 +125,11 @@ def _run_supervisor_scan() -> tuple[int, int]:
     Returns:
         Tuple of (total_issues_scanned, matched_issues_found)
     """
+    # Register event handlers before publishing (required for standalone scan)
+    from vibe3.domain import register_event_handlers
+
+    register_event_handlers()
+
     from vibe3.roles import fetch_supervisor_candidates
 
     config = load_orchestra_config()
@@ -246,6 +256,11 @@ def governance(
         typer.echo("")  # Blank line for readability
 
     _run_governance_scan(material_override=role, no_async=no_async)
+
+    # User feedback: confirm event published and handler registered
+    typer.echo(
+        "Governance scan event published. Check tmux session for execution status."
+    )
     if no_async:
         typer.echo("Governance scan completed")
 


### PR DESCRIPTION
## Summary

修复 `vibe scan governance` 和 `vibe scan supervisor` 命令因事件处理器未注册而静默失败的问题。

**问题根因**：
- 事件处理器（`@register_handler`）只在 `serve` 启动时注册
- 独立 scan 命令不经过 serve 流程，导致 handlers 未注册
- `GovernanceScanStarted` / `SupervisorIssueIdentified` 事件无人处理

**修复方案**：
- `_run_governance_scan()` 调用 `register_event_handlers()` 注册处理器
- `_run_supervisor_scan()` 同样修复
- 添加用户反馈信息

## Verification

✅ 事件处理器成功注册：
```
INFO | handle_governance_scan_started registered for GovernanceScanStarted
```

✅ 事件成功分发：
```
INFO | Publishing GovernanceScanStarted to 1 handler(s)
SUCCESS | Execution launched for governance
```

✅ Tmux session 创建成功：
```
vibe3-governance-scan-20260614-192956-t0
```

✅ 用户收到明确反馈：
```
Governance scan event published. Check tmux session for execution status.
```

## Test plan

- [x] 运行 `vibe scan governance -r roadmap-intake` 确认事件处理器注册
- [x] 运行 `vibe scan supervisor` 确认同样修复
- [x] 检查 tmux session 创建
- [x] 运行所有测试通过
- [x] Linter 和 type check 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)