### PR TITLE
refactor(projection): eliminate dual-write for FlowCompleted events

### DIFF
--- a/src/vibe3/services/flow/status.py
+++ b/src/vibe3/services/flow/status.py
@@ -75,6 +75,7 @@ class FlowStatusService:
         reason: str,
         event_type: str,
         action: str,
+        record_event: bool = True,
     ) -> None:
         """Generic method to mark flow status and record event."""
         logger.bind(
@@ -83,12 +84,13 @@ class FlowStatusService:
             branch=branch,
         ).info(f"{action}: {reason}")
         self.store.update_flow_state(branch, flow_status=status)
-        self.store.add_event(
-            branch,
-            event_type,
-            "system",
-            f"Flow auto-{status}: {reason}",
-        )
+        if record_event:
+            self.store.add_event(
+                branch,
+                event_type,
+                "system",
+                f"Flow auto-{status}: {reason}",
+            )
 
     @staticmethod
     def is_task_branch(branch: str) -> bool:
@@ -124,7 +126,12 @@ class FlowStatusService:
             logger.warning(f"Failed to save branch baseline on auto-complete: {e}")
 
         self.mark_flow_status(
-            branch, "done", reason, "flow_auto_completed", "auto_complete_flow"
+            branch,
+            "done",
+            reason,
+            "flow_auto_completed",
+            "auto_complete_flow",
+            record_event=False,
         )
 
         # Fetch task issue once for both event publish and close logic

--- a/tests/vibe3/services/test_check_merge_fix.py
+++ b/tests/vibe3/services/test_check_merge_fix.py
@@ -88,8 +88,9 @@ class TestMergedPRHandling:
         mock_store.update_flow_state.assert_called_once_with(
             "feature/test-branch", flow_status="done"
         )
-        mock_store.add_event.assert_called_once()
-        assert mock_store.add_event.call_args[0][1] == "flow_auto_completed"
+        # After dual-write elimination: add_event should NOT be called
+        # (FlowCompleted event is projected to flow_events by projection hook)
+        mock_store.add_event.assert_not_called()
         # Branch cleanup is now deferred to --clean-branch
         check_service.git_client.delete_branch.assert_not_called()
 
@@ -121,7 +122,9 @@ class TestMergedPRHandling:
         mock_store.update_flow_state.assert_called_once_with(
             "feature/test-branch", flow_status="done"
         )
-        assert mock_store.add_event.call_args[0][1] == "flow_auto_completed"
+        # After dual-write elimination: add_event should NOT be called
+        # (FlowCompleted event is projected to flow_events by projection hook)
+        mock_store.add_event.assert_not_called()
 
     def test_merged_cleanup_still_attempts_branch_delete_when_worktree_cleanup_fails(
         self, check_service, mock_store, mock_github_client


### PR DESCRIPTION
## Summary
Eliminated dual-write pattern for FlowCompleted events by removing direct `store.add_event("flow_auto_completed")` call from `mark_flow_done()`. The FlowCompleted domain event is now written exclusively to the `flow_events` table via the event_projection hook.

## Changes
- **src/vibe3/services/flow/status.py**: Added `record_event: bool = True` parameter to `mark_flow_status()`, guarded `add_event` call with `if record_event:`, modified `mark_flow_done()` to pass `record_event=False`
- **tests/vibe3/services/test_check_merge_fix.py**: Updated test assertions to expect no direct `add_event` call in `mark_flow_done` path

## Test Results
- ✅ 864 tests passed, 2 skipped, 3 xpassed (full services suite)
- ✅ Type check passed (mypy: no issues in 439 source files)
- ✅ Lint check passed (ruff: all checks passed)
- ✅ Pre-commit hooks passed (ShellCheck, Ruff, Black, MyPy)

## Acceptance Criteria Met
- ✅ No dual-write in FlowCompleted code path
- ✅ Timeline events come from projection hooks exclusively
- ✅ Tests verify single-write behavior
- ✅ Type safety maintained
- ✅ Backward compatibility preserved (default parameter value)

## Scope Verification
- **FlowCompleted**: Dual-write eliminated ✅
- **FlowBlocked**: Already clean (no changes needed) ✅
- **IssueFailed**: No actual dual-write found (no changes needed) ✅

## Implementation Details
The refactoring introduces a backward-compatible parameter `record_event` to `mark_flow_status()` that allows selective control over whether to write the timeline event directly. This enables `mark_flow_done()` to skip the direct write while preserving the existing behavior for `mark_flow_aborted()` and `mark_flow_stale()`.

The `FlowCompleted` domain event is still published, which triggers the event_projection hook to write the `flow_completed` event to the `flow_events` table.

Closes #2841

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Contributors

claude/sonnet
