### PR TITLE
feat(projection): add FlowBlocked to flow_events projection

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -140,6 +140,9 @@ code_limits:
       - path: "src/vibe3/services/flow/cleanup.py"
         limit: 420
         reason: "Flow 现场清理服务，包含 worktree/branch/handoff/flow record 等多步清理编排、live session 终端处理、prune worktree 兜底逻辑等紧密耦合的清理步骤（migrated from flow_cleanup_service.py to flow/ subpackage, Issue #2107）"
+      - path: "src/vibe3/services/flow/blocked_state_service.py"
+        limit: 450
+        reason: "Blocked state 统一管理服务，协调 issue body/database/labels 三个数据源的状态一致性；包含 block_state_only、unblock_state_only、block_flow 等核心方法，以及 consistency checking 和 repair 逻辑；Issue #2839 新增 block_flow 方法支持 FlowBlocked domain event projection（+30 行）"
       - path: "src/vibe3/services/check/cleanup.py"
         limit: 610
         reason: "终端 flow 清理 + detached worktree 清理聚合，包含 done/aborted 分类处理、live session 过滤、issue resume、detached worktree 安全清理（worktree root 比较、flow-managed scope 检查）等紧密耦合逻辑；PR #2338 新增 done/aborted 分类追踪和 summary 分段构建（cleaned_done/cleaned_aborted 替代 kept_records）；迁移至 check/ 子包（Issue #2584）"

--- a/src/vibe3/services/flow/block_mixin.py
+++ b/src/vibe3/services/flow/block_mixin.py
@@ -35,7 +35,6 @@ class FlowLifecycleMixin:
         blocked_by_issue: int | None = None,
         actor: str | None = None,
         repo: str | None = None,  # noqa: ARG002 - reserved for cross-repo scenarios
-        event_type: str = "flow_blocked",
     ) -> None:
         """Mark flow as blocked.
 
@@ -48,7 +47,6 @@ class FlowLifecycleMixin:
             blocked_by_issue: Dependency issue number
             actor: Actor performing the block
             repo: Repository (defaults to current repo)
-            event_type: Event type for timeline ("flow_blocked" or "flow_failed")
         """
         from vibe3.services.flow.blocked_state_service import BlockedStateService
 
@@ -96,13 +94,12 @@ class FlowLifecycleMixin:
         issue_number = issue_flow_service.resolve_task_issue_number(branch)
 
         service = BlockedStateService(store=self.store)
-        service.block(
+        service.block_state_only(
             branch=branch,
             reason=reason,
             blocked_by_issue=blocked_by_issue,
             actor=effective_actor,
             issue_number=issue_number,
-            event_type=event_type,
         )
 
         # Publish FlowBlocked event if we have a valid issue context

--- a/src/vibe3/services/flow/blocked_state_service.py
+++ b/src/vibe3/services/flow/blocked_state_service.py
@@ -56,6 +56,85 @@ class BlockedStateService:
     # Public API: Write Operations
     # ========================================================================
 
+    def block_state_only(
+        self,
+        branch: str,
+        reason: str | None = None,
+        blocked_by_issue: int | None = None,
+        actor: str = "system",
+        issue_number: int | None = None,
+    ) -> None:
+        """Set blocked state in body, database, and labels without timeline event.
+
+        This method is used by block_flow() when the timeline event is written
+        through the domain event projection hook instead of directly.
+
+        Args:
+            branch: Git branch to mark as blocked
+            reason: Human-readable reason for blocking
+            blocked_by_issue: Issue number causing the block (optional)
+            actor: Who initiated the block (default: "system")
+            issue_number: Issue to label as BLOCKED (optional)
+        """
+        if reason is not None and blocked_by_issue is not None:
+            raise ValueError(
+                "blocked_reason and blocked_by_issue are mutually exclusive"
+            )
+
+        if issue_number:
+            try:
+                self._io.write_body_projection(
+                    issue_number=issue_number,
+                    reason=reason,
+                    blocked_by_issue=blocked_by_issue,
+                )
+            except Exception as exc:
+                logger.bind(
+                    domain="blocked_state",
+                    action="block_state_only",
+                    branch=branch,
+                ).error(f"Failed to write issue body projection: {exc}")
+                raise
+
+        if self.store:
+            try:
+                self._io.write_database_cache(
+                    branch=branch,
+                    reason=reason,
+                    blocked_by_issue=blocked_by_issue,
+                    actor=actor,
+                )
+            except Exception as exc:
+                logger.bind(
+                    domain="blocked_state",
+                    action="block_state_only",
+                    branch=branch,
+                ).warning(f"Failed to write database cache: {exc}")
+
+        if issue_number:
+            try:
+                result = self._io.write_label_state(
+                    issue_number=issue_number,
+                    target_state=IssueState.BLOCKED,
+                    actor=actor,
+                )
+                if result == "blocked":
+                    logger.bind(
+                        domain="blocked_state",
+                        action="block_state_only",
+                        branch=branch,
+                        issue_number=issue_number,
+                    ).warning(
+                        "Label state machine blocked transition to BLOCKED; "
+                        "label may be out of sync with body/DB"
+                    )
+            except Exception as exc:
+                logger.bind(
+                    domain="blocked_state",
+                    action="block_state_only",
+                    branch=branch,
+                ).warning(f"Failed to write label state: {exc}")
+
     def block(
         self,
         branch: str,
@@ -83,65 +162,16 @@ class BlockedStateService:
             issue_number: Issue to label as BLOCKED (optional)
             event_type: Timeline event type (default: "flow_blocked")
         """
-        if reason is not None and blocked_by_issue is not None:
-            raise ValueError(
-                "blocked_reason and blocked_by_issue are mutually exclusive"
-            )
+        # Delegate to block_state_only for state updates
+        self.block_state_only(
+            branch=branch,
+            reason=reason,
+            blocked_by_issue=blocked_by_issue,
+            actor=actor,
+            issue_number=issue_number,
+        )
 
-        if issue_number:
-            try:
-                self._io.write_body_projection(
-                    issue_number=issue_number,
-                    reason=reason,
-                    blocked_by_issue=blocked_by_issue,
-                )
-            except Exception as exc:
-                logger.bind(
-                    domain="blocked_state",
-                    action="block",
-                    branch=branch,
-                ).error(f"Failed to write issue body projection: {exc}")
-                raise
-
-        if self.store:
-            try:
-                self._io.write_database_cache(
-                    branch=branch,
-                    reason=reason,
-                    blocked_by_issue=blocked_by_issue,
-                    actor=actor,
-                )
-            except Exception as exc:
-                logger.bind(
-                    domain="blocked_state",
-                    action="block",
-                    branch=branch,
-                ).warning(f"Failed to write database cache: {exc}")
-
-        if issue_number:
-            try:
-                result = self._io.write_label_state(
-                    issue_number=issue_number,
-                    target_state=IssueState.BLOCKED,
-                    actor=actor,
-                )
-                if result == "blocked":
-                    logger.bind(
-                        domain="blocked_state",
-                        action="block",
-                        branch=branch,
-                        issue_number=issue_number,
-                    ).warning(
-                        "Label state machine blocked transition to BLOCKED; "
-                        "label may be out of sync with body/DB"
-                    )
-            except Exception as exc:
-                logger.bind(
-                    domain="blocked_state",
-                    action="block",
-                    branch=branch,
-                ).warning(f"Failed to write label state: {exc}")
-
+        # Write timeline event
         if self.store and issue_number:
             try:
                 timeline = FlowTimelineService(store=self.store)

--- a/src/vibe3/services/flow/event_projection.py
+++ b/src/vibe3/services/flow/event_projection.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from vibe3.clients import SQLiteClient
-from vibe3.models import DomainEvent, FlowCompleted, PRMerged
+from vibe3.models import DomainEvent, FlowBlocked, FlowCompleted, PRMerged
 
 if TYPE_CHECKING:
     from vibe3.models import PublishHook
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 # Declarative mapping from DomainEvent types to flow_events.event_type strings.
 # Events not in this table are not projected.
 PROJECTION_TABLE: dict[type[DomainEvent], str] = {
+    FlowBlocked: "flow_blocked",
     FlowCompleted: "flow_completed",
     PRMerged: "pr_merged",
 }
@@ -58,10 +59,13 @@ def project_domain_event(event: DomainEvent) -> bool:
 
     # Build detail from key event fields
     # For FlowCompleted, include completed_state
+    # For FlowBlocked, include blocked_reason
     # For PRMerged, include pr_number and merged_by
     detail_parts = []
     if hasattr(event, "completed_state"):
         detail_parts.append(f"completed_state={event.completed_state}")
+    if hasattr(event, "blocked_reason"):
+        detail_parts.append(f"blocked_reason={event.blocked_reason}")
     if hasattr(event, "issue_number"):
         detail_parts.append(f"issue_number={event.issue_number}")
     if hasattr(event, "pr_number"):

--- a/src/vibe3/services/issue/failure.py
+++ b/src/vibe3/services/issue/failure.py
@@ -99,7 +99,6 @@ def mark_issue(
             reason=reason,
             actor=actor,
             repo=repo,
-            event_type="flow_blocked",
         )
 
 

--- a/src/vibe3/services/protocols/flow_protocols_ext.py
+++ b/src/vibe3/services/protocols/flow_protocols_ext.py
@@ -90,7 +90,6 @@ class FlowQueryProtocol(Protocol):
         blocked_by_issue: int | None = None,
         actor: str | None = None,
         repo: str | None = None,
-        event_type: str = "flow_blocked",
     ) -> None:
         """Mark a flow as blocked.
 
@@ -100,6 +99,5 @@ class FlowQueryProtocol(Protocol):
             blocked_by_issue: Dependency issue number
             actor: Actor performing the block
             repo: Repository name
-            event_type: Event type for timeline
         """
         ...

--- a/tests/vibe3/domain/test_flow_blocked_regression.py
+++ b/tests/vibe3/domain/test_flow_blocked_regression.py
@@ -99,7 +99,12 @@ def test_blocked_state_is_written_through_service_path(tmp_path: Path) -> None:
 
 
 def test_flow_blocked_event_published_after_service_writes(tmp_path: Path) -> None:
-    """Assert FlowBlocked is published after BlockedStateService writes state."""
+    """Assert FlowBlocked is published after BlockedStateService writes state.
+
+    The timeline event is now written by the projection hook, not directly by
+    BlockedStateService. This test verifies that state is written before the
+    event is published, ensuring proper ordering.
+    """
     store = SQLiteClient(db_path=str(tmp_path / "test.db"))
     store.update_flow_state("test-branch", flow_slug="test")
 
@@ -108,12 +113,14 @@ def test_flow_blocked_event_published_after_service_writes(tmp_path: Path) -> No
     call_order = []
 
     def publish_after_write(event: DomainEvent) -> None:
+        # State should be written before the event is published
         flow_state = store.get_flow_state("test-branch")
         assert flow_state is not None
         assert flow_state.get("flow_status") == "blocked"
         assert flow_state.get("blocked_reason") == "Test reason"
+        # Timeline event is NOT written before publish - it's written by projection hook
         events = store.get_events("test-branch")
-        assert [e.get("event_type") for e in events] == ["flow_blocked"]
+        assert len(events) == 0, "Timeline event should not exist before projection"
         assert isinstance(event, FlowBlocked)
         call_order.append("event_after_write")
 

--- a/tests/vibe3/services/test_event_projection.py
+++ b/tests/vibe3/services/test_event_projection.py
@@ -53,9 +53,10 @@ class TestProjectionTable:
         assert PRMerged in PROJECTION_TABLE
         assert PROJECTION_TABLE[PRMerged] == "pr_merged"
 
-    def test_flow_blocked_not_in_table(self):
-        """FlowBlocked is explicitly excluded from initial table."""
-        assert FlowBlocked not in PROJECTION_TABLE
+    def test_flow_blocked_in_table(self):
+        """FlowBlocked is in the projection table."""
+        assert FlowBlocked in PROJECTION_TABLE
+        assert PROJECTION_TABLE[FlowBlocked] == "flow_blocked"
 
     def test_dispatch_intents_not_in_table(self):
         """Dispatch intent events are not in the projection table."""
@@ -113,13 +114,34 @@ class TestProjectDomainEvent:
         assert "merged_by=user:test" in events[0]["detail"]
         assert events[0]["refs"] == {"issue_number": 100, "pr_number": 42}
 
-    def test_unknown_event_not_projected(self, temp_db):
-        """Event not in projection table is not projected."""
+    def test_flow_blocked_projects_correctly(self, temp_db):
+        """FlowBlocked is projected to flow_events."""
         event = FlowBlocked(
             issue_number=456,
             branch="task/issue-456-test",
             blocked_reason="test blocker",
             actor="test:actor",
+        )
+
+        result = project_domain_event(event)
+
+        assert result is True
+
+        events = temp_db.get_events(branch="task/issue-456-test")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "flow_blocked"
+        assert events[0]["branch"] == "task/issue-456-test"
+        assert events[0]["actor"] == "test:actor"
+        assert "blocked_reason=test blocker" in events[0]["detail"]
+        assert "issue_number=456" in events[0]["detail"]
+        assert events[0]["refs"] == {"issue_number": 456}
+
+    def test_unknown_event_not_projected(self, temp_db):
+        """Event not in projection table is not projected."""
+        event = ManagerDispatchIntent(
+            issue_number=456,
+            branch="task/issue-456-test",
+            trigger_state="ready",
         )
 
         result = project_domain_event(event)
@@ -197,15 +219,40 @@ class TestPublishIntegration:
         assert "merged_by=user:integration" in events[0]["detail"]
         assert events[0]["refs"] == {"issue_number": 200, "pr_number": 55}
 
+    def test_publish_flow_blocked_creates_timeline_record(
+        self, temp_db, clean_publisher
+    ):
+        """Publishing FlowBlocked creates a flow_events record."""
+        publisher = EventPublisher()
+
+        # Register projection hook
+        publisher.add_publish_hook(build_event_projection_hook())
+
+        # Publish FlowBlocked
+        event = FlowBlocked(
+            issue_number=999,
+            branch="task/issue-999-test",
+            blocked_reason="test blocker",
+            actor="integration:test",
+        )
+        publisher.publish(event)
+
+        # Verify projection
+        events = temp_db.get_events(branch="task/issue-999-test")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "flow_blocked"
+        assert events[0]["actor"] == "integration:test"
+        assert "blocked_reason=test blocker" in events[0]["detail"]
+
     def test_publish_unknown_event_no_timeline_record(self, temp_db, clean_publisher):
         """Publishing unknown event does not create timeline record."""
         publisher = EventPublisher()
         publisher.add_publish_hook(build_event_projection_hook())
 
-        event = FlowBlocked(
+        event = ManagerDispatchIntent(
             issue_number=888,
             branch="task/issue-888-test",
-            blocked_reason="test",
+            trigger_state="ready",
         )
         publisher.publish(event)
 

--- a/tests/vibe3/services/test_flow_block_mixin.py
+++ b/tests/vibe3/services/test_flow_block_mixin.py
@@ -6,7 +6,7 @@ from vibe3.services.flow.service import FlowService
 
 
 def test_block_flow_calls_blocked_state_service() -> None:
-    """Test that block_flow calls BlockedStateService.block method."""
+    """Test that block_flow calls BlockedStateService.block_state_only method."""
     service = FlowService()
 
     with (
@@ -41,12 +41,12 @@ def test_block_flow_calls_blocked_state_service() -> None:
             actor="claude/sonnet-4.6",
         )
 
-        # Verify BlockedStateService.block called with correct args
-        mock_blocked_instance.block.assert_called_once_with(
+        # Verify BlockedStateService.block_state_only called with correct args
+        # (no event_type parameter since timeline write is now via projection)
+        mock_blocked_instance.block_state_only.assert_called_once_with(
             branch="dev/issue-123",
             reason="API design pending",
             blocked_by_issue=456,
             actor="claude/sonnet-4.6",
             issue_number=123,
-            event_type="flow_blocked",
         )

--- a/tests/vibe3/services/test_issue_failure_service.py
+++ b/tests/vibe3/services/test_issue_failure_service.py
@@ -113,12 +113,25 @@ def test_block_flow_uses_new_fields():
         flow_service.create_flow(slug="issue-300", branch=branch, actor="test-user")
         store.add_issue_link(branch, 300, "task")
 
-        with patch(
-            "vibe3.services.flow.blocked_state_io.GitHubClient"
-        ) as mock_github_class:
+        with (
+            patch(
+                "vibe3.services.flow.blocked_state_io.GitHubClient"
+            ) as mock_github_class,
+            patch(
+                "vibe3.services.flow.event_projection.SQLiteClient", return_value=store
+            ),
+        ):
             mock_github = MagicMock()
             mock_github.get_issue_body.return_value = "User content"
             mock_github_class.return_value = mock_github
+
+            # Register projection hook to test timeline event creation
+            from vibe3.models import EventPublisher
+            from vibe3.services.flow.event_projection import build_event_projection_hook
+
+            EventPublisher.reset()
+            publisher = EventPublisher()
+            publisher.add_publish_hook(build_event_projection_hook())
 
             # Block flow with dependency issue
             flow_service.block_flow(
@@ -128,13 +141,15 @@ def test_block_flow_uses_new_fields():
                 actor="test-actor",
             )
 
+            EventPublisher.reset()
+
         # Verify flow state in database (blocked metadata, NOT flow_status)
         flow_state = store.get_flow_state(branch)
         assert flow_state is not None
         assert flow_state["blocked_by_issue"] == 301
         assert flow_state["blocked_reason"] is None
 
-        # Verify event was recorded
+        # Verify event was recorded (via projection hook)
         events = store.get_events(branch)
         blocked_events = [e for e in events if e.get("event_type") == "flow_blocked"]
         assert len(blocked_events) >= 1


### PR DESCRIPTION
Closes #2839

## Summary

Migrate FlowBlocked from dual-write to projection-only model per ADR 0004.

**Key Changes**:
- Add FlowBlocked to PROJECTION_TABLE in event_projection.py
- Create block_state_only() method in BlockedStateService (state updates without timeline)
- Remove direct timeline write from block_flow()
- Timeline events now written exclusively via projection hook

**Architecture Impact**:

Before (Dual-Write):
```
block_flow() → service.block() → timeline write #1
             → publish(FlowBlocked) → projection → timeline write #2
```

After (Single-Write via Projection):
```
block_flow() → service.block_state_only() → state updates only
             → publish(FlowBlocked) → projection → timeline write
```

This ensures ADR 0004 compliance with a single, named projection boundary for FlowBlocked events.

## Test Plan

- [x] All projection tests pass (test_event_projection.py)
- [x] FlowBlocked projection integration test added
- [x] Full test suite passes: 36 passed, 2 skipped
- [x] No type errors (MyPy clean)
- [x] No lint errors (Ruff clean)
- [x] Integration test: block → publish → projection works correctly

## References

- Issue: #2839
- ADR: docs/decisions/0004-domain-flow-event-boundary.md
- Related: #2747 (FlowCompleted projection reference), #2749 (FlowBlocked tests)

---

## Contributors

claude/sonnet
