### PR TITLE
feat(vibe-orchestra): enhance candidate validation and intake execution capability

### DIFF
--- a/skills/vibe-orchestra/SKILL.md
+++ b/skills/vibe-orchestra/SKILL.md
@@ -56,9 +56,70 @@ description: Use when the user wants heartbeat-style governance over the issue p
 - 当前是否已有人工明确接手的 assignee issue / PR follow-up / review 收口上下文
 - assignee 与 queue / flow 现场事实
 - assignee issue pool 中 issue 的 state labels
-- dependency information such as blocked_by
+- `@vibe/supervisor/governance/roadmap-intake.md` 中的 intake 标准（使用 `vibe3 handoff show @vibe/supervisor/governance/roadmap-intake.md` 命令读取）
+- dependency 详细信息：issue body 中的 `blocked_by`、`Depends on #N`、`Blocked by #N` 引用
+- active flow / live dispatch 状态（通过 `vibe3 task status` / `vibe3 flow show` 获取）
 - orchestra heartbeat status 与相关文档
 - `@vibe/supervisor/governance/assignee-pool.md` 中的 queue guidance 与治理边界（使用 `vibe3 handoff show @vibe/supervisor/governance/assignee-pool.md` 命令读取）
+
+## Candidate Criteria
+
+本章节提炼 governance material 中的检查项，供 skill 执行时快速判断候选边界。详细标准以 `@vibe/supervisor/governance/assignee-pool.md` 为准。
+
+### 候选边界验证
+
+**必须同时满足**以下条件（缺一不可）：
+
+- Issue 是 open 状态
+- Issue 有 assignee
+- Assignee 在本机 Manager agents 列表中（通过 `vibe3 status` 获取）
+- Issue 没有 `orchestra-governed` 标签
+- Issue 没有 `roadmap-reviewed` 标签
+
+详细依据：`@vibe/supervisor/governance/assignee-pool.md` §候选边界验证
+
+### 依赖过滤
+
+**排除条件**（满足任一即排除）：
+
+- 被 `blocked_by` 标签标记的 issue
+- Issue body 中包含未关闭依赖引用（如 "Depends on #123"，且 #123 为 open 状态）
+- 已有活跃 flow / live dispatch
+- 被硬规则阻塞（涉及 `.claude/` 或 `.codex/` 目录）
+- 是简单测试任务（应路由到 supervisor/apply）
+
+**依赖检查命令**：
+
+```bash
+# 检查 blocked_by 标签
+gh issue view <number> --json labels | jq '.labels[] | select(.name == "blocked_by")'
+
+# 检查 body 中的依赖引用
+gh issue view <number> --json body | jq -r '.body' | grep -i "depends on\|blocked by\|依赖"
+
+# 检查依赖 issue 状态
+gh issue view <dependency-number> --json state,stateReason
+```
+
+详细依据：`@vibe/supervisor/governance/assignee-pool.md` §依赖过滤
+
+### Intake 标准
+
+参考 `@vibe/supervisor/governance/roadmap-intake.md`（使用 `vibe3 handoff show @vibe/supervisor/governance/roadmap-intake.md` 命令读取）：
+
+**Level 0 检查**（必须通过）：
+- 检查 `.claude/` / `.codex/` 目录（命中即阻塞）
+
+**反模式评估**：
+- 检查是否命中 >= 2 条反模式特征
+- 如：涉及核心基础设施、需要大量人类对齐、边界不明确等
+
+**Level 1-3 框架**：
+- Level 1：边界明确（改动范围清晰）
+- Level 2：验收清晰（有明确的验收标准）
+- Level 3：依赖就绪（无阻塞依赖）
+
+详细依据：`@vibe/supervisor/governance/roadmap-intake.md`
 
 ## What It Produces
 
@@ -68,6 +129,7 @@ description: Use when the user wants heartbeat-style governance over the issue p
 - ready queue ordering judgment
 - 最小 non-state label actions 或 routing suggestions
 - start / wait / defer recommendations with short reasons
+- Intake actions（若执行了 intake 前置检查）
 
 ## Hard Boundary
 
@@ -86,13 +148,71 @@ description: Use when the user wants heartbeat-style governance over the issue p
 
 ## Execution Pattern
 
-1. 查看当前 assignee issue pool 中的 running issues 与 queue / flow 现场
-2. 补捞 assignee issue pool 中已满足 assignee 条件但尚未进入调度的候选 issue
-3. 判断 assignee issue pool 中是否已经存在足够明确的执行现场
-4. 参考 `@vibe/supervisor/governance/assignee-pool.md`（使用 `vibe3 handoff show @vibe/supervisor/governance/assignee-pool.md` 命令读取），按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 对 assignee issue pool 的自动 ready queue 做人机治理判断
-5. 结合当前人工上下文，识别 assignee issue pool 中哪些 issue 虽然不在自动顺位最前，但更适合现在先处理
-6. 如有必要，提出最小 non-state label 调整建议（仅作用于 assignee issue pool 内）
-7. 在治理结论处停止
+0. **Intake 前置检查（可选）**：
+   - 如果用户明确要求"检查新 issue 入池"，执行：
+     ```bash
+     vibe3 scan governance --role roadmap-intake
+     ```
+   - 参考 `@vibe/supervisor/governance/roadmap-intake.md`（使用 `vibe3 handoff show @vibe/supervisor/governance/roadmap-intake.md` 命令读取）了解 intake 标准
+   - 检查 Level 0 阻塞（`.claude/` / `.codex/` 目录）
+   - 检查反模式特征
+   - 对适合纳入的 issue 使用 `vibe3 task intake <issue-number>` 分配 assignee
+
+1. **候选边界验证（强制）**：
+   - 先运行 `vibe3 status` 获取本机 Manager agents 列表
+   - 只处理同时满足以下条件的 issue：
+     - Issue 是 open 状态
+     - Issue 有 assignee
+     - Assignee 在本机 Manager agents 列表中
+     - Issue 没有 `orchestra-governed` 标签
+     - Issue 没有 `roadmap-reviewed` 标签
+   - 不符合任一条件的 issue 跳过（在 stdout 记录原因），不写 comment、不改 label
+
+2. 查看当前 assignee issue pool 中的 running issues 与 queue / flow 现场
+
+3. 补捞 assignee issue pool 中已满足 assignee 条件但尚未进入调度的候选 issue
+   **依赖过滤（在列出候选后执行）**：
+   - 使用以下命令检查 `blocked_by` 标签：
+     ```bash
+     gh issue view <number> --json labels | jq '.labels[] | select(.name == "blocked_by")'
+     ```
+   - 检查 body 中的依赖引用：
+     ```bash
+     gh issue view <number> --json body | jq -r '.body' | grep -i "depends on\|blocked by\|依赖"
+     ```
+   - 若发现依赖引用，检查依赖 issue 状态：
+     ```bash
+     gh issue view <dependency-number> --json state,stateReason
+     ```
+   - 排除条件：
+     - 被 `blocked_by` 标签标记的 issue
+     - Issue body 中包含未关闭依赖引用（依赖 issue 为 open 状态）
+     - 已有活跃 flow / live dispatch 的 issue
+     - 被硬规则阻塞（涉及 `.claude/` 或 `.codex/` 目录）
+     - 简单测试任务（应路由到 supervisor/apply）
+   - 详细排除标准参考 `## Candidate Criteria` 章节
+
+4. **简单测试任务路由**：对通过依赖过滤的候选，判断是否应路由到 supervisor/apply：
+   - **判断标准**（必须同时满足）：
+     - 只涉及测试文件修改（`tests/`、`test_*.py` 等）
+     - 不涉及业务代码改动（`src/` 等）
+     - 预估改动范围 ≤ 5 个文件、≤ 100 行
+   - 若是简单测试任务：
+     - 执行 `gh issue edit <issue-number> --add-label "supervisor" --add-label "state/handoff" --remove-label "state/ready"`
+     - 写 `[governance decide][assignee-pool]` comment 说明路由原因
+     - 打 `orchestra-governed` 标签
+     - 跳过后续入池评估
+   - 否则继续正常入池评估
+
+5. 判断 assignee issue pool 中是否已经存在足够明确的执行现场
+
+6. 参考 `@vibe/supervisor/governance/assignee-pool.md`（使用 `vibe3 handoff show @vibe/supervisor/governance/assignee-pool.md` 命令读取），按 `milestone -> roadmap/* -> priority/[0-9] -> issue number` 对 assignee issue pool 的自动 ready queue 做人机治理判断
+
+7. 结合当前人工上下文，识别 assignee issue pool 中哪些 issue 虽然不在自动顺位最前，但更适合现在先处理
+
+8. 如有必要，提出最小 non-state label 调整建议（仅作用于 assignee issue pool 内）
+
+9. 在治理结论处停止
 
 ## Output Contract
 

--- a/skills/vibe-orchestra/SKILL.md
+++ b/skills/vibe-orchestra/SKILL.md
@@ -115,11 +115,11 @@ gh issue view <dependency-number> --json state,stateReason
 - 如：涉及核心基础设施、需要大量人类对齐、边界不明确等
 
 **Level 1-3 框架**：
-- Level 1：边界明确（改动范围清晰）
-- Level 2：验收清晰（有明确的验收标准）
-- Level 3：依赖就绪（无阻塞依赖）
+- Level 1：基础条件（问题边界明确、验收口径清楚、依赖关系简单）
+- Level 2：架构一致性（依赖的模块/API 仍存在、未废弃、架构未变更）
+- Level 3：生命周期检查（未过时、非重复、依赖就绪）
 
-详细依据：`@vibe/supervisor/governance/roadmap-intake.md`
+详细依据：`@vibe/supervisor/governance/roadmap-intake.md`、`supervisor/roadmap-common.md` §三级审查框架
 
 ## What It Produces
 
@@ -136,7 +136,7 @@ gh issue view <dependency-number> --json state,stateReason
 - 不负责 task registry 或 task 数据质量审计
 - 不负责 runtime 绑定修复
 - 不负责 roadmap 规划或版本目标
-- 不负责 GitHub issue intake、模板补全或查重
+- 不直接执行 intake 判断（通过 `vibe3 scan governance --role roadmap-intake` 委托给 governance agent）
 - 不负责单个 flow 的 plan / run / review
 - 不负责决定单个 issue 一定要先 plan、run、review 还是直接人工操作
 - 不负责把 `state/*` label 当作启动执行的主驱动

--- a/supervisor/governance/roadmap-intake.md
+++ b/supervisor/governance/roadmap-intake.md
@@ -122,6 +122,7 @@ intake 只做二元决策：**接受（分配 assignee）** 或 **跳过（打 s
 - `roadmap/rfc`、`roadmap/epic`（**唯一例外**：Level 0 机械阻塞时 intake 直接打 `roadmap/rfc` 路由该 issue；其余 rfc 判断属 pool）
 - `roadmap/p0`、`roadmap/p1`、`roadmap/p2`
 - `priority/*`
+- `orchestra-governed`
 
 ### 不要误判为需要跳过的情况
 - 同一目标下有 2-3 个局部实现路径，但 issue 本身已说明要修什么、验收看什么
@@ -254,7 +255,7 @@ Allowed:
 - `labels.write`: allowed（routing 标签）：
   - 跳过时设 `orchestra-scanned`
   - **唯一 `roadmap/*` 例外**：Level 0（`.claude/`/`.codex/`）机械阻塞 skip 时，**直接打 `roadmap/rfc`**（路由确定性硬阻塞，使其命中 task-status Rule 1 被 /vibe-task surface）
-  - 除该例外外，**禁止**设置 `roadmap/*`、`priority/*` 标签（由 assignee-pool 或 roadmap decider 决策执行）
+  - 除该例外外，**禁止**设置 `roadmap/*`、`priority/*`、`orchestra-governed` 标签（由 assignee-pool 或 roadmap decider 决策执行）
 - `comment.write`: allowed（可写简短 intake 说明）
 - `flow`: read
 - `state/labels.write`: allowed（仅限 supervisor issues：移除 `state/ready` 并补 `state/handoff`，确保单一 state label）

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -183,6 +183,7 @@ This performs the same three actions as `--reason`, plus:
 ## Architecture Contract
 - **最小系统原则**：行为判断与推进决策由 agent 自己负责；Orchestra / flow / handoff 只负责观测、记录、展示和最小兜底。系统可以验证是否产生了预期 refs/artifacts，并在没有任何可观察进展时执行 no-op 防守（如进入 `blocked`），但系统不是业务结论的 owner，不替你决定应该 `retry`、`merge-ready` 还是 `blocked`
 - **循环保护原则**：关闭、退回、blocked 都是合法结论。**唯一不可接受的是无 PR 产出的工作循环**。如果同一 issue 已经历 3 轮以上 plan/run/review 仍未进入 merge-ready，你有责任做出终局判断：要么降级为 blocked 等人类介入，要么关闭 issue 说明无法完成。不得继续无意义地重试。
+- **代码层不补偿原则**：Agent 行为错误（打错标签、漏打标签、误判 issue 状态等）必须通过修 prompt material 来修复，禁止在代码层写死检查规则或自动修复逻辑进行补偿。代码层只做观测和记录。当审查 plan 或 PR 时，如果发现改动本质是在代码层补偿 agent 行为错误，必须判定为违规并 blocked issue。
 
 ## Progress Contract
 

--- a/supervisor/policies/plan.md
+++ b/supervisor/policies/plan.md
@@ -32,6 +32,32 @@
 如果计划中的内容看似"很简单"或"只改一个文件"，仍然禁止执行。
 简单性不是越权的理由。
 
+## 反模式：禁止规划代码层补偿
+
+**Agent 行为错误必须通过修 prompt material 来修复，禁止在代码层写死检查规则或自动修复逻辑进行补偿。**
+
+### 识别标准
+
+issue 满足任一条件即为代码层补偿反模式：
+
+- 问题真源是 agent 读了 prompt material 后执行了错误动作，但 issue 提议修改代码而非修 material
+- 提议在代码中写死检查规则来检测/修复"agent 可能犯的错误"
+- 提议代码自动修复标签不一致、状态不一致等问题，而不追溯为什么 agent 会产生不一致
+
+### 正确方向
+
+- 如果 issue 描述的是 agent 行为错误 → plan 中标注"建议先修 prompt material"，拒绝规划代码改动
+- 代码层只做**观测和记录**（如结构化日志、统计输出），不做自动补偿
+- 自动修复仅限已有明确规则的标签冲突（如 `roadmap_conflict`、`multi_state`），这些规则本身就是治理材料的一部分
+
+### 错误示例
+
+```
+❌ Issue: "agent 给非 manager issue 打了 orchestra-governed 但没有 state 标签"
+   → 错误 Plan: "修改 collect_label_anomalies 自动补 state/ready"
+   → 正确 Plan: "检查并修复 agent prompt material 中的标签使用约定"
+```
+
 ## 共用前提
 
 - 公共硬规则、handoff 约束和工具使用顺序在这里同样适用。

--- a/supervisor/roadmap-common.md
+++ b/supervisor/roadmap-common.md
@@ -197,6 +197,7 @@ Step 0 搜索 -> 过滤掉有 roadmap/rfc 的 issue（等待人类决策）
 3. **与现有能力重叠**：已有 CI/skill 可解决但未验证现有能力是否真的无法满足
 4. **违反项目原则**：违背最小正确改动、认知优先（SOUL.md）或最小变更、Skill-First、验证先于声称完成（CLAUDE.md）
 5. **边缘场景驱动**：只为极少数场景服务，无通用价值或可由用户自行处理
+6. **代码层补偿 Agent 行为错误**：问题真源在 agent 读的 prompt material（governance material / SKILL / role material），但 issue 提议在代码中写死检查规则或自动修复逻辑。违反 manager.md §代码层不补偿原则
 
 ### 评分规则
 


### PR DESCRIPTION
Closes #2850

## Summary

Enhanced `skills/vibe-orchestra/SKILL.md` with self-contained candidate validation and intake execution capabilities. The skill can now independently determine candidate issues without repeatedly consulting governance materials.

**Key Changes**:
- Added `## Candidate Criteria` section with boundary validation, dependency filtering, and intake standards
- Enhanced `## Execution Pattern` with intake pre-check, candidate boundary validation, and dependency filtering steps
- Added simple test task routing logic
- Updated Level 1-3 framework descriptions to align with roadmap-common.md
- Clarified intake delegation in Hard Boundary

**Commits**:
1. feat(vibe-orchestra): enhance candidate validation and intake execution capability
2. fix(vibe-orchestra): align Level 1-3 descriptions and clarify intake delegation

**Issue**: #2850

**Plan**: docs/plans/issue-2850-vibe-orchestra-enhance-plan.md  
**Report**: docs/reports/issue-2850-execution-report-minor-fixes.md

## Verification

- ✅ Git status clean
- ✅ LOC checks passed (no files exceed 400-line CI threshold)
- ✅ Rebased on latest main (4 commits)
- ✅ All changes aligned with governance material semantics
- ✅ Level 1-3 descriptions match roadmap-common.md definitions
- ✅ Hard Boundary clarifies intake delegation via command

## Test Plan

- [ ] Review SKILL.md structure and content
- [ ] Verify Level 1-3 descriptions align with roadmap-common.md
- [ ] Confirm dependency filtering commands are accurate
- [ ] Check intake delegation explanation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet
