### PR TITLE
refactor(clients): remove redundant single-field constants

### DIFF
--- a/src/vibe3/clients/__init__.py
+++ b/src/vibe3/clients/__init__.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
     from vibe3.clients.github_field_constants import (
         GITHUB_DEFAULT_VIEW_FIELDS,
         GITHUB_FIELDS_BODY_COMMENTS,
-        GITHUB_FIELDS_STATE_ONLY,
-        GITHUB_FIELDS_TITLE_ONLY,
     )
     from vibe3.clients.github_issues_ops import parse_blocked_by, parse_linked_issues
     from vibe3.clients.github_labels import GhIssueLabelPort, IssueLabelPort
@@ -70,8 +68,6 @@ _LAZY_IMPORTS = {
     "FlowStatePort": "vibe3.clients.protocols.flow",
     "GITHUB_DEFAULT_VIEW_FIELDS": "vibe3.clients.github_field_constants",
     "GITHUB_FIELDS_BODY_COMMENTS": "vibe3.clients.github_field_constants",
-    "GITHUB_FIELDS_STATE_ONLY": "vibe3.clients.github_field_constants",
-    "GITHUB_FIELDS_TITLE_ONLY": "vibe3.clients.github_field_constants",
     "GhIssueLabelPort": "vibe3.clients.github_labels",
     "GitClient": "vibe3.clients.git_client",
     "GitClientProtocol": "vibe3.clients.git_client",
@@ -140,8 +136,6 @@ __all__ = [
     "FlowStatePort",
     "GITHUB_DEFAULT_VIEW_FIELDS",
     "GITHUB_FIELDS_BODY_COMMENTS",
-    "GITHUB_FIELDS_STATE_ONLY",
-    "GITHUB_FIELDS_TITLE_ONLY",
     "GhIssueLabelPort",
     "GitClient",
     "GitClientProtocol",

--- a/src/vibe3/clients/github_field_constants.py
+++ b/src/vibe3/clients/github_field_constants.py
@@ -30,9 +30,6 @@ GITHUB_DEFAULT_VIEW_FIELDS: Final[tuple[str, ...]] = GITHUB_FIELDS_ISSUE_META + 
 # Default fields for list_issues — excludes body (expensive) and url
 GITHUB_DEFAULT_LIST_FIELDS: Final[tuple[str, ...]] = GITHUB_FIELDS_ISSUE_META
 
-# Minimal field sets for specific operations
-GITHUB_FIELDS_STATE_ONLY: Final[tuple[str, ...]] = ("state",)
-GITHUB_FIELDS_TITLE_ONLY: Final[tuple[str, ...]] = ("title",)
 
 # Fields for operations that need body and comments
 GITHUB_FIELDS_BODY_COMMENTS: Final[tuple[str, ...]] = ("body", "comments")

--- a/src/vibe3/services/check/cleanup.py
+++ b/src/vibe3/services/check/cleanup.py
@@ -370,11 +370,8 @@ class CheckCleanupService:
             from vibe3.services.shared.label_service import LabelService
 
             gh = self._github_client or GitHubClient()
-            from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
 
-            gh_issue = gh.view_issue(
-                issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)  # type: ignore[call-overload]
-            )
+            gh_issue = gh.view_issue(issue_number, fields=["state"])
             if (
                 isinstance(gh_issue, dict)
                 and str(gh_issue.get("state", "")).upper() == "CLOSED"

--- a/src/vibe3/services/check/pr_service.py
+++ b/src/vibe3/services/check/pr_service.py
@@ -535,11 +535,7 @@ The unresolved work continues in #{bridge_issue_number}.
             )
 
         # Check if issue already closed
-        from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
-
-        gh_issue = self.github_client.view_issue(
-            task_issue_number, fields=list(GITHUB_FIELDS_STATE_ONLY)  # type: ignore[call-overload]
-        )
+        gh_issue = self.github_client.view_issue(task_issue_number, fields=["state"])
         if not isinstance(gh_issue, dict):
             # Failed to fetch issue data (network error or not found)
             logger.bind(

--- a/src/vibe3/services/flow/transition.py
+++ b/src/vibe3/services/flow/transition.py
@@ -141,12 +141,8 @@ class FlowTransitionMixin(FlowWriteMixin):
         # Try to fetch issue title from GitHub and update cache
         if effective_issue_number:
             try:
-                from vibe3.clients import GITHUB_FIELDS_TITLE_ONLY
-
                 gh = GitHubClient()
-                issue_data = gh.view_issue(
-                    effective_issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)  # type: ignore[call-overload]
-                )
+                issue_data = gh.view_issue(effective_issue_number, fields=["title"])
                 if isinstance(issue_data, dict):
                     issue_title = issue_data.get("title")
                     if issue_title:

--- a/src/vibe3/services/issue/title_cache.py
+++ b/src/vibe3/services/issue/title_cache.py
@@ -282,11 +282,7 @@ class IssueTitleCacheService:
             return None, False
 
         try:
-            from vibe3.clients import GITHUB_FIELDS_TITLE_ONLY
-
-            issue = self.github_client.view_issue(
-                issue_number, fields=list(GITHUB_FIELDS_TITLE_ONLY)  # type: ignore[call-overload]
-            )
+            issue = self.github_client.view_issue(issue_number, fields=["title"])
             if isinstance(issue, dict):
                 title = issue.get("title", f"Issue #{issue_number}")
                 self.update_title(branch, title)

--- a/src/vibe3/services/shared/dependency_resolution.py
+++ b/src/vibe3/services/shared/dependency_resolution.py
@@ -54,12 +54,8 @@ class DependencyResolutionService:
         Returns:
             DependencyResolution with resolution status and evidence
         """
-        from vibe3.clients import GITHUB_FIELDS_STATE_ONLY
-
         # Step 1: Fetch issue state
-        issue_data = github_client.view_issue(
-            issue_number, repo=repo, fields=list(GITHUB_FIELDS_STATE_ONLY)
-        )
+        issue_data = github_client.view_issue(issue_number, repo=repo, fields=["state"])
 
         # Handle error cases (fail-safe)
         if issue_data is None or issue_data == "network_error":


### PR DESCRIPTION
## Summary

Remove GITHUB_FIELDS_STATE_ONLY and GITHUB_FIELDS_TITLE_ONLY constants and replace all usages with inline list literals ["state"] and ["title"].

These single-element tuple constants added no meaningful abstraction over inline literals, yet required list() casts and # type: ignore comments at every call site. Inlining removes both the redundancy and the type friction.

## Changes
- Remove constant definitions from github_field_constants.py
- Update __init__.py exports (TYPE_CHECKING, _LAZY_IMPORTS, __all__)
- Replace list(GITHUB_FIELDS_STATE_ONLY) with ["state"] in 4 files
- Replace list(GITHUB_FIELDS_TITLE_ONLY) with ["title"] in 2 files

## Test Plan
- [x] mypy: Success (440 source files)
- [x] ruff: All checks passed
- [x] tests: 3722 passed, 2 skipped, 5 xfailed, 8 xpassed
- [x] No remaining references to removed constants (verified via grep)

Closes #2897

---

## Contributors

claude/sonnet
