### PR TITLE
refactor(queue): introduce named queue maintenance trigger methods

### DIFF
--- a/src/vibe3/domain/dispatch_coordinator.py
+++ b/src/vibe3/domain/dispatch_coordinator.py
@@ -540,18 +540,12 @@ class GlobalDispatchCoordinator:
 
         return dispatched_count
 
-    async def coordinate(self, tick_id: int = 0) -> None:
-        """Run one heartbeat tick against the frozen queue.
-
-        Args:
-            tick_id: Current tick number from heartbeat (default: 0)
-
-        Queue Collection Strategy:
-            Only collect fresh queue when actionable (non-blocked) candidates
-            are exhausted AFTER dispatch. This avoids wasted GitHub API calls.
-        """
-        # Step 1: Restore queue from persistence if None
+    def _queue_startup_restore(self) -> None:
+        """Restore queue from persistence on cold start."""
         if self._frozen_queue is None:
+            logger.bind(domain="global_dispatch", trigger="startup_restore").debug(
+                "Restoring queue from persistence"
+            )
             self._queue_persistence.frozen_queue = None
             self._sync_queue_persistence_issue_loader()
             restored = self._queue_persistence.restore()
@@ -560,7 +554,11 @@ class GlobalDispatchCoordinator:
             # Invalidate PR cache on restore to ensure fresh PR state
             self._check_service.invalidate_pr_cache()
 
-        # Step 2: Promote progressed entries (state changes)
+    def _queue_promote_progressed(self) -> None:
+        """Promote state-changed entries to front; remove terminal entries."""
+        logger.bind(domain="global_dispatch", trigger="promote_progressed").debug(
+            "Promoting progressed entries"
+        )
         self._queue_persistence.frozen_queue = self._frozen_queue
         self._sync_queue_persistence_issue_loader()
         cleared_all = self._queue_persistence.promote()
@@ -574,42 +572,39 @@ class GlobalDispatchCoordinator:
         if self._frozen_queue is None:
             self._frozen_queue = []
 
-        # Step 2.5: Periodic remote check (before collection)
-        if (
-            self._remote_check_runner
-            and tick_id - self._last_remote_check_tick >= self._remote_check_interval
-        ):
-            try:
-                self._remote_check_runner()
-            except Exception as exc:
-                logger.bind(domain="check", action="remote").warning(
-                    f"Remote check failed: {exc}"
-                )
-            finally:
-                # Always update tick to prevent repeated attempts on failure
-                self._last_remote_check_tick = tick_id
+    async def _queue_scheduled_refresh(self, tick_id: int) -> bool:
+        """Run scheduled full queue refresh if tick matches interval.
 
-        queue_refreshed = False
+        Returns:
+            True if the queue was refreshed.
+        """
         periodic_check = self._config.periodic_check
         if (
             tick_id > 0
             and periodic_check.enabled
             and tick_id % periodic_check.interval_ticks == 0
         ):
+            logger.bind(domain="global_dispatch", trigger="scheduled_refresh").debug(
+                "Running scheduled full queue refresh"
+            )
             fresh = await self._collect_frozen_queue()
             self._check_service.invalidate_pr_cache()
             self._dispatch_paused = bool(
                 fresh and all(entry.collected_state == "blocked" for entry in fresh)
             )
             self._frozen_queue = fresh
-            queue_refreshed = True
+            return True
+        return False
 
-        paused_with_pending_blocked = False
+    def _queue_paused_blocked_check(self) -> bool:
+        """Check paused state and re-qualify blocked entries.
 
-        # Step 3: Paused mode waits for human task resume to create a
-        # non-blocked candidate again. Keep existing waiting entries resident.
-        # Blocked-only rebuilds get one dispatch-time qualify pass before the
-        # coordinator enters a quiet paused state.
+        Returns:
+            True if paused with only non-qualifiable blocked entries remaining.
+        """
+        logger.bind(domain="global_dispatch", trigger="paused_blocked_check").debug(
+            "Checking paused state and blocked entries"
+        )
         if self._dispatch_paused:
             if self._has_actionable_entries():
                 self._dispatch_paused = False
@@ -618,37 +613,20 @@ class GlobalDispatchCoordinator:
                     # A blocked entry can be dispatched now — unpause to let it through
                     self._dispatch_paused = False
                 else:
-                    paused_with_pending_blocked = True
+                    return True
+        return False
 
-        # Step 4: Dispatch actionable entries FIRST
-        # Note: dispatch event logging is handled by _dispatch_loop internally
-        dispatched_count = self._dispatch_loop(tick_id)
-
-        # Step 5: Persist queue state AFTER dispatch but BEFORE collection.
-        # Entries that were dispatched this tick have been popped (blocked entries
-        # that failed qualify_gate are removed). Entries skipped due to capacity
-        # limits remain in the queue and are persisted as-is.
-        # Freshly collected entries from Step 6 are NOT included in this snapshot.
-        self._queue_persistence.frozen_queue = self._frozen_queue
-        self._queue_persistence.persist()
-
-        # Step 5b: Early-exit when paused with only non-qualifiable blocked entries.
-        # Skip collection — it would fetch the same all-blocked result again and
-        # immediately re-enter the paused state, wasting GitHub API quota.
-        if paused_with_pending_blocked:
-            append_orchestra_event(
-                "dispatcher",
-                "GlobalDispatchCoordinator: dispatch paused "
-                "(blocked entries pending, no qualifiable candidates"
-                " — skipping collection)",
-            )
-            return
-
-        # Step 6: Rebuild active candidates once active queue is exhausted.
+    async def _queue_exhausted_refresh(
+        self, dispatched_count: int, queue_refreshed: bool
+    ) -> None:
+        """Rebuild queue when actionable candidates are exhausted after dispatch."""
         need_collect = not queue_refreshed and self._should_collect_after_dispatch(
             dispatched_count
         )
         if need_collect:
+            logger.bind(domain="global_dispatch", trigger="queue_exhausted").debug(
+                "Queue exhausted after dispatch, rebuilding for next tick"
+            )
             append_orchestra_event(
                 "dispatcher",
                 "GlobalDispatchCoordinator: queue exhausted after dispatch, "
@@ -668,6 +646,63 @@ class GlobalDispatchCoordinator:
             else:
                 self._dispatch_paused = False
                 self._frozen_queue = self._merge_queue(self._frozen_queue or [], fresh)
+
+    async def coordinate(self, tick_id: int = 0) -> None:
+        """Run one heartbeat tick against the frozen queue.
+
+        Args:
+            tick_id: Current tick number from heartbeat (default: 0)
+
+        Queue Collection Strategy:
+            Only collect fresh queue when actionable (non-blocked) candidates
+            are exhausted AFTER dispatch. This avoids wasted GitHub API calls.
+        """
+        # Step 1: Restore from persistence on cold start
+        self._queue_startup_restore()
+
+        # Step 2: Promote state-changed entries
+        self._queue_promote_progressed()
+
+        # Step 2.5: Periodic remote check (before collection)
+        if (
+            self._remote_check_runner
+            and tick_id - self._last_remote_check_tick >= self._remote_check_interval
+        ):
+            try:
+                self._remote_check_runner()
+            except Exception as exc:
+                logger.bind(domain="check", action="remote").warning(
+                    f"Remote check failed: {exc}"
+                )
+            finally:
+                # Always update tick to prevent repeated attempts on failure
+                self._last_remote_check_tick = tick_id
+
+        # Step 3: Periodic full refresh
+        queue_refreshed = await self._queue_scheduled_refresh(tick_id)
+
+        # Step 4: Paused mode blocked re-qualification
+        paused_with_pending_blocked = self._queue_paused_blocked_check()
+
+        # Step 5: Dispatch actionable entries
+        dispatched_count = self._dispatch_loop(tick_id)
+
+        # Step 6: Persist queue state
+        self._queue_persistence.frozen_queue = self._frozen_queue
+        self._queue_persistence.persist()
+
+        # Step 7: Early-exit when paused with only non-qualifiable blocked
+        if paused_with_pending_blocked:
+            append_orchestra_event(
+                "dispatcher",
+                "GlobalDispatchCoordinator: dispatch paused "
+                "(blocked entries pending, no qualifiable candidates"
+                " — skipping collection)",
+            )
+            return
+
+        # Step 8: Rebuild when candidates exhausted
+        await self._queue_exhausted_refresh(dispatched_count, queue_refreshed)
 
     def is_dispatch_paused(self) -> bool:
         """Check if dispatch is paused due to exhausted pool.

--- a/tests/vibe3/orchestra/test_queue_maintenance_triggers.py
+++ b/tests/vibe3/orchestra/test_queue_maintenance_triggers.py
@@ -1,0 +1,396 @@
+"""Tests for named queue maintenance trigger methods."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibe3.models.orchestration import IssueState
+from vibe3.orchestra.global_dispatch_coordinator import QueueEntry
+
+
+class TestQueueStartupRestore:
+    """Tests for _queue_startup_restore trigger."""
+
+    @pytest.mark.asyncio
+    async def test_startup_restore_calls_persistence_restore(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Cold-start queue restoration calls persistence restore."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Mock persistence restore
+        coordinator._queue_persistence.restore = MagicMock(return_value=None)
+
+        # Ensure queue starts as None (cold start)
+        assert coordinator._frozen_queue is None
+
+        # First coordinate() should trigger restore
+        await coordinator.coordinate()
+
+        # Verify persistence restore was called
+        coordinator._queue_persistence.restore.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_startup_restore_sets_empty_list_on_none(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Startup restore sets empty list when persistence returns None."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Mock persistence to return None
+        coordinator._queue_persistence.restore = MagicMock(return_value=None)
+
+        # Ensure queue starts as None
+        assert coordinator._frozen_queue is None
+
+        # First coordinate() should trigger restore
+        await coordinator.coordinate()
+
+        # Verify queue is empty list (not None)
+        assert coordinator._frozen_queue == []
+
+
+class TestQueueScheduledRefresh:
+    """Tests for _queue_scheduled_refresh trigger."""
+
+    @pytest.mark.asyncio
+    async def test_scheduled_refresh_fires_at_interval(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Periodic refresh fires at interval_ticks."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Set interval_ticks = 10
+        coordinator._config.periodic_check.enabled = True
+        coordinator._config.periodic_check.interval_ticks = 10
+
+        # Pre-populate queue to avoid queue_exhausted trigger
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=999, collected_state="ready")
+        ]
+
+        # Mock collection to track calls
+        collect_called = []
+
+        async def mock_collect():
+            collect_called.append(True)
+            return [QueueEntry(issue_number=1, collected_state="ready")]
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        # Mock capacity to prevent dispatch (keeps queue populated)
+        coordinator._capacity.get_capacity_status = MagicMock(
+            return_value={"remaining": 0, "active_count": 10, "max_capacity": 10}
+        )
+
+        # First tick (tick_id=0) - should NOT fire (tick_id > 0 check)
+        await coordinator.coordinate(tick_id=0)
+        assert len(collect_called) == 0
+
+        # Tick 5 - should NOT fire (not at interval)
+        await coordinator.coordinate(tick_id=5)
+        assert len(collect_called) == 0
+
+        # Tick 10 - SHOULD fire
+        await coordinator.coordinate(tick_id=10)
+        assert len(collect_called) == 1
+
+    @pytest.mark.asyncio
+    async def test_scheduled_refresh_disabled(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Scheduled refresh does not fire when disabled."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Disable periodic check
+        coordinator._config.periodic_check.enabled = False
+        coordinator._config.periodic_check.interval_ticks = 10
+
+        # Pre-populate queue to avoid queue_exhausted trigger
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=999, collected_state="ready")
+        ]
+
+        # Mock collection to track calls
+        collect_called = []
+
+        async def mock_collect():
+            collect_called.append(True)
+            return []
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        # Mock capacity to prevent dispatch
+        coordinator._capacity.get_capacity_status = MagicMock(
+            return_value={"remaining": 0, "active_count": 10, "max_capacity": 10}
+        )
+
+        # Tick 10 - should NOT fire (disabled)
+        await coordinator.coordinate(tick_id=10)
+        assert len(collect_called) == 0
+
+
+class TestQueueExhaustedRefresh:
+    """Tests for _queue_exhausted_refresh trigger."""
+
+    @pytest.mark.asyncio
+    async def test_queue_exhausted_triggers_rebuild(
+        self,
+        make_issue,
+        make_capacity,
+        make_coordinator,
+        install_issue_loader,
+    ) -> None:
+        """Rebuild triggered after dispatch depletes actionable entries."""
+        _ = make_issue(1)
+        capacity = make_capacity(remaining=10)
+
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        install_issue_loader(
+            coordinator,
+            {
+                1: IssueState.READY,
+            },
+        )
+
+        # Pre-load queue with actionable entry
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="ready"),
+        ]
+
+        # Mock capacity to allow dispatch
+        coordinator._capacity.get_capacity_status = MagicMock(
+            return_value={"remaining": 10, "active_count": 0, "max_capacity": 10}
+        )
+
+        # Mock collection to track rebuild calls
+        collect_called = []
+
+        async def mock_collect():
+            collect_called.append(True)
+            return [QueueEntry(issue_number=2, collected_state="ready")]
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        # Mock dispatch to succeed (this will exhaust the queue)
+        emit_calls = []
+        coordinator._emit_dispatch_intent = (
+            lambda role, issue, tick_id: emit_calls.append((role, issue))
+        )
+
+        # Tick: dispatch entry, queue should be exhausted
+        await coordinator.coordinate()
+
+        # After dispatch, queue should be exhausted and collection triggered
+        assert len(emit_calls) >= 1  # At least one dispatch happened
+        assert len(collect_called) >= 1  # Collection was triggered
+
+    @pytest.mark.asyncio
+    async def test_queue_exhausted_not_triggered_when_refreshed(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Exhausted refresh NOT triggered when queue was already refreshed."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Set up scheduled refresh to fire
+        coordinator._config.periodic_check.enabled = True
+        coordinator._config.periodic_check.interval_ticks = 10
+
+        # Mock collection
+        collect_count = []
+
+        async def mock_collect():
+            collect_count.append("collect")
+            return [QueueEntry(issue_number=1, collected_state="ready")]
+
+        coordinator._collect_frozen_queue = mock_collect
+
+        # Tick 10 triggers scheduled refresh
+        await coordinator.coordinate(tick_id=10)
+
+        # Only one collection (scheduled), not additional exhausted collection
+        assert len(collect_count) == 1
+
+
+class TestQueuePausedBlockedCheck:
+    """Tests for _queue_paused_blocked_check trigger."""
+
+    @pytest.mark.asyncio
+    async def test_paused_blocked_check_remains_paused(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Paused state maintained when all entries blocked and none qualifiable."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Pre-load queue with all blocked entries
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="blocked"),
+            QueueEntry(issue_number=2, collected_state="blocked"),
+        ]
+
+        # Set paused state
+        coordinator._dispatch_paused = True
+
+        # Mock to indicate no actionable entries and no qualifiable blocked
+        coordinator._has_actionable_entries = MagicMock(return_value=False)
+        coordinator._has_pending_blocked_entries = MagicMock(return_value=True)
+        coordinator._has_qualifiable_blocked_entries = MagicMock(return_value=False)
+
+        await coordinator.coordinate()
+
+        # Should remain paused
+        assert coordinator._dispatch_paused is True
+
+    @pytest.mark.asyncio
+    async def test_paused_blocked_check_unpauses_when_qualifiable(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Paused cleared when a qualifiable blocked entry exists."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Pre-load queue with all blocked entries
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="blocked"),
+            QueueEntry(issue_number=2, collected_state="blocked"),
+        ]
+
+        # Set paused state
+        coordinator._dispatch_paused = True
+
+        # Mock to indicate no actionable but has qualifiable blocked
+        coordinator._has_actionable_entries = MagicMock(return_value=False)
+        coordinator._has_pending_blocked_entries = MagicMock(return_value=True)
+        coordinator._has_qualifiable_blocked_entries = MagicMock(return_value=True)
+
+        await coordinator.coordinate()
+
+        # Should unpause to let blocked entry through
+        assert coordinator._dispatch_paused is False
+
+
+class TestTriggerLogging:
+    """Tests for trigger method behavior."""
+
+    @pytest.mark.asyncio
+    async def test_startup_restore_on_cold_start(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Verify startup_restore is called on cold start."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Mock persistence restore
+        coordinator._queue_persistence.restore = MagicMock(return_value=None)
+
+        # Ensure queue starts as None
+        assert coordinator._frozen_queue is None
+
+        # coordinate() should call _queue_startup_restore
+        await coordinator.coordinate(tick_id=0)
+
+        # Verify persistence restore was called
+        coordinator._queue_persistence.restore.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_promote_progressed_called_on_coordinate(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Verify promote_progressed is called during coordinate."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Pre-populate queue
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="ready")
+        ]
+
+        # Mock promote to track calls
+        promote_called = []
+        original_promote = coordinator._queue_persistence.promote
+        coordinator._queue_persistence.promote = lambda: (
+            promote_called.append(True),
+            original_promote(),
+        )[1]
+
+        await coordinator.coordinate(tick_id=0)
+
+        # Verify promote was called
+        assert len(promote_called) >= 1
+
+    @pytest.mark.asyncio
+    async def test_paused_blocked_check_called_when_paused(
+        self,
+        make_capacity,
+        make_coordinator,
+    ) -> None:
+        """Verify paused_blocked_check is called when dispatch is paused."""
+        capacity = make_capacity(remaining=2)
+        coordinator = make_coordinator(
+            "planner", capacity=capacity, with_branches=True, mock_health_check=True
+        )
+
+        # Set paused state
+        coordinator._dispatch_paused = True
+
+        # Pre-populate queue with blocked entries
+        coordinator._frozen_queue = [
+            QueueEntry(issue_number=1, collected_state="blocked")
+        ]
+
+        # Mock methods
+        coordinator._has_actionable_entries = lambda: False
+        coordinator._has_pending_blocked_entries = lambda: True
+        coordinator._has_qualifiable_blocked_entries = lambda: False
+
+        await coordinator.coordinate(tick_id=0)
+
+        # Should remain paused (paused_blocked_check executed)
+        assert coordinator._dispatch_paused is True


### PR DESCRIPTION
Closes #2866

## Summary

Extract 5 named private methods from `GlobalDispatchCoordinator.coordinate()` to improve code readability and testability while preserving all existing behavior.

## Changes

### `src/vibe3/domain/dispatch_coordinator.py`
- **Extracted `_queue_startup_restore()`**: Restores queue from persistence on cold start
- **Extracted `_queue_promote_progressed()`**: Promotes state-changed entries and normalizes queue
- **Extracted `_queue_scheduled_refresh()`**: Runs periodic full queue refresh at interval
- **Extracted `_queue_paused_blocked_check()`**: Checks paused state and re-qualifies blocked entries
- **Extracted `_queue_exhausted_refresh()`**: Rebuilds queue when candidates exhausted after dispatch
- **Rewrote `coordinate()`**: Now calls named methods in sequence for improved readability

Each extracted method:
- Contains exact original logic (no behavioral change)
- Includes structured logging with `logger.bind(domain="global_dispatch", trigger=...)`
- Returns intermediate state where needed (bool for paused state, bool for refresh status)

### `tests/vibe3/orchestra/test_queue_maintenance_triggers.py` (new)
Created comprehensive test suite covering:
- Cold-start queue restoration from persistence
- Periodic refresh fires at correct tick intervals
- Queue exhausted triggers rebuild after dispatch depletion
- Paused state maintenance with blocked entry re-qualification
- Trigger method execution paths

Total: 11 new tests, all passing.

## Test Results
- All 189 tests pass (178 existing + 11 new)
- No regression in behavior confirmed
- Type checking passes (MyPy)
- Linting passes (Ruff, Black)

## Related
- Issue: #2866
- Parent epic: #2865

---

## Contributors

claude/sonnet
