### PR TITLE
test: add unit tests for SerenaService.analyze_symbol

### DIFF
--- a/config/v3/loc_limits.yaml
+++ b/config/v3/loc_limits.yaml
@@ -379,8 +379,8 @@ code_limits:
         limit: 500
         reason: "Snapshot service 测试集，覆盖 find_snapshot_by_branch（8 个测试含 branch 查找、origin/ 前缀归一化、glob 预过滤验证、非常规文件名回退扫描）、build_snapshot（1 个测试）、baseline 操作（5 个测试含 save/load/not found/no baseline dir/list excludes/save for diff）等 14 个紧密耦合场景，共享 snapshot_dir fixture 和 mock setup，拆分收益低；Issue #2616 新增 test_find_snapshot_by_branch_glob_filters_candidates 和 test_find_snapshot_by_branch_fallback_for_nonconforming_filename 验证 glob 预过滤与回退扫描行为（+94 行）"
       - path: "tests/vibe3/analysis/test_serena_service.py"
-        limit: 450
-        reason: "Serena service 测试集，覆盖 analyze_file/analyze_files/analyze_changes/scan_dead_code 等核心功能，包含完整的 mock setup 和参数化测试；PR #2744 新增 4 个 scan_dead_code 测试验证 line/loc 计算逻辑（+128 行）；合并 origin/main 后从 290 行增至 418 行"
+        limit: 560
+        reason: "Serena service 测试集，覆盖 analyze_file/analyze_files/analyze_changes/scan_dead_code/analyze_symbol 等核心功能，包含完整的 mock setup 和参数化测试；PR #2744 新增 4 个 scan_dead_code 测试验证 line/loc 计算逻辑（+128 行）；PR #2905 新增 6 个 analyze_symbol 测试覆盖正常提取、空结果、异常处理、CLI 检测、多引用场景（+71 行）；PR #2905 code review follow-up 完善断言覆盖与新增多引用测试（+48 行）；从 418 行增至 556 行"
       - path: "src/vibe3/commands/status_render.py"
         limit: 450
         reason: "Status 渲染层，新增 render_missing_state_items 函数（+24行），显示缺少 state label 的 issue 列表，与其他渲染函数共享 console/config 依赖，拆分收益低"

--- a/tests/vibe3/analysis/test_serena_service.py
+++ b/tests/vibe3/analysis/test_serena_service.py
@@ -295,10 +295,13 @@ class TestAnalyzeSymbol:
         result = service.analyze_symbol("foo", "src/def.py")
 
         assert result["symbol"] == "foo"
+        assert result["defined_in"] == "src/def.py"
         assert result["type"] == "function"
         assert result["reference_count"] == 1
         assert result["references"][0]["file"] == "src/caller.py"
         assert result["references"][0]["line"] == 10
+        assert result["references"][0]["kind"] == "call"
+        assert result["references"][0]["context"] == "foo()"
 
     def test_empty_result_handling(self, mock_client: MagicMock) -> None:
         """测试无引用情况。"""
@@ -343,6 +346,51 @@ class TestAnalyzeSymbol:
 
         assert result["reference_count"] == 0
         assert result["type"] == "cli_command"
+
+    def test_multiple_references_extraction(self, mock_client: MagicMock) -> None:
+        """测试多个引用的提取。"""
+        mock_client.find_references.return_value = [
+            {
+                "relative_path": "src/caller1.py",
+                "body_location": {"start_line": 10},
+                "kind": "call",
+                "content_around_reference": "foo()",
+            },
+            {
+                "relative_path": "src/caller2.py",
+                "body_location": {"start_line": 25},
+                "kind": "import",
+                "content_around_reference": "from bar import foo",
+            },
+            {
+                "relative_path": "src/caller3.py",
+                "body_location": {"start_line": 42},
+                "kind": "reference",
+                "content_around_reference": "obj.foo",
+            },
+        ]
+        service = SerenaService(client=mock_client)
+        result = service.analyze_symbol("foo", "src/def.py")
+
+        assert result["reference_count"] == 3
+        assert result["type"] == "function"
+        assert len(result["references"]) == 3
+
+        # 验证每个引用的字段提取正确
+        assert result["references"][0]["file"] == "src/caller1.py"
+        assert result["references"][0]["line"] == 10
+        assert result["references"][0]["kind"] == "call"
+        assert result["references"][0]["context"] == "foo()"
+
+        assert result["references"][1]["file"] == "src/caller2.py"
+        assert result["references"][1]["line"] == 25
+        assert result["references"][1]["kind"] == "import"
+        assert result["references"][1]["context"] == "from bar import foo"
+
+        assert result["references"][2]["file"] == "src/caller3.py"
+        assert result["references"][2]["line"] == 42
+        assert result["references"][2]["kind"] == "reference"
+        assert result["references"][2]["context"] == "obj.foo"
 
 
 class TestIsCliFile:

--- a/tests/vibe3/analysis/test_serena_service.py
+++ b/tests/vibe3/analysis/test_serena_service.py
@@ -274,6 +274,77 @@ class TestAnalyzeFilesSkipped:
         assert result == ["alpha", "beta"]
 
 
+class TestAnalyzeSymbol:
+    """analyze_symbol 测试."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        return MagicMock()
+
+    def test_normal_reference_extraction(self, mock_client: MagicMock) -> None:
+        """测试正常提取引用。"""
+        mock_client.find_references.return_value = [
+            {
+                "relative_path": "src/caller.py",
+                "body_location": {"start_line": 10},
+                "kind": "call",
+                "content_around_reference": "foo()",
+            }
+        ]
+        service = SerenaService(client=mock_client)
+        result = service.analyze_symbol("foo", "src/def.py")
+
+        assert result["symbol"] == "foo"
+        assert result["type"] == "function"
+        assert result["reference_count"] == 1
+        assert result["references"][0]["file"] == "src/caller.py"
+        assert result["references"][0]["line"] == 10
+
+    def test_empty_result_handling(self, mock_client: MagicMock) -> None:
+        """测试无引用情况。"""
+        mock_client.find_references.return_value = []
+        service = SerenaService(client=mock_client)
+
+        with patch("vibe3.analysis.serena_service._is_cli_file", return_value=False):
+            result = service.analyze_symbol("foo", "src/def.py")
+
+        assert result["reference_count"] == 0
+        assert result["type"] == "function"
+        assert result["references"] == []
+
+    def test_serena_error_handling(self, mock_client: MagicMock) -> None:
+        """测试 SerenaError 异常处理。"""
+        mock_client.find_references.side_effect = SerenaError(
+            "find_references", "timeout"
+        )
+        service = SerenaService(client=mock_client)
+
+        with pytest.raises(SerenaError) as excinfo:
+            service.analyze_symbol("foo", "src/def.py")
+        assert "timeout" in str(excinfo.value)
+
+    def test_generic_exception_wrapped(self, mock_client: MagicMock) -> None:
+        """测试普通异常被包装为 SerenaError。"""
+        mock_client.find_references.side_effect = ValueError("unexpected")
+        service = SerenaService(client=mock_client)
+
+        with pytest.raises(SerenaError) as excinfo:
+            service.analyze_symbol("foo", "src/def.py")
+        assert "analyze_symbol(foo)" in str(excinfo.value)
+        assert "unexpected" in str(excinfo.value)
+
+    def test_cli_command_detection(self, mock_client: MagicMock) -> None:
+        """测试 CLI 命令检测逻辑。"""
+        mock_client.find_references.return_value = []
+        service = SerenaService(client=mock_client)
+
+        with patch("vibe3.analysis.serena_service._is_cli_file", return_value=True):
+            result = service.analyze_symbol("main", "bin/vibe")
+
+        assert result["reference_count"] == 0
+        assert result["type"] == "cli_command"
+
+
 class TestIsCliFile:
     """_is_cli_file caching tests."""
 


### PR DESCRIPTION
Add unit tests for SerenaService.analyze_symbol to cover normal extraction, empty results, exception handling, and CLI detection. Closes #2900