### PR TITLE
chore: remove unused mypy type:ignore[misc] workarounds

### DIFF
--- a/src/vibe3/domain/qualify_gate.py
+++ b/src/vibe3/domain/qualify_gate.py
@@ -77,7 +77,7 @@ class QualifyGateService:
         self._blocked_label = self._convention.state_label(
             self._convention.blocked_label
         )
-        self._coordination_resolver = CoordinationResolver(store=store)  # type: ignore[misc]
+        self._coordination_resolver = CoordinationResolver(store=store)
 
     def run_qualify_gate(
         self,

--- a/src/vibe3/services/issue/failure.py
+++ b/src/vibe3/services/issue/failure.py
@@ -83,7 +83,7 @@ def mark_issue(
         return
 
     if action == "fail":
-        timeline = FlowTimelineService(store=store)  # type: ignore[misc]
+        timeline = FlowTimelineService(store=store)
         # Dispatcher error: record to SQLite only, do NOT write GitHub comment
         # Runtime errors are exposed via `vibe3 serve status`, not issue comments
         timeline.record_timeline_event(


### PR DESCRIPTION
## Summary

Remove two `# type: ignore[misc]` comments that were left as workarounds from PR #2697 / #2864. Mypy 1.19.1 no longer produces the false positive on lazy-imported barrel symbols.

## Changes

- `src/vibe3/services/issue/failure.py:86` - Remove `# type: ignore[misc]` from `FlowTimelineService(store=store)`
- `src/vibe3/domain/qualify_gate.py:80` - Remove `# type: ignore[misc]` from `CoordinationResolver(store=store)`

## Verification

- ✅ mypy passes: 0 errors in 438 source files
- ✅ Unit tests pass: 22 tests (6 + 16)
- ✅ Modularity tests pass: 10 tests
- ✅ No new deep imports introduced
- ✅ Services subpackage public API contract intact

Both `# type: ignore[misc]` comments verified as unused by `mypy --warn-unused-ignores`.

## Test Plan

- [x] Run `uv run mypy src/` - 0 errors
- [x] Run `uv run pytest tests/vibe3/services/test_issue_failure_service.py` - 6 tests passed
- [x] Run `uv run pytest tests/vibe3/domain/test_qualify_gate.py` - 16 tests passed
- [x] Run `uv run pytest tests/vibe3/test_modularity/` - 10 tests passed

Closes #2863

---

## Contributors

claude/sonnet
