### PR TITLE
fix: enable publish exit contract and standardize handoff show to use stable aliases

### DIFF
--- a/config/prompts/prompts.yaml
+++ b/config/prompts/prompts.yaml
@@ -542,7 +542,7 @@ run:
 
     #### Step-by-Step Verification Process
 
-    1. **Re-read the plan**: Run `uv run python src/vibe3/cli.py handoff show <plan_ref>` to extract ALL verification requirements.
+    1. **Re-read the plan**: Run `uv run python src/vibe3/cli.py handoff show @plan` to extract ALL verification requirements.
 
     2. **Extract ALL verification requirements** from the plan:
        - Find all lines starting with "Verification:" or "验证："
@@ -629,10 +629,10 @@ run:
     Look for section "给下一阶段 agent 的指令" and follow those instructions exactly.
 
     ## Read Authoritative Refs via CLI
-    Read refs via `handoff show` command (NOT direct file path to avoid permission errors):
-    - `uv run python src/vibe3/cli.py handoff show <plan_ref>` — current plan
-    - `uv run python src/vibe3/cli.py handoff show <report_ref>` — latest execution report
-    - `uv run python src/vibe3/cli.py handoff show <audit_ref>` — review findings
+    Read refs via `handoff show` with stable aliases (NOT raw paths to avoid permission errors):
+    - `uv run python src/vibe3/cli.py handoff show @plan` — current plan
+    - `uv run python src/vibe3/cli.py handoff show @report` — latest execution report
+    - `uv run python src/vibe3/cli.py handoff show @audit` — review findings
 
     Read the audit feedback carefully and fix the cited problems first.
     Keep scope tight: do not expand the change unless required to resolve the reported issues safely.
@@ -761,7 +761,7 @@ plan:
     Look for section "给下一阶段 agent 的指令" and follow those instructions exactly.
 
     ## Read Authoritative Refs via CLI
-    Read `plan_ref` via: `uv run python src/vibe3/cli.py handoff show <plan_ref>`
+    Read `plan_ref` via stable alias: `uv run python src/vibe3/cli.py handoff show @plan`
 
     Revise the plan in place based on the latest feedback and current repository state.
     You must still follow the same output format and final state transition contract as a normal planning round.
@@ -869,9 +869,9 @@ review:
     Look for section "给下一阶段 agent 的指令" and follow those instructions exactly.
 
     ## Read Authoritative Refs via CLI
-    Read refs via `handoff show` command (NOT direct file path to avoid permission errors):
-    - `uv run python src/vibe3/cli.py handoff show <report_ref>` — latest implementation report
-    - `uv run python src/vibe3/cli.py handoff show <audit_ref>` — previous audit if exists
+    Read refs via `handoff show` with stable aliases (NOT raw paths to avoid permission errors):
+    - `uv run python src/vibe3/cli.py handoff show @report` — latest implementation report
+    - `uv run python src/vibe3/cli.py handoff show @audit` — previous audit if exists
 
     Keep scope focused on verifying whether the previously raised concerns are now resolved.
     You must still follow the same output format and final state transition contract as a normal review.

--- a/src/vibe3/agents/run_prompt.py
+++ b/src/vibe3/agents/run_prompt.py
@@ -30,12 +30,15 @@ def build_run_task_section(task_text: str | None) -> str:
     """Build execution task section."""
     ref_access_guidance = (
         "## Reference Access\n\n"
-        "- Treat `plan_ref`, `report_ref`, and `audit_ref` as handoff refs.\n"
-        "- Read those refs via `uv run python src/vibe3/cli.py handoff show <ref>`.\n"
-        "- Do not call file-reading tools directly on those ref paths, "
+        "- Read handoff refs via stable aliases (not raw paths):\n"
+        "  - `uv run python src/vibe3/cli.py handoff show @plan` — plan content\n"
+        "  - `uv run python src/vibe3/cli.py handoff show @report` — execution report\n"
+        "  - `uv run python src/vibe3/cli.py handoff show @audit` — review findings\n"
+        "  - `uv run python src/vibe3/cli.py handoff show @indicate`"
+        " — manager directives\n"
+        "  - Run `vibe3 handoff show --help` for full target reference.\n"
+        "- Do not call file-reading tools directly on ref paths, "
         "even if they look local.\n"
-        "- This unified reader works for both shared handoff artifacts "
-        "and current worktree files.\n"
     )
     if task_text:
         return f"{ref_access_guidance}\n## Execution Task\n{task_text}"

--- a/src/vibe3/commands/handoff.py
+++ b/src/vibe3/commands/handoff.py
@@ -14,6 +14,7 @@ Use handoff commands to view and manage agent communication.
 Stable aliases (preferred):
   @plan     Flow plan ref          @report   Flow report ref
   @audit    Flow audit ref         @indicate Manager directives
+  @spec     Flow spec ref          @current  Current handoff file
 
 Examples:
   vibe3 handoff show @plan         # Show plan for current flow

--- a/src/vibe3/commands/handoff.py
+++ b/src/vibe3/commands/handoff.py
@@ -11,8 +11,15 @@ app = typer.Typer(
 Handoff files record agent decisions, plans, and findings.
 Use handoff commands to view and manage agent communication.
 
+Stable aliases (preferred):
+  @plan     Flow plan ref          @report   Flow report ref
+  @audit    Flow audit ref         @indicate Manager directives
+
 Examples:
   vibe3 handoff show @plan         # Show plan for current flow
+  vibe3 handoff show @report       # Show execution report
+  vibe3 handoff show @audit        # Show review findings
+  vibe3 handoff show @indicate     # Show manager directives
   vibe3 handoff show @current      # Show current handoff file
   vibe3 handoff status             # Show handoff chain for current flow
   vibe3 handoff append "Update"    # Add a handoff record

--- a/src/vibe3/commands/handoff_read.py
+++ b/src/vibe3/commands/handoff_read.py
@@ -63,24 +63,28 @@ Usage: vibe3 handoff show <target> [--branch <branch>]
 
 Show a handoff artifact by target reference.
 
-Target formats:
+Stable aliases (preferred — resolve from flow state, more robust than raw paths):
+  @plan              Flow plan ref
+  @report            Flow report ref
+  @audit             Flow audit ref
+  @indicate          Manager indicate ref (directives to downstream agents)
+  @spec              Flow spec ref
+
+Other target formats:
   @vibe/<path>       Vibe3 installation materials (governance docs, prompts, skills)
   @key               Shared artifact key (e.g. @task-476/run-1.md)
-  @plan              Flow plan ref (resolved from flow_state.plan_ref)
-  @report            Flow report ref (resolved from flow_state.report_ref)
-  @audit             Flow audit ref (resolved from flow_state.audit_ref)
   relative/path      Canonical worktree ref; defaults to current worktree,
                      use --branch for strict resolution
   /abs/path          Absolute filesystem path (debug fallback)
 
 Examples:
-  vibe3 handoff show @vibe/supervisor/apply.md
-  vibe3 handoff show @vibe/prompts/vibe-commit.md --vibe-dir /path/to/vibe3
-  vibe3 handoff show @task-476/run-1.md
   vibe3 handoff show @plan --branch task/issue-822
   vibe3 handoff show @plan
-  vibe3 handoff show --branch task/issue-476 docs/reports/audit.md
-  vibe3 handoff show /abs/path/to/artifact.md
+  vibe3 handoff show @report
+  vibe3 handoff show @audit
+  vibe3 handoff show @indicate
+  vibe3 handoff show @vibe/supervisor/apply.md
+  vibe3 handoff show @task-476/run-1.md
 
 See also:
   vibe3 handoff status          Show current flow handoff chain
@@ -99,7 +103,10 @@ def show(
     target: Annotated[
         str | None,
         typer.Argument(
-            help="Handoff target: @vibe/<path>, @key, relative/path, or /abs/path"
+            help=(
+                "Handoff target: @plan, @report, @audit, @indicate, "
+                "@spec, @key, @vibe/<path>, relative/path, or /abs/path"
+            )
         ),
     ] = None,
     branch: Annotated[

--- a/src/vibe3/config/settings.py
+++ b/src/vibe3/config/settings.py
@@ -279,6 +279,7 @@ class RunConfig(BaseModel):
     agent_config: AgentConfig = Field(default_factory=AgentConfig)
     output_format: str = Field(default="")
     run_task: str = Field(default="")
+    publish_task: str = Field(default="")
     coding_task: str = Field(default="")
     retry_task: str = Field(default="")
     run_prompt: str = Field(default="")

--- a/supervisor/manager.md
+++ b/supervisor/manager.md
@@ -317,21 +317,29 @@ uv run python src/vibe3/cli.py task show <target-branch> --comments
 
 > ⚠️ **禁止直接使用 Read 工具读取文件路径**（如 plan_ref、report_ref、audit_ref）。
 > 直接访问 `.git/vibe3/handoff/` 或 `.agent/plans/` 等路径极易触发权限错误。
+>
+> **优先使用 stable alias（推荐）**，先运行 `vibe3 handoff show --help` 了解完整用法：
 
 **必须使用 `handoff show` 命令**：
 
 ```bash
-# 读取 plan_ref（例如：docs/plans/xxx.md）
-uv run python src/vibe3/cli.py handoff show docs/plans/xxx.md --branch <branch>
+# 读取 plan_ref —— 推荐使用 stable alias
+uv run python src/vibe3/cli.py handoff show @plan
 
-# 读取 report_ref（例如：docs/reports/xxx.md）
-uv run python src/vibe3/cli.py handoff show docs/reports/xxx.md --branch <branch>
+# 读取 report_ref —— 推荐使用 stable alias
+uv run python src/vibe3/cli.py handoff show @report
 
-# 读取 audit_ref（例如：docs/audits/xxx.md）
-uv run python src/vibe3/cli.py handoff show docs/audits/xxx.md --branch <branch>
+# 读取 audit_ref —— 推荐使用 stable alias
+uv run python src/vibe3/cli.py handoff show @audit
 
-# 读取共享 artifact（例如：@task-xxx/run-yyy.md）
+# 读取 indicate_ref —— manager 发给下游的指令
+uv run python src/vibe3/cli.py handoff show @indicate
+
+# 读取共享 artifact
 uv run python src/vibe3/cli.py handoff show @task-xxx/run-yyy.md
+
+# 读取当前 handoff
+uv run python src/vibe3/cli.py handoff show @current
 ```
 
 不要：

--- a/supervisor/policies/review.md
+++ b/supervisor/policies/review.md
@@ -46,8 +46,8 @@
 git diff <base>...HEAD --stat
 
 # 2. 查看 plan 声明的 Scope Boundary
-# （通过 handoff show 读取 plan_ref）
-uv run python src/vibe3/cli.py handoff show <plan_ref> --branch <branch>
+# （通过 handoff show @plan 读取）
+uv run python src/vibe3/cli.py handoff show @plan --branch <branch>
 ```
 
 **Scope 审查检查清单**：
@@ -173,10 +173,10 @@ uv run python src/vibe3/cli.py inspect commit <sha>
 如果 flow 中有 `report_ref`，读取 executor 的执行报告：
 
 ```bash
-uv run python src/vibe3/cli.py handoff show <report_ref>
+uv run python src/vibe3/cli.py handoff show @report
 ```
 
-使用 `handoff show` 而非直接读文件路径，以正确处理跨 worktree 路径解析。
+使用 `handoff show @report`（而非直接读文件路径），以正确处理跨 worktree 路径解析。
 
 ### 7. 跨层一致性检查（命名/文档/API 变更）
 

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -171,3 +171,23 @@ def test_build_run_prompt_body_includes_deviation_declaration(tmp_path: Path) ->
     assert "Deviation Declaration" in context
     assert "❌" in context
     assert "DO NOT claim" in context or "report accuracy failure" in context
+
+
+def test_run_config_loads_publish_task_from_prompts_yaml() -> None:
+    """publish_task must round-trip from prompts.yaml into RunConfig.
+
+    Regression test for #2900.
+    """
+    config = VibeConfig.get_defaults()
+
+    assert config.run.publish_task
+    assert "MANDATORY EXIT STEP" in config.run.publish_task
+
+
+def test_publish_exit_contract_section_contains_mandatory_exit_step() -> None:
+    config = VibeConfig.get_defaults()
+
+    section = build_run_task_section(config.run.publish_task)
+
+    assert "MANDATORY EXIT STEP" in section
+    assert "state/merge-ready" in section

--- a/tests/vibe3/agents/test_run_prompt.py
+++ b/tests/vibe3/agents/test_run_prompt.py
@@ -65,7 +65,7 @@ def test_build_run_prompt_body_instructs_ref_reads_via_handoff_show(
 
     context = build_run_prompt_body(str(plan_file), config)
 
-    assert "handoff show <ref>" in context
+    assert "handoff show @plan" in context
     assert "Do not call file-reading tools directly" in context
 
 
@@ -153,7 +153,7 @@ def test_build_run_prompt_body_includes_plan_requirements_verification(
 
     # Verify instruction to extract requirements from plan
     assert "Extract ALL verification requirements" in context
-    assert "handoff show <plan_ref>" in context
+    assert "handoff show @plan" in context
 
     # Verify instruction to form checklist
     assert "Requirements Checklist" in context or "checklist" in context.lower()


### PR DESCRIPTION
## Summary
- Fix `RunConfig` missing `publish_task` field — the publish exit contract (MANDATORY EXIT STEP to change state/handoff) was silently dropped by Pydantic, so agents never received the instruction
- Standardize all handoff show references to use stable aliases (`@plan`, `@report`, `@audit`, `@indicate`) instead of raw paths
- Add `@indicate` and `@spec` to handoff show help and docs

## Root cause
`RunConfig` defined `run_task` but not `publish_task`. `_merge_prompt_fields` loaded `publish_task` from `prompts.yaml` into config data, but Pydantic silently ignored the field. This meant `build_run_task_section(None)` fell back to a generic default that contained no state transition instructions.

## Changes
| File | Change |
|------|--------|
| `src/vibe3/config/settings.py` | Add `publish_task` field to `RunConfig` |
| `src/vibe3/agents/run_prompt.py` | Reference Access now recommends `@plan`/`@report`/`@audit`/`@indicate` |
| `config/prompts/prompts.yaml` | Replace `<plan_ref>`/`<report_ref>`/`<audit_ref>` with `@plan`/`@report`/`@audit` |
| `src/vibe3/commands/handoff_read.py` | Help adds `@indicate`/`@spec`, lists stable aliases first |
| `src/vibe3/commands/handoff.py` | Top-level help adds `@report`/`@audit`/`@indicate` examples |
| `supervisor/manager.md` | All handoff show examples use `@plan` instead of paths, add `--help` guidance |
| `supervisor/policies/review.md` | `<plan_ref>` → `@plan`, `<report_ref>` → `@report` |

## Test plan
- [x] `vibe run --publish --dry-run --show-prompt` now outputs MANDATORY EXIT STEP
- [x] `vibe3 handoff show` (no args) displays all stable aliases and recommends `@plan`
- [x] `uv run pytest tests/vibe3/agents/test_run_prompt.py` — 12 passed
- [x] `uv run mypy` — no issues in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)