### PR TITLE
feat(projection): add PRMerged to flow_events projection

### DIFF
--- a/src/vibe3/services/flow/event_projection.py
+++ b/src/vibe3/services/flow/event_projection.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.models import DomainEvent, FlowCompleted
+from vibe3.models import DomainEvent, FlowCompleted, PRMerged
 
 if TYPE_CHECKING:
     from vibe3.models import PublishHook
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Events not in this table are not projected.
 PROJECTION_TABLE: dict[type[DomainEvent], str] = {
     FlowCompleted: "flow_completed",
+    PRMerged: "pr_merged",
 }
 
 
@@ -57,17 +58,25 @@ def project_domain_event(event: DomainEvent) -> bool:
 
     # Build detail from key event fields
     # For FlowCompleted, include completed_state
+    # For PRMerged, include pr_number and merged_by
     detail_parts = []
     if hasattr(event, "completed_state"):
         detail_parts.append(f"completed_state={event.completed_state}")
     if hasattr(event, "issue_number"):
         detail_parts.append(f"issue_number={event.issue_number}")
+    if hasattr(event, "pr_number"):
+        detail_parts.append(f"pr_number={event.pr_number}")
+    if hasattr(event, "merged_by") and event.merged_by is not None:
+        detail_parts.append(f"merged_by={event.merged_by}")
     detail = ", ".join(detail_parts) if detail_parts else None
 
-    # Build refs dict with issue_number if available
+    # Build refs dict with issue_number and pr_number if available
     refs = None
     if hasattr(event, "issue_number"):
         refs = {"issue_number": event.issue_number}
+    if hasattr(event, "pr_number"):
+        refs = refs or {}
+        refs["pr_number"] = event.pr_number
 
     # Write to flow_events
     store = SQLiteClient()

--- a/tests/vibe3/services/test_event_projection.py
+++ b/tests/vibe3/services/test_event_projection.py
@@ -14,6 +14,7 @@ from vibe3.models.domain_events import (
     FlowCompleted,
     ManagerDispatchIntent,
     PlannerDispatchIntent,
+    PRMerged,
     ReviewerDispatchIntent,
 )
 from vibe3.services.flow.event_projection import (
@@ -46,6 +47,11 @@ class TestProjectionTable:
         """FlowCompleted is in the projection table."""
         assert FlowCompleted in PROJECTION_TABLE
         assert PROJECTION_TABLE[FlowCompleted] == "flow_completed"
+
+    def test_pr_merged_in_table(self):
+        """PRMerged is in the projection table."""
+        assert PRMerged in PROJECTION_TABLE
+        assert PROJECTION_TABLE[PRMerged] == "pr_merged"
 
     def test_flow_blocked_not_in_table(self):
         """FlowBlocked is explicitly excluded from initial table."""
@@ -83,6 +89,29 @@ class TestProjectDomainEvent:
         assert "completed_state=done" in events[0]["detail"]
         assert "issue_number=123" in events[0]["detail"]
         assert events[0]["refs"] == {"issue_number": 123}
+
+    def test_pr_merged_projects(self, temp_db):
+        """PRMerged is projected to flow_events."""
+        event = PRMerged(
+            issue_number=100,
+            branch="task/issue-100-test",
+            pr_number=42,
+            merged_by="user:test",
+            actor="system:check",
+        )
+
+        result = project_domain_event(event)
+
+        assert result is True
+
+        events = temp_db.get_events(branch="task/issue-100-test")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "pr_merged"
+        assert events[0]["branch"] == "task/issue-100-test"
+        assert events[0]["actor"] == "system:check"
+        assert "pr_number=42" in events[0]["detail"]
+        assert "merged_by=user:test" in events[0]["detail"]
+        assert events[0]["refs"] == {"issue_number": 100, "pr_number": 42}
 
     def test_unknown_event_not_projected(self, temp_db):
         """Event not in projection table is not projected."""
@@ -142,6 +171,31 @@ class TestPublishIntegration:
         assert len(events) == 1
         assert events[0]["event_type"] == "flow_completed"
         assert events[0]["actor"] == "integration:test"
+
+    def test_publish_pr_merged_creates_timeline_record(self, temp_db, clean_publisher):
+        """Publishing PRMerged creates a flow_events record."""
+        publisher = EventPublisher()
+
+        # Register projection hook
+        publisher.add_publish_hook(build_event_projection_hook())
+
+        # Publish PRMerged
+        event = PRMerged(
+            issue_number=200,
+            branch="task/issue-200-test",
+            pr_number=55,
+            merged_by="user:integration",
+        )
+        publisher.publish(event)
+
+        # Verify projection
+        events = temp_db.get_events(branch="task/issue-200-test")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "pr_merged"
+        assert events[0]["actor"] == "system:check"
+        assert "pr_number=55" in events[0]["detail"]
+        assert "merged_by=user:integration" in events[0]["detail"]
+        assert events[0]["refs"] == {"issue_number": 200, "pr_number": 55}
 
     def test_publish_unknown_event_no_timeline_record(self, temp_db, clean_publisher):
         """Publishing unknown event does not create timeline record."""
@@ -243,3 +297,47 @@ class TestProjectionFields:
 
         events = temp_db.get_events(branch="task/issue-99")
         assert events[0]["actor"] == "system:flow"
+
+    def test_pr_merged_has_correct_fields(self, temp_db):
+        """PRMerged projection has all expected fields."""
+        event = PRMerged(
+            issue_number=42,
+            branch="feature/pr-test",
+            pr_number=123,
+            merged_by="user:alice",
+        )
+
+        project_domain_event(event)
+
+        events = temp_db.get_events(branch="feature/pr-test")
+        assert len(events) == 1
+
+        proj = events[0]
+        assert proj["event_type"] == "pr_merged"
+        assert proj["branch"] == "feature/pr-test"
+        assert proj["actor"] == "system:check"
+        assert "pr_number=123" in proj["detail"]
+        assert "merged_by=user:alice" in proj["detail"]
+        assert proj["refs"] == {"issue_number": 42, "pr_number": 123}
+
+    def test_pr_merged_without_merged_by(self, temp_db):
+        """PRMerged without merged_by still projects correctly."""
+        event = PRMerged(
+            issue_number=50,
+            branch="feature/pr-test-2",
+            pr_number=999,
+            merged_by=None,  # Explicitly None
+        )
+
+        project_domain_event(event)
+
+        events = temp_db.get_events(branch="feature/pr-test-2")
+        assert len(events) == 1
+
+        proj = events[0]
+        assert proj["event_type"] == "pr_merged"
+        assert proj["actor"] == "system:check"
+        # merged_by should not appear in detail when None
+        assert "pr_number=999" in proj["detail"]
+        assert "merged_by" not in proj["detail"]
+        assert proj["refs"] == {"issue_number": 50, "pr_number": 999}


### PR DESCRIPTION
## Summary
Add PRMerged domain event to flow_events projection table, enabling timeline records for PR merge events.

## Changes
- Add PRMerged to PROJECTION_TABLE mapping
- Extend detail builder to handle pr_number and merged_by fields
- Extend refs builder to include pr_number
- Add 5 comprehensive tests

## Test Results
- 17 tests pass (12 existing + 5 new)
- Type checking: PASS (mypy)
- No regressions in FlowCompleted projection

## Acceptance Criteria
- [x] PRMerged in PROJECTION_TABLE
- [x] Projection writes pr_merged events with correct fields
- [x] Tests verify projection works
- [x] flow show displays pr_merged events

Closes #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet
