### PR TITLE
refactor(analysis): use bounded read for snapshot metadata extraction

### DIFF
--- a/src/vibe3/analysis/snapshot_service.py
+++ b/src/vibe3/analysis/snapshot_service.py
@@ -489,22 +489,42 @@ _METADATA_FIELDS = ("snapshot_id", "created_at", "branch", "commit", "baseline_f
 def _read_snapshot_metadata(filepath: Path) -> dict[str, str | None] | None:
     """Extract top-level string fields from a snapshot JSON file.
 
-    Uses regex to extract only scalar fields without deserializing the
-    heavy nested structures (files, modules, dependencies, metrics).
+    Uses bounded head/tail reads instead of loading the full file,
+    since metadata fields are concentrated at the beginning/end of the
+    serialized JSON (StructureSnapshot). The large nested structures
+    (files, modules, dependencies, metrics) are never deserialized.
     Returns None if the file cannot be read or has no recognizable metadata.
     """
+    # --- Head read for early metadata fields ---
     try:
-        text = filepath.read_text(encoding="utf-8")
+        file_size = filepath.stat().st_size
+        head_size = min(4096, file_size)
+        with filepath.open("r", encoding="utf-8") as f:
+            head = f.read(head_size)
     except OSError:
+        return None
+    if not head.strip():
         return None
 
     try:
         metadata: dict[str, str | None] = {}
         for field in _METADATA_FIELDS:
-            m = re.search(rf'"{field}"\s*:\s*"([^"]*)"', text)
+            # baseline_for is the last field in StructureSnapshot (after metrics)
+            # -> read from tail for large files
+            source = head
+            if field == "baseline_for" and file_size > head_size:
+                try:
+                    tail_size = min(2048, file_size)
+                    with filepath.open("rb") as f:
+                        f.seek(file_size - tail_size)
+                        source = f.read(tail_size).decode("utf-8", errors="replace")
+                except OSError:
+                    source = head  # fallback to head
+
+            m = re.search(rf'"{field}"\s*:\s*"([^"]*)"', source)
             if m:
                 metadata[field] = m.group(1)
-            elif re.search(rf'"{field}"\s*:\s*null', text):
+            elif re.search(rf'"{field}"\s*:\s*null', source):
                 metadata[field] = None
         return metadata if metadata else None
     except Exception:

--- a/tests/vibe3/analysis/test_snapshot_service.py
+++ b/tests/vibe3/analysis/test_snapshot_service.py
@@ -267,6 +267,116 @@ def test_read_snapshot_metadata_nonexistent_file(tmp_path: Path) -> None:
     assert result is None
 
 
+def test_read_snapshot_metadata_large_file_tail_read(tmp_path: Path) -> None:
+    """Test tail read path for baseline_for in files >4KB."""
+    from vibe3.analysis.snapshot_service import _read_snapshot_metadata
+
+    # Create a snapshot file >4KB with large files array
+    # StructureSnapshot field order: snapshot_id → ... → files → modules →
+    # dependencies → metrics → baseline_for
+    large_files = [
+        {
+            "path": f"/path/to/file_{i}.py",
+            "language": "python",
+            "total_loc": 100,
+            "functions": [],
+            "function_count": 0,
+            "imports": [],
+        }
+        for i in range(100)
+    ]
+
+    snapshot_file = tmp_path / "large-snapshot.json"
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "snapshot_id": "2026-06-15T10-00-00_main_abc1234",
+                "created_at": "2026-06-15T10:00:00",
+                "branch": "main",
+                "commit": "abc1234",
+                "commit_short": "abc1234",
+                "root": "/project",
+                "files": large_files,
+                "modules": [],
+                "dependencies": {},
+                "metrics": {
+                    "total_files": 100,
+                    "total_loc": 10000,
+                    "total_functions": 0,
+                },
+                "baseline_for": "feature-branch",
+            },
+            indent=2,
+        )
+    )
+
+    # Verify file is large enough to trigger tail read (>4KB)
+    file_size = snapshot_file.stat().st_size
+    assert file_size > 4096, f"Test file must be >4KB, got {file_size} bytes"
+
+    # Extract metadata and verify baseline_for is found via tail read
+    result = _read_snapshot_metadata(snapshot_file)
+    assert result is not None
+    assert result["snapshot_id"] == "2026-06-15T10-00-00_main_abc1234"
+    assert result["created_at"] == "2026-06-15T10:00:00"
+    assert result["branch"] == "main"
+    assert result["commit"] == "abc1234"
+    assert (
+        result["baseline_for"] == "feature-branch"
+    ), "baseline_for must be extracted via tail read for large files"
+
+
+def test_read_snapshot_metadata_large_file_baseline_for_null(tmp_path: Path) -> None:
+    """Test tail read path extracts null baseline_for from large files."""
+    from vibe3.analysis.snapshot_service import _read_snapshot_metadata
+
+    large_files = [
+        {
+            "path": f"/path/to/file_{i}.py",
+            "language": "python",
+            "total_loc": 100,
+            "functions": [],
+            "function_count": 0,
+            "imports": [],
+        }
+        for i in range(100)
+    ]
+
+    snapshot_file = tmp_path / "large-snapshot-null.json"
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "snapshot_id": "2026-06-15T11-00-00_main_def5678",
+                "created_at": "2026-06-15T11:00:00",
+                "branch": "main",
+                "commit": "def5678",
+                "commit_short": "def5678",
+                "root": "/project",
+                "files": large_files,
+                "modules": [],
+                "dependencies": {},
+                "metrics": {
+                    "total_files": 100,
+                    "total_loc": 10000,
+                    "total_functions": 0,
+                },
+                "baseline_for": None,
+            },
+            indent=2,
+        )
+    )
+
+    file_size = snapshot_file.stat().st_size
+    assert file_size > 4096, f"Test file must be >4KB, got {file_size} bytes"
+
+    result = _read_snapshot_metadata(snapshot_file)
+    assert result is not None
+    assert result["snapshot_id"] == "2026-06-15T11-00-00_main_def5678"
+    assert (
+        result["baseline_for"] is None
+    ), "null baseline_for must be extracted via tail read for large files"
+
+
 def test_list_snapshots_with_limit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Optimize metadata extraction in `_read_snapshot_metadata` by replacing full-file read with bounded two-pass read strategy:

- **Head read (4KB)**: Extract early metadata fields (`snapshot_id`, `created_at`, `branch`, `commit`)
- **Tail read (2KB)**: Extract `baseline_for` (last field after metrics block)
- **I/O reduction**: ~118× improvement (~6KB vs ~710KB per call for large snapshot files)

This resolves the "Filter-Instead-of-Delete" antipattern identified in the issue, where full JSON files were loaded just to regex-extract 5 scalar metadata fields.

## Changes

### Production Code
- `src/vibe3/analysis/snapshot_service.py` (lines 489-531): Replace `read_text()` with bounded head/tail read strategy

### Test Coverage
- `tests/vibe3/analysis/test_snapshot_service.py`: Add two new test cases for tail read path
  - `test_read_snapshot_metadata_large_file_tail_read`: Verify string `baseline_for` extraction from >4KB files
  - `test_read_snapshot_metadata_large_file_baseline_for_null`: Verify null `baseline_for` extraction from >4KB files

**Rationale**: Test fixtures create files ~6KB to exercise the `file_size > head_size` condition (line 515), ensuring the tail read optimization path has zero coverage gaps.

## Verification

- **Tests**: 170/170 passed (tests/vibe3/analysis/)
  - Direct tests: 12/12 (was 10/10, now 12/12 with tail read coverage)
- **Type check**: mypy PASS
- **Lint**: ruff PASS + Black formatted
- **LOC limits**: All files under CI block threshold (400 lines)
- **Commits**:
  - 5fd598025: refactor(analysis): use bounded read for snapshot metadata extraction
  - 2a898415d: test(analysis): add tail read coverage for large snapshot files

## Review History

- **First review**: MINOR (tail read path lacked test coverage)
- **Second review**: PASS (test coverage gap resolved)

Closes #2846

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---

## Contributors

claude/sonnet
