### PR TITLE
fix(vibe3): sync FlowServiceProtocol block_flow signature with implementation

### DIFF
--- a/src/vibe3/domain/protocols/dispatch_protocols.py
+++ b/src/vibe3/domain/protocols/dispatch_protocols.py
@@ -198,7 +198,6 @@ class FlowServiceProtocol(Protocol):
         blocked_by_issue: int | None = None,
         actor: str | None = None,
         repo: str | None = None,
-        event_type: str = "flow_blocked",
     ) -> None:
         """Mark flow as blocked.
 
@@ -208,7 +207,6 @@ class FlowServiceProtocol(Protocol):
             blocked_by_issue: Dependency issue number
             actor: Actor performing the block
             repo: Repository (defaults to current repo)
-            event_type: Event type for timeline
         """
         ...
 

--- a/src/vibe3/orchestra/domain_types.py
+++ b/src/vibe3/orchestra/domain_types.py
@@ -155,7 +155,6 @@ class FlowServiceProtocol(Protocol):
         blocked_by_issue: int | None = None,
         actor: str | None = None,
         repo: str | None = None,
-        event_type: str = "flow_blocked",
     ) -> None:
         """Mark flow as blocked."""
         ...


### PR DESCRIPTION
Closes #2877

## Summary

Remove redundant `event_type` parameter from `FlowServiceProtocol.block_flow()` in both protocol definition files to match actual implementation.

## Changes

- `dispatch_protocols.py`: Removed `event_type` parameter and docstring entry from `block_flow()` signature
- `domain_types.py`: Removed `event_type` parameter from `block_flow()` signature

## Background

Issue #2839 removed the `event_type` parameter from the implementation in `block_mixin.py`, but two protocol definitions were not updated, creating a type contract inconsistency.

## Impact

- ✅ No runtime impact (all callers already omit the `event_type` argument)
- ✅ MyPy and ruff checks pass
- ✅ All domain tests pass (200 tests)

## Test Plan

- Type checking: `mypy` passed
- Linting: `ruff` passed  
- Unit tests: `pytest tests/vibe3/domain/` - 200 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet
