### PR TITLE
refactor(serena): replace glob with git-tracked file discovery in scan_dead_code

### DIFF
--- a/src/vibe3/analysis/serena_service.py
+++ b/src/vibe3/analysis/serena_service.py
@@ -304,7 +304,8 @@ class SerenaService:
             if not root_path.exists():
                 raise SerenaError("scan_dead_code", f"Root directory not found: {root}")
 
-            python_files = sorted(root_path.glob("**/*.py"))
+            tracked = self.git_client.get_tracked_files(pathspec=f"{root}/**/*.py")
+            python_files = sorted(tracked)
 
             log.bind(file_count=len(python_files)).debug("Found Python files")
 
@@ -318,8 +319,8 @@ class SerenaService:
             total_dead = 0
             total_excluded = 0
 
-            for file_path in python_files:
-                relative_file = str(file_path)
+            for relative_file in python_files:
+                file_path = Path(relative_file)
 
                 try:
                     # Parse once; share AST with _is_cli_file and get_router_functions

--- a/src/vibe3/clients/git_client.py
+++ b/src/vibe3/clients/git_client.py
@@ -41,6 +41,9 @@ from vibe3.clients.git_status_ops import (
     get_numstat as _get_numstat,
 )
 from vibe3.clients.git_status_ops import (
+    get_tracked_files as _get_tracked_files,
+)
+from vibe3.clients.git_status_ops import (
     get_untracked_files as _get_untracked_files,
 )
 from vibe3.clients.git_status_ops import (
@@ -313,6 +316,17 @@ class GitClient:
     def get_untracked_files(self) -> list[str]:
         """Return untracked files in the worktree."""
         return _get_untracked_files(self._run)
+
+    def get_tracked_files(self, pathspec: str | None = None) -> list[str]:
+        """Get all tracked files from git, optionally filtered by pathspec.
+
+        Args:
+            pathspec: Optional pathspec filter (e.g. "src/vibe3/**/*.py")
+
+        Returns:
+            List of tracked file paths relative to repo root
+        """
+        return _get_tracked_files(self._run, pathspec=pathspec)
 
     def has_uncommitted_changes(self) -> bool:
         """Check if working directory is dirty."""

--- a/src/vibe3/clients/git_status_ops.py
+++ b/src/vibe3/clients/git_status_ops.py
@@ -157,6 +157,27 @@ def get_untracked_files(run: Callable[[list[str]], str]) -> list[str]:
     return [f for f in output.splitlines() if f.strip()]
 
 
+def get_tracked_files(
+    run: Callable[[list[str]], str], pathspec: str | None = None
+) -> list[str]:
+    """Get all tracked files from git, optionally filtered by pathspec.
+
+    Naturally respects .gitignore since git ls-files only returns tracked files.
+
+    Args:
+        run: Git command runner function
+        pathspec: Optional pathspec filter (e.g. "src/vibe3/**/*.py")
+
+    Returns:
+        List of tracked file paths relative to repo root
+    """
+    args = ["ls-files"]
+    if pathspec:
+        args.extend(["--", pathspec])
+    output = run(args)
+    return [f for f in output.splitlines() if f.strip()]
+
+
 def _get_commit_files(
     run: Callable[[list[str]], str], sha: str, pathspec: str | None = None
 ) -> list[str]:

--- a/tests/vibe3/analysis/test_serena_service.py
+++ b/tests/vibe3/analysis/test_serena_service.py
@@ -448,16 +448,16 @@ class TestScanDeadCode:
         self, mock_client: MagicMock
     ) -> None:
         """Test that line and loc are populated from body_location."""
-        # Mock Path.glob to return only one test file
+        mock_git = MagicMock()
+        mock_git.get_tracked_files.return_value = ["src/vibe3/test.py"]
+
+        service = SerenaService(client=mock_client, git_client=mock_git)
+
         with patch("vibe3.analysis.serena_service.Path") as mock_path:
             mock_root = MagicMock()
             mock_root.exists.return_value = True
-            mock_file = MagicMock()
-            mock_file.__str__ = lambda self: "src/vibe3/test.py"
-            mock_root.glob.return_value = [mock_file]
             mock_path.return_value = mock_root
 
-            service = SerenaService(client=mock_client)
             report = service.scan_dead_code()
 
             # Should have one finding
@@ -477,16 +477,16 @@ class TestScanDeadCode:
         # Return empty references (dead code)
         client.find_references.return_value = []
 
-        # Mock Path.glob to return only one test file
+        mock_git = MagicMock()
+        mock_git.get_tracked_files.return_value = ["src/vibe3/test.py"]
+
+        service = SerenaService(client=client, git_client=mock_git)
+
         with patch("vibe3.analysis.serena_service.Path") as mock_path:
             mock_root = MagicMock()
             mock_root.exists.return_value = True
-            mock_file = MagicMock()
-            mock_file.__str__ = lambda self: "src/vibe3/test.py"
-            mock_root.glob.return_value = [mock_file]
             mock_path.return_value = mock_root
 
-            service = SerenaService(client=client)
             report = service.scan_dead_code()
 
             # Should have one finding
@@ -508,16 +508,16 @@ class TestScanDeadCode:
         }
         client.find_references.return_value = []
 
-        # Mock Path.glob to return only one test file
+        mock_git = MagicMock()
+        mock_git.get_tracked_files.return_value = ["src/vibe3/test.py"]
+
+        service = SerenaService(client=client, git_client=mock_git)
+
         with patch("vibe3.analysis.serena_service.Path") as mock_path:
             mock_root = MagicMock()
             mock_root.exists.return_value = True
-            mock_file = MagicMock()
-            mock_file.__str__ = lambda self: "src/vibe3/test.py"
-            mock_root.glob.return_value = [mock_file]
             mock_path.return_value = mock_root
 
-            service = SerenaService(client=client)
             report = service.scan_dead_code()
 
             assert len(report.findings) == 1
@@ -537,16 +537,16 @@ class TestScanDeadCode:
         }
         client.find_references.return_value = []
 
-        # Mock Path.glob to return only one test file
+        mock_git = MagicMock()
+        mock_git.get_tracked_files.return_value = ["src/vibe3/test.py"]
+
+        service = SerenaService(client=client, git_client=mock_git)
+
         with patch("vibe3.analysis.serena_service.Path") as mock_path:
             mock_root = MagicMock()
             mock_root.exists.return_value = True
-            mock_file = MagicMock()
-            mock_file.__str__ = lambda self: "src/vibe3/test.py"
-            mock_root.glob.return_value = [mock_file]
             mock_path.return_value = mock_root
 
-            service = SerenaService(client=client)
             report = service.scan_dead_code()
 
             assert len(report.findings) == 1


### PR DESCRIPTION
Closes #2885

## Summary

Replace inefficient `root_path.glob("**/*.py")` in `scan_dead_code` with `GitClient.get_tracked_files(pathspec=...)` using `git ls-files`, which naturally respects `.gitignore` and only returns tracked files. This eliminates unnecessary scanning of `tests/`, `.venv/`, `.git/`, and other irrelevant directories.

## Changes

- **src/vibe3/clients/git_status_ops.py**: Added `get_tracked_files()` function that wraps `git ls-files` with optional pathspec filtering
- **src/vibe3/clients/git_client.py**: Added `get_tracked_files()` method on `GitClient` that delegates to `_get_tracked_files`
- **src/vibe3/analysis/serena_service.py**: Replaced `root_path.glob("**/*.py")` with `self.git_client.get_tracked_files(pathspec=f"{root}/**/*.py")`
- **tests/vibe3/analysis/test_serena_service.py**: Updated 4 test methods to mock `git_client.get_tracked_files` instead of `Path.glob`

## Test plan

- [x] Run direct tests: `pytest tests/vibe3/analysis/test_serena_service.py -k TestScanDeadCode` (4/4 passed)
- [x] Run module tests: `pytest tests/vibe3/analysis/` (177 tests passed)
- [x] Type checking: `mypy src/vibe3/clients/git_status_ops.py src/vibe3/clients/git_client.py src/vibe3/analysis/serena_service.py` (no errors)
- [x] Lint checking: `ruff check src/vibe3/clients/git_status_ops.py src/vibe3/clients/git_client.py src/vibe3/analysis/serena_service.py` (all checks passed)
- [x] Pre-commit: `pre-commit run --all-files` (all checks passed)
- [x] LOC limits: `ENFORCE_LOC_LIMITS=true bash scripts/hooks/check-per-file-loc.sh` (no errors)

---

## Contributors

claude/sonnet
