### PR TITLE
fix(dispatch): suppress UserError traceback and add cwd-fallback warning

### DIFF
--- a/src/vibe3/domain/handlers/dispatch.py
+++ b/src/vibe3/domain/handlers/dispatch.py
@@ -19,6 +19,7 @@ from vibe3.domain.events.flow_lifecycle import (
     ReviewerDispatchIntent,
 )
 from vibe3.domain.handler_registry import register_handler
+from vibe3.exceptions import UserError
 from vibe3.models import ExecutionRequest
 from vibe3.services.issue import load_issue_info
 
@@ -186,10 +187,16 @@ def handle_planner_dispatch_intent(event: PlannerDispatchIntent, /) -> None:
             tick_id=event.tick_id,
         )
     except Exception as exc:
-        logger.bind(
-            domain="planner_handler",
-            issue_number=event.issue_number,
-        ).exception(f"Planner dispatch failed: {exc}")
+        if isinstance(exc, UserError):
+            logger.bind(
+                domain="planner_handler",
+                issue_number=event.issue_number,
+            ).warning(f"Planner dispatch failed: {exc}")
+        else:
+            logger.bind(
+                domain="planner_handler",
+                issue_number=event.issue_number,
+            ).exception(f"Planner dispatch failed: {exc}")
         # Propagate exception to event system for proper handling
         raise
 
@@ -239,10 +246,16 @@ def handle_executor_dispatch_intent(event: ExecutorDispatchIntent, /) -> None:
             tick_id=event.tick_id,
         )
     except Exception as exc:
-        logger.bind(
-            domain="executor_handler",
-            issue_number=event.issue_number,
-        ).exception(f"Executor dispatch failed: {exc}")
+        if isinstance(exc, UserError):
+            logger.bind(
+                domain="executor_handler",
+                issue_number=event.issue_number,
+            ).warning(f"Executor dispatch failed: {exc}")
+        else:
+            logger.bind(
+                domain="executor_handler",
+                issue_number=event.issue_number,
+            ).exception(f"Executor dispatch failed: {exc}")
         # Propagate exception to event system for proper handling
         raise
 
@@ -286,9 +299,15 @@ def handle_reviewer_dispatch_intent(event: ReviewerDispatchIntent, /) -> None:
             tick_id=event.tick_id,
         )
     except Exception as exc:
-        logger.bind(
-            domain="reviewer_handler",
-            issue_number=event.issue_number,
-        ).exception(f"Reviewer dispatch failed: {exc}")
+        if isinstance(exc, UserError):
+            logger.bind(
+                domain="reviewer_handler",
+                issue_number=event.issue_number,
+            ).warning(f"Reviewer dispatch failed: {exc}")
+        else:
+            logger.bind(
+                domain="reviewer_handler",
+                issue_number=event.issue_number,
+            ).exception(f"Reviewer dispatch failed: {exc}")
         # Propagate exception to event system for proper handling
         raise

--- a/src/vibe3/execution/codeagent_runner.py
+++ b/src/vibe3/execution/codeagent_runner.py
@@ -189,7 +189,12 @@ class CodeagentExecutionService:
         try:
             return Path(GitClient().get_worktree_root())
         except Exception:
-            return Path.cwd()
+            fallback = Path.cwd()
+            logger.bind(domain="codeagent").warning(
+                f"Failed to resolve worktree root via git, "
+                f"falling back to process cwd: {fallback}"
+            )
+            return fallback
 
     def _prepare_sync_context(self, command: CodeagentCommand) -> SyncExecutionContext:
         """Prepare execution context before agent run."""


### PR DESCRIPTION
## Summary

- **Issue #2897 contamination**: PR #2930 的修改泄漏到了 main worktree 的未提交状态
- **UserError 堆栈污染**: orchestra 事件日志中 GitHub API 临时错误打印了完整 Python 堆栈

## 修复内容

### 1. `dispatch.py` — 抑制 UserError 的堆栈打印

Tick 26 中 GitHub API 临时扰动触发 `UserError`，但 `logger.exception()` 打印了完整堆栈（从 `heartbeat.py` → `orchestration_facade.py` → `dispatch_coordinator.py` → `event_bus.py` → `dispatch.py` → `context.py`），污染了 events.log。

三个 handler（planner/executor/reviewer）中区分异常类型：
- `UserError`（如 GitHub API 临时不可用）→ `logger.warning()`，不打印堆栈
- 其他异常 → 保留 `logger.exception()` 打印堆栈

### 2. `codeagent_runner.py` — cwd 回退时添加告警

`_resolve_command_cwd` 在 `GitClient().get_worktree_root()` 失败时静默回退到 `Path.cwd()`。如果 orchestra 进程在 main worktree 运行，就会导致 agent 在主仓库目录执行，造成文件修改泄漏到 main。

回退时添加 `logger.warning()` 记录回退路径，下次出现 main 污染时可以在日志中定位。

## Files Changed

- `src/vibe3/domain/handlers/dispatch.py` — 3 处异常处理逻辑修改
- `src/vibe3/execution/codeagent_runner.py` — cwd 回退告警

## Test Plan

- [x] mypy: Success, no issues found
- [x] ruff: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>